### PR TITLE
Status script misparses quoted YAML IDs

### DIFF
--- a/docs/plans/status-script-quoted-id-parsing.md
+++ b/docs/plans/status-script-quoted-id-parsing.md
@@ -108,3 +108,11 @@ Observed symptom: an agent saw existing entities going up to 010 and chose to st
 - DONE: Added targeted coverage in `tests/test_status_script.py` for quoted IDs in `NEXT_ID` calculation and quoted `id` / `pr` filtering.
 - DONE: Verified the parser change with `uv run --with pytest python tests/test_status_script.py -q` and `python3 -m py_compile skills/commission/bin/status`; both passed.
 - DONE: The implementation stays within the existing manual YAML parsing approach and does not add new dependencies.
+
+## Stage Report: validation
+
+- PASSED: The implementation satisfies the acceptance criteria for normalization of quoted frontmatter values.
+- PASSED: `parse_frontmatter()` now strips matching surrounding quotes at the shared parse point, so downstream consumers see normalized values consistently. Evidence: [`skills/commission/bin/status`](../skills/commission/bin/status):63-66.
+- PASSED: The new test coverage exercises both quoted `id` and quoted `pr` matching, including `NEXT_ID` behavior. Evidence: [`tests/test_status_script.py`](../tests/test_status_script.py):723-741.
+- PASSED: Focused verification succeeded. Evidence: `uv run --with pytest python tests/test_status_script.py -q` returned `66 passed`, and `python3 -m py_compile skills/commission/bin/status` passed.
+- PASSED: No additional dependencies or parser rewrites were introduced; the fix remains localized to the existing frontmatter parser.

--- a/docs/plans/status-script-quoted-id-parsing.md
+++ b/docs/plans/status-script-quoted-id-parsing.md
@@ -100,3 +100,11 @@ Observed symptom: an agent saw existing entities going up to 010 and chose to st
    - Test: Create entity file with `id: 084`. Parse frontmatter and assert `id` field is `084`.
 
    **Test approach:** Unit tests in a new or existing test file that exercise `parse_frontmatter()` directly and `compute_next_id()` with fixture files in a temp directory. No E2E tests needed — the bug is purely in string handling within a single function. Estimated complexity: low (< 30 minutes).
+
+## Stage Report: implementation
+
+- DONE: Normalized quoted frontmatter values in `skills/commission/bin/status` so `id: "084"` and `pr: "#28"` are stored without surrounding quote characters.
+- DONE: Kept the change localized to the shared parser so `compute_next_id()`, `--where`, and display paths all see the same normalized values.
+- DONE: Added targeted coverage in `tests/test_status_script.py` for quoted IDs in `NEXT_ID` calculation and quoted `id` / `pr` filtering.
+- DONE: Verified the parser change with `uv run --with pytest python tests/test_status_script.py -q` and `python3 -m py_compile skills/commission/bin/status`; both passed.
+- DONE: The implementation stays within the existing manual YAML parsing approach and does not add new dependencies.

--- a/skills/commission/bin/status
+++ b/skills/commission/bin/status
@@ -60,6 +60,8 @@ def parse_frontmatter(filepath):
                     key, _, val = line.partition(':')
                     key = key.strip()
                     val = val.strip()
+                    if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+                        val = val[1:-1]
                     if not line[0].isspace():
                         fields[key] = val
     return fields

--- a/tests/test_status_script.py
+++ b/tests/test_status_script.py
@@ -711,13 +711,34 @@ class TestBootOption(unittest.TestCase):
                     'task-c.md': entity('003', 'Task C', 'backlog'),
                 },
                 archived={
-                    'task-b.md': entity('002', 'Task B', 'done'),
+                    'task-b.md': entity('"004"', 'Task B', 'done'),
                 },
             )
             result = run_status(tmpdir, '--boot', script_path=self.script_path,
                                extra_env={'PATH': self._path_without_gh()})
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertIn('NEXT_ID: 004', result.stdout)
+            self.assertIn('NEXT_ID: 005', result.stdout)
+
+    # AC4: Quoted values normalize consistently
+    def test_quoted_frontmatter_values_are_normalized(self):
+        """Quoted YAML frontmatter values are parsed without literal quote characters."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'quoted.md': entity('"084"', 'Quoted Task', 'backlog', pr='"#28"'),
+            })
+            result = run_status(tmpdir, '--where', 'id = 084', script_path=self.script_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            lines = result.stdout.strip().split('\n')[2:]
+            self.assertEqual(len(lines), 1)
+            self.assertIn('084', lines[0])
+            self.assertNotIn('"084"', result.stdout)
+
+            result2 = run_status(tmpdir, '--where', 'pr = #28', script_path=self.script_path)
+            self.assertEqual(result2.returncode, 0, result2.stderr)
+            lines2 = result2.stdout.strip().split('\n')[2:]
+            self.assertEqual(len(lines2), 1)
+            self.assertIn('quoted', lines2[0])
+            self.assertNotIn('"#28"', result2.stdout)
 
     # AC4: ORPHANS with DIR_EXISTS and BRANCH_EXISTS
     def test_orphans_with_existence_checks(self):


### PR DESCRIPTION
Workflow entity: Status script misparses quoted YAML IDs