### PR TITLE
Refresh README and architectural docs for correctness and time-to-value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,139 @@
 # Spacedock
 
-Spacedock turns directories of markdown files into structured workflows operated by AI agents. Each file is a work item that moves through defined stages. An AI first officer manages the workflow: dispatching subagents, isolating work in git worktrees, and pausing at approval gates for human review.
+Spacedock turns directories of markdown files into structured workflows operated by AI agents. Each file is a work item that moves through defined stages, with human approval gates where they matter and stage reports that give you concise, high-signal evidence at each gate.
 
-Install it as a Claude Code plugin. Run `/spacedock:commission` to design a workflow, and `claude --agent spacedock:first-officer` to run it. Experimental support for other coding agents.
+**You want Spacedock if:**
 
-## Why Plain Text Workflows?
+- **You are a human tired of context-switching** between agent sessions to make approval decisions. Spacedock batches the decisions an AI wants to hand back to you, and presents each one with structured evidence so you can approve or redirect without re-loading context.
+- **You are an agent delegating repeatable work** and you want a structured place to queue up approval-worthy decisions for your human without interrupting them for every tiny step.
 
-- **Agent-native** -- AI agents can read, write, and run markdown workflows without adapters or APIs
-- **Flexible yet enforceable** -- define stages, transitions, and quality criteria declaratively; the first officer enforces them at runtime
-- **Declarative human-in-the-loop** -- approval gates pause the workflow for human review at defined stage boundaries
-- **Plain text workflow data** -- workflow state lives in markdown; the installed Spacedock plugin supplies the runtime agents and status tooling
-- **Composable** -- support multiple interconnected workflows (experimental)
+## What's Different
 
-*"I am the master of my fate, I am the captain of my soul."* -- William Ernest Henley, *Invictus*
-
-## Concepts
-
-You are the **captain**. You define the mission, commission the ship, and make the calls at critical moments.
-
-| Concept | What it is |
-|---------|------------|
-| **Mission** | What the workflow is designed to achieve |
-| **Work item** | A markdown file with YAML frontmatter, tracked as an entity in the schema |
-| **Workflow** | A directory of work items with a README defining stages and schema |
-| **Stages** | Ordered statuses a work item moves through, with optional approval gates for human review |
-| **First officer** | The plugin-shipped `spacedock:first-officer` agent that reads workflow state, dispatches ensigns, and reports to you at gates |
-| **Ensign** | The plugin-shipped `spacedock:ensign` worker agent dispatched by the first officer to do the actual stage work |
+- **Approval gates with structured evidence.** Every gate comes with a stage report (test outputs, before/after diffs, checklist verdicts, commit SHAs, anomalies) so you can approve, redirect, or bounce back faster than hunting through a sprawling PR.
+- **Isolation.** Stages that need it run in their own git worktree and branch; lightweight stages run inline on main. You declare which is which, and the first officer enforces it.
+- **Declarative and flexible.** Mission shape, stages, work item schema, and gates all live in plain markdown. The whole workflow is a few files in your repo that you can read, edit, fork, and commit like any other code.
+- **Composable.** A single repo can host several workflows side by side, and work items in one workflow can reference items in another when your work spans more than one mission shape.
 
 ## Quick Start
 
-Add the Spacedock marketplace and install:
+**Prerequisites:** Claude Code or Codex CLI.
 
-```
-claude plugin marketplace add clkao/spacedock
-claude plugin install spacedock
-```
+### Claude Code
 
-Then commission a workflow:
+1. `claude plugin marketplace add clkao/spacedock`
+2. `claude plugin install spacedock`
+3. Start a first-officer session and commission your workflow in one command:
 
-```
-/spacedock:commission
-```
+   ```bash
+   claude --agent spacedock:first-officer "/spacedock:commission <your mission prompt>"
+   ```
 
-You can provide context in the command itself:
+### Codex CLI
 
-```
-/spacedock:commission email triage workflow using gws-cli
-/spacedock:commission track design ideas through review and implementation
-/spacedock:commission content publishing with editorial approval gates
-```
+1. Clone Spacedock and expose its skills under the Codex skills namespace:
 
-The commission skill helps you design the workflow interactively: defining your mission, entity type, stages, and seed items. You review everything before generation.
+   ```bash
+   git clone https://github.com/clkao/spacedock.git /path/to/spacedock
+   mkdir -p ~/.agents/skills
+   ln -s /path/to/spacedock/skills ~/.agents/skills/spacedock
+   ```
 
-To run the workflow:
+   This makes `~/.agents/skills/spacedock/first-officer/SKILL.md` and `~/.agents/skills/spacedock/ensign/SKILL.md` resolve to the cloned repo: the layout the Codex runtime adapters expect.
 
-```
-claude --agent spacedock:first-officer
-```
+2. Start Codex interactively with multi-agent enabled, then prompt it to use the first-officer skill and commission your workflow:
 
-### Local Development
+   ```bash
+   codex --enable multi_agent
+   ```
 
-To work on Spacedock itself, install from a local clone:
+   At the prompt: `Use the spacedock:first-officer skill to run /spacedock:commission <your mission prompt> in this directory.`
+
+> Codex multi-agent is experimental. The Claude Code path is the primary supported surface.
+
+### Example workflows
+
+**Email triage:**
 
 ```bash
-git clone git@github.com:clkao/spacedock.git /path/to/spacedock
-claude --plugin-dir /path/to/spacedock
+claude --agent spacedock:first-officer "/spacedock:commission Email triage: fetch, categorize, and act on Gmail inbox. Entity: a batch of up to 50 emails. Stages: intake (use gws-cli, triage in:inbox and read email body if necessary, categorize, propose action per email, output as table) → approval (Captain reviews proposal) -> execute (carry out approved actions, do not mark as read). Use gws-cli (https://github.com/googleworkspace/cli/tree/main/skills/gws-gmail), GOOGLE_WORKSPACE_CLI_CONFIG_DIR=~/.config/gws/<account> for different accounts. Walk me through gws-cli setup if not already done."
 ```
+
+**[Superpowers](https://github.com/anthropics/superpowers)-style dev task workflow:**
+
+```bash
+claude --agent spacedock:first-officer "/spacedock:commission Dev task workflow: superpowers-style design → plan → implement → review with ## Design and ## Implementation Plan inlined in the entity body (no separate spec/plan files), implement on isolated worktrees with strict TDD, design and review gated for approval."
+```
+
+## What a Work Item Looks Like
+
+```yaml
+---
+id: 054
+title: Session debrief command
+status: done
+---
+
+Problem statement, design notes, acceptance criteria, and stage reports
+all live in the body of this file as the work moves through stages.
+```
+
+See [a completed example](https://github.com/clkao/spacedock/blob/main/docs/plans/_archive/session-debrief.md) from Spacedock's own workflow.
+
+## Concepts
+
+| Concept | What it is |
+|---------|------------|
+| **Mission** | The purpose of the workflow: what it processes and what it delivers. |
+| **Work item** | A single markdown file describing one thing being worked on: an email batch, a dev task, a draft. |
+| **Workflow** | A directory of work items plus the README that defines stages, schema, and gates. |
+| **Stage** | A named step a work item passes through (e.g. design, implement, review). |
+| **Gate** | A pause point at a stage boundary where the captain approves, redirects, or bounces the work back. |
+
+*"I am the master of my fate, I am the captain of my soul."* -- William Ernest Henley, *Invictus*
+
+| Role | Who |
+|---------|------------|
+| **Captain** | You. You define the mission and make the calls at approval gates. |
+| **First Officer** | The orchestrator agent that manages the workflow and reports to you at gates. |
+| **Ensign** | The worker agent that moves a single item forward through one stage. |
 
 ## How It Works
 
-The first officer reads the workflow README, checks work item statuses, and dispatches ensigns for items ready to advance. Each ensign works in an isolated git worktree so multiple items can be processed in parallel without interfering with each other.
-
-At approval gates, the first officer pauses and presents the ensign's work for your review. You can approve, request a redo with feedback, or reject.
+The first officer reads the workflow README, checks work item statuses, and dispatches ensigns for items ready to advance. Stages that need isolation (typically implementation work with commits) run inside their own git worktree; lightweight stages (design, review, triage) run inline. At approval gates the first officer pauses and presents the ensign's stage report for your review: approve, redo with feedback, or reject. Rejected work automatically bounces back for revision in a fresh round of the earlier stage, with a hard cap so you never get stuck in an infinite loop. When you end a session, `/spacedock:debrief` captures what happened (commits, task state changes, decisions, open issues) into a record the next session picks up automatically (see [an example debrief](https://github.com/clkao/spacedock/blob/main/docs/plans/_debriefs/2026-04-09-01.md) from a real session).
 
 ## What Gets Generated
 
-- **`{dir}/README.md`** -- workflow schema, stage definitions, and entity template
-- **`{dir}/*.md`** -- seed work item files
-- **`agents/first-officer.md`** -- plugin-shipped AI agent that orchestrates the workflow
-- **`skills/commission/bin/status`** -- plugin-shipped status viewer used against the workflow directory
+When you run `/spacedock:commission`, the following files are added to your workflow directory:
 
-The README is the single source of truth. The first officer reads it to know what stages exist, what quality criteria to enforce, and when to pause for your review.
+- **`{dir}/README.md`**: workflow schema, stage definitions, and work item template
+- **`{dir}/*.md`**: seed work item files
+- **`{dir}/_mods/`**: local modifications carried across refits
+
+**Shipped by the Spacedock plugin:**
+
+- **`spacedock:first-officer`**: the orchestrator agent that reads workflow state and dispatches ensigns
+- **`spacedock:ensign`**: the worker agent dispatched to do stage work
+- **`skills/commission/bin/status`**: read and advance workflow state without switching to a separate tracking tool
+
+The generated workflow README is the single source of truth. The first officer reads it to know what stages exist, what quality criteria to enforce, and when to pause for your review.
+
+Workflows can extend their own behavior via markdown mod files (`_mods/*.md`) that declare hook handlers for lifecycle events like startup, idle, or merge. For example, the [`pr-merge` mod](docs/plans/_mods/pr-merge.md) opens a pull request automatically when a completed worktree branch is ready to land.
 
 When a new Spacedock release is available, use `/spacedock:refit` to upgrade your workflow scaffolding while keeping local modifications.
 
-At the end of a session, use `/spacedock:debrief` to capture what happened -- tasks completed, decisions made, issues found. The debrief is written to `{dir}/_debriefs/` and automatically read by the first officer at next startup for session continuity.
+## Tips
+
+- **Run Spacedock inside a sandbox.** Recommended: [agent-safehouse](https://github.com/eugene1g/agent-safehouse) (macOS), [packnplay](https://github.com/obra/packnplay), a devcontainer, or a VM.
+- **Talk directly to an ensign.** Claude Code supports agent team chat: while a dispatched ensign is running, you can `Shift+Up` / `Shift+Down` to switch panes and give the ensign feedback directly instead of routing everything through the first officer.
 
 ## Use Cases
 
-- **Feature tracking** -- track ideas through ideation, implementation, validation, and approval
-- **Email triage** -- classify and route incoming messages with AI agents, escalate to human at review gates
-- **Content publishing** -- manage drafts through editing, review, and publication stages
-- **Research workflows** -- process papers or data through analysis, synthesis, and validation
+- **Email triage**: classify and route incoming messages with AI agents, escalate to a human at review gates
+- **Dev task workflow**: [superpowers](https://github.com/anthropics/superpowers)-style design -> plan -> implement -> review with approval gates
+- **Content publishing**: manage drafts through editing, review, and publication stages
+- **Research workflows**: process papers or data through analysis, synthesis, and validation
+- **Dogfooding Spacedock's own development.** Spacedock is self-hosted. Its own development runs on a plain text workflow at [`docs/plans/`](docs/plans/). Run `skills/commission/bin/status --workflow-dir docs/plans` to see the current state.
 
-Spacedock is self-hosted and bootstrapped: it manages its own development with a plain text workflow at [`docs/plans/`](docs/plans/). Run `docs/plans/status` to see the current state.
+## License
+
+Spacedock is released under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
README refresh for correctness, time-to-value, and user-facing framing. New users can now self-select in or out within 60 seconds ("You want Spacedock if" with two concrete audience clauses), copy-paste a real commission prompt (email triage via Gmail or superpowers-style dev workflow), and understand the concepts after seeing the tool in action rather than before.

## What changed

- Rewrote the opening pitch and added a two-clause "You want Spacedock if" section targeting both humans (tired of context-switching for approvals) and agents (delegating repeatable work to a structured approval queue).
- Replaced "Why Plain Text Workflows?" with a concrete "What's Different" section covering approval gates, isolation, declarative config, and composability.
- Compressed Quick Start to prerequisites + 3-step Claude Code install + Codex CLI symlink install + two verbatim example commission prompts (email triage and superpowers-style dev workflow).
- Moved Concepts table after Quick Start (vocabulary after context), split into a Concepts vocabulary table (Mission, Work item, Workflow, Stage, Gate) and a Roles table (Captain, First Officer, Ensign), stripped all implementation-label jargon.
- Added "What a Work Item Looks Like" section with a minimal YAML example and a link to a real completed entity from Spacedock's own workflow.
- Added feedback-cycles value mention, composability bullet, mods/hooks mention, debrief skill mention with link to a real session debrief, License section.
- Removed: Known Quirks section (upstream issues belong in issue tracker, not README), Local Development section (contributor-facing), standalone Dogfooding section (folded into Use Cases).

## Evidence

- 3 independent DevRel cold-read reviews across the iteration (cycle 1: REVISE with 3 P0s, cycle 2: SHIP, cycle 3: REVISE with 1 P0 on marketplace publication status which is a release concern not a README bug).
- 2 independent FO-agent reviews from downstream projects (GTM pipeline, experimentation harness) confirming factual accuracy against lived operational experience.
- 3 independent AC-9 fresh-reader proxy tests (Explore agents reading only README.md, answering the 3 time-to-value questions) all PASS.
- Captain direct-edited the final pass (commission prompt verbatim wording, sandbox recommendations, entity vocabulary cleanup, section ordering).

---
Workflow entity: Refresh README and architectural docs for correctness and time-to-value
