### PR TITLE
Fix status --set silently dropping fields missing from frontmatter

### DIFF
--- a/docs/plans/status-set-missing-field-silent-noop.md
+++ b/docs/plans/status-set-missing-field-silent-noop.md
@@ -124,3 +124,30 @@ The captain should decide between (1) "add fields on demand" and (2+3) "enforce 
 - Task 118 `pr-merge-mod-rich-body-template` — whose seed I wrote minimally, which is where I hit the bug twice.
 - Task 121 `fo-context-aware-reuse` — adjacent FO reliability concern, tangential.
 - The minimal seed pattern was written because the FO Write Scope rule says "new entity files — seed task creation (frontmatter + brief description body)" without specifying which fields are required. Seeds should probably have a canonical schema.
+
+## Stage Report: implementation
+
+**Approach:** Option 1 — add missing fields automatically. When `--set` targets a field not present in the frontmatter, insert it before the closing `---`.
+
+**Root cause:** `update_frontmatter()` in `skills/commission/bin/status` (line 574) iterates only over existing frontmatter lines and rewrites matches. Fields not already present are silently ignored — `resolved` dict contains the intended values but they are never written.
+
+**Fix (8 lines changed in `skills/commission/bin/status`):**
+- Track which resolved fields were actually written during the existing-line rewrite loop (`written` set).
+- After the loop, compute `missing = [f for f in resolved if f not in written]`.
+- Insert each missing field as `{field}: {value}` before the closing `---` line, incrementing `fm_end` to keep the insertion point correct for multiple missing fields.
+
+**Tests added (`tests/test_status_set_missing_field.py`, 5 tests):**
+1. `test_set_missing_field_inserts_it` — core bug fix: missing `pr` field is inserted.
+2. `test_set_existing_field_still_works` — regression: existing field update path unchanged.
+3. `test_set_mixed_existing_and_missing_fields` — mixed: `status` (existing) + `pr` + `worktree` (missing) all written.
+4. `test_set_missing_field_preserves_body` — body content after frontmatter is intact.
+5. `test_set_missing_field_preserves_existing_fields` — unmodified fields (id, title, status) are untouched.
+
+**Test results:**
+- New tests: 5/5 passed (2 failed before fix, confirming bug).
+- Existing `test_status_script.py`: 66/66 passed (no regressions).
+- Static suite `test_agent_content.py`: 18/18 passed.
+
+**Commits:**
+- `2d11d2e` — test: add failing tests for --set with missing frontmatter field
+- `166ecb1` — fix: update_frontmatter inserts fields missing from frontmatter

--- a/docs/plans/status-set-missing-field-silent-noop.md
+++ b/docs/plans/status-set-missing-field-silent-noop.md
@@ -151,3 +151,27 @@ The captain should decide between (1) "add fields on demand" and (2+3) "enforce 
 **Commits:**
 - `2d11d2e` — test: add failing tests for --set with missing frontmatter field
 - `166ecb1` — fix: update_frontmatter inserts fields missing from frontmatter
+
+## Stage Report: validation
+
+**Validator:** Claude (ensign worker)
+
+**Verification performed:**
+
+1. **Diff inspection:** 3 commits on branch (`2d11d2e`, `166ecb1`, `aca4884`). Changed files: `skills/commission/bin/status` (8-line fix), `tests/test_status_set_missing_field.py` (149 lines, 5 tests), `docs/plans/status-set-missing-field-silent-noop.md` (stage report). Two phantom diffs on unrelated plan files from main advancing. Scope is clean.
+
+2. **Fix logic review:** The fix tracks written fields in a `set`, computes missing fields after the rewrite loop, and inserts them before the closing `---` with correct `fm_end` increment for multiple inserts. Edge cases verified: empty frontmatter (all fields inserted), special YAML characters (matches existing behavior), empty values (works), insertion order (stable, follows `resolved` dict order).
+
+3. **New tests:** 5/5 passed.
+4. **Existing status tests:** 66/66 passed, no regressions.
+5. **Static suite:** 18/18 passed.
+6. **Manual repro:** Created temp entity with only `id`, `title`, `status`. Ran `status --set task-x pr=#99`. Confirmed `pr: #99` inserted before closing `---`, body preserved, existing fields untouched.
+
+**Per-AC verdicts:**
+
+- **AC1** (missing field written or errors loudly): PASS — `pr=#99` on a seed missing `pr` inserts the field. Confirmed via test and manual repro.
+- **AC2** (existing behavior not broken): PASS — 66/66 existing tests pass; `test_set_existing_field_still_works` confirms update path.
+- **AC3** (SKILL.md / README template updated if schema stricter): N/A — fix is additive (auto-inserts missing fields), schema is not stricter.
+- **AC4** (tests cover four cases): PASS — 5 tests cover: insertion of missing field, existing field update, mixed fields, body preservation, existing field preservation.
+
+**Recommendation: PASSED**

--- a/skills/commission/bin/status
+++ b/skills/commission/bin/status
@@ -572,6 +572,7 @@ def update_frontmatter(filepath, updates):
             resolved[field] = value
 
     # Rewrite matching lines in frontmatter
+    written = set()
     for i in range(fm_start + 1, fm_end):
         line = lines[i]
         if ':' in line and not line[0].isspace():
@@ -579,6 +580,13 @@ def update_frontmatter(filepath, updates):
             key_stripped = key.strip()
             if key_stripped in resolved:
                 lines[i] = f'{key_stripped}: {resolved[key_stripped]}'
+                written.add(key_stripped)
+
+    # Insert fields not already present in frontmatter before closing ---
+    missing = [f for f in resolved if f not in written]
+    for field in missing:
+        lines.insert(fm_end, f'{field}: {resolved[field]}')
+        fm_end += 1
 
     with open(filepath, 'w') as f:
         f.write('\n'.join(lines))

--- a/tests/test_status_set_missing_field.py
+++ b/tests/test_status_set_missing_field.py
@@ -1,0 +1,149 @@
+# ABOUTME: Tests for --set inserting fields missing from YAML frontmatter.
+# ABOUTME: Covers adding new fields, updating existing fields, and mixed scenarios.
+
+import os
+import tempfile
+import textwrap
+import unittest
+
+from test_status_script import (
+    build_status_script,
+    make_pipeline,
+    run_status,
+    README_WITH_STAGES,
+)
+
+
+def minimal_entity(id, title, status):
+    """Generate entity frontmatter with only id, title, status — no pr, worktree, etc."""
+    return textwrap.dedent(f"""\
+        ---
+        id: {id}
+        title: {title}
+        status: {status}
+        ---
+
+        Description.
+        """)
+
+
+class TestSetMissingField(unittest.TestCase):
+    """Test --set when target field is missing from frontmatter."""
+
+    def setUp(self):
+        self._script_dir = tempfile.mkdtemp()
+        self.script_path = build_status_script(self._script_dir)
+
+    def tearDown(self):
+        os.unlink(self.script_path)
+        os.rmdir(self._script_dir)
+
+    def _read_frontmatter(self, filepath):
+        """Read frontmatter from a file, returning dict of fields."""
+        fields = {}
+        in_fm = False
+        with open(filepath, 'r') as f:
+            for line in f:
+                line = line.rstrip('\n')
+                if line == '---':
+                    if in_fm:
+                        break
+                    in_fm = True
+                    continue
+                if in_fm and ':' in line:
+                    key, _, val = line.partition(':')
+                    fields[key.strip()] = val.strip()
+        return fields
+
+    def _read_body(self, filepath):
+        """Read file content after frontmatter."""
+        lines = []
+        in_fm = False
+        past_fm = False
+        with open(filepath, 'r') as f:
+            for line in f:
+                if past_fm:
+                    lines.append(line)
+                    continue
+                if line.rstrip('\n') == '---':
+                    if in_fm:
+                        past_fm = True
+                    else:
+                        in_fm = True
+        return ''.join(lines)
+
+    def test_set_missing_field_inserts_it(self):
+        """Setting a field not present in frontmatter should insert it."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'task-a.md': minimal_entity('001', 'Task A', 'backlog'),
+            })
+            result = run_status(tmpdir, '--set', 'task-a', 'pr=#42',
+                                script_path=self.script_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            fields = self._read_frontmatter(os.path.join(tmpdir, 'task-a.md'))
+            self.assertIn('pr', fields,
+                          'Missing field "pr" should have been inserted into frontmatter')
+            self.assertEqual(fields['pr'], '#42')
+
+    def test_set_existing_field_still_works(self):
+        """Regression: setting a field that already exists should update it."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'task-a.md': minimal_entity('001', 'Task A', 'backlog'),
+            })
+            result = run_status(tmpdir, '--set', 'task-a', 'status=ideation',
+                                script_path=self.script_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            fields = self._read_frontmatter(os.path.join(tmpdir, 'task-a.md'))
+            self.assertEqual(fields['status'], 'ideation')
+
+    def test_set_mixed_existing_and_missing_fields(self):
+        """Setting multiple fields where some exist and some don't — all should be written."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'task-a.md': minimal_entity('001', 'Task A', 'backlog'),
+            })
+            result = run_status(tmpdir, '--set', 'task-a',
+                                'status=implementation', 'pr=#42',
+                                'worktree=.worktrees/foo',
+                                script_path=self.script_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            fields = self._read_frontmatter(os.path.join(tmpdir, 'task-a.md'))
+            self.assertEqual(fields['status'], 'implementation',
+                             'Existing field should be updated')
+            self.assertEqual(fields['pr'], '#42',
+                             'Missing field "pr" should be inserted')
+            self.assertEqual(fields['worktree'], '.worktrees/foo',
+                             'Missing field "worktree" should be inserted')
+
+    def test_set_missing_field_preserves_body(self):
+        """Inserting a missing field should not corrupt the body after frontmatter."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'task-a.md': minimal_entity('001', 'Task A', 'backlog'),
+            })
+            result = run_status(tmpdir, '--set', 'task-a', 'pr=#42',
+                                script_path=self.script_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            body = self._read_body(os.path.join(tmpdir, 'task-a.md'))
+            self.assertIn('Description.', body,
+                          'Body content after frontmatter should be preserved')
+
+    def test_set_missing_field_preserves_existing_fields(self):
+        """Inserting a missing field should not alter existing fields."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'task-a.md': minimal_entity('001', 'Task A', 'backlog'),
+            })
+            result = run_status(tmpdir, '--set', 'task-a', 'pr=#42',
+                                script_path=self.script_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            fields = self._read_frontmatter(os.path.join(tmpdir, 'task-a.md'))
+            self.assertEqual(fields['id'], '001')
+            self.assertEqual(fields['title'], 'Task A')
+            self.assertEqual(fields['status'], 'backlog')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`status --set` now inserts fields that don't already exist in the frontmatter instead of silently dropping them. Previously, setting a field like `pr=#42` on a seed with minimal frontmatter echoed success to stdout but wrote nothing to the file.

## What changed

- Fixed `update_frontmatter()` in `skills/commission/bin/status` to track which fields were written during the rewrite loop and insert missing fields before the closing `---` (8 lines changed).
- Added 5 new tests in `tests/test_status_set_missing_field.py`: missing field insertion, existing field regression, mixed fields, body preservation, existing-field preservation.

## Evidence

- `tests/test_status_set_missing_field.py`: 5/5 passed (2 confirmed failing pre-fix)
- `tests/test_status_script.py`: 66/66 passed (no regressions)
- `tests/test_agent_content.py`: 18/18 passed
- Manual repro confirmed: `pr=#99` on minimal-frontmatter seed correctly inserts the field

---
Workflow entity: status --set silently no-ops when target field is missing from frontmatter
Related: task 123 (status tool as workflow-op CLI, adjacent improvements to the same tool)