### PR TITLE
Debrief skill: PR links + drop per-PR commits + explicit non-PR section

### DIFF
--- a/docs/plans/debrief-skill-conciseness-and-pr-links.md
+++ b/docs/plans/debrief-skill-conciseness-and-pr-links.md
@@ -114,3 +114,32 @@ Update `skills/debrief/SKILL.md`:
 - **Task 116** `readme-and-architecture-refresh` — the session's largest task, contributed to the debrief verbosity observation.
 - **Task 118** `pr-merge-mod-rich-body-template` — established the pattern of "roll up detail into structured PR bodies". This task applies the same principle to debriefs.
 - **2026-04-10 #1 debrief** — the hand-crafted target shape the revised skill should produce automatically.
+
+---
+
+## Stage Report — implementation (cycle 1)
+
+**Scope:** `skills/debrief/SKILL.md` rewrite. Replaced the grouped-by-entity "Commits" section with three new sections: Shipped (one bullet per task with PR link), Filed (backlog), and Non-PR commits (workflow-only). PR URL construction reuses the existing `.claude-plugin/plugin.json` reader from Phase 3 Step 3.
+
+**What changed:**
+
+- **Phase 2a (Commits)** — now splits commits into three buckets: (1) PR squash-merges ending `(#NN)` roll up into Shipped, (2) pr-merge mod landings (`merge: {slug} done (PASSED) via PR #NN`) are consumed by 2b to resolve PR numbers, (3) non-PR commits are listed individually. Routine state churn (`dispatch:`, `advance:`, `state:`, `track:`) and captured commits (`seed:`, `file:`, `merge: ... via PR #NN`) are explicitly suppressed to avoid noise. Consolidation guidance for feedback/ideation cycle groups and revert cross-referencing preserved from the target's hand-crafted format.
+- **Phase 2b (Task state changes)** — retitled "Shipped entities". Resolves PR number(s) per entity from the pr-merge landing commit, pulls one-sentence description from the entity's problem-statement paragraph (fallback to title), and emits the `- **{id}** \`{slug}\` — [#{N}]({url}). {desc}` format. Multi-PR (main + fixups) variant documented inline.
+- **Phase 2f (NEW — Filed entities)** — scans for `seed:`/`file:` commits and emits one bullet per new backlog entity. Dual-listing rule: entities that both filed and shipped the same session appear in both sections.
+- **Phase 3 Step 1 (Draft template)** — replaced with the new Shipped / Filed / Non-PR commits / Decisions / Issues—Workflow / Issues—Spacedock / Observations / What's Next structure. PR URL construction logic inlined at the top of Step 1 with a forward-reference to Step 3 for the reader.
+- **Phase 4 Step 3 (File template)** — mirrors the Phase 3 draft structure. Adds optional narrative framing above Shipped (matching `2026-04-10-01.md`'s opening paragraph) and the "organized by tier" hint for What's Next.
+
+**Preserved unchanged:** Phase 1 (Discovery), Phase 2c/d/e (gate decisions, issues scan, what's next), Phase 3 Step 2 (captain commentary), Phase 3 Step 3 (GitHub issue filing), Phase 4 Steps 1/2/4 (sequence, duration, commit).
+
+**Verification (by eye):** walked through the 2026-04-10 session commit range (`31a3cb5..df72c7e`) mentally against the rewritten skill. Confirmed:
+- All ten shipped entities (059, 060, 061, 115, 116, 118, 121, 122, 125, 126) resolve their PR numbers from the `merge: ... done (PASSED) via PR #NN` landing commits.
+- 116's multi-PR case (#65 + #66 fixups) is handled by the multi-PR format variant.
+- All nine filed entities (117–126) caught by the `seed:`/`file:` scan in 2f.
+- The Non-PR commits section would capture `5c0a472` (docs:), `5acdbff` + `461f4cc` (direct-merge + revert), feedback cycles on 116 (consolidated), ideation stage reports on 121/125 (consolidated), `d9bab3c`/`850dcc1`/`ffb3fe1`/`fbee0d2` (update: mid-session scope) — matching the target.
+- Routine state commits (`dispatch:`, `advance:`, `state:`, `track:`) and `seed:`/`file:` commits would be suppressed from Non-PR — matching the target's omissions.
+
+**Scope compliance:** docs-only; no code, tests, or runtime adapters touched. Only `skills/debrief/SKILL.md` and this plan's stage report appended.
+
+**Commits:** `c5b8dee` (SKILL.md rewrite).
+
+**Result:** PASSED — ready for validation gate.

--- a/docs/plans/debrief-skill-conciseness-and-pr-links.md
+++ b/docs/plans/debrief-skill-conciseness-and-pr-links.md
@@ -143,3 +143,18 @@ Update `skills/debrief/SKILL.md`:
 **Commits:** `c5b8dee` (SKILL.md rewrite).
 
 **Result:** PASSED — ready for validation gate.
+
+---
+
+## Stage Report — validation
+
+**Scope verified:** `skills/debrief/SKILL.md` + this plan only. `git diff main..HEAD --stat` confirms two files touched.
+
+**Checks performed:**
+- SKILL.md read end-to-end. Phase 2a splits commits into PR-squash / pr-merge-mod-landing / non-PR buckets with explicit suppression rules; no longer groups by entity slug (line 103 says so explicitly). Phase 2b emits `- **{id}** \`{slug}\` — [#{N}]({pr_url}). {desc}` with multi-PR variant. Phase 2f scans `seed:`/`file:` prefixes for Filed section. Phase 3 Step 1 draft template has the expected sections (Shipped, Filed, Non-PR commits, Decisions, Issues—Workflow, Issues—Spacedock, Observations, What's Next). Phase 4 Step 3 file template mirrors Phase 3. PR URL construction at Phase 3 Step 1 line 179 reads `.claude-plugin/plugin.json` `repository` (string and object forms).
+- Unchanged surface: Phase 1 Discovery, Phase 2c/d/e, Phase 3 Step 2–3, Phase 4 Steps 1/2/4 — confirmed.
+- Target-shape cross-check: read `_debriefs/2026-04-10-01.md` once. Section structure and PR link format line up with Phase 3/4 templates.
+- Mental walkthrough (3 shipped + 2 seeds): instructions are unambiguous for commit splitting, PR-number resolution from pr-merge-mod commits, and bullet emission. Clear.
+- Regression: `unset CLAUDECODE && uv run --with pytest python tests/test_agent_content.py -q` → 25 passed, 1 warning. Grep confirms no test file references the debrief skill — no direct coverage exists for skill instructions (noted, not a blocker).
+
+**Result:** PASSED — recommend merge.

--- a/skills/debrief/SKILL.md
+++ b/skills/debrief/SKILL.md
@@ -66,27 +66,67 @@ All extraction uses git and local files only — no external services.
 
 ```bash
 git log {from_commit}..HEAD --oneline -- {dir}
+git log {from_commit}..HEAD --oneline
 ```
 
-Group commits by entity slug. Parse commit message prefixes to categorize:
-- `dispatch:` — stage transitions
-- `done:` — completed entities (archived)
-- `fix:` — bug fixes
-- `feat:` — features added
-- `refit:` — scaffolding upgrades
-- Other prefixes — list as-is
+Run both — the first scoped to `{dir}` for entity-linked commits, the second unscoped to catch workflow-level commits (scaffolding edits, reverts, merge commits) that may live outside `{dir}`.
 
-Store the full list and the first/last commit hashes for frontmatter.
+Split every commit into one of three buckets:
 
-### 2b. Task state changes
+1. **PR squash-merge commits** — any commit whose message ends with `(#NN)` (GitHub's squash-merge pattern). These are the actual PR landings. They are **rolled up into the Shipped section as a PR link** — never enumerated individually.
 
-For each entity file in `{dir}/*.md` and `{dir}/_archive/*.md`, read the YAML frontmatter. Identify entities that changed status during this session by cross-referencing with commit messages containing `dispatch:` or `done:` prefixes.
+2. **pr-merge mod landing commits** — commits with the pattern `merge: {slug} done (PASSED) via PR #NN`. These are Spacedock's post-merge state-transition commits emitted by the pr-merge mod after a PR lands. Use them in Phase 2b to resolve shipped entities to their PR numbers. Do NOT list them in the Non-PR section — the information is already captured by the Shipped section's PR link.
 
-For each changed entity, record:
-- Entity slug, ID, and title
-- Stage transitions that occurred (from commit messages)
-- Current status
-- Verdict (if completed)
+3. **Non-PR commits** — workflow-only commits worth surfacing that did not flow through a PR. Include commits with these prefixes:
+   - Scaffolding edits: `docs:`, `debrief:`, `refit:`
+   - Feedback cycles: `feedback:`
+   - Ideation stage reports: `ideation:`
+   - Mid-session scope updates: `update:` (entity scope changes, refactors to in-progress specs)
+   - Direct merges on main that bypassed the pr-merge mod (e.g. `merge: {slug} done (PASSED) — direct merge from branch`)
+   - Reverts: `Revert ...`
+
+   **Suppress as routine state churn** (do NOT list):
+   - `dispatch:`, `advance:`, `state:`, `track:` — normal stage-machine transitions; redundant with the Shipped section.
+   - `seed:`, `file:` — captured in the Filed section (2f).
+   - `merge: {slug} done (PASSED) via PR #NN` — captured in the Shipped section via the PR link.
+
+   Collect the surfaced commits into a list. For each, record the short hash, a compact description (derived from the commit message), and — where useful — a one-clause context note (e.g., "feedback cycle 2 on 116", "reverted in `{hash}`").
+
+   **Consolidate adjacent related commits** onto a single line when they share context. Examples:
+   - `Feedback cycle commits on 116: \`88fe41b\`, \`bf93c00\`, \`5306fa4\`, \`31abc13\` (cycle 1, cycle 1 addendum, cycle 2, cycle 2 addendum).`
+   - `Ideation stage-report commits on 121 and 125: \`d0a7365\`, \`e1af6cf\`.`
+
+   If a commit was later reverted in the same session, mark it `**[reverted]**` and cross-reference the revert commit on the following line.
+
+Record the first and last commit hashes of the full range for frontmatter.
+
+Do NOT group all commits by entity slug — the old grouped-by-entity format is superseded.
+
+### 2b. Task state changes (Shipped entities)
+
+For each entity file in `{dir}/*.md` and `{dir}/_archive/*.md`, read the YAML frontmatter. Identify entities that reached a terminal/`done` state during this session by cross-referencing with commit messages containing `done:` / `merge: ... done` prefixes.
+
+For each **shipped** entity, resolve the merged PR(s) by scanning the session commit log for the pr-merge squash pattern matching that entity's slug, or by looking at the `merge: {slug} done (PASSED) via PR #NN` commit. Extract the PR number(s).
+
+Extract a one-sentence description from the entity body: read the entity file, locate the problem statement (the paragraph between the closing `---` of the frontmatter and the first `## ` heading). Use the first sentence as the description. Fallback to the entity title if the problem statement is empty.
+
+For each shipped entity, record:
+- Entity ID (numeric, e.g. `115`)
+- Entity slug (backticked)
+- PR number(s) with linked URL (see Phase 3 Step 3 for URL construction)
+- One-sentence description
+
+Emit one bullet per shipped entity in this format:
+
+```
+- **{id}** `{slug}` — [#{N}]({pr_url}). {one-sentence description}
+```
+
+If an entity shipped via multiple PRs (e.g. main + fixups), include all PR links inline:
+
+```
+- **{id}** `{slug}` — [#{N1}]({url1}) + [#{N2}]({url2}) fixups. {description}
+```
 
 ### 2c. Gate decisions
 
@@ -114,30 +154,51 @@ Run `{dir}/status --next` to find dispatchable entities. Also run `{dir}/status`
 - Entities with non-empty `worktree` field (in-progress or orphaned)
 - Overall workflow state
 
+### 2f. Filed entities (new backlog seeds)
+
+Scan the session commit log for new entity files created during this session. Look for commits with prefix `seed:` or `file:` in `{dir}`:
+
+```bash
+git log {from_commit}..HEAD --oneline -- {dir} | grep -E '^[a-f0-9]+ (seed|file):'
+```
+
+For each newly-filed entity, read the entity file and extract a one-sentence description from the problem statement (same method as 2b). Emit one bullet per filed entity:
+
+```
+- **{id}** `{slug}` — {one-sentence description}
+```
+
+If a filed entity also shipped in the same session (appears in both 2b and 2f), still list it in both sections — the Filed section documents what was added to the backlog, the Shipped section documents what landed.
+
 ---
 
 ## Phase 3: Draft and Review
 
 ### Step 1 — Present the draft
 
+Before drafting, construct PR URLs by reading the Spacedock plugin manifest (same logic as Step 3 below). Find the `skills/` directory containing this skill file, read `.claude-plugin/plugin.json`, and extract the `repository` field. The field may be a plain URL string (e.g. `https://github.com/clkao/spacedock`) or an object (e.g. `{"type": "git", "url": "..."}`) — handle both. Derive `{owner}` and `{repo}` for PR links of the form `https://github.com/{owner}/{repo}/pull/{N}`.
+
 Assemble the extracted data into a draft debrief and present it to the captain:
 
 > **Draft Debrief — {date} #{sequence}**
 >
-> ## Work Completed
-> {list of entities that completed stages, with one-line summaries}
+> ## Shipped
+> {one bullet per shipped task from 2b, with PR link(s) and one-sentence description}
 >
-> ## Commits
-> {grouped by entity}
+> ## Filed (backlog)
+> {one bullet per new entity from 2f, with one-sentence description}
+>
+> ## Non-PR commits (workflow-only)
+> {list of non-PR commits from 2a, each as "- `{hash}` {description} — {optional context}"}
 >
 > ## Decisions
 > {placeholder — captain fills this in}
 >
 > ## Issues — Workflow
-> {workflow-specific issues found}
+> {workflow-specific issues found, or "None identified."}
 >
 > ## Issues — Spacedock
-> {spacedock framework issues found}
+> {spacedock framework issues found, or "None identified."}
 >
 > ## Observations
 > {placeholder — captain fills this in}
@@ -147,6 +208,8 @@ Assemble the extracted data into a draft debrief and present it to the captain:
 >
 > ---
 > Add your commentary to **Decisions** and **Observations**, or confirm as-is.
+
+Note: there is no longer a grouped-by-entity "Commits" section. PR-associated commits are rolled up into the Shipped section via their PR link. Only workflow-only commits that did not flow through a PR appear in the "Non-PR commits" section.
 
 ### Step 2 — Captain commentary
 
@@ -229,14 +292,33 @@ duration: {approximate duration}
 
 # Session Debrief — {YYYY-MM-DD} #{N}
 
-## Work Completed
-{entity entries with stage completions and one-line summaries}
+{optional 1-3 sentence narrative framing of the session — headline theme, task counts, phase structure}
 
-## Commits
-{grouped by entity slug, each commit as "- `{hash}` {message}"}
+## Shipped
+{one bullet per shipped task in the format:
+"- **{id}** `{slug}` — [#{N}]({pr_url}). {one-sentence description}"
+Multiple PRs inline with "+":
+"- **{id}** `{slug}` — [#{N1}]({url1}) + [#{N2}]({url2}) fixups. {description}"}
+
+## Filed (backlog)
+{one bullet per new entity in the format:
+"- **{id}** `{slug}` — {one-sentence description}"
+If a filed entity also shipped in the same session, note that inline:
+"- **{id}** `{slug}` — shipped same session."}
+
+## Non-PR commits (workflow-only)
+{brief lead-in line, e.g. "State transitions and scaffolding that don't belong to a PR:"}
+
+{list of non-PR commits, each as:
+"- `{hash}` {description} — {optional context}"
+Reverts and reverted commits should be cross-referenced, e.g.:
+"- `{hash}` **[reverted]** {description}. {context}"
+"- `{hash}` Revert \"{original}\" — {context}"}
+
+{optional trailing note: "All other session commits are rolled up in the shipped PRs above."}
 
 ## Decisions
-{captain-contributed content, or empty if none provided}
+{captain-contributed content, or "_(none recorded)_" if none provided}
 
 ## Issues — Workflow
 {workflow-specific issues, or "None identified." if empty}
@@ -246,10 +328,12 @@ duration: {approximate duration}
 {or "None identified." if empty}
 
 ## Observations
-{captain-contributed content, or empty if none provided}
+{captain-contributed content, or "_(none recorded)_" if none provided}
 
 ## What's Next
-{dispatchable entities, gate-blocked entities, deferred items}
+{dispatchable entities, gate-blocked entities, deferred items — organized by
+tier or category where useful, e.g. "Stalled from prior sessions", "Recommended
+next session", "Other backlog", "Ideation"}
 ```
 
 ### Step 4 — Commit the debrief


### PR DESCRIPTION
Future session debriefs stay concise: one-line-per-task with PR links instead of 10-20 lines of enumerated commits per shipped task. This session's debrief (`docs/plans/_debriefs/2026-04-10-01.md`) was hand-crafted by the FO to match the new target shape — ~90 lines covering 10 shipped tasks, 9 filed tasks, and the non-PR commits that don't belong in any PR. The debrief skill is now updated to produce that same shape automatically.

## What changed

- **`skills/debrief/SKILL.md` Phase 2a (Commits extraction)** — splits commits into three buckets: PR squash-merges ending `(#NN)` roll up into the Shipped section; pr-merge mod landings (`merge: {slug} done (PASSED) via PR #NN`) supply PR numbers to Phase 2b; everything else (state transitions, feedback cycles, ideation stage reports, reverts, scaffolding edits) lands in the Non-PR commits section. Routine state churn (`dispatch:`, `advance:`, `state:`, `track:`) and already-captured commits (`seed:`, `file:`) are explicitly suppressed.
- **`skills/debrief/SKILL.md` Phase 2b (Task state → Shipped entities)** — resolves PR numbers from the pr-merge landing commits, pulls a one-sentence description from the entity's problem-statement paragraph (fallback to title), emits one bullet per shipped task with a GitHub PR link. Multi-PR variant covers the case where a task has multiple PRs (main + fixups).
- **`skills/debrief/SKILL.md` Phase 2f (new — Filed entities)** — scans `seed:`/`file:` commits for new backlog entries and emits one bullet per entity. Dual-lists same-session file-and-ship entities.
- **`skills/debrief/SKILL.md` Phase 3 Step 1 + Phase 4 Step 3 (draft and file templates)** — replaced the old Work Completed / Commits grouped-by-entity structure with Shipped / Filed (backlog) / Non-PR commits (workflow-only) / Decisions / Issues — Workflow / Issues — Spacedock / Observations / What's Next. PR URL construction reads `.claude-plugin/plugin.json` `repository` field (reusing the Phase 3 Step 3 GitHub issue filing logic, handling both string and object forms).
- **Preserved unchanged:** Phase 1 Discovery, Phase 2c/d/e (gate decisions, issues scan, what's next), Phase 3 Step 2–3 (captain commentary + GitHub issue filing), Phase 4 Steps 1/2/4 (sequence, duration, commit).

## Evidence

- Mental walkthrough against the 2026-04-10 session commit range (`31a3cb5..df72c7e`): all 10 shipped entities resolve their PR numbers from `merge: ... via PR #NN` commits; 116's multi-PR case (#65 + #66 fixups) handled; all 9 filed entities caught; Non-PR section captures the direct-merge + revert, tests/README.md clarification, feedback cycles, ideation stage reports, and mid-session scope updates while suppressing routine state churn.
- `tests/test_agent_content.py`: 25/25 passed (no regression — the debrief skill is not exercised by any test file, so this is an adjacent-suite check).
- Target shape: `docs/plans/_debriefs/2026-04-10-01.md` (hand-crafted this session, ~90 lines).

## Review guidance

The skill file is now ~140 lines longer than it was, but the generated debrief is ~310 lines shorter for a 10-task session. The tradeoff is extraction complexity in the skill prose vs. verbosity in every produced debrief. Worth noting: skills are markdown instructions for Claude, not tested code, so the only verification is the mental walkthrough against a target session. If a future session's debrief deviates from the expected shape, the skill prose is the place to tighten.

---
Workflow entity: Debrief skill — tighten output: PR links, drop per-PR commit lists, keep non-PR commits
Related: task 116 (`readme-and-architecture-refresh`, largest task this session, contributed to the debrief verbosity observation); task 118 (`pr-merge-mod-rich-body-template`, established the pattern of rolling up detail into structured PR bodies — this task applies the same principle to debriefs); 2026-04-10 #1 debrief (the hand-crafted target shape)
