### PR TITLE
claude-team context-budget: derive context limit from runtime model, not config

### DIFF
--- a/docs/plans/claude-team-context-limit-config-lie.md
+++ b/docs/plans/claude-team-context-limit-config-lie.md
@@ -103,3 +103,36 @@ Example drifted output:
 - **Task 121** `fo-context-aware-reuse` — the umbrella task for FO reuse reliability. This bug directly undermines 121's safety check.
 - **Task 116** `readme-and-architecture-refresh` — the task that killed two impl ensigns from context overflow. Was likely a victim of BOTH 125's accumulation bug and this config-lie bug. Worth checking the 116 cycle-2/cycle-3 jsonls to see if the runtime model was bare there too.
 - Session log from 2026-04-11 — parallel session (likely Codex FO or a separate Claude session) independently discovered this during a reuse-path postmortem, providing the empirical evidence cited above.
+
+## Stage Report: implementation
+
+### Summary
+
+Fixed `claude-team context-budget` to derive the context limit from the runtime model observed in the subagent jsonl rather than from the team config's declared model string. Two files changed: `skills/commission/bin/claude-team` (new `extract_runtime_models()` function + updated `cmd_context_budget()`) and `tests/test_claude_team.py` (4 new test scenarios + `model` parameter added to fixture helper). All 24 tests pass (20 existing + 4 new). Status script smoke regression: 90/90.
+
+The drift comparison uses context limit equality rather than string equality, because config stores short names (e.g. `opus[1m]`) while runtime uses full model IDs (e.g. `claude-opus-4-6[1m]`). A string comparison would false-positive on every run even when the context windows match.
+
+### Checklist
+
+1. **Read the entity seed** — DONE. Problem statement, ACs, test plan, edge cases all reviewed.
+2. **Read `skills/commission/bin/claude-team`** — DONE. Confirmed bug at lines 107 (lookup_model returns config string), 122 ([1m] check), 145 (denominator).
+3. **Read `tests/test_claude_team.py`** — DONE. 20 existing tests, subprocess-based pattern with `make_jsonl_fixture` and `make_team_config` helpers.
+4. **Implement runtime-model extraction from jsonl** — DONE. `extract_runtime_models(jsonl_path) -> set[str]` walks assistant entries and collects `message.model` values.
+5. **Update `cmd_context_budget`** — DONE. Prefers runtime model over config, with fallback + drift warning + fallback warning + mixed-models warning.
+6. **Add four new tests** — DONE.
+   - `test_config_1m_runtime_bare_uses_200k` — config `opus[1m]`, runtime bare → 200k, drift warning, `config_declared_model` present.
+   - `test_config_1m_runtime_1m_uses_1m` — config `opus[1m]`, runtime `claude-opus-4-6[1m]` → 1M, no drift warning.
+   - `test_mixed_models_uses_smallest_context` — two models in jsonl → picks smallest (200k), `mixed_models_warning` present.
+   - `test_no_model_in_jsonl_falls_back_to_config` — no model field → uses config `opus[1m]` → 1M, `config_fallback_warning` present.
+7. **pytest: 24/24 green** — DONE. `unset CLAUDECODE && uv run --with pytest python -m pytest tests/test_claude_team.py -q` → 24 passed.
+8. **Status script regression: 90/90** — DONE. `unset CLAUDECODE && uv run tests/test_status_script.py` → 90 tests OK.
+9. **AC verification:**
+   - AC1 (context_limit from jsonl runtime model) — VERIFIED: `test_config_1m_runtime_bare_uses_200k` asserts `context_limit == 200000` when runtime is bare.
+   - AC2 (config_drift_warning when models differ) — VERIFIED: `test_config_1m_runtime_bare_uses_200k` asserts `config_drift_warning` present and `config_declared_model == "opus[1m]"`.
+   - AC3 (85k on bare opus → usage_pct ~42.6) — VERIFIED: `test_config_1m_runtime_bare_uses_200k` asserts `usage_pct == pytest.approx(42.6)`.
+   - AC4 (four new test scenarios) — VERIFIED: all four listed in item 6 above.
+   - AC5 (existing 20 tests green) — VERIFIED: 20 passed in the test run.
+   - AC6 (no FO scaffolding changes needed) — VERIFIED: only `claude-team` and `test_claude_team.py` changed.
+10. **Terminology check** — DONE. Grepped for stray 1M assumptions — none found. The fix is general: reads runtime model string, applies `context_limit_for_model()` to it.
+11. **Commit on branch** — DONE. Single commit `2e7d59e` on `spacedock-ensign/claude-team-context-limit-config-lie`.
+12. **Scope audit** — DONE. `git diff --name-only main...HEAD` shows exactly `skills/commission/bin/claude-team`, `tests/test_claude_team.py`, and this entity file.

--- a/skills/commission/bin/claude-team
+++ b/skills/commission/bin/claude-team
@@ -89,6 +89,29 @@ def extract_resident_tokens(jsonl_path: str) -> int | None:
     return None
 
 
+def extract_runtime_models(jsonl_path: str) -> set[str]:
+    """Extract distinct model strings from assistant entries in the jsonl."""
+    models = set()
+    with open(jsonl_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("type") != "assistant":
+                continue
+            msg = entry.get("message", {})
+            if not isinstance(msg, dict):
+                continue
+            model = msg.get("model")
+            if model:
+                models.add(model)
+    return models
+
+
 def lookup_model(name: str) -> str | None:
     """Find the model for a team member by name.
 
@@ -137,12 +160,35 @@ def cmd_context_budget(args: argparse.Namespace) -> int:
         print(f"Error: no assistant entries with usage in {jsonl_path}", file=sys.stderr)
         return 1
 
-    model = lookup_model(name)
-    if model is None:
+    config_model = lookup_model(name)
+    if config_model is None:
         print(f"Error: no team config found for member '{name}'", file=sys.stderr)
         return 1
 
+    runtime_models = extract_runtime_models(jsonl_path)
+    warnings = {}
+
+    if len(runtime_models) > 1:
+        model = min(runtime_models, key=context_limit_for_model)
+        warnings["mixed_models_warning"] = (
+            f"multiple models seen in jsonl: {sorted(runtime_models)} — using smallest context window"
+        )
+    elif len(runtime_models) == 1:
+        model = next(iter(runtime_models))
+    else:
+        model = config_model
+        warnings["config_fallback_warning"] = (
+            "no model field in jsonl assistant entries — using config-declared model (provisional)"
+        )
+
     context_limit = context_limit_for_model(model)
+    config_limit = context_limit_for_model(config_model)
+
+    if runtime_models and config_limit != context_limit:
+        warnings["config_drift_warning"] = (
+            f"team config requested {config_model} but runtime is {model}"
+        )
+
     usage_pct = round(resident_tokens / context_limit * 100, 1)
     reuse_ok = usage_pct <= THRESHOLD_PCT
 
@@ -155,6 +201,9 @@ def cmd_context_budget(args: argparse.Namespace) -> int:
         "threshold_pct": THRESHOLD_PCT,
         "reuse_ok": reuse_ok,
     }
+    if runtime_models and config_limit != context_limit:
+        result["config_declared_model"] = config_model
+    result.update(warnings)
 
     print(json.dumps(result, indent=2))
     return 0

--- a/tests/test_claude_team.py
+++ b/tests/test_claude_team.py
@@ -25,6 +25,7 @@ def make_jsonl_fixture(
     tmp_path: Path,
     agent_name: str,
     usage: dict | None = None,
+    model: str | None = None,
 ) -> tuple[Path, Path]:
     """Create a fake subagent jsonl + meta.json pair.
 
@@ -43,9 +44,12 @@ def make_jsonl_fixture(
     lines.append(json.dumps({"type": "human", "message": {"role": "user", "content": "hello"}}))
     # An assistant entry with usage
     if usage is not None:
+        msg = {"role": "assistant", "usage": usage}
+        if model is not None:
+            msg["model"] = model
         lines.append(json.dumps({
             "type": "assistant",
-            "message": {"role": "assistant", "usage": usage},
+            "message": msg,
         }))
     jsonl_path.write_text("\n".join(lines) + "\n")
 
@@ -403,6 +407,96 @@ class TestMostRecentMatch:
         assert result.returncode == 0
         data = json.loads(result.stdout)
         assert data["resident_tokens"] == 99000
+
+
+class TestRuntimeModelDetection:
+    """Runtime model from jsonl overrides config-declared model."""
+
+    def test_config_1m_runtime_bare_uses_200k(self, tmp_path):
+        """Config says opus[1m] but runtime jsonl shows bare opus → 200k limit, drift warning."""
+        usage = {
+            "input_tokens": 85179,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
+        make_jsonl_fixture(tmp_path, "spacedock-ensign-foo-impl", usage, model="claude-opus-4-6")
+        make_team_config(tmp_path, "test-team", "spacedock-ensign-foo-impl", "opus[1m]")
+
+        result = run_context_budget(tmp_path, "spacedock-ensign-foo-impl")
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["model"] == "claude-opus-4-6"
+        assert data["context_limit"] == 200000
+        assert data["usage_pct"] == pytest.approx(42.6)
+        assert "config_drift_warning" in data
+        assert data["config_declared_model"] == "opus[1m]"
+
+    def test_config_1m_runtime_1m_uses_1m(self, tmp_path):
+        """Config says opus[1m] and runtime jsonl also shows [1m] → 1M limit, no drift."""
+        usage = {
+            "input_tokens": 85179,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
+        make_jsonl_fixture(tmp_path, "spacedock-ensign-foo-impl", usage, model="claude-opus-4-6[1m]")
+        make_team_config(tmp_path, "test-team", "spacedock-ensign-foo-impl", "opus[1m]")
+
+        result = run_context_budget(tmp_path, "spacedock-ensign-foo-impl")
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["model"] == "claude-opus-4-6[1m]"
+        assert data["context_limit"] == 1000000
+        assert data["usage_pct"] == pytest.approx(8.5)
+        assert "config_drift_warning" not in data
+
+    def test_mixed_models_uses_smallest_context(self, tmp_path):
+        """Jsonl has mixed models → use smallest context window, emit warning."""
+        projects_dir = tmp_path / ".claude" / "projects" / "test-project" / "session-1" / "subagents"
+        projects_dir.mkdir(parents=True, exist_ok=True)
+
+        meta_path = projects_dir / "agent-abc123.meta.json"
+        jsonl_path = projects_dir / "agent-abc123.jsonl"
+
+        meta_path.write_text(json.dumps({"agentType": "spacedock-ensign-foo-impl"}))
+
+        lines = [
+            json.dumps({"type": "assistant", "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-6[1m]",
+                "usage": {"input_tokens": 10000, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+            }}),
+            json.dumps({"type": "assistant", "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-6",
+                "usage": {"input_tokens": 50000, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+            }}),
+        ]
+        jsonl_path.write_text("\n".join(lines) + "\n")
+
+        make_team_config(tmp_path, "test-team", "spacedock-ensign-foo-impl", "opus[1m]")
+
+        result = run_context_budget(tmp_path, "spacedock-ensign-foo-impl")
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["context_limit"] == 200000
+        assert "mixed_models_warning" in data
+
+    def test_no_model_in_jsonl_falls_back_to_config(self, tmp_path):
+        """Jsonl assistant entries have no model field → fall back to config with warning."""
+        usage = {
+            "input_tokens": 5000,
+            "cache_creation_input_tokens": 3000,
+            "cache_read_input_tokens": 2000,
+        }
+        make_jsonl_fixture(tmp_path, "spacedock-ensign-foo-impl", usage)
+        make_team_config(tmp_path, "test-team", "spacedock-ensign-foo-impl", "opus[1m]")
+
+        result = run_context_budget(tmp_path, "spacedock-ensign-foo-impl")
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["model"] == "opus[1m]"
+        assert data["context_limit"] == 1000000
+        assert "config_fallback_warning" in data
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix context-budget to read the runtime model from the subagent jsonl instead of the team config, which stores a [1m] suffix that Claude Code strips at spawn time.

## What changed

- Derive context limit from jsonl assistant entries, not team config model string.
- Emit config_drift_warning when runtime model differs from config declaration.
- Fall back to config with config_fallback_warning when jsonl has no entries yet.
- Add 4 unit tests covering drift, match, mixed-model, and empty-jsonl scenarios.

## Evidence

- `tests/test_claude_team.py` — **24/24 passed** (20 existing + 4 new).

---

[131](/clkao/spacedock/blob/a681de1/docs/plans/claude-team-context-limit-config-lie.md)
