### PR TITLE
Narrow next-id path for task creation

### DIFF
--- a/docs/plans/narrow-next-id-path-for-task-creation.md
+++ b/docs/plans/narrow-next-id-path-for-task-creation.md
@@ -74,3 +74,20 @@ Estimated cost is low to moderate. The command logic is small, the shared id sca
 ### Summary
 
 The task is now scoped as a narrow CLI addition plus aligned first-officer guidance updates. The body describes the current overuse of `--boot`, the proposed `--next-id` path, the non-goals, and a test plan that stays proportional to the change.
+
+## Stage Report: implementation
+
+- [x] Implement a narrow `status --next-id` path that prints only the next sequential id.
+  `status --next-id` now exits before table rendering; verified with a fixture containing active and archived ids (`010` output only).
+- [x] Preserve `--boot` behavior and NEXT_ID reporting.
+  `python3 /Users/clkao/git/spacedock/.worktrees/spacedock-ensign-narrow-next-id-path-for-task-creation/tests/test_status_script.py` passed 91 tests, including the existing `--boot` NEXT_ID and section-order coverage.
+- [x] Update FO/shared/runtime guidance to use `--next-id` for task creation instead of `--boot`.
+  Updated `skills/first-officer/references/first-officer-shared-core.md`, `skills/first-officer/references/claude-first-officer-runtime.md`, and `skills/first-officer/references/codex-first-officer-runtime.md` in the worktree.
+- [x] Add targeted tests for `--next-id` output/behavior and guidance references.
+  Added `TestNextIdOption` in `tests/test_status_script.py` plus content assertions in `tests/test_agent_content.py`.
+- [x] Run the relevant verification and record concrete evidence.
+  Verified with `python3 /Users/clkao/git/spacedock/.worktrees/spacedock-ensign-narrow-next-id-path-for-task-creation/tests/test_status_script.py` and `uv run --with pytest pytest /Users/clkao/git/spacedock/.worktrees/spacedock-ensign-narrow-next-id-path-for-task-creation/tests/test_agent_content.py -k 'next_id_for_task_creation or covers_all_behavioral_sections'`, both passing.
+
+### Summary
+
+Implemented a dedicated `--next-id` CLI mode that reuses the existing id scan but suppresses all other output. The broader `--boot` flow remains intact, and the first-officer guidance now points task creation at the narrow command instead of the startup scan.

--- a/docs/plans/narrow-next-id-path-for-task-creation.md
+++ b/docs/plans/narrow-next-id-path-for-task-creation.md
@@ -91,3 +91,24 @@ The task is now scoped as a narrow CLI addition plus aligned first-officer guida
 ### Summary
 
 Implemented a dedicated `--next-id` CLI mode that reuses the existing id scan but suppresses all other output. The broader `--boot` flow remains intact, and the first-officer guidance now points task creation at the narrow command instead of the startup scan.
+
+## Stage Report: validation
+
+- [x] Verify the implementation against the acceptance criteria with concrete evidence.
+  `skills/commission/bin/status` now has a standalone `--next-id` branch, and the tests assert the narrow output shape plus archive-aware ID calculation. The guidance checks also confirm the first-officer docs point task creation at `status --next-id`.
+- [x] Re-run the relevant tests and record actual outcomes.
+  `python3 /Users/clkao/git/spacedock/.worktrees/spacedock-ensign-narrow-next-id-path-for-task-creation/tests/test_status_script.py` passed `91` tests. `uv run --with pytest pytest /Users/clkao/git/spacedock/.worktrees/spacedock-ensign-narrow-next-id-path-for-task-creation/tests/test_agent_content.py -k 'next_id_for_task_creation or covers_all_behavioral_sections'` passed `2` tests.
+- [x] Confirm the new `--next-id` path and the guidance updates are both covered by tests with clear purpose.
+  `tests/test_status_script.py:416-438` covers `--next-id` output and archived IDs. `tests/test_status_script.py:880-896` covers `--boot` NEXT_ID parity. `tests/test_agent_content.py:377-385` covers the shared-core and runtime guidance updates.
+- [x] Recommend PASSED or REJECTED with precise evidence.
+  PASSED. The narrow CLI path works, the archive-inclusive ID scan is verified, `--boot` still reports `NEXT_ID`, and the runtime guidance now prefers `status --next-id` for new task creation.
+- [x] Commit your validation work in the assigned worktree before reporting completion.
+  Commit will be created after this report is written.
+
+### Summary
+
+Validation passed. The worktree contains the intended narrow `--next-id` path, the broader `--boot` flow still behaves as before, and the guidance tests explicitly cover the new task-creation instruction. The evidence is localized and sufficient for acceptance.
+
+### Recommendation
+
+PASSED

--- a/skills/commission/bin/status
+++ b/skills/commission/bin/status
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # commissioned-by: spacedock@{spacedock_version}
 # ABOUTME: Workflow status viewer — shows entity overview from YAML frontmatter.
-# ABOUTME: Supports default table, --archived, --next, and --boot (FO startup data).
+# ABOUTME: Supports default table, --archived, --next, --next-id, and --boot (FO startup data).
 #
 # goal: Show one-line-per-{entity_label} workflow overview from YAML frontmatter.
 #
@@ -11,6 +11,7 @@
 #   Sorted by stage order ascending, then score descending.
 #   Default: scan only $DIR/*.md. With --archived, also scan $DIR/_archive/*.md.
 #   With --next, read stage metadata from README frontmatter and output dispatchable entities.
+#   With --next-id, print only the next sequential ID across active and archived entities.
 #
 # --where filters: Supply one or more --where clauses to filter the output.
 #   Accepted forms (operators `=` and `!=` only, with or without spaces around the operator):
@@ -408,6 +409,12 @@ def compute_next_id(active_entities, archive_dir):
             except ValueError:
                 pass
     return '%03d' % (max_id + 1)
+
+
+def print_next_id(entities, workflow_dir):
+    """Print only the next sequential ID."""
+    archive_dir = os.path.join(workflow_dir, '_archive')
+    print(compute_next_id(entities, archive_dir))
 
 
 def scan_orphans(entities, git_root):
@@ -920,13 +927,17 @@ def main():
 
     include_archive = '--archived' in args
     show_next = '--next' in args
+    show_next_id = '--next-id' in args
     show_boot = '--boot' in args
     has_fields_flag = explicit_fields is not None or all_fields_flag
 
-    # --boot is incompatible with --next, --archived, --where, --fields, --all-fields
+    # --boot is incompatible with --next, --next-id, --archived, --where, --fields, --all-fields
     if show_boot:
         if show_next:
             print('Error: --boot is incompatible with --next', file=sys.stderr)
+            sys.exit(1)
+        if show_next_id:
+            print('Error: --boot is incompatible with --next-id', file=sys.stderr)
             sys.exit(1)
         if include_archive:
             print('Error: --boot is incompatible with --archived', file=sys.stderr)
@@ -945,6 +956,31 @@ def main():
         print('Error: --boot is incompatible with --where', file=sys.stderr)
         sys.exit(1)
 
+    if show_next_id:
+        incompatible = []
+        if show_next:
+            incompatible.append('--next')
+        if include_archive:
+            incompatible.append('--archived')
+        if show_boot:
+            incompatible.append('--boot')
+        if where_filters:
+            incompatible.append('--where')
+        if has_fields_flag:
+            incompatible.append('--fields/--all-fields')
+        if archive_slug is not None:
+            incompatible.append('--archive')
+        if set_result is not None:
+            incompatible.append('--set')
+        if incompatible:
+            print(f'Error: --next-id cannot be combined with {", ".join(incompatible)}',
+                  file=sys.stderr)
+            sys.exit(1)
+
+        entities = scan_entities(pipeline_dir)
+        print_next_id(entities, pipeline_dir)
+        sys.exit(0)
+
     if archive_slug is not None:
         incompatible = []
         if show_next:
@@ -953,6 +989,8 @@ def main():
             incompatible.append('--archived')
         if show_boot:
             incompatible.append('--boot')
+        if show_next_id:
+            incompatible.append('--next-id')
         if where_filters:
             incompatible.append('--where')
         if has_fields_flag:
@@ -976,6 +1014,8 @@ def main():
             incompatible.append('--archived')
         if show_boot:
             incompatible.append('--boot')
+        if show_next_id:
+            incompatible.append('--next-id')
         if where_filters:
             incompatible.append('--where')
         if has_fields_flag:

--- a/skills/first-officer/references/claude-first-officer-runtime.md
+++ b/skills/first-officer/references/claude-first-officer-runtime.md
@@ -23,6 +23,8 @@ At startup (after reading the README, before dispatch):
 
 In single-entity mode, skip team creation entirely. Use bare-mode dispatch for all agent spawning — the Agent tool without `team_name` blocks until the subagent completes, which prevents premature session termination in `-p` mode.
 
+When filing a new task, use `status --next-id` to fetch only the next sequential ID. Reserve `status --boot` for startup diagnostics and broader workflow inventory.
+
 ## Worker Resolution
 
 The default `dispatch_agent_id` is `spacedock:ensign`. When a stage defines `agent: {name}` in the README, use that value as the dispatch agent id.

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -20,6 +20,8 @@ When the workflow path is explicit, do not spend time rediscovering alternatives
 - `status` output
 - the in-scope entity file
 
+When creating a new entity, use `status --next-id` to fetch only the next sequential ID. Reserve `status --boot` for startup diagnostics and broader workflow inventory.
+
 ## Packaged Worker Resolution
 
 - Treat names like `spacedock:ensign` as logical ids, not native Codex agent types.

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -11,7 +11,7 @@ This file captures the shared first-officer semantics. Keep it aligned with `age
    - entity labels
    - stage ordering and defaults from `stages.defaults` / `stages.states`
    - stage properties such as `initial`, `terminal`, `gate`, `worktree`, `concurrency`, `feedback-to`, and `agent`
-4. Run `status --boot` to gather all startup information in one call. Parse the output sections:
+4. Run `status --boot` to gather all startup information in one call. When creating a new entity, use `status --next-id` instead of `--boot` to fetch only the next sequential ID. Parse the output sections:
    - **MODS** — registered mod hooks grouped by lifecycle point (startup, idle, merge). Run startup hooks before normal dispatch.
    - **NEXT_ID** — next available sequential entity ID.
    - **ORPHANS** — entities with worktree fields, cross-referenced against filesystem and git state. Report anomalies rather than auto-redispatching.
@@ -24,10 +24,10 @@ The status viewer ships with the plugin at `skills/commission/bin/status`. Resol
 
 Invoke it as:
 ```
-{spacedock_plugin_dir}/skills/commission/bin/status --workflow-dir {workflow_dir} [--next|--archived|--where ...|--boot]
+{spacedock_plugin_dir}/skills/commission/bin/status --workflow-dir {workflow_dir} [--next-id|--next|--archived|--where ...|--boot]
 ```
 
-Use `--boot` at startup to gather mods, next ID, orphans, PR state, and dispatchable entities in a single call. Use `--next`, `--where "pr !="`, etc. for targeted queries during the event loop. `--boot` is incompatible with `--next`, `--archived`, and `--where`.
+Use `--boot` at startup to gather mods, next ID, orphans, PR state, and dispatchable entities in a single call. Use `--next-id` when filing a new task so you only fetch the next sequential ID. Use `--next`, `--where "pr !="`, etc. for targeted queries during the event loop. `--boot` is incompatible with `--next`, `--next-id`, `--archived`, and `--where`.
 
 The `--set` flag updates entity frontmatter fields:
 - `--set {slug} field=value` sets a field

--- a/tests/test_agent_content.py
+++ b/tests/test_agent_content.py
@@ -91,6 +91,8 @@ def test_first_officer_shared_core_covers_all_behavioral_sections():
 
     assert "Output Format" in text
     assert "feedback-to" in text
+    assert "--next-id" in text
+    assert "status --boot" in text
 
 
 def test_ensign_shared_core_keeps_stage_report_protocol():
@@ -383,6 +385,17 @@ def test_fo_completion_reads_last_stage_report():
     assert "last" in completion_section.lower(), (
         "Completion and Gates must reference reading the last stage report"
     )
+
+
+def test_first_officer_runtime_docs_use_next_id_for_task_creation():
+    shared = read_text("skills/first-officer/references/first-officer-shared-core.md")
+    claude_runtime = read_text("skills/first-officer/references/claude-first-officer-runtime.md")
+    codex_runtime = read_text("skills/first-officer/references/codex-first-officer-runtime.md")
+
+    assert "status --next-id" in shared
+    assert "status --boot" in shared
+    assert "status --next-id" in claude_runtime
+    assert "status --next-id" in codex_runtime
 
 
 def test_assembled_codex_ensign_has_completion_summary_contract():

--- a/tests/test_status_script.py
+++ b/tests/test_status_script.py
@@ -414,6 +414,31 @@ class TestNextOption(unittest.TestCase):
             self.assertIn('042', data_lines[0])
 
 
+class TestNextIdOption(unittest.TestCase):
+    """Test the narrow --next-id output path."""
+
+    def setUp(self):
+        self._script_dir = tempfile.mkdtemp()
+        self.script_path = build_status_script(self._script_dir)
+
+    def tearDown(self):
+        os.unlink(self.script_path)
+        os.rmdir(self._script_dir)
+
+    def test_next_id_prints_only_value(self):
+        """--next-id prints just the next sequential ID, with archived ids included."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(
+                tmpdir,
+                README_WITH_STAGES,
+                entities={'active.md': entity('001', 'Active', 'backlog', '0.50')},
+                archived={'archived.md': entity('009', 'Archived', 'done', '0.80')},
+            )
+            result = run_status(tmpdir, '--next-id', script_path=self.script_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, '010\n')
+
+
 class TestFrontmatterParsing(unittest.TestCase):
     """Test edge cases in YAML frontmatter parsing."""
 


### PR DESCRIPTION
Add a dedicated next-id command so task creation can fetch the next workflow id without paying for a full startup scan. This keeps routine filing quieter and makes the first-officer guidance match the actual narrow operation.

## What changed
- Add `status --next-id` output mode
- Reuse archive-aware next-id calculation
- Preserve existing `--boot` NEXT_ID output
- Update FO guidance to prefer `--next-id`
- Add targeted status and content tests

## Evidence
- `tests/test_status_script.py`: 91/91 passed
- `tests/test_agent_content.py -k next_id_for_task_creation or covers_all_behavioral_sections`: 2/2 passed

---
[139](/clkao/spacedock/blob/45ba992/docs/plans/narrow-next-id-path-for-task-creation.md)