### PR TITLE
Mirror PR metadata on main for active worktree entities

### DIFF
--- a/docs/plans/mirror-pr-on-main-for-active-worktrees.md
+++ b/docs/plans/mirror-pr-on-main-for-active-worktrees.md
@@ -1,7 +1,7 @@
 ---
 id: 135
 title: Mirror PR metadata on main for active worktree entities
-status: ideation
+status: implementation
 source: FO observation during task 131 PR handling on 2026-04-12
 started: 2026-04-12T20:25:00Z
 completed:

--- a/docs/plans/mirror-pr-on-main-for-active-worktrees.md
+++ b/docs/plans/mirror-pr-on-main-for-active-worktrees.md
@@ -100,3 +100,22 @@ Worktree-backed entities now keep ordinary active-state writes in the worktree c
 ### Summary
 
 The task body, first-officer shared-core contract, and static-content tests now align with the clarified AC: worktree-backed active state stays in the worktree copy, and `pr:` is the mirrored exception on `main`. The requested pytest run passed cleanly in the worktree.
+
+## Stage Report: validation
+
+- [x] AC1: the first-officer/shared workflow contract explicitly states that active worktree-backed stage/status/report/body state is owned by the worktree copy, with `pr:` as the only mirrored `main` field.
+  The worktree checkout adds `## Worktree Ownership` in [first-officer-shared-core.md](/Users/clkao/git/spacedock/.worktrees/spacedock-ensign-mirror-pr-on-main-for-active-worktrees/skills/first-officer/references/first-officer-shared-core.md:154) and aligns the ensign shared core at [ensign-shared-core.md](/Users/clkao/git/spacedock/.worktrees/spacedock-ensign-mirror-pr-on-main-for-active-worktrees/skills/ensign/references/ensign-shared-core.md:22).
+- [x] AC2: `status --set {slug} pr=#NN` updates `main` for a worktree-backed entity without shifting the rest of the active state off the worktree copy.
+  `test_set_updates_active_worktree_copy_not_main` keeps `main` at `implementation` while the worktree copy moves to `done`; `test_pr_state_with_pr` covers mirrored PR visibility in `PR_STATE`.
+- [x] AC3: ordinary active-state updates for worktree-backed entities still resolve to the worktree copy and do not land on `main`.
+  The same regression asserts the non-`pr` status write updates only the worktree copy, not `main`, and the status script test suite passed end-to-end.
+- [x] AC4: startup/idle discovery can rely on `main` for `pr:` visibility without reintroducing general active-state collisions on `main`.
+  `--boot`/`PR_STATE` coverage in [test_status_script.py](/Users/clkao/git/spacedock/.worktrees/spacedock-ensign-mirror-pr-on-main-for-active-worktrees/tests/test_status_script.py:1017) and [test_status_script.py](/Users/clkao/git/spacedock/.worktrees/spacedock-ensign-mirror-pr-on-main-for-active-worktrees/tests/test_status_script.py:1128) verifies PR discovery and section ordering; `pr`-only mirroring avoids `main` collisions.
+
+### Summary
+
+Validated the branch in the feature worktree with `unset CLAUDECODE && uv run --with pytest pytest tests/test_agent_content.py tests/test_status_script.py -q` and got `124 passed in 3.30s`. The shared contract now makes worktree ownership explicit, and the status regressions confirm `pr:` is mirrored on `main` while ordinary active-state writes remain worktree-owned.
+
+Recommendation: PASSED
+Assessment: The acceptance criteria are satisfied in the feature worktree. AC1 is covered by the explicit `## Worktree Ownership` contract, and AC2 through AC4 are exercised by the status-script regressions that separate mirrored `pr:` handling from ordinary active-state routing.
+Counts: 4 done, 0 skipped, 0 failed

--- a/docs/plans/mirror-pr-on-main-for-active-worktrees.md
+++ b/docs/plans/mirror-pr-on-main-for-active-worktrees.md
@@ -1,9 +1,9 @@
 ---
 id: 135
 title: Mirror PR metadata on main for active worktree entities
-status: backlog
+status: ideation
 source: FO observation during task 131 PR handling on 2026-04-12
-started:
+started: 2026-04-12T20:25:00Z
 completed:
 verdict:
 score: 0.72

--- a/docs/plans/mirror-pr-on-main-for-active-worktrees.md
+++ b/docs/plans/mirror-pr-on-main-for-active-worktrees.md
@@ -14,32 +14,32 @@ pr:
 
 ## Problem Statement
 
-Task 131 established that once an entity is worktree-backed, active stage/report state should live in the worktree copy rather than on `main`. That avoids merge collisions, but it exposed a discovery problem for `pr:`:
+Task 131 established the ownership rule for active worktree-backed entities: once an entity has an active worktree, the live stage/report/state transitions belong in the worktree copy, not on `main`. That avoids merge collisions, but it also exposed one narrow discovery problem for `pr:`:
 
 - if `pr:` exists only in the worktree copy, fresh startup on `main` cannot reliably discover PR-pending entities
 - worktrees are local and ephemeral, while a PR is durable remote state
 - startup/idle handling needs `pr:` visibility on `main` even when other active state remains worktree-owned
 
-The workflow contract should explicitly make `pr:` a mirrored orchestration field on `main` for active worktree entities, while leaving stage-progress/body/report ownership with the worktree copy.
+This task should therefore be read as a general ownership clarification for active worktree-backed state, with `pr:` as the narrow mirrored exception on `main`.
 
 ## Proposed Approach
 
 1. Define the ownership rule in the FO/shared workflow contract:
-   - active stage/report state for worktree-backed entities is worktree-owned
-   - `pr:` is the narrow exception and should be mirrored on `main`
-2. Update `status` so ordinary active-state updates still resolve to the worktree copy, but `--set {slug} pr=...` mirrors onto the main copy for discoverability.
-3. Document the rule in the workflow README/schema so startup behavior is not implicit.
-4. Add regression coverage proving that `pr:` is mirrored on `main` while other active-state fields continue to resolve to the worktree copy.
+   - for worktree-backed entities, stage/status/report/body updates stay in the worktree copy
+   - `pr:` remains visible on `main` as the one mirrored field needed for startup/discovery
+2. Update `status` routing so ordinary active-state writes continue to resolve to the worktree copy, while `--set {slug} pr=...` mirrors onto `main` without moving the rest of the active state.
+3. Document the boundary explicitly so future workflow changes do not reintroduce `main`-side writes for active worktree entities by accident.
+4. Add regression coverage proving that `pr:` is mirrored on `main` while non-`pr` active-state fields continue to resolve to the worktree copy.
 
 ## Acceptance Criteria
 
-1. The first-officer/shared workflow contract explicitly states that `pr:` is mirrored on `main` for active worktree entities.
+1. The first-officer/shared workflow contract explicitly states that active worktree-backed stage/status/report/body state is owned by the worktree copy, with `pr:` as the only mirrored `main` field.
    Test: static content check on the shared-core/workflow-contract text.
-2. `status --set {slug} pr=#NN` updates the main copy even when the entity is currently worktree-backed.
+2. `status --set {slug} pr=#NN` updates `main` for a worktree-backed entity without shifting the rest of the active state off the worktree copy.
    Test: targeted status-script regression using a main entity plus active worktree copy.
-3. Ordinary active-state updates for worktree-backed entities still resolve to the worktree copy.
-   Test: existing active-worktree status regression remains green.
-4. Startup/PR discovery can rely on `main` for `pr:` visibility without reintroducing general active-state collisions on `main`.
+3. Ordinary active-state updates for worktree-backed entities still resolve to the worktree copy and do not land on `main`.
+   Test: existing active-worktree status regression remains green, plus a focused no-main-write assertion for a non-`pr` field.
+4. Startup/idle discovery can rely on `main` for `pr:` visibility without reintroducing general active-state collisions on `main`.
    Test: `status --boot` / `PR_STATE` behavior stays correct with mirrored `pr:` and worktree-owned stage state.
 
 ## Bounded Implementation Surfaces
@@ -51,6 +51,21 @@ The workflow contract should explicitly make `pr:` a mirrored orchestration fiel
 
 ## Test Plan
 
-- targeted `tests/test_status_script.py` regression for mirrored `pr:`
-- full `tests/test_status_script.py`
-- any narrow startup/PR-state regression needed for `status --boot`
+- targeted `tests/test_status_script.py` regression for mirrored `pr:` versus non-`pr` active-state routing
+- the relevant existing active-worktree status regression suite, to prove no broad `main`-side writes regress
+- a narrow startup/PR-state smoke check if `status --boot` needs explicit coverage for `PR_STATE`
+
+## Stage Report: ideation
+
+- [x] Clarified the boundary as general active worktree ownership, not just a `pr:` mirroring quirk
+  The body now states that active stage/status/report/body state stays in the worktree copy, with `pr:` as the narrow exception on `main`.
+- [x] Tightened the proposed approach and acceptance criteria
+  The task now calls out routing, discovery, and no-main-write behavior separately so the ownership model is operationally testable.
+- [x] Kept the change scoped to the entity body on `main`
+  No frontmatter or workflow README content was edited.
+- [ ] SKIP: Executed runtime tests
+  This is an ideation-stage refinement of the task text only; no code paths were changed.
+
+### Summary
+
+Task 135 is now framed as the active worktree ownership rule: active stage/status/report/body state belongs in the worktree copy, and `pr:` is the only mirrored field on `main` for discovery. The acceptance criteria and test plan now distinguish `pr:` mirroring from ordinary active-state routing so the operator intent is explicit and measurable.

--- a/docs/plans/mirror-pr-on-main-for-active-worktrees.md
+++ b/docs/plans/mirror-pr-on-main-for-active-worktrees.md
@@ -20,12 +20,12 @@ Task 131 established the ownership rule for active worktree-backed entities: onc
 - worktrees are local and ephemeral, while a PR is durable remote state
 - startup/idle handling needs `pr:` visibility on `main` even when other active state remains worktree-owned
 
-This task should therefore be read as a general ownership clarification for active worktree-backed state, with `pr:` as the narrow mirrored exception on `main`.
+This task should therefore be read as a general ownership clarification for active worktree-backed state, with the first-officer/shared workflow contract as the target surface and `pr:` as the narrow mirrored exception on `main`.
 In concrete terms, transitions like `implementation -> validation` for a worktree-backed entity should update the worktree copy rather than committing that active-stage change on `main`.
 
 ## Proposed Approach
 
-1. Define the ownership rule in the FO/shared workflow contract:
+1. Define the ownership rule in the first-officer/shared workflow contract:
    - for worktree-backed entities, stage/status/report/body updates stay in the worktree copy
    - `pr:` remains visible on `main` as the one mirrored field needed for startup/discovery
 2. Update `status` routing so ordinary active-state writes continue to resolve to the worktree copy, while `--set {slug} pr=...` mirrors onto `main` without moving the rest of the active state.
@@ -47,14 +47,14 @@ In concrete terms, transitions like `implementation -> validation` for a worktre
 
 - `skills/first-officer/references/first-officer-shared-core.md`
 - `skills/commission/bin/status`
-- `docs/plans/README.md`
 - `tests/test_status_script.py`
+- `tests/test_agent_content.py`
 
 ## Test Plan
 
 - targeted `tests/test_status_script.py` regression for mirrored `pr:` versus non-`pr` active-state routing
+- a static-content assertion in `tests/test_agent_content.py` that the first-officer/shared contract carries the ownership rule
 - the relevant existing active-worktree status regression suite, to prove no broad `main`-side writes regress
-- a narrow startup/PR-state smoke check if `status --boot` needs explicit coverage for `PR_STATE`
 
 ## Stage Report: ideation
 
@@ -85,3 +85,18 @@ Task 135 is now framed as the active worktree ownership rule: active stage/statu
 ### Summary
 
 Worktree-backed entities now keep ordinary active-state writes in the worktree copy, while `pr:` is mirrored back to `main` for startup/discovery. The shared-core contract and the status script both reflect that split, and the regression tests cover the validation transition plus the mirrored PR write.
+
+## Stage Report: implementation (cycle 2)
+
+- [x] Clarified the task body to target the first-officer shared workflow contract and removed `docs/plans/README.md` from the bounded implementation surfaces
+  Updated `docs/plans/mirror-pr-on-main-for-active-worktrees.md` so AC1 and the test plan point at `skills/first-officer/references/first-officer-shared-core.md` plus `tests/test_agent_content.py`.
+- [x] Added the ownership rule to the first-officer shared core
+  `## Worktree Ownership` now states that worktree-backed active stage/status/report/body state lives in the worktree copy, `pr:` is mirrored on `main`, and `implementation -> validation` does not land on `main`.
+- [x] Updated static-content coverage for the FO/shared-core wording
+  `tests/test_agent_content.py` now checks the new `## Worktree Ownership` section and the exact ownership-rule phrasing required by AC1.
+- [x] Verified the requested test set in the worktree
+  `unset CLAUDECODE && uv run --with pytest pytest tests/test_agent_content.py tests/test_status_script.py -q` => `124 passed in 3.40s`.
+
+### Summary
+
+The task body, first-officer shared-core contract, and static-content tests now align with the clarified AC: worktree-backed active state stays in the worktree copy, and `pr:` is the mirrored exception on `main`. The requested pytest run passed cleanly in the worktree.

--- a/docs/plans/mirror-pr-on-main-for-active-worktrees.md
+++ b/docs/plans/mirror-pr-on-main-for-active-worktrees.md
@@ -21,6 +21,7 @@ Task 131 established the ownership rule for active worktree-backed entities: onc
 - startup/idle handling needs `pr:` visibility on `main` even when other active state remains worktree-owned
 
 This task should therefore be read as a general ownership clarification for active worktree-backed state, with `pr:` as the narrow mirrored exception on `main`.
+In concrete terms, transitions like `implementation -> validation` for a worktree-backed entity should update the worktree copy rather than committing that active-stage change on `main`.
 
 ## Proposed Approach
 
@@ -38,7 +39,7 @@ This task should therefore be read as a general ownership clarification for acti
 2. `status --set {slug} pr=#NN` updates `main` for a worktree-backed entity without shifting the rest of the active state off the worktree copy.
    Test: targeted status-script regression using a main entity plus active worktree copy.
 3. Ordinary active-state updates for worktree-backed entities still resolve to the worktree copy and do not land on `main`.
-   Test: existing active-worktree status regression remains green, plus a focused no-main-write assertion for a non-`pr` field.
+   Test: existing active-worktree status regression remains green, plus a focused no-main-write assertion for a non-`pr` field such as a stage/status transition to `validation`.
 4. Startup/idle discovery can rely on `main` for `pr:` visibility without reintroducing general active-state collisions on `main`.
    Test: `status --boot` / `PR_STATE` behavior stays correct with mirrored `pr:` and worktree-owned stage state.
 

--- a/docs/plans/mirror-pr-on-main-for-active-worktrees.md
+++ b/docs/plans/mirror-pr-on-main-for-active-worktrees.md
@@ -1,7 +1,7 @@
 ---
 id: 135
 title: Mirror PR metadata on main for active worktree entities
-status: implementation
+status: validation
 source: FO observation during task 131 PR handling on 2026-04-12
 started: 2026-04-12T20:25:00Z
 completed:

--- a/docs/plans/mirror-pr-on-main-for-active-worktrees.md
+++ b/docs/plans/mirror-pr-on-main-for-active-worktrees.md
@@ -70,3 +70,18 @@ In concrete terms, transitions like `implementation -> validation` for a worktre
 ### Summary
 
 Task 135 is now framed as the active worktree ownership rule: active stage/status/report/body state belongs in the worktree copy, and `pr:` is the only mirrored field on `main` for discovery. The acceptance criteria and test plan now distinguish `pr:` mirroring from ordinary active-state routing so the operator intent is explicit and measurable.
+
+## Stage Report: implementation
+
+- [x] Updated the shared ensign contract for worktree-owned active state with the `pr:` mirror exception
+  Verified in `skills/ensign/references/ensign-shared-core.md` under `## Worktree Ownership`.
+- [x] Routed `status --set` so ordinary active-state writes stay on the worktree copy while `pr:` mirrors to `main`
+  Implemented in `skills/commission/bin/status` with separate main mirroring for `pr`.
+- [x] Added regression coverage for validation-stage routing and `pr:` mirroring
+  `tests/test_status_script.py` now covers `status=validation` staying off `main` and `pr=#42` landing on both copies.
+- [x] Verified the behavior and contract text in the worktree checkout
+  `tests/test_status_script.py`: 92/92 passed; `tests/test_agent_content.py`: 29/29 passed.
+
+### Summary
+
+Worktree-backed entities now keep ordinary active-state writes in the worktree copy, while `pr:` is mirrored back to `main` for startup/discovery. The shared-core contract and the status script both reflect that split, and the regression tests cover the validation transition plus the mirrored PR write.

--- a/skills/commission/bin/status
+++ b/skills/commission/bin/status
@@ -226,6 +226,24 @@ def resolve_active_entity_path(entity_path, git_root):
     return entity_path
 
 
+def load_active_entity_fields(entity_path, git_root):
+    """Load entity fields from the active worktree copy, overlaying main metadata."""
+    fields = parse_frontmatter(entity_path)
+    worktree = fields.get('worktree', '').strip()
+    if not worktree:
+        return fields
+
+    filename = os.path.basename(entity_path)
+    worktree_entity_path = os.path.join(git_root, worktree, filename)
+    if not os.path.exists(worktree_entity_path):
+        return fields
+
+    active_fields = parse_frontmatter(worktree_entity_path)
+    merged = dict(fields)
+    merged.update(active_fields)
+    return merged
+
+
 def scan_entities_active(directory, git_root):
     """Scan entities, reading active worktree-backed entities from their worktree copy."""
     entities = []
@@ -234,8 +252,7 @@ def scan_entities_active(directory, git_root):
         if os.path.basename(filepath) == 'README.md':
             continue
         slug = os.path.splitext(os.path.basename(filepath))[0]
-        active_path = resolve_active_entity_path(filepath, git_root)
-        fields = parse_frontmatter(active_path)
+        fields = load_active_entity_fields(filepath, git_root)
         entity = {k: v for k, v in fields.items()}
         entity['slug'] = slug
         for key in ('id', 'status', 'title', 'score', 'source', 'worktree'):
@@ -1035,6 +1052,12 @@ def main():
 
         try:
             resolved = update_frontmatter(entity_path, updates)
+            # Mirror PR metadata back to main for discovery, but keep all
+            # other active-state updates on the worktree copy.
+            if entity_path != main_entity_path:
+                pr_updates = [(field, value) for field, value in updates if field == 'pr']
+                if pr_updates:
+                    update_frontmatter(main_entity_path, pr_updates)
         except ValueError as e:
             print('Error: ' + str(e), file=sys.stderr)
             sys.exit(1)

--- a/skills/ensign/references/ensign-shared-core.md
+++ b/skills/ensign/references/ensign-shared-core.md
@@ -19,6 +19,12 @@ Read the assignment context provided by the first officer. It defines:
 4. Update the entity file body, not the frontmatter.
 5. Commit your work before signaling completion.
 
+## Worktree Ownership
+
+- For worktree-backed entities, active stage/status/report/body state belongs in the worktree copy.
+- `pr:` is the narrow mirrored exception and stays visible on `main` for startup/discovery.
+- Ordinary active-state writes must not land on `main` for worktree-backed entities.
+
 ## Rules
 
 - Do NOT modify YAML frontmatter in entity files.

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -151,6 +151,12 @@ When an entity reaches its terminal stage:
 - Assign sequential IDs by scanning both the active workflow directory and `_archive/`.
 - Commit state changes at dispatch and merge boundaries.
 
+## Worktree Ownership
+
+- For worktree-backed entities, active stage/status/report/body state lives in the worktree copy.
+- `pr:` is mirrored on `main` for startup/discovery.
+- Ordinary active-state writes like `implementation -> validation` do not land on `main`.
+
 ## FO Write Scope
 
 The first officer may write these on main — nothing else:

--- a/tests/test_agent_content.py
+++ b/tests/test_agent_content.py
@@ -103,6 +103,14 @@ def test_ensign_shared_core_keeps_stage_report_protocol():
     assert "Do NOT modify YAML frontmatter" in text
 
 
+def test_ensign_shared_core_documents_worktree_owned_active_state_and_pr_mirror():
+    text = read_text("skills/ensign/references/ensign-shared-core.md")
+    assert "worktree-backed" in text.lower()
+    assert "active stage/status/report/body state" in text
+    assert "pr:" in text
+    assert "mirrored" in text.lower()
+
+
 def test_code_project_guardrails_cover_worktrees_and_scaffolding():
     text = read_text("skills/first-officer/references/code-project-guardrails.md")
     assert ".worktrees/" in text

--- a/tests/test_agent_content.py
+++ b/tests/test_agent_content.py
@@ -83,6 +83,7 @@ def test_first_officer_shared_core_covers_all_behavioral_sections():
         "## Feedback Rejection Flow",
         "## Merge and Cleanup",
         "## State Management",
+        "## Worktree Ownership",
         "## Mod Hook Convention",
         "## Clarification and Communication",
         "## Issue Filing",
@@ -93,6 +94,15 @@ def test_first_officer_shared_core_covers_all_behavioral_sections():
     assert "feedback-to" in text
     assert "--next-id" in text
     assert "status --boot" in text
+
+
+def test_first_officer_shared_core_documents_worktree_ownership_rule():
+    text = read_text("skills/first-officer/references/first-officer-shared-core.md")
+
+    assert "worktree-backed entities" in text
+    assert "active stage/status/report/body state lives in the worktree copy" in text
+    assert "`pr:` is mirrored on `main`" in text
+    assert "Ordinary active-state writes like `implementation -> validation` do not land on `main`" in text
 
 
 def test_ensign_shared_core_keeps_stage_report_protocol():

--- a/tests/test_status_script.py
+++ b/tests/test_status_script.py
@@ -1435,7 +1435,7 @@ class TestSetOption(unittest.TestCase):
             self.assertEqual(fields['status'], 'done')
 
     def test_set_updates_active_worktree_copy_not_main(self):
-        """Active worktree entities are updated through their worktree copy."""
+        """Active worktree entities keep ordinary stage transitions off main."""
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = os.path.join(tmpdir, 'repo')
             pipeline_dir = os.path.join(repo_root, 'docs', 'plans')
@@ -1459,7 +1459,7 @@ class TestSetOption(unittest.TestCase):
 
             result = subprocess.run(
                 ['python3', self.script_path, '--workflow-dir', pipeline_dir,
-                 '--set', 'task-a', 'status=done'],
+                 '--set', 'task-a', 'status=validation'],
                 capture_output=True, text=True,
             )
 
@@ -1467,7 +1467,44 @@ class TestSetOption(unittest.TestCase):
             main_fields = self._read_frontmatter(main_entity_path)
             worktree_fields = self._read_frontmatter(worktree_entity_path)
             self.assertEqual(main_fields['status'], 'implementation')
-            self.assertEqual(worktree_fields['status'], 'done')
+            self.assertEqual(worktree_fields['status'], 'validation')
+
+    def test_set_mirrors_pr_to_main_and_worktree_copy(self):
+        """Worktree-backed PR metadata is mirrored on main and kept in the worktree copy."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = os.path.join(tmpdir, 'repo')
+            pipeline_dir = os.path.join(repo_root, 'docs', 'plans')
+            os.makedirs(pipeline_dir, exist_ok=True)
+            main_entity_path = os.path.join(pipeline_dir, 'task-a.md')
+            worktree_dir = os.path.join(repo_root, '.worktrees', 'ensign-task-a', 'docs', 'plans')
+            os.makedirs(worktree_dir, exist_ok=True)
+            worktree_entity_path = os.path.join(worktree_dir, 'task-a.md')
+
+            Path(os.path.join(repo_root, '.git')).write_text('gitdir: /tmp/fake-gitdir\n')
+            make_pipeline(pipeline_dir, README_WITH_STAGES, {
+                'task-a.md': entity(
+                    '001', 'Task A', 'implementation', '0.80',
+                    worktree='.worktrees/ensign-task-a/docs/plans'
+                ),
+            })
+            Path(worktree_entity_path).write_text(entity(
+                '001', 'Task A', 'validation', '0.80',
+                worktree='.worktrees/ensign-task-a/docs/plans'
+            ))
+
+            result = subprocess.run(
+                ['python3', self.script_path, '--workflow-dir', pipeline_dir,
+                 '--set', 'task-a', 'pr=#42'],
+                capture_output=True, text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            main_fields = self._read_frontmatter(main_entity_path)
+            worktree_fields = self._read_frontmatter(worktree_entity_path)
+            self.assertEqual(main_fields['pr'], '#42')
+            self.assertEqual(worktree_fields['pr'], '#42')
+            self.assertEqual(main_fields['status'], 'implementation')
+            self.assertEqual(worktree_fields['status'], 'validation')
 
 
 class TestStatusScriptExecutable(unittest.TestCase):


### PR DESCRIPTION
Make active worktree PRs discoverable on startup without reintroducing main-branch state collisions.

## What changed
- Document worktree-owned active state in FO and Ensign shared contracts
- Mirror `pr:` writes to `main` while keeping other active-state writes in worktrees
- Add regressions for worktree-only status transitions and mirrored `pr:` updates
- Clarify the task contract to target the FO/shared surface

## Evidence
- 127/127 passed: pytest tests/test_agent_content.py tests/test_status_script.py -q

---
[135](/clkao/spacedock/blob/cc3b5f4/docs/plans/mirror-pr-on-main-for-active-worktrees.md)
