### PR TITLE
claude-team build: fix entity path translation and raise name limit

### DIFF
--- a/docs/plans/claude-team-build-entity-path-bug.md
+++ b/docs/plans/claude-team-build-entity-path-bug.md
@@ -115,3 +115,27 @@ The bug is small, well-understood, and blocks clean dispatch for #148 (pytest mi
 
 - 2026-04-14: FO dry-run for #148 implementation dispatch exposed entity-path translation bug
 - 2026-04-14: FO dry-run for #114 cycle 4 dispatch exposed 63-char name limit as over-restrictive (real entity slug + stage suffix exceeds the rule)
+
+## Stage Report
+
+### Summary
+Fixed both bugs in `skills/commission/bin/claude-team` `build` subcommand:
+- **Entity path translation** now computes `os.path.relpath(entity_path, git_root)` and joins onto the worktree root, preserving nested workflow subpaths like `docs/plans/`. Before: `{worktree_root}/{basename(entity_path)}`. After: `{worktree_root}/{rel_path_from_repo_root}`.
+- **Name length limit** raised from 63 to 200 via the `NAME_MAX_LEN` constant. The rule-7 error message now interpolates the constant rather than hardcoding `63`.
+
+### Checklist
+1. **Read entity file for full spec** — DONE
+2. **Fix path computation in prompt assembly** — DONE. `skills/commission/bin/claude-team:194-196` now uses `os.path.relpath(entity_path, git_root)`.
+3. **Raise Rule 7 limit to 200** — DONE. `skills/commission/bin/claude-team:36` updated `NAME_MAX_LEN = 200`; error message at line 165 uses the constant.
+4. **Dry-run verifies corrected subpath in output prompt** — DONE. Non-worktree dry-run against `docs/plans/claude-team-build-entity-path-bug.md` emits the untranslated main-branch path. Nested-workflow translation is covered end-to-end by `test_build_entity_path_nested_workflow_dir`, which constructs a `docs/plans/` fixture and asserts the exact worktree-local path.
+5. **71-char derived name emits valid JSON** — DONE. `test_build_long_derived_name` asserts a 71-char derived name builds successfully.
+6. **Pytest tests for all 5 ACs in tests/test_claude_team.py** — DONE:
+   - `TestBuildEntityPathTranslation::test_build_entity_path_nested_workflow_dir` (AC-1)
+   - `TestBuildWorktreeStage::test_build_worktree_stage_dispatch` extended to assert exact worktree path (AC-2)
+   - `TestBuildEntityPathTranslation::test_build_entity_path_non_worktree` (AC-3)
+   - `TestBuildValidationRules::test_build_long_derived_name` (AC-5)
+   - `TestBuildValidationRules::test_build_very_long_name_still_rejected` (sanity bound)
+   - `test_build_validation_rule_7_name_too_long` updated to use 220-char slug and assert "exceeds 200 characters" message.
+7. **make test-static green** — DONE. 271 passed, 10 subtests passed (baseline 267; +4 new test functions, AC-2 extension within existing test).
+8. **Commit on the branch** — DONE.
+

--- a/docs/plans/claude-team-build-entity-path-bug.md
+++ b/docs/plans/claude-team-build-entity-path-bug.md
@@ -139,3 +139,24 @@ Fixed both bugs in `skills/commission/bin/claude-team` `build` subcommand:
 7. **make test-static green** — DONE. 271 passed, 10 subtests passed (baseline 267; +4 new test functions, AC-2 extension within existing test).
 8. **Commit on the branch** — DONE.
 
+## Stage Report — validation
+
+### Summary
+Validated both fixes against all 5 acceptance criteria. Code change at `skills/commission/bin/claude-team:194-196` correctly computes `os.path.relpath(entity_path, git_root)` and joins it onto the worktree root, preserving nested workflow subpaths. `NAME_MAX_LEN` raised to 200 at line 36 and referenced in the Rule 7 error message at line 165. Static suite is green at 271 passed / 10 subtests passed; the six targeted tests (AC-1/2/3/5 + sanity bounds) pass individually. Real dry-runs against the live `docs/plans/` entities for `fo-enforce-mod-blocking-at-runtime` (implementation, worktree stage) and `claude-team-build-entity-path-bug` (ideation, non-worktree stage) match the expected prompt shapes exactly. Recommendation: **PASSED**.
+
+### Checklist
+1. **Read the entity file for the 5 ACs** — DONE. ACs 1–5 and the test-plan table at lines 70–107 inform what follows.
+2. **Run `make test-static` — report pass/fail count; note regressions from baseline** — DONE. Result: `271 passed, 10 subtests passed in 70.26s`. Baseline per implementation stage report was 267 passed; delta +4 matches the 4 new test functions (`test_build_entity_path_nested_workflow_dir`, `test_build_entity_path_non_worktree`, `test_build_long_derived_name`, `test_build_very_long_name_still_rejected`). No regressions.
+3. **Verify AC-1: Nested workflow dir produces correct path via a real `claude-team build` dry-run** — DONE. Input: `entity_path=/Users/clkao/git/spacedock/docs/plans/fo-enforce-mod-blocking-at-runtime.md`, `workflow_dir=/Users/clkao/git/spacedock/docs/plans`, `stage=implementation`, team mode. Output prompt's entity-read line: `Read the entity file at /Users/clkao/git/spacedock/.worktrees/spacedock-ensign-fo-enforce-mod-blocking-at-runtime/docs/plans/fo-enforce-mod-blocking-at-runtime.md for the full spec.` — the `docs/plans/` subpath is preserved as required. `test_build_entity_path_nested_workflow_dir` also passes in the pytest harness.
+4. **Verify AC-2: Flat workflow dir still works** — DONE. `test_build_worktree_stage_dispatch` (at `tests/test_claude_team.py:709`) was extended (lines 728–733) to assert the exact worktree path `{tmp_path}/.worktrees/spacedock-ensign-wt-task/workflow/wt-task.md`. In this fixture the workflow dir is one level deep (`tmp_path/workflow`), so the relpath logic still produces the right shape — `workflow/wt-task.md` is preserved, no spurious subpath collapse. Test passes.
+5. **Verify AC-3: Non-worktree stages preserve the main-path (no translation)** — DONE. Real dry-run with `stage=ideation` against `docs/plans/claude-team-build-entity-path-bug.md` emits: `Read the entity file at /Users/clkao/git/spacedock/docs/plans/claude-team-build-entity-path-bug.md for the current spec.` — no `.worktrees` substring anywhere in the prompt. `test_build_entity_path_non_worktree` passes and explicitly asserts `".worktrees" not in out["prompt"]`.
+6. **Verify AC-4: Static suite green** — DONE. Covered by checklist item 2 — 271 passed, 0 failed, 0 errored.
+7. **Verify AC-5: Longer derived name (e.g., 71 chars) succeeds — no exit 1 from validation rule** — DONE. Real dry-run with the #114 slug (`fo-enforce-mod-blocking-at-runtime`, stage `implementation`) yields `name=spacedock-ensign-fo-enforce-mod-blocking-at-runtime-implementation` (66 chars, well above the old 63-char cap) with exit code 0 and a valid JSON dispatch. The pytest `test_build_long_derived_name` exercises a 71-char name specifically and asserts success; `test_build_very_long_name_still_rejected` confirms the new 200-char cap still rejects pathological inputs. Both pass.
+8. **PASSED/REJECTED recommendation with Assessment line** — DONE. See below.
+
+### Assessment
+
+8 done, 0 skipped, 0 failed.
+
+Recommendation: **PASSED**. All 5 acceptance criteria verified with evidence from both targeted pytest runs and real `claude-team build` dry-runs against live repo entities. Static suite is green with +4 net tests and no regressions. The implementation matches the fix specified in the entity (lines 60–68): `os.path.relpath(entity_path, git_root)` joined onto the worktree root. `NAME_MAX_LEN` is now a named constant referenced in both the guard and the error message, matching the scope item at lines 94–95.
+

--- a/skills/commission/bin/claude-team
+++ b/skills/commission/bin/claude-team
@@ -33,7 +33,7 @@ find_git_root = _status.find_git_root
 SCHEMA_VERSION = 1
 BUILD_REQUIRED_FIELDS = ('schema_version', 'entity_path', 'workflow_dir', 'stage', 'checklist')
 NAME_PATTERN = re.compile(r'^[a-z0-9][a-z0-9-]*[a-z0-9]$')
-NAME_MAX_LEN = 63
+NAME_MAX_LEN = 200
 
 
 def extract_stage_subsection(readme_path, stage_name):
@@ -162,7 +162,7 @@ def cmd_build(args):
 
     # Rule 7: Name length and safety
     if len(derived_name) > NAME_MAX_LEN:
-        return _build_error(f"derived name '{derived_name}' exceeds 63 characters")
+        return _build_error(f"derived name '{derived_name}' exceeds {NAME_MAX_LEN} characters")
     if not NAME_PATTERN.match(derived_name):
         return _build_error(f"derived name '{derived_name}' contains invalid characters")
 
@@ -192,8 +192,8 @@ def cmd_build(args):
 
     # 4. Entity read instruction
     if worktree_path:
-        entity_filename = os.path.basename(entity_path)
-        worktree_entity_path = os.path.join(worktree_path, entity_filename)
+        entity_rel = os.path.relpath(entity_path, git_root)
+        worktree_entity_path = os.path.join(worktree_path, entity_rel)
         prompt_parts.append(
             f'Read the entity file at {worktree_entity_path} for the full spec. '
             f'It contains:\n'

--- a/tests/test_claude_team.py
+++ b/tests/test_claude_team.py
@@ -725,6 +725,88 @@ class TestBuildWorktreeStage:
         assert "Your git branch is" in out["prompt"]
         assert "spacedock-ensign/wt-task" in out["prompt"]
         assert "Do NOT switch branches" in out["prompt"]
+        # AC-2: assert exact worktree-local entity path preserves workflow-dir subpath.
+        # Fixture: git_root=tmp_path, workflow under tmp_path/workflow/, so subpath is "workflow/".
+        expected_entity = str(
+            tmp_path / ".worktrees" / "spacedock-ensign-wt-task" / "workflow" / "wt-task.md"
+        )
+        assert f"Read the entity file at {expected_entity}" in out["prompt"]
+
+
+class TestBuildEntityPathTranslation:
+    """AC-1/AC-2/AC-3: Entity path translation preserves workflow_dir subpath."""
+
+    def test_build_entity_path_nested_workflow_dir(self, tmp_path):
+        """AC-1: Nested workflow dir (docs/plans/) preserves subpath in worktree entity path."""
+        (tmp_path / ".git").mkdir()
+        wf_dir = tmp_path / "docs" / "plans"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "README.md").write_text(
+            "---\n"
+            "commissioned-by: spacedock@test\n"
+            "entity-label: task\n"
+            "stages:\n"
+            "  defaults:\n"
+            "    worktree: false\n"
+            "  states:\n"
+            "    - name: ideation\n"
+            "      initial: true\n"
+            "    - name: implementation\n"
+            "      worktree: true\n"
+            "    - name: done\n"
+            "      terminal: true\n"
+            "---\n"
+            "\n"
+            "## Stages\n\n"
+            "### `ideation`\n\nThink.\n\n"
+            "### `implementation`\n\nBuild.\n\n"
+            "### `done`\n\nTerminal.\n"
+        )
+        wt_rel = ".worktrees/spacedock-ensign-task"
+        wt_abs = tmp_path / wt_rel
+        (wt_abs / "docs" / "plans").mkdir(parents=True)
+        entity = wf_dir / "task.md"
+        entity.write_text(
+            "---\n"
+            "id: 100\n"
+            "title: Nested task\n"
+            "status: implementation\n"
+            f"worktree: {wt_rel}\n"
+            "---\n"
+        )
+        (wt_abs / "docs" / "plans" / "task.md").write_text(entity.read_text())
+        inp = {
+            "schema_version": 1,
+            "entity_path": str(entity),
+            "workflow_dir": str(wf_dir),
+            "stage": "implementation",
+            "checklist": ["1. Build"],
+            "team_name": "t",
+            "bare_mode": False,
+        }
+        result = run_build(wf_dir, inp, cwd=tmp_path)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        out = json.loads(result.stdout)
+        expected_entity = str(wt_abs / "docs" / "plans" / "task.md")
+        assert f"Read the entity file at {expected_entity}" in out["prompt"]
+
+    def test_build_entity_path_non_worktree(self, tmp_path):
+        """AC-3: Non-worktree stage leaves entity path untranslated (main-branch path)."""
+        wf_dir, entity = _make_workflow_fixture(tmp_path)
+        inp = {
+            "schema_version": 1,
+            "entity_path": str(entity),
+            "workflow_dir": str(wf_dir),
+            "stage": "ideation",
+            "checklist": ["1. Think"],
+            "team_name": "t",
+            "bare_mode": False,
+        }
+        result = run_build(wf_dir, inp)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        out = json.loads(result.stdout)
+        assert f"Read the entity file at {entity}" in out["prompt"]
+        assert ".worktrees" not in out["prompt"]
 
 
 class TestBuildFeedbackDispatch:
@@ -856,9 +938,9 @@ class TestBuildValidationRules:
         assert "feedback_context is missing" in result.stderr
 
     def test_build_validation_rule_7_name_too_long(self, tmp_path):
-        """Rule 7: Derived name exceeds 63 characters."""
+        """Rule 7: Derived name exceeds NAME_MAX_LEN (200) characters."""
         wf_dir, _ = _make_workflow_fixture(tmp_path)
-        long_slug = "a" * 60
+        long_slug = "a" * 220
         entity = wf_dir / f"{long_slug}.md"
         entity.write_text(
             "---\n"
@@ -878,7 +960,62 @@ class TestBuildValidationRules:
         }
         result = run_build(wf_dir, inp)
         assert result.returncode == 1
-        assert "exceeds 63 characters" in result.stderr
+        assert "exceeds 200 characters" in result.stderr
+
+    def test_build_long_derived_name(self, tmp_path):
+        """AC-5: Derived name longer than the old 63-char limit succeeds."""
+        wf_dir, _ = _make_workflow_fixture(tmp_path)
+        # "spacedock-ensign-" (17) + slug (45) + "-ideation" (9) = 71 chars total.
+        slug = "fo-enforce-mod-blocking-at-runtime-cycle-three"[:45]
+        assert len(slug) == 45
+        entity = wf_dir / f"{slug}.md"
+        entity.write_text(
+            "---\n"
+            "id: 005\n"
+            "title: Long slug in real life\n"
+            "status: ideation\n"
+            "worktree:\n"
+            "---\n"
+        )
+        inp = {
+            "schema_version": 1,
+            "entity_path": str(entity),
+            "workflow_dir": str(wf_dir),
+            "stage": "ideation",
+            "checklist": ["1. Item"],
+            "team_name": "t",
+            "bare_mode": False,
+        }
+        result = run_build(wf_dir, inp)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        out = json.loads(result.stdout)
+        assert len(out["name"]) == 71
+        assert out["name"] == f"spacedock-ensign-{slug}-ideation"
+
+    def test_build_very_long_name_still_rejected(self, tmp_path):
+        """Sanity bound: a name above 200 chars still rejects."""
+        wf_dir, _ = _make_workflow_fixture(tmp_path)
+        long_slug = "z" * 205
+        entity = wf_dir / f"{long_slug}.md"
+        entity.write_text(
+            "---\n"
+            "id: 006\n"
+            "title: Pathological slug\n"
+            "status: ideation\n"
+            "worktree:\n"
+            "---\n"
+        )
+        inp = {
+            "schema_version": 1,
+            "entity_path": str(entity),
+            "workflow_dir": str(wf_dir),
+            "stage": "ideation",
+            "checklist": ["1. Item"],
+            "team_name": "t",
+        }
+        result = run_build(wf_dir, inp)
+        assert result.returncode == 1
+        assert "exceeds 200 characters" in result.stderr
 
     def test_build_validation_rule_8_team_name_missing(self, tmp_path):
         """Rule 8: Team mode without team_name."""


### PR DESCRIPTION
Two bugs in the structured dispatch helper surfaced during FO dry-runs — entity paths dropped the workflow-dir subpath on nested layouts like `docs/plans/`, and a 63-char name cap rejected real entity slugs that the Agent tool would happily accept.

## What changed

- Compute worktree-local entity paths with `os.path.relpath(entity_path, git_root)` to preserve nested subpaths
- Raise `NAME_MAX_LEN` from 63 to 200 and interpolate the constant into Rule 7's error message
- Add 4 new pytest cases plus tightened assertions on existing worktree-dispatch test

## Evidence

- Static suite: 271/271 passed (+4 from baseline; no regressions)
- Real dry-run against `docs/plans/fo-enforce-mod-blocking-at-runtime.md`: output prompt now contains the full `.worktrees/.../docs/plans/...` path
- Real dry-run with 66-char derived name: succeeds with exit 0 where it previously failed Rule 7

---
[#151](/clkao/spacedock/blob/83c93750/docs/plans/claude-team-build-entity-path-bug.md)