### PR TITLE
Split runtime adapter into core + recovery (-675w boot path)

### DIFF
--- a/scripts/test_lib.py
+++ b/scripts/test_lib.py
@@ -636,7 +636,9 @@ def assembled_agent_content(runner: TestRunner, agent_name: str, runtime: str = 
     skill_root = runner.repo_root / "skills"
     if agent_name == "first-officer":
         skill_path = skill_root / "first-officer" / "SKILL.md"
-        runtime_path = skill_root / "first-officer" / "references" / f"{runtime}-first-officer-runtime.md"
+        core_path = skill_root / "first-officer" / "references" / f"{runtime}-first-officer-runtime-core.md"
+        legacy_path = skill_root / "first-officer" / "references" / f"{runtime}-first-officer-runtime.md"
+        runtime_path = core_path if core_path.exists() else legacy_path
     elif agent_name == "ensign":
         skill_path = skill_root / "ensign" / "SKILL.md"
         runtime_path = skill_root / "ensign" / "references" / f"{runtime}-ensign-runtime.md"

--- a/skills/first-officer/SKILL.md
+++ b/skills/first-officer/SKILL.md
@@ -21,7 +21,7 @@ If this skill is invoked directly in a non-interactive run and the prompt names 
 ## Runtime adapter
 
 Load the runtime adapter for your platform:
-- Claude Code (`CLAUDECODE` env var is set): read `references/claude-first-officer-runtime.md`
+- Claude Code (`CLAUDECODE` env var is set): read `references/claude-first-officer-runtime-core.md`
 - Codex (`CODEX_HOME` env var is set): read `references/codex-first-officer-runtime.md`
 
 Then begin the Startup procedure from the shared core.

--- a/skills/first-officer/references/claude-first-officer-runtime-core.md
+++ b/skills/first-officer/references/claude-first-officer-runtime-core.md
@@ -1,3 +1,6 @@
+<!-- ABOUTME: Core runtime adapter for the Claude Code first officer — dispatch happy path, -->
+<!-- ABOUTME: event loop, context budget, captain interaction, gate presentation, idle guardrails. -->
+
 # Claude Code First Officer Runtime
 
 This file defines how the shared first-officer core executes on Claude Code.
@@ -15,13 +18,9 @@ At startup (after reading the README, before dispatch):
 
 **Diagnostic-only startup probe:** At startup the FO MAY inspect `~/.claude/teams/` with `ls` or `test -f ~/.claude/teams/{project_name}-{dir_basename}*/config.json` to REPORT stale on-disk team directories from prior sessions in the boot summary. This probe is DIAGNOSTIC-ONLY. Its result does NOT gate or skip `TeamCreate` — `TeamCreate` always runs with the fresh-suffixed name regardless of what the probe reports. On-disk state is not evidence of team health (Claude Code bug anthropics/claude-code#36806 leaves config files on disk after the in-memory registry desyncs). Deletion remains forbidden per the NEVER-delete constraint above — the probe surfaces stale directories; it does not authorize removal. No such probe belongs in the `## Dispatch Adapter` pre-dispatch path.
 
-**TeamCreate recovery procedure:** Call TeamDelete in its own message (no other tool calls). Wait for the result. Then call TeamCreate in a subsequent message. Store the returned `team_name`. Do NOT combine TeamDelete, TeamCreate, or Agent dispatch in the same message — Claude Code executes tool calls in a message in parallel, and dependent calls will race. This procedure applies ONLY to the narrow "Already leading team" case at startup (where Claude Code's in-memory slot holds a team the FO wants to replace cleanly). It is NOT a mid-session failure recovery and MUST NOT be invoked in response to "Team does not exist" or any other registry-desync signal — see Degraded Mode below.
+**TeamCreate recovery procedure:** Call TeamDelete in its own message (no other tool calls). Wait for the result. Then call TeamCreate in a subsequent message. Store the returned `team_name`. Do NOT combine TeamDelete, TeamCreate, or Agent dispatch in the same message — Claude Code executes tool calls in a message in parallel, and dependent calls will race. This procedure applies ONLY to the narrow "Already leading team" case at startup (where Claude Code's in-memory slot holds a team the FO wants to replace cleanly). It is NOT a mid-session failure recovery and MUST NOT be invoked in response to "Team does not exist" or any other registry-desync signal — see the recovery file below.
 
-**TeamCreate failure recovery (priority-ordered ladder):** If TeamCreate or any subsequent `Agent()` dispatch surfaces "Team does not exist" or any equivalent registry-desync signal mid-session, follow this ladder in order — do NOT retry within the same tier:
-
-1. **Fresh-suffixed TeamCreate.** Attempt one new `TeamCreate` with a fresh name `{project_name}-{dir_basename}-{YYYYMMDD-HHMM}-{shortuuid}` computed at call time (new timestamp, new shortuuid, distinct from any name used earlier this session). Retry to the same team name is banned. Do NOT call `TeamDelete` on the failed team — the registry is already desynced and another `TeamDelete → TeamCreate` cycle will re-contaminate the same slot per anthropics/claude-code#36806. Store the returned `team_name`. All prior agent names are presumed zombified — do not SendMessage them; re-dispatch from entity frontmatter.
-2. **Fall back to Degraded Mode per the Degraded Mode section below.** A second dispatch failure (including failure of the tier-1 fresh-suffixed TeamCreate, or a second "Team does not exist" at any point in the session) trips Degraded Mode immediately.
-3. **Surface to captain** with an explicit recovery prompt if tiers 1 and 2 both fail (e.g., TeamCreate errors with quota or internal failure on the fresh name, AND Degraded Mode cannot be entered because `Agent` itself is unavailable). Do not silently retry. Do not block indefinitely — report the failure, name the tiers attempted, and wait for captain direction.
+On any of these fault signals, read `claude-first-officer-runtime-recovery.md` for the full recovery procedure: "Team does not exist" error, second dispatch failure, explicit `/spacedock bare`, or `claude-team build` non-zero exit.
 
 **Block all Agent dispatch** until team setup resolves (tier-1 fresh-suffixed TeamCreate succeeds or Degraded Mode is entered). Never dispatch while team state is uncertain.
 
@@ -58,11 +57,11 @@ Use the Agent tool to spawn each worker. **Use Agent() for initial dispatch** �
 
 **Sequencing rule:** Team lifecycle calls (TeamCreate, TeamDelete) and Agent dispatch must NEVER appear in the same tool-call message — parallel execution causes races (see recovery procedure above). Resolve team state in one message, then dispatch in a subsequent message.
 
-**No pre-dispatch filesystem probe.** Do NOT run any filesystem check against `~/.claude/teams/{team_name}/` before `Agent()` in the normal dispatch path. The on-disk check is a guaranteed false positive under registry-desync (anthropics/claude-code#36806 leaves on-disk state intact even when the in-memory team slot is invalidated). Trust the in-memory handle returned by `TeamCreate` and let `Agent()` surface any registry-desync error. On such an error, follow the TeamCreate failure recovery ladder (Team Creation section) and Degraded Mode semantics below — do NOT reintroduce a pre-dispatch probe.
+**No pre-dispatch filesystem probe.** Do NOT run any filesystem check against `~/.claude/teams/{team_name}/` before `Agent()` in the normal dispatch path. The on-disk check is a guaranteed false positive under registry-desync (anthropics/claude-code#36806 leaves on-disk state intact even when the in-memory team slot is invalidated). Trust the in-memory handle returned by `TeamCreate` and let `Agent()` surface any registry-desync error. On such an error, follow the TeamCreate failure recovery ladder and Degraded Mode semantics in `claude-first-officer-runtime-recovery.md` — do NOT reintroduce a pre-dispatch probe.
 
 **MANDATORY — Dispatch assembly via `claude-team build`:**
 
-Do NOT assemble `Agent()` prompts manually. Do NOT construct the `prompt` string yourself. Do NOT invent `name` values. ALWAYS pipe input through `claude-team build` and forward its output to `Agent()` verbatim. The key fields that MUST come from helper output are `subagent_type`, `name`, `team_name`, `model`, and `prompt` (which contains the completion signal). Manual assembly is a protocol violation except in the documented break-glass fallback below.
+Do NOT assemble `Agent()` prompts manually. Do NOT construct the `prompt` string yourself. Do NOT invent `name` values. ALWAYS pipe input through `claude-team build` and forward its output to `Agent()` verbatim. The key fields that MUST come from helper output are `subagent_type`, `name`, `team_name`, `model`, and `prompt` (which contains the completion signal). Manual assembly is a protocol violation except in the documented break-glass fallback in `claude-first-officer-runtime-recovery.md`.
 
 The only permitted path for initial `Agent()` dispatch is:
 
@@ -96,55 +95,11 @@ The only permitted path for initial `Agent()` dispatch is:
        prompt=output.prompt
    )
    ```
-4. **On non-zero exit ONLY** (or if the binary is unavailable): read stderr, report the helper failure to the captain, and fall back to Break-Glass Manual Dispatch below. A zero-exit run is never a break-glass trigger.
+4. **On non-zero exit ONLY** (or if the binary is unavailable): read stderr, report the helper failure to the captain, and fall back to Break-Glass Manual Dispatch in `claude-first-officer-runtime-recovery.md`. A zero-exit run is never a break-glass trigger.
 
 In bare mode, dispatch blocks until the subagent completes — concurrent dispatch is not possible. Dispatch one entity at a time and process completions inline.
 
 **Reuse dispatch (SendMessage advancement):** `claude-team build` serves only initial `Agent()` dispatch. When advancing a reused ensign via `SendMessage(to="{ensign_name}")`, assemble the advancement message directly — the helper is not involved in the reuse path.
-
-**Break-Glass Manual Dispatch (fallback ONLY when `claude-team build` exits non-zero or is unavailable):** Do NOT use this template while the helper is working. Report the helper failure to the captain before proceeding. Use this minimal template as a degraded fallback:
-```
-Agent(
-    subagent_type="{dispatch_agent_id}",
-    name="{worker_key}-{slug}-{stage}",
-    team_name="{team_name}",
-    model="{effective_model}",
-    prompt="You are working on: {entity title}\n\nStage: {stage}\n\n### Stage definition:\n\n{copy stage subsection from README verbatim}\n\nRead the entity file at {entity_file_path}.\n\n### Completion checklist\n\n{numbered checklist}\n\n### Completion Signal\n\nSendMessage(to=\"team-lead\", message=\"Done: {entity title} completed {stage}. Report written to {entity_file_path}.\")"
-)
-```
-The break-glass template omits worktree instructions, feedback context, and scope notes. The `model=` slot is conditional — include it only when the stage (or `stages.defaults`) declares a model from `sonnet | opus | haiku`; omit the entire `model=` argument otherwise. Use only when the helper is unavailable.
-
-## Degraded Mode
-
-Degraded Mode is an explicit, session-wide mid-session transition. Once entered, it persists until the session ends — there is no recovery back to teams mode in the same session.
-
-### Triggers
-
-Any one of the following trips Degraded Mode:
-
-- First "Team does not exist" error (or equivalent registry-desync signal) surfaced by `Agent()` or any team-registry tool.
-- Any SECOND dispatch failure within the session — no time window, no durable counter. The counter-free rule is deliberate: the FO cannot reliably track failure timestamps across context pressure and idle notifications, so "second failure anywhere in the session" is the fail-early trigger.
-- Captain command `/spacedock bare` (explicit operator-initiated degrade).
-
-### Effects
-
-Once Degraded Mode is active, the following invariants hold for the remainder of the session:
-
-- No `team_name` parameter on any subsequent `Agent()` dispatch. The input JSON sets `team_name: null` and `bare_mode: true`; `claude-team build` emits a bare-mode Agent call with `name` and `team_name` absent.
-- Every stage dispatches fresh and blocks until completion. No concurrent dispatch; one entity through one stage at a time.
-- No SendMessage reuse of prior agent names. Stage advancement is always a fresh `Agent()` dispatch seeded from entity frontmatter. `SendMessage(to="{ensign_name}")` against any pre-degrade name is forbidden.
-
-### Captain Report Template
-
-On Degraded Mode entry, the FO emits the following sentence verbatim to the captain (direct text output, not SendMessage):
-
-> Falling back to bare mode for the remainder of this session due to team-infrastructure failure. Prior team agents are presumed-zombified; I will not route work to them or through the team registry. If you want to escalate: restart the session to retry team mode with a fresh name, or let me continue — every stage will still complete, just without concurrent dispatch.
-
-### Cooperative Shutdown Sweep
-
-On Degraded Mode entry, perform a single-pass cooperative shutdown sweep of every known agent name from session memory: one `SendMessage(to="{ensign_name}", message="shutdown_request")` per name. Ignore failures — best-effort, not transactional. Do not retry, track responses, or block on the outcome; proceed immediately to the first fresh bare-mode dispatch.
-
-Exempt any agent whose entity is in an active feedback-cycle state (tracked via a `### Feedback Cycles` subsection in the entity body). Those reviewers may hold load-bearing context from the prior cycle that re-dispatch cannot reconstruct. Sweep feedback-cycle reviewers only on explicit captain confirmation.
 
 ## Context Budget and Dead Ensign Handling
 

--- a/skills/first-officer/references/claude-first-officer-runtime-recovery.md
+++ b/skills/first-officer/references/claude-first-officer-runtime-recovery.md
@@ -1,0 +1,60 @@
+<!-- ABOUTME: Recovery procedures for the Claude Code first officer — TeamCreate failure ladder, -->
+<!-- ABOUTME: Degraded Mode, Break-Glass manual dispatch, and cooperative shutdown sweep. -->
+
+# Claude Code First Officer Runtime — Recovery
+
+This file contains fault-recovery procedures for the Claude Code first officer runtime. It is loaded on demand when a fault signal occurs — see the core runtime file for the trigger list.
+
+## TeamCreate Failure Recovery (priority-ordered ladder)
+
+If TeamCreate or any subsequent `Agent()` dispatch surfaces "Team does not exist" or any equivalent registry-desync signal mid-session, follow this ladder in order — do NOT retry within the same tier:
+
+1. **Fresh-suffixed TeamCreate.** Attempt one new `TeamCreate` with a fresh name `{project_name}-{dir_basename}-{YYYYMMDD-HHMM}-{shortuuid}` computed at call time (new timestamp, new shortuuid, distinct from any name used earlier this session). Retry to the same team name is banned. Do NOT call `TeamDelete` on the failed team — the registry is already desynced and another `TeamDelete → TeamCreate` cycle will re-contaminate the same slot per anthropics/claude-code#36806. Store the returned `team_name`. All prior agent names are presumed zombified — do not SendMessage them; re-dispatch from entity frontmatter.
+2. **Fall back to Degraded Mode per the Degraded Mode section below.** A second dispatch failure (including failure of the tier-1 fresh-suffixed TeamCreate, or a second "Team does not exist" at any point in the session) trips Degraded Mode immediately.
+3. **Surface to captain** with an explicit recovery prompt if tiers 1 and 2 both fail (e.g., TeamCreate errors with quota or internal failure on the fresh name, AND Degraded Mode cannot be entered because `Agent` itself is unavailable). Do not silently retry. Do not block indefinitely — report the failure, name the tiers attempted, and wait for captain direction.
+
+## Break-Glass Manual Dispatch
+
+**Fallback ONLY when `claude-team build` exits non-zero or is unavailable.** Do NOT use this template while the helper is working. Report the helper failure to the captain before proceeding. Use this minimal template as a degraded fallback:
+```
+Agent(
+    subagent_type="{dispatch_agent_id}",
+    name="{worker_key}-{slug}-{stage}",
+    team_name="{team_name}",
+    model="{effective_model}",
+    prompt="You are working on: {entity title}\n\nStage: {stage}\n\n### Stage definition:\n\n{copy stage subsection from README verbatim}\n\nRead the entity file at {entity_file_path}.\n\n### Completion checklist\n\n{numbered checklist}\n\n### Completion Signal\n\nSendMessage(to=\"team-lead\", message=\"Done: {entity title} completed {stage}. Report written to {entity_file_path}.\")"
+)
+```
+The break-glass template omits worktree instructions, feedback context, and scope notes. The `model=` slot is conditional — include it only when the stage (or `stages.defaults`) declares a model from `sonnet | opus | haiku`; omit the entire `model=` argument otherwise. Use only when the helper is unavailable.
+
+## Degraded Mode
+
+Degraded Mode is an explicit, session-wide mid-session transition. Once entered, it persists until the session ends — there is no recovery back to teams mode in the same session.
+
+### Triggers
+
+Any one of the following trips Degraded Mode:
+
+- First "Team does not exist" error (or equivalent registry-desync signal) surfaced by `Agent()` or any team-registry tool.
+- Any SECOND dispatch failure within the session — no time window, no durable counter. The counter-free rule is deliberate: the FO cannot reliably track failure timestamps across context pressure and idle notifications, so "second failure anywhere in the session" is the fail-early trigger.
+- Captain command `/spacedock bare` (explicit operator-initiated degrade).
+
+### Effects
+
+Once Degraded Mode is active, the following invariants hold for the remainder of the session:
+
+- No `team_name` parameter on any subsequent `Agent()` dispatch. The input JSON sets `team_name: null` and `bare_mode: true`; `claude-team build` emits a bare-mode Agent call with `name` and `team_name` absent.
+- Every stage dispatches fresh and blocks until completion. No concurrent dispatch; one entity through one stage at a time.
+- No SendMessage reuse of prior agent names. Stage advancement is always a fresh `Agent()` dispatch seeded from entity frontmatter. `SendMessage(to="{ensign_name}")` against any pre-degrade name is forbidden.
+
+### Captain Report Template
+
+On Degraded Mode entry, the FO emits the following sentence verbatim to the captain (direct text output, not SendMessage):
+
+> Falling back to bare mode for the remainder of this session due to team-infrastructure failure. Prior team agents are presumed-zombified; I will not route work to them or through the team registry. If you want to escalate: restart the session to retry team mode with a fresh name, or let me continue — every stage will still complete, just without concurrent dispatch.
+
+### Cooperative Shutdown Sweep
+
+On Degraded Mode entry, perform a single-pass cooperative shutdown sweep of every known agent name from session memory: one `SendMessage(to="{ensign_name}", message="shutdown_request")` per name. Ignore failures — best-effort, not transactional. Do not retry, track responses, or block on the outcome; proceed immediately to the first fresh bare-mode dispatch.
+
+Exempt any agent whose entity is in an active feedback-cycle state (tracked via a `### Feedback Cycles` subsection in the entity body). Those reviewers may hold load-bearing context from the prior cycle that re-dispatch cannot reconstruct. Sweep feedback-cycle reviewers only on explicit captain confirmation.

--- a/tests/test_agent_content.py
+++ b/tests/test_agent_content.py
@@ -44,7 +44,7 @@ def test_first_officer_skill_reads_references_directly():
     text = read_text("skills/first-officer/SKILL.md")
     assert "@references/first-officer-shared-core.md" in text
     assert "@references/code-project-guardrails.md" in text
-    assert "claude-first-officer-runtime.md" in text
+    assert "claude-first-officer-runtime-core.md" in text
     assert "codex-first-officer-runtime.md" in text
     assert "CLAUDECODE" in text
     assert "CODEX_HOME" in text
@@ -325,11 +325,15 @@ def test_assembled_claude_first_officer_has_teamcreate_failure_recovery():
 
     # "Already leading team" stays as a narrow startup-only recovery case.
     assert "Already leading team" in assembled
-    # Fail-early ladder: fresh-suffixed TeamCreate as tier 1.
+    # Core file references fresh-suffixed recovery and points to recovery file.
     assert re.search(r"fresh[-\s]?suffixed", assembled, re.IGNORECASE), (
-        "Recovery ladder must call for a fresh-suffixed TeamCreate."
+        "Core must reference fresh-suffixed TeamCreate recovery."
     )
-    assert "Retry to the same team name is banned" in assembled
+
+    # Recovery-specific content lives in the on-demand recovery file.
+    recovery_path = Path(__file__).resolve().parent.parent / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-recovery.md"
+    recovery_text = recovery_path.read_text()
+    assert "Retry to the same team name is banned" in recovery_text
 
     # Block Agent dispatch while team state is uncertain.
     assert re.search(r"Block all Agent dispatch", assembled)
@@ -366,9 +370,11 @@ def test_assembled_claude_first_officer_has_no_predispatch_health_check():
         "must be gone."
     )
 
-    # Degraded Mode must be declared as a first-class section.
-    assert "## Degraded Mode" in assembled, (
-        "Assembled contract must declare the `## Degraded Mode` section."
+    # Degraded Mode must be declared as a first-class section in the recovery file.
+    recovery_path = Path(__file__).resolve().parent.parent / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-recovery.md"
+    recovery_text = recovery_path.read_text()
+    assert "## Degraded Mode" in recovery_text, (
+        "Recovery file must declare the `## Degraded Mode` section."
     )
 
 
@@ -401,12 +407,12 @@ def test_assembled_claude_first_officer_dispatch_template_has_team_mode_completi
     t = TestRunner("agent content", keep_test_dir=False)
     text = assembled_agent_content(t, "first-officer")
 
-    runtime_path = Path(__file__).resolve().parent.parent / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
-    runtime_text = runtime_path.read_text()
+    core_path = Path(__file__).resolve().parent.parent / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-core.md"
+    core_text = core_path.read_text()
 
-    dispatch_section = section_text(runtime_text, "## Dispatch Adapter", (r"^## ",))
+    dispatch_section = section_text(core_text, "## Dispatch Adapter", (r"^## ",))
 
-    # The break-glass Agent() template includes an explicit SendMessage completion
+    # The structured helper output template includes an explicit SendMessage completion
     # instruction for team-mode dispatch.
     assert re.search(
         r'SendMessage\(to=\\?"team-lead\\?"',
@@ -471,7 +477,7 @@ def test_ensign_stage_report_uses_append_mode():
 
 
 def test_dispatch_template_uses_targeted_read_instruction():
-    text = read_text("skills/first-officer/references/claude-first-officer-runtime.md")
+    text = read_text("skills/first-officer/references/claude-first-officer-runtime-core.md")
     dispatch_section = section_text(text, "## Dispatch Adapter", (r"^## ",))
     assert "for full context" not in dispatch_section, (
         "Dispatch template must not unconditionally instruct reading 'for full context'"
@@ -488,7 +494,7 @@ def test_fo_completion_reads_last_stage_report():
 
 def test_first_officer_runtime_docs_use_next_id_for_task_creation():
     shared = read_text("skills/first-officer/references/first-officer-shared-core.md")
-    claude_runtime = read_text("skills/first-officer/references/claude-first-officer-runtime.md")
+    claude_runtime = read_text("skills/first-officer/references/claude-first-officer-runtime-core.md")
     codex_runtime = read_text("skills/first-officer/references/codex-first-officer-runtime.md")
 
     assert "status --next-id" in shared
@@ -550,8 +556,8 @@ def test_assembled_claude_first_officer_has_structured_dispatch():
     t = TestRunner("agent content", keep_test_dir=False)
     assembled = assembled_agent_content(t, "first-officer")
 
-    runtime_path = Path(__file__).resolve().parent.parent / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
-    runtime_text = runtime_path.read_text()
+    core_path = Path(__file__).resolve().parent.parent / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-core.md"
+    runtime_text = core_path.read_text()
 
     dispatch_section = section_text(runtime_text, "## Dispatch Adapter", (r"^## ",))
 
@@ -576,32 +582,32 @@ def test_assembled_claude_first_officer_has_structured_dispatch():
 
 def test_assembled_claude_first_officer_has_break_glass_dispatch():
     """AC-12: Runtime adapter contains Break-Glass Manual Dispatch with minimal Agent() template."""
-    runtime_path = Path(__file__).resolve().parent.parent / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
-    runtime_text = runtime_path.read_text()
+    recovery_path = Path(__file__).resolve().parent.parent / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-recovery.md"
+    recovery_text = recovery_path.read_text()
 
-    dispatch_section = section_text(runtime_text, "## Dispatch Adapter", (r"^## ",))
+    breakglass_section = section_text(recovery_text, "## Break-Glass Manual Dispatch", (r"^## ",))
 
     # Break-glass section exists
-    assert "Break-Glass Manual Dispatch" in dispatch_section, (
-        "Dispatch Adapter must contain Break-Glass Manual Dispatch section"
+    assert breakglass_section, (
+        "Recovery file must contain Break-Glass Manual Dispatch section"
     )
 
     # The break-glass template includes the essential Agent() fields
-    assert 'subagent_type="{dispatch_agent_id}"' in dispatch_section
-    assert 'name="{worker_key}-{slug}-{stage}"' in dispatch_section
-    assert 'team_name="{team_name}"' in dispatch_section
+    assert 'subagent_type="{dispatch_agent_id}"' in breakglass_section
+    assert 'name="{worker_key}-{slug}-{stage}"' in breakglass_section
+    assert 'team_name="{team_name}"' in breakglass_section
 
     # It has the SendMessage completion signal
     assert re.search(
         r'SendMessage\(to=\\?"team-lead\\?"',
-        dispatch_section,
+        breakglass_section,
     )
 
 
 def test_assembled_claude_first_officer_has_bare_mode_guardrail():
     """Implementation Note 6: bare_mode guardrail sentence is present in dispatch prose."""
-    runtime_path = Path(__file__).resolve().parent.parent / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
-    runtime_text = runtime_path.read_text()
+    core_path = Path(__file__).resolve().parent.parent / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-core.md"
+    runtime_text = core_path.read_text()
 
     dispatch_section = section_text(runtime_text, "## Dispatch Adapter", (r"^## ",))
 
@@ -640,7 +646,7 @@ def test_shared_core_grep_over_read_discipline_for_entity_body():
 
 def test_claude_runtime_points_to_shared_core_entity_body_inspection_rule():
     """AC-2 (#159): the Claude runtime adapter carries a short pointer to the shared-core rule."""
-    text = read_text("skills/first-officer/references/claude-first-officer-runtime.md")
+    text = read_text("skills/first-officer/references/claude-first-officer-runtime-core.md")
     assert "## Probe and Ideation Discipline" in text, (
         "Claude runtime must point to the shared-core `## Probe and Ideation Discipline` section"
     )

--- a/tests/test_claude_team.py
+++ b/tests/test_claude_team.py
@@ -1178,7 +1178,9 @@ class TestBuildBreakGlassFallback:
     def test_break_glass_template_is_parseable(self):
         """The break-glass Agent() template in the runtime adapter is valid Python syntax."""
         import ast
-        runtime_path = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
+        recovery_path = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-recovery.md"
+        legacy_path = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
+        runtime_path = recovery_path if recovery_path.exists() else legacy_path
         text = runtime_path.read_text()
 
         # Extract the break-glass code block
@@ -1439,7 +1441,9 @@ class TestRuntimeAdapterModelProse:
     """AC-adapter-prose + AC-break-glass: Claude runtime adapter forwards model."""
 
     def test_claude_runtime_adapter_forwards_model(self):
-        runtime_path = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
+        core_path = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-core.md"
+        legacy_path = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
+        runtime_path = core_path if core_path.exists() else legacy_path
         text = runtime_path.read_text()
         # Emitted-fields enumeration includes `model`.
         assert "`model`" in text
@@ -1448,7 +1452,9 @@ class TestRuntimeAdapterModelProse:
         assert "model=" in text
 
     def test_break_glass_template_has_conditional_model_slot(self):
-        runtime_path = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
+        recovery_path = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-recovery.md"
+        legacy_path = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
+        runtime_path = recovery_path if recovery_path.exists() else legacy_path
         text = runtime_path.read_text()
         # Locate the break-glass code block and assert the model= slot appears inside.
         marker = "Break-Glass Manual Dispatch"

--- a/tests/test_reuse_dispatch.py
+++ b/tests/test_reuse_dispatch.py
@@ -145,7 +145,7 @@ def test_reuse_dispatch(test_project, model, effort):
     print()
     print("[Static Template Checks]")
     core = (REPO_ROOT / "skills" / "first-officer" / "references" / "first-officer-shared-core.md").read_text()
-    runtime_ref = (REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md").read_text()
+    runtime_ref = (REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-core.md").read_text()
     assembled = assembled_agent_content(t, "first-officer")
 
     t.check("reuse conditions documented in shared-core",

--- a/tests/test_standing_teammate_prose.py
+++ b/tests/test_standing_teammate_prose.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-CLAUDE_RUNTIME = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
+CLAUDE_RUNTIME = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-core.md"
 SHARED_CORE = REPO_ROOT / "skills" / "first-officer" / "references" / "first-officer-shared-core.md"
 COMM_OFFICER_MOD = REPO_ROOT / "docs" / "plans" / "_mods" / "comm-officer.md"
 

--- a/tests/test_team_fail_early.py
+++ b/tests/test_team_fail_early.py
@@ -18,7 +18,8 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-ADAPTER_PATH = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime.md"
+ADAPTER_CORE_PATH = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-core.md"
+ADAPTER_RECOVERY_PATH = REPO_ROOT / "skills" / "first-officer" / "references" / "claude-first-officer-runtime-recovery.md"
 
 
 def parse_sections(text: str) -> dict[str, str]:
@@ -49,7 +50,7 @@ def parse_sections(text: str) -> dict[str, str]:
 
 @pytest.fixture(scope="module")
 def adapter_text() -> str:
-    return ADAPTER_PATH.read_text()
+    return ADAPTER_CORE_PATH.read_text() + "\n" + ADAPTER_RECOVERY_PATH.read_text()
 
 
 @pytest.fixture(scope="module")
@@ -106,14 +107,14 @@ def test_ac2_retry_same_name_banned_and_no_same_name_teamdelete_teamcreate(
     """AC-2: The failure recovery prose bans retry-to-same-name and specifies
     a fresh-suffixed TeamCreate. The old `TeamDelete -> TeamCreate` same-name
     recovery sequence must not appear as a recovery path."""
-    team_creation = sections["## Team Creation"]
+    recovery = sections["## TeamCreate Failure Recovery (priority-ordered ladder)"]
     # Positive: retry-to-same-name ban exact phrase.
-    assert "Retry to the same team name is banned" in team_creation, (
+    assert "Retry to the same team name is banned" in recovery, (
         "Recovery prose must include the exact phrase "
         "'Retry to the same team name is banned'."
     )
     # Positive: fresh-suffixed phrasing.
-    assert "fresh-suffixed" in team_creation.lower() or "Fresh-suffixed" in team_creation, (
+    assert "fresh-suffixed" in recovery.lower() or "Fresh-suffixed" in recovery, (
         "Recovery prose must describe the ladder's first tier as fresh-suffixed."
     )
     # Negative: the old prescriptive "Call TeamDelete ... then call TeamCreate"
@@ -123,12 +124,12 @@ def test_ac2_retry_same_name_banned_and_no_same_name_teamdelete_teamcreate(
     # scoped to the prescriptive instruction shape.
     assert not re.search(
         r"Call\s+TeamDelete[^\.]*(?:then|Then)\s+call\s+TeamCreate",
-        team_creation,
+        recovery,
     ), "Old prescriptive 'Call TeamDelete ... then call TeamCreate' recovery must be gone."
     # Positive: the prose must forbid TeamDelete as a response to registry-desync.
     assert re.search(
         r"Do NOT\s+call\s+`?TeamDelete`?",
-        team_creation,
+        recovery,
     ), "Recovery prose must explicitly forbid calling TeamDelete on registry-desync."
 
 
@@ -137,11 +138,11 @@ def test_ac2b_prior_agents_presumed_zombified_and_redispatch_from_frontmatter(
 ) -> None:
     """AC-2b: The recovery prose presumes all prior agent names zombified and
     prescribes re-dispatch from entity frontmatter."""
-    team_creation = sections["## Team Creation"]
-    assert "presumed zombified" in team_creation, (
+    recovery = sections["## TeamCreate Failure Recovery (priority-ordered ladder)"]
+    assert "presumed zombified" in recovery, (
         "Recovery prose must state prior agent names are 'presumed zombified'."
     )
-    assert "re-dispatch from entity frontmatter" in team_creation, (
+    assert "re-dispatch from entity frontmatter" in recovery, (
         "Recovery prose must instruct 're-dispatch from entity frontmatter'."
     )
 


### PR DESCRIPTION
## Summary

Split `claude-first-officer-runtime.md` (3,184 w post-tighten) into two files:
- **`claude-first-officer-runtime-core.md`** (2,509 w) — loaded at boot: dispatch adapter, event loop, context budget, captain interaction, gate presentation, idle guardrails
- **`claude-first-officer-runtime-recovery.md`** (803 w) — loaded on demand at fault: TeamCreate failure ladder, Degraded Mode, Break-Glass, cooperative shutdown sweep

Boot-path savings: **-675 w (-9.9%)** on Claude FO assembly (6,850 → 6,175). Total overhead +128 w from ABOUTME lines, pointer paragraphs, and section headings. Recovery file loaded only on fault signals ("Team does not exist", second dispatch failure, `/spacedock bare`, `claude-team build` non-zero exit).

## Files changed

- `skills/first-officer/references/claude-first-officer-runtime.md` → deleted
- `skills/first-officer/references/claude-first-officer-runtime-core.md` → new (core sections, verbatim move)
- `skills/first-officer/references/claude-first-officer-runtime-recovery.md` → new (recovery sections, verbatim move)
- `skills/first-officer/SKILL.md` → updated @references (core file only at boot)
- `scripts/test_lib.py` → `assembled_agent_content` resolves core file with legacy fallback
- `tests/test_agent_content.py` → recovery-specific assertions read the recovery file directly
- `tests/test_claude_team.py` → model-prose and break-glass tests resolve split files with fallback
- `tests/test_reuse_dispatch.py` → static template check reads core file
- `tests/test_standing_teammate_prose.py` → CLAUDE_RUNTIME path updated to core
- `tests/test_team_fail_early.py` → adapter fixture reads both files; section lookups target recovery

## Pre-flight results

- Static: 395/395 PASS (12s) — rebased on 12512a5
- Live smoke (gate guardrail, haiku): PASS (82s)

## Test plan

- [x] `make test-static` (395/395)
- [x] `pytest tests/test_gate_guardrail.py --runtime claude --model haiku` (PASS)
- [ ] CI: `make test-live-claude` (Haiku)

Workflow entity: experiments/022 split-runtime-adapter (spacedock-prompt)

Note: if 016/017/018 (extract-break-glass, collapse-degraded-captain-report, extract-teamcreate-recovery) were to be adopted, they are subsumed by this split — those sections already live in the recovery file.