### PR TITLE
CI workflow model_override input — parameterize Claude model for bisection

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: ""
+      model_override:
+        description: "Override --model passed to pytest for Claude jobs (e.g. claude-opus-4-6, opus, sonnet). Substitutes the job's default. No-op on codex-live. Empty = preserve per-job default."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read

--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -166,6 +166,7 @@ jobs:
         env:
           TEST_SELECTOR: ${{ inputs.test_selector }}
           EFFORT_OVERRIDE: ${{ inputs.effort_override }}
+          MODEL_OVERRIDE: ${{ inputs.model_override }}
         run: |
           if [ -n "$TEST_SELECTOR" ]; then
             echo "Running selector: $TEST_SELECTOR"
@@ -173,8 +174,12 @@ jobs:
             if [ -n "$EFFORT_OVERRIDE" ]; then
               EFFORT_ARGS=(--effort "$EFFORT_OVERRIDE")
             fi
+            MODEL_ARGS=()
+            if [ -n "$MODEL_OVERRIDE" ]; then
+              MODEL_ARGS=(--model "$MODEL_OVERRIDE")
+            fi
             unset CLAUDECODE
-            uv run pytest "$TEST_SELECTOR" --runtime claude "${EFFORT_ARGS[@]}" -v
+            uv run pytest "$TEST_SELECTOR" --runtime claude "${MODEL_ARGS[@]}" "${EFFORT_ARGS[@]}" -v
           else
             make test-live-claude
           fi
@@ -319,6 +324,7 @@ jobs:
         env:
           TEST_SELECTOR: ${{ inputs.test_selector }}
           EFFORT_OVERRIDE: ${{ inputs.effort_override }}
+          MODEL_OVERRIDE: ${{ inputs.model_override }}
         run: |
           if [ -n "$TEST_SELECTOR" ]; then
             echo "Running selector: $TEST_SELECTOR"
@@ -326,8 +332,12 @@ jobs:
             if [ -n "$EFFORT_OVERRIDE" ]; then
               EFFORT_ARGS=(--effort "$EFFORT_OVERRIDE")
             fi
+            MODEL_ARGS=()
+            if [ -n "$MODEL_OVERRIDE" ]; then
+              MODEL_ARGS=(--model "$MODEL_OVERRIDE")
+            fi
             unset CLAUDECODE CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS
-            uv run pytest "$TEST_SELECTOR" --runtime claude --team-mode=bare "${EFFORT_ARGS[@]}" -v
+            uv run pytest "$TEST_SELECTOR" --runtime claude --team-mode=bare "${MODEL_ARGS[@]}" "${EFFORT_ARGS[@]}" -v
           else
             make test-live-claude-bare
           fi
@@ -472,6 +482,7 @@ jobs:
         env:
           TEST_SELECTOR: ${{ inputs.test_selector }}
           EFFORT_OVERRIDE: ${{ inputs.effort_override }}
+          MODEL_OVERRIDE: ${{ inputs.model_override }}
         run: |
           if [ -n "$TEST_SELECTOR" ]; then
             echo "Running selector: $TEST_SELECTOR"
@@ -480,9 +491,15 @@ jobs:
             else
               EFFORT_FLAG="low"
             fi
+            if [ -n "$MODEL_OVERRIDE" ]; then
+              MODEL_FLAG="$MODEL_OVERRIDE"
+            else
+              MODEL_FLAG="opus"
+            fi
             echo "Opus effort: $EFFORT_FLAG"
+            echo "Opus model: $MODEL_FLAG"
             unset CLAUDECODE
-            uv run pytest "$TEST_SELECTOR" --runtime claude --model opus --effort "$EFFORT_FLAG" -v
+            uv run pytest "$TEST_SELECTOR" --runtime claude --model "$MODEL_FLAG" --effort "$EFFORT_FLAG" -v
           else
             make test-live-claude-opus
           fi
@@ -605,7 +622,11 @@ jobs:
         env:
           TEST_SELECTOR: ${{ inputs.test_selector }}
           EFFORT_OVERRIDE: ${{ inputs.effort_override }}
+          MODEL_OVERRIDE: ${{ inputs.model_override }}
         run: |
+          if [ -n "$MODEL_OVERRIDE" ]; then
+            echo "Note: model_override ignored for codex-live (Codex uses its own model-selection path)."
+          fi
           if [ -n "$TEST_SELECTOR" ]; then
             echo "Running selector: $TEST_SELECTOR"
             EFFORT_ARGS=()

--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -146,11 +146,17 @@ jobs:
       - name: Show tool versions
         env:
           CLAUDE_VERSION: ${{ inputs.claude_version }}
+          MODEL_OVERRIDE: ${{ inputs.model_override }}
         run: |
           CLAUDE_VERSION_OUT=$(claude --version)
           UV_VERSION_OUT=$(uv --version)
           echo "$CLAUDE_VERSION_OUT"
           echo "$UV_VERSION_OUT"
+          if [ -n "$MODEL_OVERRIDE" ]; then
+            EFFECTIVE_MODEL="$MODEL_OVERRIDE"
+          else
+            EFFECTIVE_MODEL="(pytest default — haiku)"
+          fi
           {
             echo "### Tool versions"
             if [ -n "$CLAUDE_VERSION" ]; then
@@ -160,6 +166,7 @@ jobs:
             fi
             echo "- Installed \`claude --version\`: \`$CLAUDE_VERSION_OUT\`"
             echo "- Installed \`uv --version\`: \`$UV_VERSION_OUT\`"
+            echo "- Effective model: \`$EFFECTIVE_MODEL\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Claude live suite
@@ -304,11 +311,17 @@ jobs:
       - name: Show tool versions
         env:
           CLAUDE_VERSION: ${{ inputs.claude_version }}
+          MODEL_OVERRIDE: ${{ inputs.model_override }}
         run: |
           CLAUDE_VERSION_OUT=$(claude --version)
           UV_VERSION_OUT=$(uv --version)
           echo "$CLAUDE_VERSION_OUT"
           echo "$UV_VERSION_OUT"
+          if [ -n "$MODEL_OVERRIDE" ]; then
+            EFFECTIVE_MODEL="$MODEL_OVERRIDE"
+          else
+            EFFECTIVE_MODEL="(pytest default — haiku)"
+          fi
           {
             echo "### Tool versions"
             if [ -n "$CLAUDE_VERSION" ]; then
@@ -318,6 +331,7 @@ jobs:
             fi
             echo "- Installed \`claude --version\`: \`$CLAUDE_VERSION_OUT\`"
             echo "- Installed \`uv --version\`: \`$UV_VERSION_OUT\`"
+            echo "- Effective model: \`$EFFECTIVE_MODEL\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Claude live suite (bare mode)
@@ -462,11 +476,17 @@ jobs:
       - name: Show tool versions
         env:
           CLAUDE_VERSION: ${{ inputs.claude_version }}
+          MODEL_OVERRIDE: ${{ inputs.model_override }}
         run: |
           CLAUDE_VERSION_OUT=$(claude --version)
           UV_VERSION_OUT=$(uv --version)
           echo "$CLAUDE_VERSION_OUT"
           echo "$UV_VERSION_OUT"
+          if [ -n "$MODEL_OVERRIDE" ]; then
+            EFFECTIVE_MODEL="$MODEL_OVERRIDE"
+          else
+            EFFECTIVE_MODEL="opus"
+          fi
           {
             echo "### Tool versions"
             if [ -n "$CLAUDE_VERSION" ]; then
@@ -476,6 +496,7 @@ jobs:
             fi
             echo "- Installed \`claude --version\`: \`$CLAUDE_VERSION_OUT\`"
             echo "- Installed \`uv --version\`: \`$UV_VERSION_OUT\`"
+            echo "- Effective model: \`$EFFECTIVE_MODEL\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Claude live suite (opus)

--- a/docs/plans/ci-workflow-model-override-input.md
+++ b/docs/plans/ci-workflow-model-override-input.md
@@ -69,3 +69,38 @@ Live validation: one manual `gh workflow run` after merge, same pattern as #108'
 - Makefile target changes. `make test-live-claude-opus` continues to hardcode `--model opus --effort low` as the developer-local default. `model_override` affects only CI dispatches.
 - Codex runtime model parameterization. Codex has its own model-selection path; out of scope for this Claude-focused input.
 - Documentation in `tests/README.md` beyond what the no-op bullet requires. A fuller `tests/README.md` refresh covering all four `workflow_dispatch` inputs is a separate task.
+
+## Stage Report (implementation)
+
+1. Entity body read in full (Problem Statement, Proposed design, ACs 1-6, Test plan, Out of Scope). DONE. Existing four inputs preserved verbatim (`pr_number`, `claude_version`, `test_selector`, `effort_override`).
+2. `.github/workflows/runtime-live-e2e.yml` read in full (623 lines pre-change). `workflow_dispatch.inputs` block and the four per-job run steps identified. DONE.
+3. `model_override` added to `workflow_dispatch.inputs` — `type: string`, `required: false`, `default: ""`, description documents the substitution semantics and codex-live no-op. DONE (commit `ba10bec7`).
+4. `MODEL_OVERRIDE: ${{ inputs.model_override }}` threaded into each job's test-run step env block (step-level, matching #174's pattern for `TEST_SELECTOR` / `EFFORT_OVERRIDE`). DONE (commit `03af04db`).
+5. Per-job threading in the three Claude test-run steps:
+   - `claude-live` and `claude-live-bare`: MODEL_ARGS array populated with `--model "$MODEL_OVERRIDE"` only when set; default-unset path passes no `--model` flag (preserves haiku default). DONE.
+   - `claude-live-opus`: MODEL_FLAG substitutes `$MODEL_OVERRIDE` when set, defaults to `opus` when unset; `--model "$MODEL_FLAG"` always emitted (preserves `--model opus` default). DONE.
+   - `codex-live`: added log line `"Note: model_override ignored for codex-live (Codex uses its own model-selection path)."` when the input is set. DONE.
+   All landed in commit `03af04db`.
+6. `Show tool versions` step in each of the three Claude jobs extended with `EFFECTIVE_MODEL` computation and a new `- Effective model:` line in `GITHUB_STEP_SUMMARY`. Haiku jobs default to `"(pytest default — haiku)"`, opus job defaults to `"opus"`. Existing `claude --version` and `uv --version` lines from #174 preserved. DONE (commit `020d7b26`).
+7. YAML sanity check with `uv run --with pyyaml python -c ...` — parses cleanly. All five `workflow_dispatch.inputs` present (`pr_number`, `claude_version`, `test_selector`, `effort_override`, `model_override`). All four jobs parse (`claude-live`, `claude-live-bare`, `claude-live-opus`, `codex-live`). DONE.
+8. `bash -n` verified for every modified step under both set (`MODEL_OVERRIDE=claude-opus-4-6`, `EFFORT_OVERRIDE=low`) and unset branches — 16 rendered-step checks, all `rc=0` with no stderr. DONE.
+9. Default-unset behavior preservation: on `claude-live` and `claude-live-bare`, empty `MODEL_ARGS` array expands to nothing, leaving pytest invocation functionally identical to pre-change (`uv run pytest "$TEST_SELECTOR" --runtime claude "${EFFORT_ARGS[@]}" -v`). On `claude-live-opus`, `MODEL_FLAG=opus` when unset, so `--model "$MODEL_FLAG"` renders as `--model opus` — identical to pre-change. On `codex-live`, the new log line is guarded by `[ -n "$MODEL_OVERRIDE" ]` and emits nothing when unset. DONE.
+10. Four focused commits: (i) `ba10bec7` add input, (ii) `03af04db` thread env + per-job conditionals + codex no-op log, (iii) `020d7b26` effective-model summary line, (iv) this Stage Report commit. DONE.
+11. Stage Report written. DONE.
+
+### Validation recommendation
+
+Same pattern as #174 — CI-on-CI self-validation is chicken-and-egg, so offline validation is YAML lint (`yaml.safe_load`) + `bash -n` on rendered step blocks under both branches. Both passed.
+
+Post-merge spot-check: captain fires one
+
+```
+gh workflow run runtime-live-e2e.yml --ref main \
+  -f pr_number=<N> \
+  -f claude_version=2.1.111 \
+  -f test_selector=tests/test_standing_teammate_spawn.py::test_standing_teammate_spawns_and_roundtrips \
+  -f effort_override=low \
+  -f model_override=claude-opus-4-6
+```
+
+Expected outcome: `claude-live-opus` passes in ~2-3 minutes on 2.1.111 with the dated-model pin, confirming the hypothesis that 2.1.111's `--model opus` alias flip is the regression and that pinning to `claude-opus-4-6` is a valid mitigation.


### PR DESCRIPTION
Add the fourth workflow_dispatch input to close the last bisection gap: pin an explicit Claude model (e.g. claude-opus-4-6) to bypass default-alias drift, complementing #174's claude_version/test_selector/effort_override inputs.

## What changed

- Add `model_override` optional input to `runtime-live-e2e.yml`. `pr_number`, `claude_version`, `test_selector`, `effort_override` preserved verbatim.
- Thread into claude-live, claude-live-bare, claude-live-opus: substitute `--model $MODEL_OVERRIDE` when set; default-unset preserves current `--model opus` (opus job) and implicit haiku default (others).
- codex-live: documented no-op with a single log line when the input is set (Codex has its own model path).
- GITHUB_STEP_SUMMARY now records `Effective model` per Claude job alongside `claude --version` from #174.

## Evidence

- YAML parsed clean via `yaml.safe_load`.
- `bash -n` verified all 16 conditional branches across set + unset paths.
- Local confirmation (2026-04-16): 2.1.111 + `--model claude-opus-4-6` + `--effort low` passes `test_standing_teammate_spawns_and_roundtrips` in 2m5s (same as 2.1.107/2.1.110 + opus alias). This input lets us reproduce and mitigate that pattern in CI.

## Review guidance

Default-unset paths preserve pre-change behavior line-for-line; risk is scoped to the new conditional branches.

---
[176](/clkao/spacedock/blob/ebb1efd6/docs/plans/ci-workflow-model-override-input.md)