### PR TITLE
Fix marketplace.json to match Claude Code schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,19 +1,13 @@
 {
   "name": "spacedock",
-  "interface": {
-    "displayName": "Spacedock"
+  "owner": {
+    "name": "CL Kao"
   },
   "plugins": [
     {
       "name": "spacedock",
-      "source": {
-        "source": "local",
-        "path": "./plugins/spacedock"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
+      "source": "./plugins/spacedock",
+      "description": "Turn directories of markdown files into structured workflows operated by AI agents",
       "category": "workflow"
     }
   ]


### PR DESCRIPTION
## Problem

`claude plugin marketplace add clkao/spacedock` currently fails with a schema validation error:

```
Adding marketplace…✘ Failed to add marketplace: Failed to parse marketplace file at
.../clkao-spacedock/.claude-plugin/marketplace.json: Invalid schema:
  owner: Invalid input: expected object, received undefined
  plugins.0.source: Invalid input
```

This blocks the documented install path `claude plugin marketplace add clkao/spacedock && claude plugin install spacedock`.

## Root cause

The existing `.claude-plugin/marketplace.json` has two schema violations, plus two fields that don't belong at the marketplace level:

1. **Missing required `owner` object** — Claude Code's marketplace schema requires a top-level `owner: { name: ... }` block.
2. **Malformed `plugins[].source`** — it was written as a nested object `{ "source": "local", "path": "./plugins/spacedock" }`, which isn't a valid source shape. Valid shapes are a plain string path (for in-repo plugins) or a typed object like `{ "source": "github", "repo": "..." }` / `{ "source": "git-subdir", ... }` / etc.
3. **`interface` at the marketplace level** — this field belongs in `plugin.json` (where it already exists), not `marketplace.json`.
4. **`policy` at the plugin entry level** — not part of the marketplace schema.

Reference: https://code.claude.com/docs/en/plugin-marketplaces

## Fix

Before:

```json
{
  "name": "spacedock",
  "interface": { "displayName": "Spacedock" },
  "plugins": [
    {
      "name": "spacedock",
      "source": { "source": "local", "path": "./plugins/spacedock" },
      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
      "category": "workflow"
    }
  ]
}
```

After:

```json
{
  "name": "spacedock",
  "owner": { "name": "CL Kao" },
  "plugins": [
    {
      "name": "spacedock",
      "source": "./plugins/spacedock",
      "description": "Turn directories of markdown files into structured workflows operated by AI agents",
      "category": "workflow"
    }
  ]
}
```

## Verification

Locally validated against Claude Code's parser:

```
$ claude plugin marketplace add /path/to/spacedock
Adding marketplace…✔ Successfully added marketplace: spacedock (declared in user settings)
```

Happy to adjust `owner.name` (used "CL Kao" matching `plugin.json`'s `author.name`) or add back any marketplace-level metadata if there's a field I missed.