### PR TITLE
Fix marketplace.json to match Claude Code schema

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,19 +1,13 @@
 {
   "name": "spacedock",
-  "interface": {
-    "displayName": "Spacedock"
+  "owner": {
+    "name": "CL Kao"
   },
   "plugins": [
     {
       "name": "spacedock",
-      "source": {
-        "source": "local",
-        "path": "./plugins/spacedock"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
+      "source": "./plugins/spacedock",
+      "description": "Turn directories of markdown files into structured workflows operated by AI agents",
       "category": "workflow"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,19 +1,13 @@
 {
   "name": "spacedock",
-  "interface": {
-    "displayName": "Spacedock"
+  "owner": {
+    "name": "CL Kao"
   },
   "plugins": [
     {
       "name": "spacedock",
-      "source": {
-        "source": "local",
-        "path": "./plugins/spacedock"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
+      "source": "./plugins/spacedock",
+      "description": "Turn directories of markdown files into structured workflows operated by AI agents",
       "category": "workflow"
     }
   ]

--- a/tests/test_codex_plugin_packaging.py
+++ b/tests/test_codex_plugin_packaging.py
@@ -56,18 +56,12 @@ def test_codex_marketplace_matches_approved_contract():
 
     marketplace = read_json(".agents/plugins/marketplace.json")
     assert marketplace["name"] == "spacedock"
-    assert marketplace["interface"] == {"displayName": "Spacedock"}
+    assert marketplace["owner"] == {"name": "CL Kao"}
     assert marketplace["plugins"] == [
         {
             "name": "spacedock",
-            "source": {
-                "source": "local",
-                "path": "./plugins/spacedock",
-            },
-            "policy": {
-                "installation": "AVAILABLE",
-                "authentication": "ON_INSTALL",
-            },
+            "source": "./plugins/spacedock",
+            "description": "Turn directories of markdown files into structured workflows operated by AI agents",
             "category": "workflow",
         }
     ]


### PR DESCRIPTION
Continuation of #114 — adds the authoritative-file + test updates that complete the fix.

## Summary

`claude plugin marketplace add clkao/spacedock` was failing with schema validation errors (missing `owner`, invalid `source` shape). PR #114 from @ijac13 correctly diagnosed and fixed the user-facing `.claude-plugin/marketplace.json` mirror.

This PR preserves that commit and adds the two pieces needed for completeness:

- `.agents/plugins/marketplace.json` is the authoritative source per `scripts/release.sh` (it syncs `.agents/` → `.claude-plugin/`). Without fixing it too, the next release would regenerate the mirror with the broken schema.
- `tests/test_codex_plugin_packaging.py` pinned the old invalid schema as an approved contract; updated to pin the correct shape.

## Commits

1. `79a3b13` — @ijac13's fix to `.claude-plugin/marketplace.json`
2. `0820529` — authoritative file + test update (co-authored with @ijac13)

## Evidence

- Static suite: 426 passed, 22 deselected, 10 subtests passed. Packaging tests 7/7.
- Contributor's own validation: `claude plugin marketplace add` now succeeds.

Closes #114

Co-Authored-By: Karen Hsieh <ijac.wei@gmail.com>