### PR TITLE
feat(engine): stage skill: property — programmatic plugin skill binding

### DIFF
--- a/skills/commission/SKILL.md
+++ b/skills/commission/SKILL.md
@@ -219,6 +219,7 @@ stages:
       {feedback-to: {target_stage} — if this stage has a rejection flow that bounces back to {target_stage}. Infer from the rejection_flow derived in Confirm Design.}
       {gate: true — if this stage is an approval gate}
       {agent: {agent-name} — only if {captain} specifies a non-default agent for this stage. Omit to use the default ensign. The value is the agent file basename without .md.}
+      {skill: {plugin:skill-name} — only if the stage should load a specific skill from an installed plugin. The ensign will invoke Skill("{plugin:skill-name}") before starting stage work. Omit for stages without a plugin-provided skill.}
     - name: {last_stage}
       terminal: true
   transitions:
@@ -262,6 +263,8 @@ Every {entity_label} file has YAML frontmatter. Fields are documented below; see
 {For EACH stage in the ordered list, generate a subsection:}
 
 ### `{stage_name}`
+
+{If this stage has a `skill:` property: "**Load skill:** Invoke `Skill(\"{skill_value}\")` before starting stage work." Otherwise omit this line.}
 
 {A sentence describing who sets this status and what it means for an {entity_label} to be in this stage.}
 

--- a/skills/commission/bin/claude-team
+++ b/skills/commission/bin/claude-team
@@ -215,11 +215,19 @@ def cmd_build(args):
     if stage_subsection is None:
         return _build_error(f"stage '{stage}' heading not found in {readme_path}")
 
-    # --- Prompt Assembly (9 components) ---
+    # --- Prompt Assembly (10 components) ---
     prompt_parts = []
 
     # 1. Header
     prompt_parts.append(f'You are working on: {entity_title}\n\nStage: {stage}\n')
+
+    # 1.5. Skill loading instruction (conditional)
+    stage_skill = stage_meta.get('skill')
+    if stage_skill:
+        prompt_parts.append(
+            f'**Before starting work**, invoke `Skill("{stage_skill}")` to load '
+            f'the stage skill. Follow its instructions for this stage.\n'
+        )
 
     # 2. Stage definition
     prompt_parts.append(f'### Stage definition:\n\n{stage_subsection}\n')

--- a/skills/commission/bin/status
+++ b/skills/commission/bin/status
@@ -258,7 +258,7 @@ def parse_stages_block(filepath):
             'terminal': state.get('terminal', 'false').lower() == 'true',
             'initial': state.get('initial', 'false').lower() == 'true',
         }
-        for optional_field in ('feedback-to', 'agent', 'fresh', 'model'):
+        for optional_field in ('feedback-to', 'agent', 'fresh', 'model', 'skill'):
             if optional_field in state:
                 stage[optional_field] = state[optional_field]
         result.append(stage)


### PR DESCRIPTION
## Problem

Workflow plugins (like ship-flow) provide stage-specific skills, but there's no structured way for the engine to tell an ensign which plugin skill to load for a given stage. Currently ensigns improvise from README prose — unreliable for complex stages.

## Solution

Three small changes that enable structured skill binding:

### 1. Commission template: `skill:` stage property
```yaml
- name: plan
  skill: ship-flow:ship-plan   # ← new
  model: sonnet
```
Commission now documents `skill:` alongside existing properties (worktree, gate, agent, model).

### 2. Status parser: preserve `skill:` in stage dict
```python
# bin/status line 261
for optional_field in ('feedback-to', 'agent', 'fresh', 'model', 'skill'):
```
One field added to the optional list.

### 3. claude-team build: inject `Skill()` into ensign prompt
```python
stage_skill = stage_meta.get('skill')
if stage_skill:
    prompt_parts.append(
        f'**Before starting work**, invoke `Skill("{stage_skill}")` to load '
        f'the stage skill. Follow its instructions for this stage.\n'
    )
```
Ensign prompt now gets a structured Skill() instruction before the stage definition.

## Verified

Tested against a live ship-flow workflow (4 stages: sharp/plan/execute/ship). All 4 stages correctly inject their `Skill()` call into the ensign prompt with the matching model dispatch.

## Diff

- `skills/commission/SKILL.md`: +3 lines (skill: property in template + prose instruction)
- `skills/commission/bin/status`: +1 field in optional_fields list
- `skills/commission/bin/claude-team`: +6 lines (skill injection in prompt assembly)

Total: **10 insertions, 2 deletions.**