### PR TITLE
Separate acceptance criteria (entity-level) from checklist (stage-level)

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -72,6 +72,7 @@ A task moves to ideation when a pilot starts fleshing out the idea: clarify the 
 - **Inputs:** The seed description and any relevant context (existing code, user feedback, related tasks)
 - **Outputs:** A fleshed-out task body with problem statement, proposed approach, acceptance criteria, and a test plan
   - Acceptance criteria must include how each criterion will be tested
+  - Acceptance criteria are **entity-level** — they describe properties of the finished task (end-state facts a future reader can verify), not stage actions. Items that describe stage work ("run X 3 times", "produce analysis Y") belong in the stage report's checklist, not in the AC list. If an AC item reads as an imperative verb phrase ("Run …", "Produce …", "Capture …"), rewrite it as the end-state property it produces ("Test X passes reliably", "Analysis Y concludes with cited evidence", "File Z contains string W").
   - Test plan: what tests verify the implementation, estimated cost/complexity, whether E2E tests are needed
   - For template changes: specific before/after wording, not just "change X"
 - **Good:** Clearly scoped, actionable, addresses a real need, considers edge cases, test plan proportional to risk (static checks for simple wording, E2E for behavioral guarantees)
@@ -97,6 +98,7 @@ A task moves to validation after implementation is complete. The work here is to
     - Use `tests/README.md` to choose the right harness and entrypoint before running tests
     - Prefer the stable repo-level entrypoints when they fit the task: `make test-static` for the offline suite, `make test-live-claude` / `make test-live-codex` for tier-aware live runs, and `make test-e2e TEST=... RUNTIME=...` for single-file runtime-specific E2E checks
   - Verify each acceptance criterion with evidence
+  - Pull every `**AC-N**` item from the entity body's `## Acceptance criteria` section; reproduce the evidence cited in each "Verified by" clause; flag any AC without evidence. Validation's job is cross-check, not re-derive.
   - A PASSED/REJECTED recommendation
 - **Good:** Thorough testing against acceptance criteria, clear evidence of pass/fail, honest assessment
 - **Bad:** Rubber-stamping without actually testing, ignoring failing edge cases, validating against wrong criteria
@@ -154,7 +156,14 @@ score:
 worktree:
 ---
 
-Description of this task and what it aims to achieve.
+Brief description of this task and what it aims to achieve.
+
+## Acceptance criteria
+
+Each AC names a property of the finished entity (not a stage action) and how it is verified.
+
+**AC-1 — {End-state property.}**
+Verified by: {grep / test name / file path / command a future reader can reproduce.}
 ```
 
 ## Testing Resources

--- a/docs/plans/separate-ac-from-checklist-entity-vs-stage.md
+++ b/docs/plans/separate-ac-from-checklist-entity-vs-stage.md
@@ -322,3 +322,43 @@ All three Edit blocks applied on branch `spacedock-ensign/separate-ac-from-check
 2. **Edit 2 (`docs/plans/README.md`) — DONE.** Ideation-stage AC-entity-level paragraph appended as a new bullet under the existing "Acceptance criteria must include how each criterion will be tested" bullet. Validation-stage cross-check sentence appended as a bullet after "Verify each acceptance criterion with evidence". Task Template at the bottom replaced per spec — `## Acceptance criteria` heading with the "Each AC names a property" guidance line and a `**AC-1 — ...**` exemplar followed by a `Verified by:` line. AC-3 grep (`Acceptance criteria are \*\*entity-level\*\*`), AC-4 grep (`Pull every \`\*\*AC-N\*\*\` item`), and AC-5 grep (`## Acceptance criteria` inside the Task Template) all pass.
 
 3. **Edit 3 (`skills/commission/SKILL.md`) + static test — DONE.** Generated-README Entity Template mirrors the new `## Acceptance criteria` block (heading, guidance line, AC-1 exemplar, `Verified by:` line). The per-stage Outputs-guidance sentence is appended inline in the existing Outputs bullet description (same paragraph as the "become checklist items at dispatch time" prose). `tests/test_commission_template.py` gains `test_entity_label_template_has_acceptance_criteria_block` asserting the generated-template block contains the `## Acceptance criteria` heading, the `Each AC names a property` guidance, and a `Verified by:` exemplar line. `make test-static` green (438 passed). AC-6 grep returns matches; AC-8 holds.
+
+## Stage Report — validation
+
+### Summary
+
+Re-verified all 7 mechanical ACs against the branch `spacedock-ensign/separate-ac-from-checklist-entity-vs-stage` at commit `9b05fa8c`: every static grep matches as specified, `make test-static` is green (438 passed, 22 deselected), and #192's linchpin paragraph is preserved verbatim. The required behavioral spot-check ran on haiku against the `spike-gated` fixture with an AC block injected in the new template shape — evidence confirms both behavioral signals #193 prescribes: (a) the FO-built dispatch checklist is distinct from the entity's AC list (the checklist has 1 stage-level linchpin, the entity retains 2 entity-level ACs; neither copies the other), and (b) the FO's gate-review prose names AC Coverage as a separate section from the DONE/SKIPPED/FAILED checklist accounting. The spot-check cost ~$0.01 (1,119k cache-read, 75 output tokens on haiku, 65s wallclock). Recommendation: PASSED.
+
+### Checklist
+
+1. **All 7 mechanical ACs re-verified with concrete evidence — DONE.**
+   - **AC-1** (shared-core distinguishes AC from checklist): `grep` for `Entity-level acceptance criteria (AC) are properties of the finished entity` in `skills/first-officer/references/first-officer-shared-core.md` → 1 match at line 62 (inside the `## Dispatch` section, appended to the #192 linchpin paragraph).
+   - **AC-2** (shared-core gate review adds AC coverage cross-check): `grep` for `AC coverage cross-check` in the same file → 1 match at line 98 inside `## Completion and Gates`. The prose references `**AC-N**` anchors and names the REJECT condition.
+   - **AC-3** (`docs/plans/README.md` ideation names the AC-vs-stage-action rule): `grep` for `Acceptance criteria are \*\*entity-level\*\*` → 1 match at line 75 under `### ideation`.
+   - **AC-4** (validation stage names the cross-check): `grep` for `Pull every \`\*\*AC-N\*\*\` item` → 1 match at line 101 under `### validation`.
+   - **AC-5** (task template includes `## Acceptance criteria` section): read of `docs/plans/README.md` lines 155–167 confirms the Task Template ends with a `## Acceptance criteria` heading, the "Each AC names a property" guidance, and a `**AC-1 — {End-state property.}**` exemplar with a `Verified by:` line.
+   - **AC-6** (commission SKILL.md generated template mirrors the convention): `grep` for `## Acceptance criteria` in `skills/commission/SKILL.md` → match at line 326; `grep` for `Each AC names a property` → match at line 328. Commission-harness test `test_entity_label_template_has_acceptance_criteria_block` at `tests/test_commission_template.py:62` asserts the heading, the guidance line, and the `Verified by:` exemplar all appear inside the `## {Entity_label} Template` block.
+   - **AC-8** (static suite green): `make test-static` returns `438 passed, 22 deselected, 10 subtests passed in 20.16s`.
+   - **#192 linchpin preservation cross-check:** `grep` for `at most 3 items` and `Name what separates a good outcome from a ceremonial one` in shared-core → both return 1 match each at line 62 (same paragraph as the AC-distinction sentence). #192's framing is intact verbatim.
+
+2. **Behavioral spot-check executed — DONE.** Single live FO dispatch on haiku against a throwaway `spike-gated` fixture, with an AC block in the new `## Acceptance criteria` template shape injected into `test-entity.md` (AC-1: "task body contains 'Spike test complete.'", AC-2: "task file remains valid UTF-8"). The FO dispatched an ensign into the `work` stage (gated), and the ensign returned; the FO produced its gate review. Evidence for both required signals:
+
+   **(a) FO-built checklist is distinct from the entity's AC list.** The dispatch prompt's `### Completion checklist` section contains exactly one item — `1. Append a brief summary of work to the task body containing "Spike test complete."` — derived from the stage's `Outputs:` bullet, not enumerated from the entity's AC block. The entity body (which the ensign reads directly per the `Read the entity file at ...` instruction) retains its 2 entity-level ACs (AC-1, AC-2). The prompt does NOT copy the `## Acceptance criteria` block into the checklist, which is the correct behavior under #193 — AC items are entity-level properties the ensign reads from the body, not stage-level checklist work.
+
+   **(b) FO gate-review names AC-coverage separately from DONE/SKIPPED/FAILED accounting.** The FO's gate-review text contains two distinctly labeled sections:
+
+   > **Assessment:** 1 done, 0 skipped, 0 failed.
+   >
+   > **AC Coverage:**
+   > - **AC-1** (task body contains "Spike test complete.") — ✓ Verified. Work Summary section on line 17 contains the exact required string.
+   > - **AC-2** (task file remains valid UTF-8) — ✓ Verified. File is well-formed UTF-8.
+   >
+   > **Recommendation: APPROVE**
+
+   The `**Assessment:**` line is the checklist accounting; the `**AC Coverage:**` subsection is the AC cross-check with per-AC reproduction evidence. They are distinctly named and independently reported — exactly the discipline `## Completion and Gates` prescribes after Edit 1 landed.
+
+   Run metadata: claude-haiku-4-5-20251001, 65s wallclock, 14,787 input / 75 output tokens, 1,119,461 cache-read, FO exit 0. Cost well under the $1-3 behavioral budget.
+
+### Verdict
+
+**PASSED.** All 7 mechanical ACs verified with reproducible evidence; behavioral spot-check demonstrates both prescribed signals (checklist-distinct-from-AC, gate-review-separates-AC-coverage) in a live FO dispatch; #192's linchpin framing survives the rewrite verbatim; static suite green. The entity is ready to advance past validation.

--- a/docs/plans/separate-ac-from-checklist-entity-vs-stage.md
+++ b/docs/plans/separate-ac-from-checklist-entity-vs-stage.md
@@ -308,3 +308,17 @@ Three blocking amendments from staff review applied in-place on main (non-worktr
 ### Summary
 
 Staff-review blockers landed. Edit 1 now merges lines 60 and 62 verbatim + append, preserving #192's linchpin framing while adding the AC-vs-checklist distinction. AC-7's `Verified by:` clause is now internally consistent (captain judgment for a meta-AC). Behavioral spot-check is required, not optional. Non-blocking nice-to-haves from the staff review (diagnostic-class exemplar, legacy-entities note, evidence-reproduction cost cap) were captain-deferred and remain out of scope.
+
+## Stage Report — implementation
+
+### Summary
+
+All three Edit blocks applied on branch `spacedock-ensign/separate-ac-from-checklist-entity-vs-stage`. Edit 1 preserved #192's linchpin paragraph verbatim and appended the AC-vs-checklist sentence; item 2 was rewritten to drop the conflated source wording. Edit 2 appended two sentences (ideation + validation) and replaced the Task Template with one that includes a `## Acceptance criteria` block. Edit 3 mirrored the template block into the commission generator's Entity Template and added the per-stage Outputs-guidance sentence. A new static assertion `test_entity_label_template_has_acceptance_criteria_block` covers AC-6. `make test-static` is green (438 passed, 22 deselected). Committed as `implement: #193 separate AC (entity-level) from checklist (stage-level)` in a single coherent commit.
+
+### Checklist
+
+1. **Edit 1 (shared-core) — DONE.** Line 60 rewritten to the new single sentence framing the checklist as dispatch-specific linchpins sourced from stage `Outputs:` plus stage-appropriate AC advancement. The #192 linchpin paragraph below it is preserved verbatim with the AC-vs-checklist sentence appended as its final sentence. The `AC coverage cross-check` paragraph is added in `## Completion and Gates` directly after the `{N} done, {N} skipped, {N} failed` line. AC-1 grep (`Entity-level acceptance criteria (AC) are properties of the finished entity`) returns 1 match; AC-2 grep (`AC coverage cross-check`) returns 1 match.
+
+2. **Edit 2 (`docs/plans/README.md`) — DONE.** Ideation-stage AC-entity-level paragraph appended as a new bullet under the existing "Acceptance criteria must include how each criterion will be tested" bullet. Validation-stage cross-check sentence appended as a bullet after "Verify each acceptance criterion with evidence". Task Template at the bottom replaced per spec — `## Acceptance criteria` heading with the "Each AC names a property" guidance line and a `**AC-1 — ...**` exemplar followed by a `Verified by:` line. AC-3 grep (`Acceptance criteria are \*\*entity-level\*\*`), AC-4 grep (`Pull every \`\*\*AC-N\*\*\` item`), and AC-5 grep (`## Acceptance criteria` inside the Task Template) all pass.
+
+3. **Edit 3 (`skills/commission/SKILL.md`) + static test — DONE.** Generated-README Entity Template mirrors the new `## Acceptance criteria` block (heading, guidance line, AC-1 exemplar, `Verified by:` line). The per-stage Outputs-guidance sentence is appended inline in the existing Outputs bullet description (same paragraph as the "become checklist items at dispatch time" prose). `tests/test_commission_template.py` gains `test_entity_label_template_has_acceptance_criteria_block` asserting the generated-template block contains the `## Acceptance criteria` heading, the `Each AC names a property` guidance, and a `Verified by:` exemplar line. `make test-static` green (438 passed). AC-6 grep returns matches; AC-8 holds.

--- a/skills/commission/SKILL.md
+++ b/skills/commission/SKILL.md
@@ -266,7 +266,7 @@ Every {entity_label} file has YAML frontmatter. Fields are documented below; see
 {A sentence describing who sets this status and what it means for an {entity_label} to be in this stage.}
 
 - **Inputs:** {What the worker reads to do this stage's work — be specific to the mission}
-- **Outputs:** {What the worker produces — be specific to the mission. Keep bullets concise and verifiable — these become checklist items at dispatch time. Focus on non-obvious requirements that catch skipping, not obvious actions like "write code."}
+- **Outputs:** {What the worker produces — be specific to the mission. Keep bullets concise and verifiable — these become checklist items at dispatch time. Focus on non-obvious requirements that catch skipping, not obvious actions like "write code." Stage-output bullets become checklist items at dispatch; any entity-level end-state properties the stage produces belong under the entity body's `## Acceptance criteria` heading, not in the stage Outputs.}
 - **Good:** {Quality criteria for work done in this stage}
 - **Bad:** {Anti-patterns to avoid in this stage}
 
@@ -321,7 +321,14 @@ issue:
 pr:
 ---
 
-Description of this {entity_label} and what it aims to achieve.
+Brief description of this {entity_label} and what it aims to achieve.
+
+## Acceptance criteria
+
+Each AC names a property of the finished entity (not a stage action) and how it is verified.
+
+**AC-1 — {End-state property.}**
+Verified by: {grep / test name / file path / command a future reader can reproduce.}
 ```
 
 ## Commit Discipline

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -57,9 +57,9 @@ The FO MUST use the runtime-specific dispatch mechanism described in the runtime
 For each entity reported by `status --next`:
 
 1. Read the entity file and the target stage definition.
-2. Build a numbered checklist from stage outputs and entity acceptance criteria.
+2. Build a numbered checklist of dispatch-specific linchpins from the target stage's `Outputs:` bullets and any entity-level acceptance criteria this stage is the natural place to advance. Checklist items are the per-dispatch signals that this stage's contribution is sound; they are not the AC list and are not a work-breakdown.
 
-   The dispatch checklist is a **per-dispatch, stage-level** list of linchpin signals — at most 3 items — that demonstrate this specific dispatch's job is done well. It is distinct from entity-level acceptance criteria. The cap is an upper bound, not a target: 0, 1, 2, or 3 items are all valid; do not pad to reach 3. This is not a work-breakdown. The ensign already knows how to read the entity body, commit before signaling complete, and write a stage report; those are covered by structural conventions and MUST NOT appear in the checklist. Name what separates a good outcome from a ceremonial one.
+   The dispatch checklist is a **per-dispatch, stage-level** list of linchpin signals — at most 3 items — that demonstrate this specific dispatch's job is done well. It is distinct from entity-level acceptance criteria. The cap is an upper bound, not a target: 0, 1, 2, or 3 items are all valid; do not pad to reach 3. This is not a work-breakdown. The ensign already knows how to read the entity body, commit before signaling complete, and write a stage report; those are covered by structural conventions and MUST NOT appear in the checklist. Name what separates a good outcome from a ceremonial one. **Entity-level acceptance criteria (AC) are properties of the finished entity, not stage actions** — they live in the entity body's `## Acceptance criteria` section and are cross-checked at every gate (see `## Completion and Gates`), independent of this checklist's DONE/SKIPPED/FAILED accounting.
 3. Check for obvious conflicts if multiple worktree stages would touch overlapping files.
 4. Determine `dispatch_agent_id` from the stage `agent:` property. Default to `ensign` when absent.
 5. Update main-branch frontmatter for dispatch:
@@ -94,6 +94,8 @@ When a worker completes:
 
 The checklist review produces an explicit count summary:
 - `{N} done, {N} skipped, {N} failed`
+
+**AC coverage cross-check.** Additionally, at every gate, scan the entity body's `## Acceptance criteria` section and confirm each `**AC-N**` item has at least one evidence citation from this stage's report or a prior stage report. Name any AC without evidence; REJECT if this stage was the natural place to address it. This cross-check is independent of checklist DONE/SKIPPED/FAILED accounting — checklist items are dispatch signals, AC items are entity properties.
 
 If the stage is not gated: if terminal, proceed to merge. Otherwise, decide reuse-or-fresh for the next stage.
 

--- a/tests/test_commission_template.py
+++ b/tests/test_commission_template.py
@@ -57,3 +57,25 @@ def test_entity_label_template_section_has_yaml_fence():
     assert "```yaml" in match.group(1), (
         "## {Entity_label} Template section must contain a ```yaml fence"
     )
+
+
+def test_entity_label_template_has_acceptance_criteria_block():
+    text = read_skill()
+    match = re.search(
+        r"^## \{Entity_label\} Template\n(.*?)^## Commit Discipline",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, "Could not find ## {Entity_label} Template section in SKILL.md"
+    body = match.group(1)
+    assert "## Acceptance criteria" in body, (
+        "## {Entity_label} Template must include an '## Acceptance criteria' "
+        "heading so generated workflows inherit the AC convention"
+    )
+    assert "Each AC names a property" in body, (
+        "## {Entity_label} Template must include the 'Each AC names a property' "
+        "guidance line from the AC convention"
+    )
+    assert "Verified by:" in body, (
+        "## {Entity_label} Template must include a 'Verified by:' exemplar line"
+    )


### PR DESCRIPTION
Separate entity-level acceptance criteria (done-ness properties) from per-dispatch stage checklists (linchpins) so ensigns stop treating AC items as deferrable to-dos.

## What changed
- Split shared-core dispatch contract: checklists are per-dispatch linchpins, ACs are entity-level end-state properties
- Add `## Completion and Gates` AC-coverage cross-check at every gate, independent of DONE/SKIPPED/FAILED accounting
- Update workflow README ideation/validation prose plus task template with a `## Acceptance criteria` block
- Mirror the AC template into the commission generator and add a static test for the generated shape

## Evidence
- `make test-static`: 438 passed, 22 deselected — `test_entity_label_template_has_acceptance_criteria_block` added
- Behavioral spot-check: one live haiku FO dispatch (~\$0.01, 65s) confirmed both signals — FO-built checklist distinct from entity AC list; gate review names "AC Coverage" separately from "Assessment"

---
[193](/clkao/spacedock/blob/93cf1f3a/docs/plans/separate-ac-from-checklist-entity-vs-stage.md)