### PR TITLE
fix: default claude-opus-4-7 to 1M context without [1m] suffix

### DIFF
--- a/docs/plans/claude-team-context-budget-opus-4-7-default-1m.md
+++ b/docs/plans/claude-team-context-budget-opus-4-7-default-1m.md
@@ -57,3 +57,25 @@ Unit tests in the same style as existing `context_limit_for_model` coverage (if 
 
 - #203 — surfaced this during cycle-7/cycle-8 ensign orchestration. Multiple ensigns shut down prematurely on false signals.
 - #202 — FO behavior spec + RTM; if it lands first, this fix's AC-3 should land as a requirement entry.
+
+## Stage Report — implementation (2026-04-19)
+
+**Approach:** Option 3 from the entity body — model-family allow-list with config-declared-model trust. Added `NATIVE_1M_MODEL_PREFIXES = ("claude-opus-4-7", "claude-opus-4-8", "claude-opus-4-9", "claude-opus-5")` constant in `skills/commission/bin/claude-team`. Extended `context_limit_for_model` to return `EXTENDED_CONTEXT_LIMIT` when the base model (before any `[...]` suffix) matches any prefix in that tuple. Existing `[1m]` bracket detection preserved for older families.
+
+**Why Option 3 (allow-list):** Version parsing (Option 2) would require a regex contract that's fragile against future naming drift. The allow-list is three lines of data, greps cleanly, and explicit. Opus-4-6 and earlier still need the bracket to opt in, so no old behavior breaks.
+
+**Commits:**
+- 579b1924 — fix: default claude-opus-4-7 context limit to 1M without [1m] suffix
+
+**Test evidence:**
+- `make test-static` → 480 passed, 22 deselected, 10 subtests passed (baseline before change was 476; +4 new assertions: 3 parametrized model-mapping entries for 4-7, 4-7[1m], 4-8 + 1 drift scenario in `TestRuntimeModelDetection.test_opus_4_7_bare_runtime_gets_1m`).
+- Older-model tests unchanged (opus-4-6 → 200k; opus-4-6[1m] → 1M; haiku → 200k; unknown → 200k).
+
+**AC check:**
+- AC-1 — `context_limit_for_model("claude-opus-4-7")` returns 1M. Covered by `TestModelMapping` parametrize.
+- AC-2 — 285k resident tokens on claude-opus-4-7 → `usage_pct: 28.5`, `reuse_ok: true`. Covered by `test_opus_4_7_bare_runtime_gets_1m`.
+- AC-3 — no `config_drift_warning` when config is `opus[1m]` and runtime is bare `claude-opus-4-7`. Covered by same test (`assert "config_drift_warning" not in data`).
+- AC-4 — `claude-opus-4-6` without `[1m]` still 200k; `claude-opus-4-6[1m]` still 1M. Preserved by existing parametrize entries.
+- AC-5 — `make test-static` green.
+
+**PR:** https://github.com/clkao/spacedock/pull/139

--- a/docs/plans/claude-team-context-budget-opus-4-7-default-1m.md
+++ b/docs/plans/claude-team-context-budget-opus-4-7-default-1m.md
@@ -60,15 +60,17 @@ Unit tests in the same style as existing `context_limit_for_model` coverage (if 
 
 ## Stage Report — implementation (2026-04-19)
 
-**Approach:** Option 3 from the entity body — model-family allow-list with config-declared-model trust. Added `NATIVE_1M_MODEL_PREFIXES = ("claude-opus-4-7", "claude-opus-4-8", "claude-opus-4-9", "claude-opus-5")` constant in `skills/commission/bin/claude-team`. Extended `context_limit_for_model` to return `EXTENDED_CONTEXT_LIMIT` when the base model (before any `[...]` suffix) matches any prefix in that tuple. Existing `[1m]` bracket detection preserved for older families.
+**Approach:** Option 1 (allow-list) with empirically-verified entries only. Added `NATIVE_1M_MODELS = frozenset({"claude-opus-4-7"})` constant in `skills/commission/bin/claude-team`. `context_limit_for_model` returns `EXTENDED_CONTEXT_LIMIT` when (a) the model string contains `[1m]` (existing behavior, preserved for opus-4-6 and any future opt-in), or (b) the base model (before any `[...]` suffix) is exactly in `NATIVE_1M_MODELS`. No version parsing, no prefix matching, no speculation about unreleased models.
 
-**Why Option 3 (allow-list):** Version parsing (Option 2) would require a regex contract that's fragile against future naming drift. The allow-list is three lines of data, greps cleanly, and explicit. Opus-4-6 and earlier still need the bracket to opt in, so no old behavior breaks.
+**Scope correction (captain, 2026-04-19):** Initial implementation used a prefix allow-list including `claude-opus-4-8`/`4-9`/`opus-5` — that was speculation. Captain constrained the allow-list to the single model we have empirical evidence for this session (`claude-opus-4-7` at 285k resident → no compaction, no errors). Future models must default to 200k until the empirical check is re-run and the exact string is added.
 
 **Commits:**
-- 579b1924 — fix: default claude-opus-4-7 context limit to 1M without [1m] suffix
+- 579b1924 — fix: default claude-opus-4-7 context limit to 1M without [1m] suffix (initial, over-broad prefix list)
+- ab232ad3 — report: #207 implementation stage report appended
+- (next commit) — scope correction: constrain allow-list to claude-opus-4-7 only + add no-speculation test
 
 **Test evidence:**
-- `make test-static` → 480 passed, 22 deselected, 10 subtests passed (baseline before change was 476; +4 new assertions: 3 parametrized model-mapping entries for 4-7, 4-7[1m], 4-8 + 1 drift scenario in `TestRuntimeModelDetection.test_opus_4_7_bare_runtime_gets_1m`).
+- `make test-static` → 481 passed, 22 deselected, 10 subtests passed (baseline before change was 476; +5 new assertions: 4 parametrized model-mapping entries for 4-7 (→1M), 4-7[1m] (→1M), 4-8 (→200k locks no-speculation), 4-8[1m] (→1M bracket still works) + 1 drift scenario in `TestRuntimeModelDetection.test_opus_4_7_bare_runtime_gets_1m`).
 - Older-model tests unchanged (opus-4-6 → 200k; opus-4-6[1m] → 1M; haiku → 200k; unknown → 200k).
 
 **AC check:**
@@ -77,5 +79,7 @@ Unit tests in the same style as existing `context_limit_for_model` coverage (if 
 - AC-3 — no `config_drift_warning` when config is `opus[1m]` and runtime is bare `claude-opus-4-7`. Covered by same test (`assert "config_drift_warning" not in data`).
 - AC-4 — `claude-opus-4-6` without `[1m]` still 200k; `claude-opus-4-6[1m]` still 1M. Preserved by existing parametrize entries.
 - AC-5 — `make test-static` green.
+
+**No-speculation lock-in:** `claude-opus-4-8` → 200k parametrize entry encodes the discipline. The `claude-opus-4-8[1m]` → 1M entry shows the bracket opt-in still works for any future model without adding it to the allow-list.
 
 **PR:** https://github.com/clkao/spacedock/pull/139

--- a/skills/commission/bin/claude-team
+++ b/skills/commission/bin/claude-team
@@ -407,12 +407,9 @@ DEFAULT_CONTEXT_LIMIT = 200000
 EXTENDED_CONTEXT_LIMIT = 1000000
 THRESHOLD_PCT = 60
 
-NATIVE_1M_MODEL_PREFIXES = (
+NATIVE_1M_MODELS = frozenset({
     "claude-opus-4-7",
-    "claude-opus-4-8",
-    "claude-opus-4-9",
-    "claude-opus-5",
-)
+})
 
 
 def find_subagent_jsonl(name: str) -> str | None:
@@ -900,15 +897,17 @@ def context_limit_for_model(model: str) -> int:
     """Infer the context window size from the model name.
 
     Claude Code encodes opt-in extended-context variants with a bracket suffix
-    like `[1m]` (e.g. `claude-opus-4-6[1m]`). Models whose base name matches a
-    native-1M family (claude-opus-4-7 and later) default to 1M regardless of
-    the bracket. Everything else defaults to 200k, the standard Claude context
-    window and safe fallback for unknown models.
+    like `[1m]` (e.g. `claude-opus-4-6[1m]`). Models whose base name appears in
+    NATIVE_1M_MODELS default to 1M regardless of the bracket — this list only
+    contains model strings we have empirically verified to be 1M-native on
+    production Claude Code, not predictions about unreleased models. Everything
+    else defaults to 200k, the standard Claude context window and safe fallback
+    for unknown models.
     """
     if "[1m]" in model:
         return EXTENDED_CONTEXT_LIMIT
     base = model.split("[", 1)[0]
-    if base.startswith(NATIVE_1M_MODEL_PREFIXES):
+    if base in NATIVE_1M_MODELS:
         return EXTENDED_CONTEXT_LIMIT
     return DEFAULT_CONTEXT_LIMIT
 

--- a/skills/commission/bin/claude-team
+++ b/skills/commission/bin/claude-team
@@ -407,6 +407,13 @@ DEFAULT_CONTEXT_LIMIT = 200000
 EXTENDED_CONTEXT_LIMIT = 1000000
 THRESHOLD_PCT = 60
 
+NATIVE_1M_MODEL_PREFIXES = (
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-opus-4-9",
+    "claude-opus-5",
+)
+
 
 def find_subagent_jsonl(name: str) -> str | None:
     """Find the most recently modified subagent jsonl matching the given name.
@@ -890,14 +897,18 @@ def lookup_model(name: str) -> str | None:
 
 
 def context_limit_for_model(model: str) -> int:
-    """Infer the context window size from the model name suffix.
+    """Infer the context window size from the model name.
 
-    Claude Code encodes extended-context variants with a bracket suffix like
-    `[1m]` (e.g. `claude-opus-4-6[1m]`). Any model name containing `[1m]` is
-    the 1M-context variant. Everything else defaults to 200k, which is the
-    standard Claude context window and safe fallback for unknown models.
+    Claude Code encodes opt-in extended-context variants with a bracket suffix
+    like `[1m]` (e.g. `claude-opus-4-6[1m]`). Models whose base name matches a
+    native-1M family (claude-opus-4-7 and later) default to 1M regardless of
+    the bracket. Everything else defaults to 200k, the standard Claude context
+    window and safe fallback for unknown models.
     """
     if "[1m]" in model:
+        return EXTENDED_CONTEXT_LIMIT
+    base = model.split("[", 1)[0]
+    if base.startswith(NATIVE_1M_MODEL_PREFIXES):
         return EXTENDED_CONTEXT_LIMIT
     return DEFAULT_CONTEXT_LIMIT
 

--- a/tests/test_claude_team.py
+++ b/tests/test_claude_team.py
@@ -195,9 +195,13 @@ class TestModelMapping:
         ("claude-haiku-4-5-20251001", 200000),
         ("unknown-model-xyz", 200000),
         ("unknown-model-xyz[1m]", 1000000),  # heuristic works on unknown models too
-        ("claude-opus-4-7", 1000000),  # native-1M family, no bracket needed
+        ("claude-opus-4-7", 1000000),  # empirically verified 1M-native, no bracket needed
         ("claude-opus-4-7[1m]", 1000000),
-        ("claude-opus-4-8", 1000000),  # future native-1M family
+        # Future models default to 200k until empirically verified. Locks in the
+        # no-speculation discipline: when a new opus ships, someone re-runs the
+        # check and adds the exact string to NATIVE_1M_MODELS.
+        ("claude-opus-4-8", 200000),
+        ("claude-opus-4-8[1m]", 1000000),  # bracket opt-in still works for any future model
     ])
     def test_model_context_limits(self, tmp_path, model, expected_limit):
         usage = {

--- a/tests/test_claude_team.py
+++ b/tests/test_claude_team.py
@@ -195,6 +195,9 @@ class TestModelMapping:
         ("claude-haiku-4-5-20251001", 200000),
         ("unknown-model-xyz", 200000),
         ("unknown-model-xyz[1m]", 1000000),  # heuristic works on unknown models too
+        ("claude-opus-4-7", 1000000),  # native-1M family, no bracket needed
+        ("claude-opus-4-7[1m]", 1000000),
+        ("claude-opus-4-8", 1000000),  # future native-1M family
     ])
     def test_model_context_limits(self, tmp_path, model, expected_limit):
         usage = {
@@ -497,6 +500,25 @@ class TestRuntimeModelDetection:
         assert data["model"] == "opus[1m]"
         assert data["context_limit"] == 1000000
         assert "config_fallback_warning" in data
+
+    def test_opus_4_7_bare_runtime_gets_1m(self, tmp_path):
+        """Runtime reports bare claude-opus-4-7 → native-1M family, 1M limit, no drift warning."""
+        usage = {
+            "input_tokens": 285000,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
+        make_jsonl_fixture(tmp_path, "spacedock-ensign-foo-impl", usage, model="claude-opus-4-7")
+        make_team_config(tmp_path, "test-team", "spacedock-ensign-foo-impl", "opus[1m]")
+
+        result = run_context_budget(tmp_path, "spacedock-ensign-foo-impl")
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["model"] == "claude-opus-4-7"
+        assert data["context_limit"] == 1000000
+        assert data["usage_pct"] == pytest.approx(28.5)
+        assert data["reuse_ok"] is True
+        assert "config_drift_warning" not in data
 
 
 # --- Build subcommand tests ---


### PR DESCRIPTION
## Motivation

`context_limit_for_model` in `skills/commission/bin/claude-team` required a literal `[1m]` bracket suffix in the runtime model string to pick 1M. Runtime Claude Code consistently reports bare `claude-opus-4-7`, which is natively 1M — so the helper returned 200k and produced false `usage_pct: 142.7` readings plus `reuse_ok: false` on ensigns that were structurally fine. Multiple cycle-3/cycle-4 ensigns this session were shut down prematurely on these false signals, each shutdown costing a fresh-dispatch cycle.

## What changed

- Added `NATIVE_1M_MODEL_PREFIXES` allow-list (`claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-4-9`, `claude-opus-5`) in `skills/commission/bin/claude-team`.
- `context_limit_for_model` now returns `EXTENDED_CONTEXT_LIMIT` (1M) when the base model matches that list, even without the `[1m]` bracket suffix.
- Existing bracket-suffix detection preserved for opus-4-6 and earlier, where the bracket is the real opt-in signal.
- Added tests: `claude-opus-4-7` → 1M, `claude-opus-4-7[1m]` → 1M, `claude-opus-4-8` → 1M (parametrized in `TestModelMapping`); plus `test_opus_4_7_bare_runtime_gets_1m` covering AC-3 (no `config_drift_warning` when config says `opus[1m]` and runtime reports bare `claude-opus-4-7`).
- Older-model behavior unchanged: `claude-opus-4-6` without `[1m]` still returns 200k; `claude-opus-4-6[1m]` still returns 1M.

## Evidence

- `make test-static` → 480 passed, 22 deselected, 10 subtests passed (was 476 baseline; +4 new assertions).
- Offline tests only; no live LLM needed.

## Audit

- Entity: [docs/plans/claude-team-context-budget-opus-4-7-default-1m.md](./docs/plans/claude-team-context-budget-opus-4-7-default-1m.md)

Closes #207