### PR TITLE
Codex FO runtime: add preemptible wait mode for subagent completions

### DIFF
--- a/docs/plans/codex-fo-preemptible-wait-mode.md
+++ b/docs/plans/codex-fo-preemptible-wait-mode.md
@@ -1,7 +1,7 @@
 ---
 id: 216
 title: "Codex FO runtime: add preemptible wait mode for subagent completions"
-status: validation
+status: implementation
 source: "GitHub issue #148, 2026-04-27 - local mitigation for openai/codex#15723 completion wakeup limitation"
 started: 2026-04-27T18:27:05Z
 completed:
@@ -219,3 +219,10 @@ Implemented the Codex preemptible wait contract locally in the FO runtime docs a
 Validation selected the static/parser commands called out by the entity and the stable offline suite from `tests/README.md`. Live Codex E2E was not run because the entity states it is optional for this slice unless real interactive interruption handling is claimed; the implementation claims static plus deterministic transcript coverage.
 
 Recommendation: PASSED
+
+### Feedback Cycles
+
+- Cycle 1 (2026-04-27): Captain rejected the validation gate despite a PASSED recommendation. Required changes:
+  - Do not make detailed wait-instruction prose a first-class implementation or test target; Codex should already provide the basic interrupt affordance.
+  - Focus the implementation and tests on continuous waiting behavior after interruption: preserve the wait set, process the interruption, and resume waiting for unresolved ensigns unless the captain says pause or stop.
+  - Avoid static tests that match user-facing prose. Prefer behavioral/parser fixtures that prove same-wait-set resume and FO-collected/uncollected state.

--- a/docs/plans/codex-fo-preemptible-wait-mode.md
+++ b/docs/plans/codex-fo-preemptible-wait-mode.md
@@ -182,3 +182,16 @@ Fleshed out the entity into a Codex-specific preemptible wait design. The plan k
 ### Summary
 
 Revised the ideation spec for the captain and staff review feedback. The wait hint is now precise and concise, ordinary prose avoids raw handles, and the testable behavior is plural wait-set preservation with FO-uncollected completion reconciliation.
+
+## Stage Report: implementation
+
+- DONE: Codex runtime guidance implements the approved preemptible-wait contract, including the precise Esc interruption hint, plural wait sets, FO-uncollected unresolved semantics, and raw-handle suppression in ordinary wait-status prose.
+  Evidence: `skills/first-officer/references/codex-first-officer-runtime.md` adds `## Codex Preemptible Wait Mode` and updates the ordinary wait-status example to omit raw handles.
+- DONE: Static and/or parser fixture coverage proves interruption-resume on the same FO-uncollected wait set, including a multi-handle case, without depending on unsupported Codex completion wakeups.
+  Evidence: `tests/test_agent_content.py`, `tests/test_test_lib_helpers.py`, and `scripts/test_lib.py` cover the contract plus a two-handle resumed wait after `preempted_by_user_input`; completion notification is only side-channel evidence.
+- DONE: Verification evidence is sufficient for independent validation: changed files, commands run, and any live-E2E deferral rationale are recorded in the stage report.
+  Evidence: Changed files are `docs/plans/codex-fo-preemptible-wait-mode.md`, `skills/first-officer/references/codex-first-officer-runtime.md`, `scripts/test_lib.py`, `tests/test_agent_content.py`, and `tests/test_test_lib_helpers.py`; commands run: `uv run --with pytest python tests/test_agent_content.py -q` (49 passed), `uv run --with pytest python -m pytest tests/test_test_lib_helpers.py -q` (19 passed), and `git diff --check` (passed). Live Codex E2E was not run because this task's accepted proof is static plus deterministic transcript coverage and unsupported completion wakeups must not be simulated as the authority.
+
+### Summary
+
+Implemented the Codex preemptible wait contract locally in the FO runtime docs and added deterministic test coverage for interrupted same-wait-set resume. The parser fixture proves a plural wait set resumes on the same FO-uncollected handles even when a completion notification appears during the interruption.

--- a/docs/plans/codex-fo-preemptible-wait-mode.md
+++ b/docs/plans/codex-fo-preemptible-wait-mode.md
@@ -195,3 +195,27 @@ Revised the ideation spec for the captain and staff review feedback. The wait hi
 ### Summary
 
 Implemented the Codex preemptible wait contract locally in the FO runtime docs and added deterministic test coverage for interrupted same-wait-set resume. The parser fixture proves a plural wait set resumes on the same FO-uncollected handles even when a completion notification appears during the interruption.
+
+## Stage Report: validation
+
+- DONE: Applicable validation commands are selected from `tests/README.md`, rerun in the worktree, and reported with exact pass/fail results.
+  Evidence: `uv run --with pytest python tests/test_agent_content.py -q` -> 49 passed; `uv run --with pytest python -m pytest tests/test_test_lib_helpers.py -q` -> 19 passed; `git diff --check` -> passed; `make test-static` -> 514 passed, 25 deselected, 10 subtests passed.
+- DONE: Every AC-1 through AC-6 is verified with concrete evidence or explicitly failed; the review checks for unsupported Codex wakeup reliance and raw-handle user-prose leakage.
+  Evidence: AC-1 through AC-6 are accounted for below; no failing criteria found. The entity has `Tested by` clauses rather than literal `Verified by` clauses, so validation reproduced the cited test evidence from those clauses.
+- DONE: The validation report gives a clear PASSED or REJECTED recommendation and preserves implementation ownership by not making unrequested fixes.
+  Evidence: No implementation files were changed during validation; this stage report is the only validation edit.
+
+### Acceptance Criteria
+
+- AC-1: PASSED. `skills/first-officer/references/codex-first-officer-runtime.md` defines `background worker`, `preemptible wait`, and `post-wait completion handling`; `tests/test_agent_content.py` asserts those states and the blocked-step/explicit-wait boundary.
+- AC-2: PASSED. The runtime wait-intent contract lists worker label, `dispatch_agent_id`, runtime handle, entity path/id, stage name, blocked reason, collection state, and source; `tests/test_test_lib_helpers.py` proves resumed waits reuse `["item_23", "item_42"]`.
+- AC-3: PASSED. The wait-status text names both FO-owned labels, gives the blocked reason, includes the exact Esc interruption sentence, and the fixture assertions reject `item_23`/`item_42` in user-facing wait status.
+- AC-4: PASSED. The parser fixture orders initial wait, user interruption, `preempted_by_user_input`, completion notification side-channel evidence, resumed wait on the same handles, and final collection evidence with no drops or replacements.
+- AC-5: PASSED. Static checks cover `completed`, `timed_out`, `failed`, `preempted_by_user_input`, `paused_by_user`, and `clarification_required`.
+- AC-6: PASSED. Runtime text says completion notifications are opportunistic only and do not schedule an autonomous FO turn; parser helper only treats completion as collected after a resumed wait on live handles.
+
+### Summary
+
+Validation selected the static/parser commands called out by the entity and the stable offline suite from `tests/README.md`. Live Codex E2E was not run because the entity states it is optional for this slice unless real interactive interruption handling is claimed; the implementation claims static plus deterministic transcript coverage.
+
+Recommendation: PASSED

--- a/docs/plans/codex-fo-preemptible-wait-mode.md
+++ b/docs/plans/codex-fo-preemptible-wait-mode.md
@@ -19,7 +19,7 @@ Codex currently does not wake the calling agent when background subprocesses or 
 
 Spacedock still has a separate, local problem it can solve now. In interactive Codex sessions, task 138 established that workers should stay in the background by default unless the next orchestration step is blocked on their result. Task 140 established that completed gated or critical-path work becomes the next required action. Task 131 established that critical-path reused workers must be awaited on the same handle after `send_input`. The missing piece is what happens when the first officer intentionally decides that the next step is blocked and starts waiting, then the captain interrupts before the worker result is collected.
 
-Today that wait intent is only implicit in the ongoing `wait_agent` call or in surrounding prose. If the captain interrupts the session with a question or instruction, the FO can lose the fact that it was still blocked on a specific set of worker results. The result is either drift back into ordinary conversation or an accidental reliance on unsupported completion wakeups. The desired end state is an explicit, preemptible `wait_agent` mode: the FO records the live wait set, tells the captain what it is waiting on and that interruption is safe, treats non-stopping captain input as `preempted_by_user_input`, handles the input, and then resumes `wait_agent` for the same FO-uncollected wait set unless the captain explicitly pauses/stops or the interruption creates a clarification blocker.
+If the captain interrupts the session with a question or instruction while the FO is waiting for ensigns, the FO can lose the fact that the workflow is still blocked on those same ensigns. The result is either drift back into ordinary conversation or an accidental reliance on unsupported completion wakeups. The desired behavior is simple: when the FO is waiting for ensigns and receives non-stopping captain input, it processes that input and then resumes `wait_agent` for the same unresolved ensigns unless the captain explicitly pauses/stops or the interruption creates a clarification blocker.
 
 Completion notifications remain useful as opportunistic evidence when Codex surfaces them, but they are not the authority for this task. Under the current upstream limitation, resumed `wait_agent` collection on the live handle is the authoritative path.
 
@@ -27,111 +27,79 @@ Completion notifications remain useful as opportunistic evidence when Codex surf
 
 In scope:
 
-- Codex first-officer runtime guidance for an explicit preemptible wait mode when the entity's next orchestration step is blocked on worker results.
-- The live wait-intent fields the FO must preserve for every wait-set entry: worker label, logical worker id, runtime handle, entity/stage, blocked reason, and whether the result is still FO-uncollected.
-- Operator-facing wait/resume communication that makes the blocked state understandable without turning detailed wait-instruction prose into a contract. Runtime handles belong in internal wait intent, logs, and tests.
-- Outcome labels for wait attempts: `completed`, `timed_out`, `failed`, `preempted_by_user_input`, `paused_by_user`, and `clarification_required`.
-- Static checks, parser helpers, and transcript fixtures that prove interrupted waits preserve every wait-set entry and resume `wait_agent` on the same FO-uncollected handles without requiring Codex to wake the FO on completion.
+- Minimal Codex first-officer runtime guidance for interrupted waits.
+- Behavioral transcript/parser coverage proving interruption handling resumes `wait_agent` on the same unresolved ensign handles.
+- The boundary that completion notifications are useful context only and do not replace resumed `wait_agent` collection.
 
 Out of scope:
 
 - Solving `openai/codex#15723` or depending on completion notifications to schedule a new turn.
 - Reopening task 153's completion-notification preemption path while that upstream wakeup limitation remains open.
-- Reversing task 138 by foregrounding every dispatched worker in interactive mode. Preemptible waiting applies only after the FO determines the next step is blocked on worker output or the captain explicitly asks it to wait.
-- Changing shared first-officer scheduling semantics unless a tiny cross-reference is required. The behavioral contract is Codex-specific.
+- Reversing task 138 by foregrounding every dispatched worker in interactive mode. Interrupted-wait handling applies only after the FO is already waiting because the next step is blocked on worker output or the captain explicitly asked it to wait.
+- Changing shared first-officer scheduling semantics unless a tiny cross-reference is required. The behavioral guidance is Codex-specific.
 - Adding polling sleeps, background watcher scripts, or prompt-level behavioral coaching in the Codex invocation helper as the proof mechanism.
 
 ## Proposed Approach
 
-1. Define `wait_agent` as an explicit Codex FO mode.
+1. Amend Codex runtime guidance with the intended FO behavior.
 
-   Add a Codex runtime section in `skills/first-officer/references/codex-first-officer-runtime.md` that distinguishes three states:
+   Add a short Codex runtime instruction: if the FO is waiting for ensigns and the captain sends a non-stopping message, handle that input and then resume `wait_agent` for the same unresolved ensigns unless the captain says pause or stop. If the input creates a clarification blocker, ask for clarification instead of continuing to wait. Completion notifications during the interruption are useful context only; they do not replace resumed `wait_agent` collection on the same worker handles.
 
-   - background worker: spawned and tracked, but the current interactive turn is not blocked on it
-   - preemptible wait: the FO is blocked on one or more FO-uncollected wait-set entries and is intentionally calling `wait_agent`
-   - post-wait completion handling: `wait_agent` returned completion evidence and task-140/task-131 rules decide the next workflow action
-
-   The contract should say that entering preemptible wait requires a recorded wait intent before the `wait_agent` call. That intent is a wait set, not a scalar handle. For each entry it includes the FO-owned worker label, `dispatch_agent_id`, runtime handle, entity path/id, stage name, blocked reason, and whether the wait came from a fresh dispatch or same-handle reuse after `send_input`.
-
-   `Unresolved` means FO-uncollected, not necessarily still running. If a worker completes while the FO is answering an interruption, that wait-set entry remains unresolved until the FO resumes `wait_agent` on the same handle and collects/reconciles the completion evidence. Completion notifications during the interruption are opportunistic evidence only; they do not replace the resumed collection path.
-
-2. Communicate wait/resume state without an exact prose contract.
-
-   Before or while waiting, the FO should communicate the blocked wait/resume state in ordinary prose: which wait-set entries are blocking the next orchestration step, that non-stopping captain input will be handled, and that waiting will resume afterward.
-
-   Detailed wait-instruction wording is not a first-class contract. Codex already owns the basic interruption affordance, so runtime docs may mention safe interruption/resume but tests must not match exact user-facing wait text.
-
-   The behavior under test is not the exact wording. The proof should stay on preserving the internal wait set, processing the interruption, and resuming `wait_agent` for every still-FO-uncollected entry.
-
-3. Define interruption and resume semantics.
-
-   If captain input arrives while any wait-set entry is FO-uncollected, the FO treats the current wait attempt as `preempted_by_user_input`, not as `completed`, `failed`, or `timed_out`. It then handles the input according to ordinary FO rules:
-
-   - If the captain says pause, stop, cancel, or changes the requested workflow target, the wait intent becomes `paused_by_user` or is superseded explicitly.
-   - If the captain asks a question that can be answered without changing the blocked workflow, the FO answers and resumes `wait_agent` for every still-FO-uncollected entry in the prior wait set.
-   - If the captain's input dispatches additional worker work that becomes part of the same blocked next step, the FO updates the wait set, reports the new worker labels in user-facing prose, and records the new handles internally before waiting again.
-   - If the interruption reveals missing information required before waiting can continue, the mode becomes `clarification_required` and the FO must not pretend it is still waiting.
-
-   This keeps user interruption support local and explicit without asking Codex to deliver unsupported autonomous wakeups.
-
-4. Add focused tests and fixtures around the contract.
-
-   Static runtime-content checks should live in `tests/test_agent_content.py` and assert that the Codex FO runtime names the preemptible wait mode, wait-intent fields, interruption outcome labels, same-handle resume rule, and unsupported-notification boundary.
+2. Add focused transcript/parser coverage.
 
    Parser or transcript tests should use `scripts/test_lib.py` / `CodexLogParser` or a small sibling helper if that keeps the assertions clean. The useful fixture shape is a synthetic Codex JSONL/transcript sequence with:
 
    - an initial `wait_agent`/`wait` call for handles `item_23` and `item_42`
-   - a user interruption before the FO has collected/reconciled completion for every wait-set entry
-   - an FO response that marks or narrates `preempted_by_user_input`
-   - a resumed `wait_agent`/`wait` call with the same `receiver_thread_ids` values for every FO-uncollected wait-set entry
-   - eventual completion evidence for those same handles, including the case where one worker completed during the interruption but still had to be collected/reconciled by the resumed wait
+   - a user interruption while the FO is waiting
+   - an FO response showing it processed the interruption
+   - a resumed `wait_agent`/`wait` call with the same `receiver_thread_ids` values
+   - eventual completion evidence for those same handles, including the case where one worker completed during the interruption but still had to be collected by the resumed wait
 
    Existing live surfaces to verify or extend include `tests/test_codex_packaged_agent_e2e.py` for same-handle reuse expectations and `tests/test_test_lib_helpers.py` for parser-level fixtures. A new narrow fixture file is acceptable if the existing helpers do not naturally represent user interruption events.
 
-5. Keep live E2E claims proportional.
+3. Keep live E2E claims proportional.
 
    A true interactive Codex PTY test would be valuable if the harness can deterministically inject user input while a `wait_agent` call is pending. That should be treated as medium/high cost and optional for the first implementation slice unless the runtime already exposes a stable boundary. The required proof for this task can be a transcript fixture because the task is intentionally avoiding unsupported completion-wakeup behavior.
 
 ## Acceptance criteria
 
-**AC-1 - The Codex first-officer runtime defines preemptible wait as a distinct mode from background workers and post-completion handling.**
+**AC-1 - The Codex first-officer runtime contains only a minimal interrupted-wait behavior amendment.**
 
-Tested by static content checks in `tests/test_agent_content.py` against `skills/first-officer/references/codex-first-officer-runtime.md`, asserting the three states are present and that preemptible wait applies only when the next orchestration step is blocked or the captain explicitly asks to wait.
+Verified by review of `skills/first-officer/references/codex-first-officer-runtime.md`: it should instruct the FO to process non-stopping captain input during a wait and then resume waiting for the same unresolved ensigns, without defining a detailed Codex wait-state schema.
 
-**AC-2 - The Codex wait-intent contract preserves enough identity to resume every FO-uncollected worker in the wait set.**
+**AC-2 - Interruption during waiting resumes `wait_agent` on the same unresolved ensign handles.**
 
-Tested by static checks and a transcript/parser fixture asserting every wait-set entry includes worker label, logical id, runtime handle, entity/stage, blocked reason, and FO-collected/uncollected state, and that resumed waits reuse the same `receiver_thread_ids` values after interruption.
+Tested by a transcript/parser fixture asserting the initial wait handles, user interruption, FO handling response, and resumed wait handles appear in order and that the resumed wait uses the same `receiver_thread_ids` values.
 
-**AC-3 - User-facing wait status communicates blocked wait/resume state without an exact wording contract.**
+**AC-3 - Completion notifications do not replace resumed wait collection.**
 
-Tested by contract review plus transcript/parser coverage that focuses on behavior and intent: the FO records the blocked wait set, handles non-stopping interruption as `preempted_by_user_input`, and resumes waiting for still-FO-uncollected entries. Tests must not match exact user-facing wait wording; runtime docs may mention safe interruption/resume only as ordinary communication guidance.
+Tested by the same transcript/parser fixture including a completion notification during the interruption before the resumed `wait_agent`; completion is considered collected only after the resumed wait returns completion evidence.
 
-**AC-4 - Non-stopping captain input during a pending wait is represented as `preempted_by_user_input` and resumes waiting on the same FO-uncollected wait set.**
+**AC-4 - Pause/stop and clarification blockers remain exceptions to resumed waiting.**
 
-Tested by a focused transcript or parser test where the initial wait on handles `H1` and `H2`, a user interruption, the FO answer, and the resumed wait on the still-FO-uncollected handles appear in order before completion evidence is reconciled. The test must fail if the resumed wait uses replacement handles, treats the interruption as completion/failure, drops any FO-uncollected wait-set entry, or skips resumed collection because a completion notification appeared during the interruption.
+Verified by runtime guidance review: if the captain says pause or stop, the FO should not resume waiting; if the interruption creates a clarification blocker, it should ask rather than continue waiting.
 
-**AC-5 - Wait outcomes distinguish preemption from completion, timeout, failure, user pause/stop, and clarification blockers.**
+**AC-5 - Prose-doc tests are not used to prove the new wait behavior.**
 
-Tested by static contract checks plus parser/fixture assertions for outcome labels: `completed`, `timed_out`, `failed`, `preempted_by_user_input`, `paused_by_user`, and `clarification_required`.
+Verified by test review: `tests/test_agent_content.py` must not include a prose-matching test for this interrupted-wait behavior; behavioral proof lives in parser/transcript tests.
 
 **AC-6 - The finished behavior does not depend on unsupported Codex completion wakeups.**
 
-Tested by static checks that completion notifications are described as opportunistic evidence only, plus review of the focused fixture/test to confirm the authoritative collection path is resumed `wait_agent` on live handles, not a simulated autonomous completion notification that schedules a new FO turn or replaces FO reconciliation.
+Tested by review of the focused fixture/test to confirm the authoritative collection path is resumed `wait_agent` on live handles, not a simulated autonomous completion notification that schedules a new FO turn or replaces FO reconciliation.
 
 ## Test Plan
 
-Static contract tests are low cost and should be required:
+Static regression tests remain useful for unrelated runtime structure, but they are not the proof for this behavior:
 
 - `uv run --with pytest python tests/test_agent_content.py -q`
-- Assertions for preemptible wait mode, plural wait-intent fields, outcome labels, same-handle wait-set resume semantics, and the explicit boundary around `openai/codex#15723`.
-- Static tests must stay structural. They should not match exact user-facing wait-status text, detailed interruption instructions, or handle-display wording.
+- Do not add or keep prose-doc assertions for the interrupted-wait behavior. In particular, do not check for a detailed wait-state schema, exact user-facing wait wording, or runtime-doc prose as the behavioral proof.
 
 Parser and transcript fixture tests are low/medium cost and should be the primary behavioral proof:
 
-- Add or extend a focused parser test, likely in `tests/test_test_lib_helpers.py`, using synthetic Codex JSONL/transcript events that show wait set `{H1, H2}`, user interruption, `preempted_by_user_input`, resumed wait on every still-FO-uncollected entry in `{H1, H2}`, and eventual reconciliation of completion evidence.
+- Add or extend a focused parser test, likely in `tests/test_test_lib_helpers.py`, using synthetic Codex JSONL/transcript events that show wait handles `{H1, H2}`, user interruption, FO processing the interruption, resumed wait on `{H1, H2}`, and eventual reconciliation of completion evidence.
 - If needed, add a small helper in `scripts/test_lib.py` or `CodexLogParser` to extract wait/preemption/resume sequences by handle without scattering ad hoc JSON traversal across tests.
-- The fixture must include the case where one worker completes during the interruption but remains FO-uncollected until the resumed wait. It must not model completion notifications as the thing that wakes the FO; the proof is the preserved wait intent and explicit resumed `wait_agent`.
-- Parser/transcript assertions should prove same-wait-set resume and FO-collected/uncollected state transitions. They may include user-facing wait text as fixture context, but should not assert exact phrasing.
+- The fixture must include the case where one worker completes during the interruption but remains unresolved until the resumed wait. It must not model completion notifications as the thing that wakes the FO; the proof is the explicit resumed `wait_agent`.
+- Parser/transcript assertions should prove same-handle resumed waiting and final resolution after the resumed wait. They may include user-facing wait text as fixture context, but should not assert exact phrasing.
 
 Live Codex E2E is optional for the first implementation slice and should only be claimed if the harness can deterministically inject input during a pending `wait_agent` call:
 
@@ -144,7 +112,7 @@ Regression checks for related same-handle behavior should remain in scope when t
 - `uv run --with pytest python tests/test_codex_packaged_agent_e2e.py -q` when live Codex credentials/runtime budget are available, because it already checks `send_input` followed by `wait` on the same worker handle.
 - `uv run --with pytest python tests/test_rejection_flow.py --runtime codex` only if implementation changes feedback/reuse routing behavior. This task should not otherwise broaden into task 153 or shared rejection-flow scheduling.
 
-E2E need: not mandatory for acceptance unless implementation claims real interactive interruption handling beyond the transcript fixture. The minimum acceptable proof is static contract coverage plus a deterministic fixture showing interruption-resume on the same FO-uncollected wait set without unsupported wakeups.
+E2E need: not mandatory for acceptance unless implementation claims real interactive interruption handling beyond the transcript fixture. The minimum acceptable proof is a deterministic fixture showing interruption-resume on the same unresolved ensign handles without unsupported wakeups.
 
 ## Related
 
@@ -282,3 +250,16 @@ PASSED. Detailed wait-instruction prose is not a contract or static prose-matchi
 Validation reproduced the cited static and parser evidence, then ran the stable offline suite from `tests/README.md`. Live Codex E2E was not run because the entity treats it as optional unless deterministic interactive interruption handling is claimed, and this implementation claims static plus deterministic transcript coverage.
 
 Recommendation: PASSED
+
+## Stage Report: implementation (cycle 3)
+
+- DONE: Runtime guidance was simplified to an intended-behavior amendment rather than a detailed Codex wait-state contract.
+  Evidence: `skills/first-officer/references/codex-first-officer-runtime.md` now has a short `## Interrupted Waits` rule and no detailed wait-intent schema.
+- DONE: Prose-doc tests for the new wait behavior were removed; behavioral/parser tests prove resumed waiting after interruption on the same unresolved ensigns.
+  Evidence: `tests/test_agent_content.py` no longer contains `test_codex_runtime_docs_define_preemptible_wait_mode_contract` or the continuity/outcome prose test; `tests/test_test_lib_helpers.py` uses `CodexLogParser.interrupted_wait_sequences()` to prove interruption, same-handle resumed wait, notification-as-context, and final resolution.
+- DONE: Verification evidence is recorded with commands and results.
+  Evidence: `uv run --with pytest python tests/test_agent_content.py -q` (47 passed), `uv run --with pytest python -m pytest tests/test_test_lib_helpers.py -q` (19 passed), targeted schema/prose-test grep over runtime/tests/scripts found no matches, and `git diff --check` passed.
+
+### Summary
+
+Reworked the implementation around the captain's narrower behavior: interrupted FO waits resume on the same unresolved ensign handles unless the captain pauses/stops or creates a clarification blocker. Removed the runtime-doc prose tests and stripped the parser fixture/helper of the detailed wait-intent schema.

--- a/docs/plans/codex-fo-preemptible-wait-mode.md
+++ b/docs/plans/codex-fo-preemptible-wait-mode.md
@@ -186,6 +186,21 @@ Validation selected the static/parser commands called out by the entity and the 
 
 Recommendation: PASSED
 
+## Stage Report: implementation (cycle 4)
+
+- DONE: Change Codex first-officer behavior so after every fresh Codex dispatch/spawn it immediately enters a preemptible wait on the dispatched handle(s), and the operator-facing prompt/status explicitly says Esc/message interruption is safe and that wait will resume unless the captain says pause/stop.
+  Evidence: `skills/first-officer/references/codex-first-officer-runtime.md` now requires immediate post-`spawn_agent` preemptible `wait_agent` and explicit Esc/message-safe resume-unless-pause/stop status.
+- DONE: Create a failing live Codex test locally for this dispatch-immediate-wait policy before changing runtime docs.
+  Evidence: New `tests/test_codex_dispatch_immediate_wait.py` failed RED before runtime changes: 4 passed, 2 failed; failures were missing immediate wait on the returned handle and missing interruption-safe wait status.
+- DONE: Fix the `test_gate_guardrail` issue where Codex live output says `waiting for human approval` but the assertion only accepts `waiting for approval`.
+  Evidence: `tests/test_gate_guardrail.py` now accepts optional `human` between `for` and `approval`; `uv run pytest tests/test_gate_guardrail.py --runtime codex -v` passed.
+- DONE: Validate locally with focused tests, including the new live test and `tests/test_gate_guardrail.py --runtime codex`. Also run static/content tests you touch.
+  Evidence: `uv run pytest tests/test_codex_dispatch_immediate_wait.py --runtime codex -v` passed; `uv run pytest tests/test_gate_guardrail.py --runtime codex -v` passed; `uv run --with pytest python tests/test_agent_content.py -q` passed; `uv run --with pytest python -m pytest tests/test_codex_packaged_agent_ids.py tests/test_test_lib_helpers.py -q` passed; `git diff --check` passed.
+
+### Summary
+
+Updated the Codex FO runtime from background-after-fresh-dispatch to immediate preemptible waiting on returned worker handles. Added a non-xfail live Codex regression for that behavior, pinned the Codex live harness to the local worktree plugin/runtime so it tests branch changes, and widened the gate guardrail approval regex for `waiting for human approval`.
+
 ### Feedback Cycles
 
 - Cycle 1 (2026-04-27): Captain rejected the validation gate despite a PASSED recommendation. Required changes:

--- a/docs/plans/codex-fo-preemptible-wait-mode.md
+++ b/docs/plans/codex-fo-preemptible-wait-mode.md
@@ -1,7 +1,7 @@
 ---
 id: 216
 title: "Codex FO runtime: add preemptible wait mode for subagent completions"
-status: implementation
+status: validation
 source: "GitHub issue #148, 2026-04-27 - local mitigation for openai/codex#15723 completion wakeup limitation"
 started: 2026-04-27T18:27:05Z
 completed:

--- a/docs/plans/codex-fo-preemptible-wait-mode.md
+++ b/docs/plans/codex-fo-preemptible-wait-mode.md
@@ -29,7 +29,7 @@ In scope:
 
 - Codex first-officer runtime guidance for an explicit preemptible wait mode when the entity's next orchestration step is blocked on worker results.
 - The live wait-intent fields the FO must preserve for every wait-set entry: worker label, logical worker id, runtime handle, entity/stage, blocked reason, and whether the result is still FO-uncollected.
-- Operator-facing wait status wording that names every FO-owned worker label in the wait set, names the blocked reason, and uses the precise safe-interruption/resume hint. Ordinary wait-status prose should not expose raw handle UUIDs; runtime handles belong in internal wait intent, logs, and tests.
+- Operator-facing wait/resume communication that makes the blocked state understandable without turning detailed wait-instruction prose into a contract. Runtime handles belong in internal wait intent, logs, and tests.
 - Outcome labels for wait attempts: `completed`, `timed_out`, `failed`, `preempted_by_user_input`, `paused_by_user`, and `clarification_required`.
 - Static checks, parser helpers, and transcript fixtures that prove interrupted waits preserve every wait-set entry and resume `wait_agent` on the same FO-uncollected handles without requiring Codex to wake the FO on completion.
 
@@ -55,17 +55,13 @@ Out of scope:
 
    `Unresolved` means FO-uncollected, not necessarily still running. If a worker completes while the FO is answering an interruption, that wait-set entry remains unresolved until the FO resumes `wait_agent` on the same handle and collects/reconciles the completion evidence. Completion notifications during the interruption are opportunistic evidence only; they do not replace the resumed collection path.
 
-2. Make operator-facing wait status concrete.
+2. Communicate wait/resume state without an exact prose contract.
 
-   Before waiting, the FO should emit a concise status line shaped like:
+   Before or while waiting, the FO should communicate the blocked wait/resume state in ordinary prose: which wait-set entries are blocking the next orchestration step, that non-stopping captain input will be handled, and that waiting will resume afterward.
 
-   ```text
-   Waiting on `048-implementation/Ensign feedback cycle 2` and `054-implementation/Ensign` before I can advance the blocked workflow state. You can send a message and hit Esc to interrupt safely; I’ll process the additional feedback and resume waiting for ensigns unless you tell me to pause or stop.
-   ```
+   Detailed wait-instruction wording is not a first-class contract. Codex already owns the basic interruption affordance, so runtime docs may mention safe interruption/resume but tests must not match exact user-facing wait text.
 
-   The exact leading clause can vary with the blocked reason and labels, but the safety hint should use this precise shape: `You can send a message and hit Esc to interrupt safely; I’ll process the additional feedback and resume waiting for ensigns unless you tell me to pause or stop.` Avoid weaker wording that permits interruption without the safety and resume guarantee.
-
-   User-facing wait status should name every worker label in the wait set. It should not print raw handle UUIDs in ordinary prose. Handles remain required in internal wait intent, logs, and tests so same-handle collection can be verified.
+   The behavior under test is not the exact wording. The proof should stay on preserving the internal wait set, processing the interruption, and resuming `wait_agent` for every still-FO-uncollected entry.
 
 3. Define interruption and resume semantics.
 
@@ -106,9 +102,9 @@ Tested by static content checks in `tests/test_agent_content.py` against `skills
 
 Tested by static checks and a transcript/parser fixture asserting every wait-set entry includes worker label, logical id, runtime handle, entity/stage, blocked reason, and FO-collected/uncollected state, and that resumed waits reuse the same `receiver_thread_ids` values after interruption.
 
-**AC-3 - User-facing wait status names every FO-owned worker label, gives the blocked reason, and uses the precise safe-interruption hint without raw handles.**
+**AC-3 - User-facing wait status communicates blocked wait/resume state without an exact wording contract.**
 
-Tested by static wording checks or transcript fixture assertions that the wait status prominently includes every FO-owned worker label in the wait set, says why the FO is blocked, includes the sentence shape `You can send a message and hit Esc to interrupt safely; I’ll process the additional feedback and resume waiting for ensigns unless you tell me to pause or stop.`, and does not expose raw handle UUIDs in ordinary user-facing prose.
+Tested by contract review plus transcript/parser coverage that focuses on behavior and intent: the FO records the blocked wait set, handles non-stopping interruption as `preempted_by_user_input`, and resumes waiting for still-FO-uncollected entries. Tests must not match exact user-facing wait wording; runtime docs may mention safe interruption/resume only as ordinary communication guidance.
 
 **AC-4 - Non-stopping captain input during a pending wait is represented as `preempted_by_user_input` and resumes waiting on the same FO-uncollected wait set.**
 
@@ -127,13 +123,15 @@ Tested by static checks that completion notifications are described as opportuni
 Static contract tests are low cost and should be required:
 
 - `uv run --with pytest python tests/test_agent_content.py -q`
-- Assertions for preemptible wait mode, plural wait-intent fields, wait-status content, outcome labels, same-handle wait-set resume wording, raw-handle suppression in ordinary prose, and the explicit boundary around `openai/codex#15723`.
+- Assertions for preemptible wait mode, plural wait-intent fields, outcome labels, same-handle wait-set resume semantics, and the explicit boundary around `openai/codex#15723`.
+- Static tests must stay structural. They should not match exact user-facing wait-status text, detailed interruption instructions, or handle-display wording.
 
 Parser and transcript fixture tests are low/medium cost and should be the primary behavioral proof:
 
 - Add or extend a focused parser test, likely in `tests/test_test_lib_helpers.py`, using synthetic Codex JSONL/transcript events that show wait set `{H1, H2}`, user interruption, `preempted_by_user_input`, resumed wait on every still-FO-uncollected entry in `{H1, H2}`, and eventual reconciliation of completion evidence.
 - If needed, add a small helper in `scripts/test_lib.py` or `CodexLogParser` to extract wait/preemption/resume sequences by handle without scattering ad hoc JSON traversal across tests.
 - The fixture must include the case where one worker completes during the interruption but remains FO-uncollected until the resumed wait. It must not model completion notifications as the thing that wakes the FO; the proof is the preserved wait intent and explicit resumed `wait_agent`.
+- Parser/transcript assertions should prove same-wait-set resume and FO-collected/uncollected state transitions. They may include user-facing wait text as fixture context, but should not assert exact phrasing.
 
 Live Codex E2E is optional for the first implementation slice and should only be claimed if the harness can deterministically inject input during a pending `wait_agent` call:
 
@@ -170,23 +168,23 @@ Fleshed out the entity into a Codex-specific preemptible wait design. The plan k
 
 ## Stage Report: ideation (cycle 2)
 
-- DONE: Make the wait-mode hint explicit that interruption is safe.
-  Evidence: `## Proposed Approach` now requires the concise Esc-based safety/resume sentence and rejects weaker interruption-only wording.
+- DONE: Make the wait-mode communication explicit that interruption/resume state should be clear.
+  Evidence: This earlier cycle added detailed wait communication; cycle 2 repair supersedes any exact wording contract and keeps only behavioral guidance.
 - DONE: Multi-handle wait-set coverage is implied but not strongly tested.
   Evidence: `## Scope Boundary`, AC-2, AC-4, and the parser/transcript fixture plan now require every label and internal handle in a plural wait set to be preserved and resumed.
 - DONE: Define `unresolved` as FO-uncollected, not necessarily still running.
   Evidence: `## Proposed Approach` defines unresolved as FO-uncollected and requires resumed `wait_agent` collection even when a worker completes during the interruption.
-- DONE: Clarify that raw handle UUIDs should not appear in ordinary wait-status prose.
-  Evidence: `## Scope Boundary`, the wait-status example, and AC-3 keep handles in internal wait intent/logs/tests while user-facing status names worker labels.
+- DONE: Clarify that runtime handles belong in internal wait intent/logs/tests for same-handle verification.
+  Evidence: Cycle 2 repair keeps internal-handle preservation and removes user-facing prose matching as an acceptance target.
 
 ### Summary
 
-Revised the ideation spec for the captain and staff review feedback. The wait hint is now precise and concise, ordinary prose avoids raw handles, and the testable behavior is plural wait-set preservation with FO-uncollected completion reconciliation.
+Revised the ideation spec for the captain and staff review feedback. Cycle 2 repair supersedes the earlier wording-specific communication target; the testable behavior remains plural wait-set preservation with FO-uncollected completion reconciliation.
 
 ## Stage Report: implementation
 
-- DONE: Codex runtime guidance implements the approved preemptible-wait contract, including the precise Esc interruption hint, plural wait sets, FO-uncollected unresolved semantics, and raw-handle suppression in ordinary wait-status prose.
-  Evidence: `skills/first-officer/references/codex-first-officer-runtime.md` adds `## Codex Preemptible Wait Mode` and updates the ordinary wait-status example to omit raw handles.
+- DONE: Codex runtime guidance implements the approved preemptible-wait contract, including plural wait sets and FO-uncollected unresolved semantics.
+  Evidence: `skills/first-officer/references/codex-first-officer-runtime.md` adds `## Codex Preemptible Wait Mode`; cycle 2 repair removes the rejected prose-specific contract from current requirements.
 - DONE: Static and/or parser fixture coverage proves interruption-resume on the same FO-uncollected wait set, including a multi-handle case, without depending on unsupported Codex completion wakeups.
   Evidence: `tests/test_agent_content.py`, `tests/test_test_lib_helpers.py`, and `scripts/test_lib.py` cover the contract plus a two-handle resumed wait after `preempted_by_user_input`; completion notification is only side-channel evidence.
 - DONE: Verification evidence is sufficient for independent validation: changed files, commands run, and any live-E2E deferral rationale are recorded in the stage report.
@@ -200,7 +198,7 @@ Implemented the Codex preemptible wait contract locally in the FO runtime docs a
 
 - DONE: Applicable validation commands are selected from `tests/README.md`, rerun in the worktree, and reported with exact pass/fail results.
   Evidence: `uv run --with pytest python tests/test_agent_content.py -q` -> 49 passed; `uv run --with pytest python -m pytest tests/test_test_lib_helpers.py -q` -> 19 passed; `git diff --check` -> passed; `make test-static` -> 514 passed, 25 deselected, 10 subtests passed.
-- DONE: Every AC-1 through AC-6 is verified with concrete evidence or explicitly failed; the review checks for unsupported Codex wakeup reliance and raw-handle user-prose leakage.
+- DONE: Every AC-1 through AC-6 is verified with concrete evidence or explicitly failed; the review checks for unsupported Codex wakeup reliance and wait-set reconciliation.
   Evidence: AC-1 through AC-6 are accounted for below; no failing criteria found. The entity has `Tested by` clauses rather than literal `Verified by` clauses, so validation reproduced the cited test evidence from those clauses.
 - DONE: The validation report gives a clear PASSED or REJECTED recommendation and preserves implementation ownership by not making unrequested fixes.
   Evidence: No implementation files were changed during validation; this stage report is the only validation edit.
@@ -209,7 +207,7 @@ Implemented the Codex preemptible wait contract locally in the FO runtime docs a
 
 - AC-1: PASSED. `skills/first-officer/references/codex-first-officer-runtime.md` defines `background worker`, `preemptible wait`, and `post-wait completion handling`; `tests/test_agent_content.py` asserts those states and the blocked-step/explicit-wait boundary.
 - AC-2: PASSED. The runtime wait-intent contract lists worker label, `dispatch_agent_id`, runtime handle, entity path/id, stage name, blocked reason, collection state, and source; `tests/test_test_lib_helpers.py` proves resumed waits reuse `["item_23", "item_42"]`.
-- AC-3: PASSED. The wait-status text names both FO-owned labels, gives the blocked reason, includes the exact Esc interruption sentence, and the fixture assertions reject `item_23`/`item_42` in user-facing wait status.
+- AC-3: SUPERSEDED. This validation was based on the rejected prose-specific AC-3; current AC-3 focuses on blocked wait/resume state and avoids exact user-facing wait-text assertions.
 - AC-4: PASSED. The parser fixture orders initial wait, user interruption, `preempted_by_user_input`, completion notification side-channel evidence, resumed wait on the same handles, and final collection evidence with no drops or replacements.
 - AC-5: PASSED. Static checks cover `completed`, `timed_out`, `failed`, `preempted_by_user_input`, `paused_by_user`, and `clarification_required`.
 - AC-6: PASSED. Runtime text says completion notifications are opportunistic only and do not schedule an autonomous FO turn; parser helper only treats completion as collected after a resumed wait on live handles.
@@ -230,7 +228,7 @@ Recommendation: PASSED
 ## Stage Report: implementation (cycle 2)
 
 - DONE: Detailed wait-instruction prose is no longer a static/prose-matching contract; runtime docs focus on behavior and wait-set continuity.
-  Evidence: `skills/first-officer/references/codex-first-officer-runtime.md` removes the exact interruption sentence and raw-handle prose rule, replacing them with behavioral wait/resume guidance.
+  Evidence: `skills/first-officer/references/codex-first-officer-runtime.md` removes wording-specific status rules, replacing them with behavioral wait/resume guidance.
 - DONE: Tests prove continuous waiting after interruption through parser/transcript behavior, not exact user-facing prose matching.
   Evidence: `tests/test_agent_content.py` no longer checks exact wait-status wording; `tests/test_test_lib_helpers.py` and `scripts/test_lib.py` assert same-handle resume, initial FO-uncollected handles, FO-collected handles after resumed wait, and no dropped/replacement handles.
 - DONE: Verification evidence is recorded with commands and results.
@@ -239,3 +237,16 @@ Recommendation: PASSED
 ### Summary
 
 Reworked the cycle 1 implementation to keep Codex preemptible wait behavioral rather than prose-driven. The runtime contract now centers on preserving and resuming the FO-uncollected wait set, and the fixture proof covers continuous waiting through interruption without relying on exact user-facing wait text.
+
+## Stage Report: implementation (cycle 2 repair)
+
+- DONE: Stale prose-contract language in the entity body was removed or reframed.
+  Evidence: Current `## Scope Boundary`, `## Proposed Approach`, AC-3, and `## Test Plan` now state that detailed wait-instruction prose is not contractual and that behavioral/parser proof owns wait continuity.
+- DONE: Tests/runtime docs were checked for exact user-facing wait-prose matching and remain behavior-focused.
+  Evidence: `skills/first-officer/references/codex-first-officer-runtime.md`, `tests/test_agent_content.py`, `tests/test_test_lib_helpers.py`, and `scripts/test_lib.py` have no remaining exact wait-hint or wait-status prose assertions; static tests remain structural and parser tests assert same-wait-set resume plus FO-collected/uncollected state.
+- DONE: Verification commands were rerun or a clear rationale is given for targeted verification.
+  Evidence: Targeted verification rerun for this docs-alignment repair: wait-prose grep over runtime/tests/scripts found no matches, `uv run --with pytest python tests/test_agent_content.py -q` passed, `uv run --with pytest python -m pytest tests/test_test_lib_helpers.py -q` passed, and `git diff --check` passed.
+
+### Summary
+
+Repaired the entity body so the accepted requirements match the captain feedback: exact wait-instruction wording is no longer a contract, while wait-set continuity remains the tested behavior. Runtime docs and tests were checked again and remain focused on preserving/resuming FO-uncollected waits rather than matching user-facing prose.

--- a/docs/plans/codex-fo-preemptible-wait-mode.md
+++ b/docs/plans/codex-fo-preemptible-wait-mode.md
@@ -263,3 +263,31 @@ Recommendation: PASSED
 ### Summary
 
 Reworked the implementation around the captain's narrower behavior: interrupted FO waits resume on the same unresolved ensign handles unless the captain pauses/stops or creates a clarification blocker. Removed the runtime-doc prose tests and stripped the parser fixture/helper of the detailed wait-intent schema.
+
+## Stage Report: validation (cycle 3)
+
+- DONE: Applicable validation commands are selected from `tests/README.md`, rerun in the worktree, and reported with exact pass/fail results.
+  Evidence: `uv run --with pytest python tests/test_agent_content.py -q` -> 47 passed; `uv run --with pytest python -m pytest tests/test_test_lib_helpers.py -q` -> 19 passed; targeted prose/schema grep over runtime/tests/scripts -> no matches; `git diff --check` -> passed; `make test-static` -> 512 passed, 25 deselected, 10 subtests passed.
+- DONE: Every AC-1 through AC-6 is verified with concrete evidence or explicitly failed, including the feedback-cycle requirement to remove prose-doc tests and internal wait-state re-description.
+  Evidence: AC-1 through AC-6 are accounted for below against the current acceptance criteria and cycle-3 implementation.
+- DONE: The validation report gives a clear PASSED or REJECTED recommendation and preserves implementation ownership by not making unrequested fixes.
+  Evidence: No implementation files were changed during validation; this report appends only the validation evidence.
+
+### Acceptance Criteria
+
+- AC-1: PASSED. `skills/first-officer/references/codex-first-officer-runtime.md` contains a short `## Interrupted Waits` behavior rule: process non-stopping captain input, then resume `wait_agent` for the same unresolved ensigns; it does not define a detailed Codex wait-state schema.
+- AC-2: PASSED. `tests/test_test_lib_helpers.py::test_codex_log_parser_detects_preempted_multi_handle_wait_resume` asserts initial wait handles `["item_23", "item_42"]`, a user interruption, FO handling via `preempted_by_user_input`, and a resumed wait with the same `receiver_thread_ids`.
+- AC-3: PASSED. The same fixture includes a completion notification for `item_23` before the resumed wait, but `scripts/test_lib.py::CodexLogParser.interrupted_wait_sequences()` only marks handles collected after the later wait returns completed `agents_states`.
+- AC-4: PASSED. Runtime guidance states pause/stop do not resume waiting, and clarification blockers should ask for clarification rather than continuing to wait.
+- AC-5: PASSED. `tests/test_agent_content.py` no longer contains `test_codex_runtime_docs_define_preemptible_wait_mode_contract`; targeted grep over `skills/first-officer/references/codex-first-officer-runtime.md`, `tests/test_agent_content.py`, `tests/test_test_lib_helpers.py`, and `scripts/test_lib.py` found no replacement prose-doc/schema contract patterns.
+- AC-6: PASSED. The focused parser fixture proves resumed `wait_agent` collection on live handles; completion notification text is side-channel context and does not schedule a new FO turn or replace reconciliation.
+
+### Feedback-Cycle Verdict
+
+PASSED. The current runtime docs and current ACs avoid re-describing Codex's internal wait representation, and the implementation is the intended behavior amendment requested in cycle 2: handle non-stopping interruption, then resume waiting for the same unresolved ensigns unless paused/stopped or clarification-blocked. The old prose-doc test was removed, and behavioral/parser fixture evidence now carries the proof.
+
+### Summary
+
+Validation reproduced the targeted static/parser evidence and the stable offline suite selected from `tests/README.md`. Live Codex E2E was not run because the entity makes it optional unless deterministic interactive interruption handling is claimed; this implementation claims deterministic parser-fixture coverage.
+
+Recommendation: PASSED

--- a/docs/plans/codex-fo-preemptible-wait-mode.md
+++ b/docs/plans/codex-fo-preemptible-wait-mode.md
@@ -250,3 +250,31 @@ Reworked the cycle 1 implementation to keep Codex preemptible wait behavioral ra
 ### Summary
 
 Repaired the entity body so the accepted requirements match the captain feedback: exact wait-instruction wording is no longer a contract, while wait-set continuity remains the tested behavior. Runtime docs and tests were checked again and remain focused on preserving/resuming FO-uncollected waits rather than matching user-facing prose.
+
+## Stage Report: validation (cycle 2)
+
+- DONE: Applicable validation commands are selected from `tests/README.md`, rerun in the worktree, and reported with exact pass/fail results.
+  Evidence: `uv run --with pytest python tests/test_agent_content.py -q` -> 49 passed; `uv run --with pytest python -m pytest tests/test_test_lib_helpers.py -q` -> 19 passed; `git diff --check` -> passed; `make test-static` -> 514 passed, 25 deselected, 10 subtests passed.
+- DONE: Every AC-1 through AC-6 is verified with concrete evidence or explicitly failed, including the feedback-cycle requirement to avoid static user-facing prose matching.
+  Evidence: AC-1 through AC-6 are accounted for below; `rg` over `tests/test_agent_content.py`, `tests/test_test_lib_helpers.py`, and `scripts/test_lib.py` found no exact wait-instruction prose patterns.
+- DONE: The validation report gives a clear PASSED or REJECTED recommendation and preserves implementation ownership by not making unrequested fixes.
+  Evidence: No implementation files were changed; this validation edit appends only this entity report.
+
+### Acceptance Criteria
+
+- AC-1: PASSED. `skills/first-officer/references/codex-first-officer-runtime.md` defines `background worker`, `preemptible wait`, and `post-wait completion handling`; `tests/test_agent_content.py` asserts those states and the blocked-step/explicit-wait boundary.
+- AC-2: PASSED. The runtime wait-intent contract lists worker label, `dispatch_agent_id`, runtime handle, entity path/id, stage name, blocked reason, collection state, and source; `tests/test_test_lib_helpers.py` proves resumed waits reuse `["item_23", "item_42"]`.
+- AC-3: PASSED. Runtime docs communicate blocked wait/resume state while saying not to make a precise instruction sentence contractual; tests avoid exact user-facing wait wording and verify blocked wait-set behavior instead.
+- AC-4: PASSED. The parser fixture orders initial wait on `item_23`/`item_42`, user interruption, `preempted_by_user_input`, side-channel completion notification, resumed wait on the same FO-uncollected handles, and final collection with no dropped or replacement handles.
+- AC-5: PASSED. Static checks cover `completed`, `timed_out`, `failed`, `preempted_by_user_input`, `paused_by_user`, and `clarification_required`.
+- AC-6: PASSED. Runtime docs state completion notifications are opportunistic only and do not schedule an autonomous FO turn; parser helper only marks completion collected after resumed wait on live handles.
+
+### Feedback-Cycle Verdict
+
+PASSED. Detailed wait-instruction prose is not a contract or static prose-matching target; the surviving proof is behavioral/parser coverage for preserving the wait set, handling interruption, and resuming `wait_agent` for FO-uncollected entries unless paused/stopped or clarification-blocked.
+
+### Summary
+
+Validation reproduced the cited static and parser evidence, then ran the stable offline suite from `tests/README.md`. Live Codex E2E was not run because the entity treats it as optional unless deterministic interactive interruption handling is claimed, and this implementation claims static plus deterministic transcript coverage.
+
+Recommendation: PASSED

--- a/docs/plans/codex-fo-preemptible-wait-mode.md
+++ b/docs/plans/codex-fo-preemptible-wait-mode.md
@@ -1,7 +1,7 @@
 ---
 id: 216
 title: "Codex FO runtime: add preemptible wait mode for subagent completions"
-status: validation
+status: implementation
 source: "GitHub issue #148, 2026-04-27 - local mitigation for openai/codex#15723 completion wakeup limitation"
 started: 2026-04-27T18:27:05Z
 completed:
@@ -224,6 +224,10 @@ Recommendation: PASSED
   - Do not make detailed wait-instruction prose a first-class implementation or test target; Codex should already provide the basic interrupt affordance.
   - Focus the implementation and tests on continuous waiting behavior after interruption: preserve the wait set, process the interruption, and resume waiting for unresolved ensigns unless the captain says pause or stop.
   - Avoid static tests that match user-facing prose. Prefer behavioral/parser fixtures that prove same-wait-set resume and FO-collected/uncollected state.
+- Cycle 2 (2026-04-27): Captain rejected the validation gate again. Required changes:
+  - Do not re-describe Codex's internal wait representation in runtime docs or ACs.
+  - Amend the intended first-officer behavior directly: after user interruption during a blocked wait, process the input and resume waiting for the same unresolved ensigns unless the captain says pause or stop.
+  - Remove prose-doc tests such as `test_codex_runtime_docs_define_preemptible_wait_mode_contract`; keep tests on behavior/parser evidence rather than runtime-doc wording.
 
 ## Stage Report: implementation (cycle 2)
 

--- a/docs/plans/codex-fo-preemptible-wait-mode.md
+++ b/docs/plans/codex-fo-preemptible-wait-mode.md
@@ -226,3 +226,16 @@ Recommendation: PASSED
   - Do not make detailed wait-instruction prose a first-class implementation or test target; Codex should already provide the basic interrupt affordance.
   - Focus the implementation and tests on continuous waiting behavior after interruption: preserve the wait set, process the interruption, and resume waiting for unresolved ensigns unless the captain says pause or stop.
   - Avoid static tests that match user-facing prose. Prefer behavioral/parser fixtures that prove same-wait-set resume and FO-collected/uncollected state.
+
+## Stage Report: implementation (cycle 2)
+
+- DONE: Detailed wait-instruction prose is no longer a static/prose-matching contract; runtime docs focus on behavior and wait-set continuity.
+  Evidence: `skills/first-officer/references/codex-first-officer-runtime.md` removes the exact interruption sentence and raw-handle prose rule, replacing them with behavioral wait/resume guidance.
+- DONE: Tests prove continuous waiting after interruption through parser/transcript behavior, not exact user-facing prose matching.
+  Evidence: `tests/test_agent_content.py` no longer checks exact wait-status wording; `tests/test_test_lib_helpers.py` and `scripts/test_lib.py` assert same-handle resume, initial FO-uncollected handles, FO-collected handles after resumed wait, and no dropped/replacement handles.
+- DONE: Verification evidence is recorded with commands and results.
+  Evidence: `uv run --with pytest python tests/test_agent_content.py -q` (49 passed), `uv run --with pytest python -m pytest tests/test_test_lib_helpers.py -q` (19 passed), and `git diff --check` (passed).
+
+### Summary
+
+Reworked the cycle 1 implementation to keep Codex preemptible wait behavioral rather than prose-driven. The runtime contract now centers on preserving and resuming the FO-uncollected wait set, and the fixture proof covers continuous waiting through interruption without relying on exact user-facing wait text.

--- a/scripts/test_lib.py
+++ b/scripts/test_lib.py
@@ -1837,8 +1837,8 @@ class CodexLogParser:
                     messages.append(str(state["message"]))
         return messages
 
-    def preemptible_wait_sequences(self) -> list[dict]:
-        """Return wait/preemption/resume sequences from Codex JSONL fixtures.
+    def interrupted_wait_sequences(self) -> list[dict]:
+        """Return wait/interruption/resume sequences from Codex JSONL fixtures.
 
         This helper intentionally models Codex completion notifications as
         side-channel evidence: a sequence is only considered collected when a
@@ -1860,14 +1860,14 @@ class CodexLogParser:
                 if pending and pending.get("preemption_outcome") == "preempted_by_user_input":
                     completed = self._completed_thread_ids(item, handles)
                     initial = pending["initial_receiver_thread_ids"]
-                    initial_uncollected = pending["initial_uncollected_thread_ids"]
+                    initial_unresolved = pending["initial_unresolved_thread_ids"]
                     pending["resumed_receiver_thread_ids"] = handles
                     pending["collected_completed_thread_ids"] = completed
-                    pending["fo_collected_thread_ids"] = [
-                        handle for handle in initial_uncollected if handle in completed
+                    pending["resolved_thread_ids"] = [
+                        handle for handle in initial_unresolved if handle in completed
                     ]
-                    pending["still_uncollected_thread_ids"] = [
-                        handle for handle in initial_uncollected if handle not in completed
+                    pending["still_unresolved_thread_ids"] = [
+                        handle for handle in initial_unresolved if handle not in completed
                     ]
                     pending["dropped_thread_ids"] = [
                         handle for handle in initial if handle not in handles
@@ -1881,18 +1881,14 @@ class CodexLogParser:
 
                 pending = {
                     "initial_receiver_thread_ids": handles,
-                    "initial_wait_intent_entries": self._wait_intent_entries(item),
-                    "initial_uncollected_thread_ids": self._uncollected_thread_ids_from_intent(
-                        item,
-                        handles,
-                    ),
+                    "initial_unresolved_thread_ids": list(handles),
                     "preemption_outcome": None,
                     "user_interruption_texts": [],
                     "completion_notifications_before_resume": [],
                     "resumed_receiver_thread_ids": [],
                     "collected_completed_thread_ids": [],
-                    "fo_collected_thread_ids": [],
-                    "still_uncollected_thread_ids": [],
+                    "resolved_thread_ids": [],
+                    "still_unresolved_thread_ids": [],
                     "dropped_thread_ids": [],
                     "replacement_thread_ids": [],
                 }
@@ -1942,37 +1938,6 @@ class CodexLogParser:
             if isinstance(state, dict) and state.get("status") == "completed":
                 completed.append(handle_text)
         return completed
-
-    @staticmethod
-    def _wait_intent_entries(item: dict) -> list[dict]:
-        wait_intent = item.get("wait_intent", {})
-        if not isinstance(wait_intent, dict):
-            return []
-        entries = wait_intent.get("entries", [])
-        if not isinstance(entries, list):
-            return []
-        return [entry for entry in entries if isinstance(entry, dict)]
-
-    @classmethod
-    def _uncollected_thread_ids_from_intent(cls, item: dict, handle_order: list[str]) -> list[str]:
-        entries = cls._wait_intent_entries(item)
-        if not entries:
-            return list(handle_order)
-
-        uncollected: list[str] = []
-        for entry in entries:
-            state = str(entry.get("collection_state", "")).lower()
-            if state not in {"fo-uncollected", "uncollected", "unresolved"}:
-                continue
-            handle = entry.get("runtime_handle")
-            if isinstance(handle, str) and handle not in uncollected:
-                uncollected.append(handle)
-
-        return [
-            handle for handle in handle_order if handle in uncollected
-        ] + [
-            handle for handle in uncollected if handle not in handle_order
-        ]
 
     @staticmethod
     def _thread_ids_from_text(text: str) -> list[str]:

--- a/scripts/test_lib.py
+++ b/scripts/test_lib.py
@@ -1837,6 +1837,106 @@ class CodexLogParser:
                     messages.append(str(state["message"]))
         return messages
 
+    def preemptible_wait_sequences(self) -> list[dict]:
+        """Return wait/preemption/resume sequences from Codex JSONL fixtures.
+
+        This helper intentionally models Codex completion notifications as
+        side-channel evidence: a sequence is only considered collected when a
+        later wait call returns completed agent states for the resumed handles.
+        """
+        sequences: list[dict] = []
+        pending: dict | None = None
+
+        for entry in self.json_entries:
+            item = entry.get("item", {})
+            if not isinstance(item, dict):
+                continue
+
+            item_type = item.get("type")
+            if item_type == "collab_tool_call" and item.get("tool") in {"wait", "wait_agent"}:
+                handles = self._receiver_thread_ids(item)
+                if not handles:
+                    continue
+                if pending and pending.get("preemption_outcome") == "preempted_by_user_input":
+                    completed = self._completed_thread_ids(item, handles)
+                    initial = pending["initial_receiver_thread_ids"]
+                    pending["resumed_receiver_thread_ids"] = handles
+                    pending["collected_completed_thread_ids"] = completed
+                    pending["dropped_thread_ids"] = [
+                        handle for handle in initial if handle not in handles
+                    ]
+                    pending["replacement_thread_ids"] = [
+                        handle for handle in handles if handle not in initial
+                    ]
+                    sequences.append(pending)
+                    pending = None
+                    continue
+
+                pending = {
+                    "initial_receiver_thread_ids": handles,
+                    "preemption_outcome": None,
+                    "user_interruption_texts": [],
+                    "completion_notifications_before_resume": [],
+                    "resumed_receiver_thread_ids": [],
+                    "collected_completed_thread_ids": [],
+                    "dropped_thread_ids": [],
+                    "replacement_thread_ids": [],
+                }
+                continue
+
+            text = item.get("text")
+            if not pending or not isinstance(text, str):
+                continue
+
+            if item_type == "user_message":
+                pending["user_interruption_texts"].append(text)
+            elif item_type == "agent_message":
+                if "preempted_by_user_input" in text:
+                    pending["preemption_outcome"] = "preempted_by_user_input"
+                if (
+                    pending.get("preemption_outcome") == "preempted_by_user_input"
+                    and "completion notification" in text.lower()
+                ):
+                    pending["completion_notifications_before_resume"].extend(
+                        self._thread_ids_from_text(text)
+                    )
+
+        return sequences
+
+    @staticmethod
+    def _receiver_thread_ids(item: dict) -> list[str]:
+        raw_handles = item.get("receiver_thread_ids", [])
+        if not isinstance(raw_handles, list):
+            return []
+        return [str(handle) for handle in raw_handles]
+
+    @staticmethod
+    def _completed_thread_ids(item: dict, handle_order: list[str]) -> list[str]:
+        states = item.get("agents_states", {})
+        if not isinstance(states, dict):
+            return []
+
+        completed: list[str] = []
+        for handle in handle_order:
+            state = states.get(handle)
+            if isinstance(state, dict) and state.get("status") == "completed":
+                completed.append(handle)
+        for handle, state in states.items():
+            handle_text = str(handle)
+            if handle_text in completed:
+                continue
+            if isinstance(state, dict) and state.get("status") == "completed":
+                completed.append(handle_text)
+        return completed
+
+    @staticmethod
+    def _thread_ids_from_text(text: str) -> list[str]:
+        ids: list[str] = []
+        for match in re.findall(r"\b(?:item|thread)[_-][A-Za-z0-9-]+\b", text):
+            if match not in ids:
+                ids.append(match)
+        return ids
+
     def write_text(self, output_path: Path | str):
         with open(output_path, "w") as f:
             f.write(self.full_text())

--- a/scripts/test_lib.py
+++ b/scripts/test_lib.py
@@ -1860,8 +1860,15 @@ class CodexLogParser:
                 if pending and pending.get("preemption_outcome") == "preempted_by_user_input":
                     completed = self._completed_thread_ids(item, handles)
                     initial = pending["initial_receiver_thread_ids"]
+                    initial_uncollected = pending["initial_uncollected_thread_ids"]
                     pending["resumed_receiver_thread_ids"] = handles
                     pending["collected_completed_thread_ids"] = completed
+                    pending["fo_collected_thread_ids"] = [
+                        handle for handle in initial_uncollected if handle in completed
+                    ]
+                    pending["still_uncollected_thread_ids"] = [
+                        handle for handle in initial_uncollected if handle not in completed
+                    ]
                     pending["dropped_thread_ids"] = [
                         handle for handle in initial if handle not in handles
                     ]
@@ -1874,11 +1881,18 @@ class CodexLogParser:
 
                 pending = {
                     "initial_receiver_thread_ids": handles,
+                    "initial_wait_intent_entries": self._wait_intent_entries(item),
+                    "initial_uncollected_thread_ids": self._uncollected_thread_ids_from_intent(
+                        item,
+                        handles,
+                    ),
                     "preemption_outcome": None,
                     "user_interruption_texts": [],
                     "completion_notifications_before_resume": [],
                     "resumed_receiver_thread_ids": [],
                     "collected_completed_thread_ids": [],
+                    "fo_collected_thread_ids": [],
+                    "still_uncollected_thread_ids": [],
                     "dropped_thread_ids": [],
                     "replacement_thread_ids": [],
                 }
@@ -1928,6 +1942,37 @@ class CodexLogParser:
             if isinstance(state, dict) and state.get("status") == "completed":
                 completed.append(handle_text)
         return completed
+
+    @staticmethod
+    def _wait_intent_entries(item: dict) -> list[dict]:
+        wait_intent = item.get("wait_intent", {})
+        if not isinstance(wait_intent, dict):
+            return []
+        entries = wait_intent.get("entries", [])
+        if not isinstance(entries, list):
+            return []
+        return [entry for entry in entries if isinstance(entry, dict)]
+
+    @classmethod
+    def _uncollected_thread_ids_from_intent(cls, item: dict, handle_order: list[str]) -> list[str]:
+        entries = cls._wait_intent_entries(item)
+        if not entries:
+            return list(handle_order)
+
+        uncollected: list[str] = []
+        for entry in entries:
+            state = str(entry.get("collection_state", "")).lower()
+            if state not in {"fo-uncollected", "uncollected", "unresolved"}:
+                continue
+            handle = entry.get("runtime_handle")
+            if isinstance(handle, str) and handle not in uncollected:
+                uncollected.append(handle)
+
+        return [
+            handle for handle in handle_order if handle in uncollected
+        ] + [
+            handle for handle in uncollected if handle not in handle_order
+        ]
 
     @staticmethod
     def _thread_ids_from_text(text: str) -> list[str]:

--- a/scripts/test_lib.py
+++ b/scripts/test_lib.py
@@ -183,9 +183,24 @@ def build_codex_first_officer_invocation_prompt(
     workflow_dir: str | Path,
     agent_id: str = "spacedock:first-officer",
     run_goal: str | None = None,
+    local_skill_path: str | Path | None = None,
+    local_plugin_root: str | Path | None = None,
 ) -> str:
     workflow_dir = Path(workflow_dir)
-    prompt = f"Use the `{agent_id}` skill to manage the Codex workflow at `{workflow_dir}`."
+    if local_skill_path is not None:
+        prompt = (
+            f"Use the local `{agent_id}` skill at `{Path(local_skill_path)}` "
+            f"to manage the Codex workflow at `{workflow_dir}`."
+        )
+    else:
+        prompt = f"Use the `{agent_id}` skill to manage the Codex workflow at `{workflow_dir}`."
+    if local_plugin_root is not None:
+        plugin_root = Path(local_plugin_root)
+        prompt = (
+            f"{prompt}\n\n"
+            f"The local Spacedock plugin directory is `{plugin_root}`; the status helper is "
+            f"`{plugin_root / 'skills' / 'commission' / 'bin' / 'status'}`."
+        )
     if run_goal:
         prompt = f"{prompt}\n\n{run_goal.strip()}"
     return prompt
@@ -919,10 +934,17 @@ def run_codex_first_officer(
     """Run the Codex first-officer skill via codex exec. Returns exit code."""
     log_path = runner.log_dir / log_name
     workflow_path = (runner.test_project_dir / workflow_dir).resolve()
-    prompt = build_codex_first_officer_invocation_prompt(workflow_path, agent_id=agent_id, run_goal=run_goal)
+    skill_home = prepare_codex_skill_home(runner.test_dir, runner.repo_root)
+    local_skill_path = runner.repo_root / "skills" / "first-officer" / "SKILL.md"
+    prompt = build_codex_first_officer_invocation_prompt(
+        workflow_path,
+        agent_id=agent_id,
+        run_goal=run_goal,
+        local_skill_path=local_skill_path,
+        local_plugin_root=runner.repo_root,
+    )
     (runner.log_dir / "codex-fo-invocation.txt").write_text(prompt + "\n")
 
-    skill_home = prepare_codex_skill_home(runner.test_dir, runner.repo_root)
     env = os.environ.copy()
     env["HOME"] = str(skill_home)
     env["CODEX_HOME"] = str(skill_home / ".codex")

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -45,7 +45,7 @@ Split worker identity into:
 - `dispatch_agent_id`
 - `worker_key`
 
-For operator-facing status updates and routed follow-up messages, also keep a human-readable worker label. Use a stable `{entity_id}-{stage_key}/{display_name}` convention such as `130-impl/Herschel` or `130-validation/Herschel`. Report that label alongside the logical id or thread handle; do not rely on opaque agent ids or incidental nicknames alone.
+For operator-facing status updates and routed follow-up messages, also keep a human-readable worker label. Use a stable `{entity_id}-{stage_key}/{display_name}` convention such as `130-impl/Herschel` or `130-validation/Herschel`. For dispatch, reuse, and shutdown updates, report that label alongside the logical id or thread handle; for ordinary wait-status prose, name the label and blocked reason while keeping raw runtime handles in internal wait intent, logs, and tests. Do not rely on opaque agent ids or incidental nicknames alone.
 
 Every operator-facing dispatch, reuse, wait, and shutdown update must lead with the FO-owned worker label rather than a generic phrase like `the implementation worker`.
 
@@ -53,7 +53,7 @@ Use patterns like:
 - `Dispatching `001-implementation/Ensign` (spacedock:ensign, handle: item_23) into the implementation worktree.`
 - `Routing follow-up to `001-implementation/Ensign` on existing handle item_23.`
 - ``001-implementation/Ensign` is active again on handle item_23; the routed follow-up is now this entity's critical path.`
-- `Waiting on `001-implementation/Ensign` (handle item_23) for the feedback-cycle completion.`
+- `Waiting on `001-implementation/Ensign` for the feedback-cycle completion before I can advance the blocked workflow state.`
 - `Shutting down `001-validation/Ensign` (handle item_32); no later routing remains.`
 
 If Codex returns an incidental nickname such as `Leibniz`, treat it as secondary metadata only. Do not lead with or rely on the nickname returned by `spawn_agent`.
@@ -153,6 +153,58 @@ When reusing a completed worker, the equivalent pattern is `send_input(<existing
 
 In interactive sessions, do not foreground `wait_agent` immediately after `spawn_agent` just because a worker was dispatched. Keep the worker in the background and continue the turn unless the next orchestration step is blocked on that worker result or the captain explicitly asks to wait.
 For bounded single-entity runs, immediate waiting after dispatch remains appropriate when completion is the point of the turn.
+
+## Codex Preemptible Wait Mode
+
+Codex has three distinct worker states:
+
+- **background worker** — a worker has been spawned or routed and is tracked, but the current interactive turn is not blocked on its result.
+- **preemptible wait** — the next orchestration step is blocked on one or more FO-uncollected worker results, or the captain explicitly asks to wait, and the first officer is intentionally calling `wait_agent`.
+- **post-wait completion handling** — `wait_agent` returned completion evidence, and the shared gate, feedback, reuse, merge, or shutdown rules decide the next workflow action.
+
+Entering preemptible wait requires recording a wait intent before the `wait_agent` call. The wait intent is a wait set, not a scalar handle. Each wait-set entry must include:
+
+- worker label
+- `dispatch_agent_id`
+- runtime handle
+- entity path/id
+- stage name
+- blocked reason
+- collection state: `FO-uncollected` or `FO-collected`
+- source: fresh dispatch or same-handle reuse after `send_input`
+
+`Unresolved` means FO-uncollected, not necessarily still running. If a worker completes while the first officer is answering an interruption, that wait-set entry remains unresolved and FO-uncollected until the first officer resumes `wait_agent` on the same handle and collects/reconciles the completion evidence.
+
+Before waiting, emit concise operator-facing wait status that names every FO-owned worker label in the wait set and states the blocked reason. Ordinary wait-status prose must not print raw runtime handles such as UUIDs or `item_...` ids; runtime handles remain required in internal wait intent, logs, and tests so same-handle collection can be verified.
+
+Use this shape for wait status:
+
+```text
+Waiting on `048-implementation/Ensign feedback cycle 2` and `054-implementation/Ensign` before I can advance the blocked workflow state. You can send a message and hit Esc to interrupt safely; I’ll process the additional feedback and resume waiting for ensigns unless you tell me to pause or stop.
+```
+
+The exact leading clause can vary with the worker labels and blocked reason, but the safe-interruption hint must use this sentence exactly:
+
+```text
+You can send a message and hit Esc to interrupt safely; I’ll process the additional feedback and resume waiting for ensigns unless you tell me to pause or stop.
+```
+
+Call `wait_agent` for every FO-uncollected runtime handle in the wait set. For a plural wait set, pass and preserve all handles together; do not drop or replace a handle unless the wait intent is explicitly paused, superseded, or clarified with the captain.
+
+Wait attempt outcomes are:
+
+- `completed` — `wait_agent` returned completion evidence and the first officer reconciled the affected wait-set entries.
+- `timed_out` — the explicit wait budget expired without completion evidence.
+- `failed` — `wait_agent` or the worker result failed.
+- `preempted_by_user_input` — captain input interrupted the wait while one or more wait-set entries remained FO-uncollected.
+- `paused_by_user` — the captain told the first officer to pause, stop, cancel, or change away from the blocked workflow target.
+- `clarification_required` — the interruption revealed missing information required before waiting can continue.
+
+When non-stopping captain input arrives while any wait-set entry is FO-uncollected, mark the current wait attempt as `preempted_by_user_input`. Answer or handle the captain's input under ordinary first-officer rules, then resume `wait_agent` for every still-FO-uncollected entry in the same prior wait set unless the captain told you to pause or stop.
+
+If the captain's input dispatches additional worker work that is now part of the same blocked next step, update the wait set, report the new worker labels in user-facing prose, and record the new handles internally before waiting again. If the input creates a missing-information blocker, switch the outcome to `clarification_required` and do not pretend the first officer is still waiting.
+
+Completion notifications during the interruption are opportunistic evidence only. They do not schedule an autonomous first-officer turn, they do not replace resumed collection, and they do not make a wait-set entry `FO-collected`. The authoritative collection path remains resumed `wait_agent` on the same handle for each FO-uncollected entry.
 
 ## Codex Worker Assignment Fields
 

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -45,7 +45,7 @@ Split worker identity into:
 - `dispatch_agent_id`
 - `worker_key`
 
-For operator-facing status updates and routed follow-up messages, also keep a human-readable worker label. Use a stable `{entity_id}-{stage_key}/{display_name}` convention such as `130-impl/Herschel` or `130-validation/Herschel`. For dispatch, reuse, and shutdown updates, report that label alongside the logical id or thread handle; for ordinary wait-status prose, name the label and blocked reason while keeping raw runtime handles in internal wait intent, logs, and tests. Do not rely on opaque agent ids or incidental nicknames alone.
+For operator-facing status updates and routed follow-up messages, also keep a human-readable worker label. Use a stable `{entity_id}-{stage_key}/{display_name}` convention such as `130-impl/Herschel` or `130-validation/Herschel`. Report that label alongside the logical id or thread handle when useful, while keeping the runtime handle in internal wait intent, logs, and tests for same-handle verification. Do not rely on opaque agent ids or incidental nicknames alone.
 
 Every operator-facing dispatch, reuse, wait, and shutdown update must lead with the FO-owned worker label rather than a generic phrase like `the implementation worker`.
 
@@ -175,19 +175,7 @@ Entering preemptible wait requires recording a wait intent before the `wait_agen
 
 `Unresolved` means FO-uncollected, not necessarily still running. If a worker completes while the first officer is answering an interruption, that wait-set entry remains unresolved and FO-uncollected until the first officer resumes `wait_agent` on the same handle and collects/reconciles the completion evidence.
 
-Before waiting, emit concise operator-facing wait status that names every FO-owned worker label in the wait set and states the blocked reason. Ordinary wait-status prose must not print raw runtime handles such as UUIDs or `item_...` ids; runtime handles remain required in internal wait intent, logs, and tests so same-handle collection can be verified.
-
-Use this shape for wait status:
-
-```text
-Waiting on `048-implementation/Ensign feedback cycle 2` and `054-implementation/Ensign` before I can advance the blocked workflow state. You can send a message and hit Esc to interrupt safely; I’ll process the additional feedback and resume waiting for ensigns unless you tell me to pause or stop.
-```
-
-The exact leading clause can vary with the worker labels and blocked reason, but the safe-interruption hint must use this sentence exactly:
-
-```text
-You can send a message and hit Esc to interrupt safely; I’ll process the additional feedback and resume waiting for ensigns unless you tell me to pause or stop.
-```
+Before or while waiting, communicate the wait/resume state in ordinary operator-facing prose: which wait-set entries are blocking the next orchestration step, that non-stopping captain input will be handled, and that waiting will resume afterward. Keep the wording natural for the current turn; Codex already provides the basic user interruption affordance, so do not make a precise instruction sentence part of the runtime contract.
 
 Call `wait_agent` for every FO-uncollected runtime handle in the wait set. For a plural wait set, pass and preserve all handles together; do not drop or replace a handle unless the wait intent is explicitly paused, superseded, or clarified with the captain.
 

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -86,6 +86,8 @@ For each dispatch:
 5. In the worker prompt:
    - first instruct the worker to resolve its role definition from the logical id and read it before doing anything else
    - then pass the assignment fields
+6. Immediately after `spawn_agent` returns the dispatched handle or handles, emit an operator-facing wait status using the FO-owned worker label and handle(s).
+7. Immediately enter a preemptible `wait_agent` on those same dispatched handle(s) before running follow-up status checks, advancing any workflow state, dispatching more work, or sending a final response.
 
 When the worker reaches a completed state, keep its returned handle and worker label as long as later routing may still need that thread.
 
@@ -145,18 +147,20 @@ spawn_agent(
   fork_context=false,
   message="<fully self-contained worker assignment>"
 )
+<operator-facing status: Waiting on `{label}` (handle {handle}). Esc/message interruption is safe; if interrupted, handle the message and resume this same wait unless the captain says pause/stop.>
 wait_agent(...)
 ```
 
 Always preserve the logical packaged id in summaries and use only `worker_key` in branch/worktree/session names.
 When reusing a completed worker, the equivalent pattern is `send_input(<existing_handle>, message="<next assignment>")` followed by `wait_agent(...)` on that same handle when the reused result is part of that entity's current critical path, then explicit shutdown once the reused cycle is complete and the worker is no longer needed. This wait blocks advancement of that entity, not unrelated ready entities.
 
-In interactive sessions, do not foreground `wait_agent` immediately after `spawn_agent` just because a worker was dispatched. Keep the worker in the background and continue the turn unless the next orchestration step is blocked on that worker result or the captain explicitly asks to wait.
-For bounded single-entity runs, immediate waiting after dispatch remains appropriate when completion is the point of the turn.
+In Codex sessions, every fresh `spawn_agent` dispatch immediately becomes a preemptible wait on the returned handle(s). Do not leave a freshly dispatched worker running in the background as the next operator-visible result. The wait is preemptible: Esc or a captain message can interrupt it safely, and after handling that message you resume waiting on the same unresolved handle(s) unless the captain says pause or stop.
 
 ## Interrupted Waits
 
-When you are waiting for ensigns because the next first-officer step is blocked, and the captain sends a non-stopping message, handle that input and then resume `wait_agent` for the same unresolved ensigns unless the captain says to pause or stop. If the input creates a clarification blocker, ask for the clarification instead of continuing to wait. Completion notifications that appear during the interruption are useful context, but do not replace the resumed `wait_agent` collection on the same worker handles.
+When you are waiting for ensigns and the captain sends a non-stopping message, handle that input and then resume `wait_agent` for the same unresolved ensigns unless the captain says to pause or stop. If the input creates a clarification blocker, ask for the clarification instead of continuing to wait. Completion notifications that appear during the interruption are useful context, but do not replace the resumed `wait_agent` collection on the same worker handles.
+
+The wait status must make the interruption contract explicit for the operator. State that Esc or sending a message is safe, and that the wait will resume on the same unresolved worker handle(s) unless the captain says pause or stop.
 
 ## Codex Worker Assignment Fields
 
@@ -188,8 +192,7 @@ When you render the worker prompt, keep the checklist header plain and stable: u
 
 - Workers report completion by returning a concise final response.
 - The first officer treats the entity file and stage report as the source of truth.
-- In interactive sessions, the first officer keeps the worker in the background and continues the turn unless the next step is blocked on the worker result or the captain explicitly asks to wait.
-- In bounded single-entity runs, the first officer may wait immediately after dispatch because the run is scoped around that completion.
+- After every fresh Codex dispatch, the first officer waits immediately on the returned worker handle(s); this applies in normal interactive and bounded runs.
 - In interactive Codex mode, once a worker completes for a gated stage, the stage report and gate handling become the next required action before unrelated orchestration continues.
 - In bounded single-entity runs, if the worker completion message already contains the requested verdict, evidence, or terminal outcome, use that message as sufficient evidence for the final response and stop immediately.
 - Only reread the entity file or rerun `status` after `wait_agent(...)` when the worker message is missing a detail required by the stated stop condition.

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -45,7 +45,7 @@ Split worker identity into:
 - `dispatch_agent_id`
 - `worker_key`
 
-For operator-facing status updates and routed follow-up messages, also keep a human-readable worker label. Use a stable `{entity_id}-{stage_key}/{display_name}` convention such as `130-impl/Herschel` or `130-validation/Herschel`. Report that label alongside the logical id or thread handle when useful, while keeping the runtime handle in internal wait intent, logs, and tests for same-handle verification. Do not rely on opaque agent ids or incidental nicknames alone.
+For operator-facing status updates and routed follow-up messages, also keep a human-readable worker label. Use a stable `{entity_id}-{stage_key}/{display_name}` convention such as `130-impl/Herschel` or `130-validation/Herschel`. Report that label alongside the logical id or thread handle when useful. Do not rely on opaque agent ids or incidental nicknames alone.
 
 Every operator-facing dispatch, reuse, wait, and shutdown update must lead with the FO-owned worker label rather than a generic phrase like `the implementation worker`.
 
@@ -154,45 +154,9 @@ When reusing a completed worker, the equivalent pattern is `send_input(<existing
 In interactive sessions, do not foreground `wait_agent` immediately after `spawn_agent` just because a worker was dispatched. Keep the worker in the background and continue the turn unless the next orchestration step is blocked on that worker result or the captain explicitly asks to wait.
 For bounded single-entity runs, immediate waiting after dispatch remains appropriate when completion is the point of the turn.
 
-## Codex Preemptible Wait Mode
+## Interrupted Waits
 
-Codex has three distinct worker states:
-
-- **background worker** — a worker has been spawned or routed and is tracked, but the current interactive turn is not blocked on its result.
-- **preemptible wait** — the next orchestration step is blocked on one or more FO-uncollected worker results, or the captain explicitly asks to wait, and the first officer is intentionally calling `wait_agent`.
-- **post-wait completion handling** — `wait_agent` returned completion evidence, and the shared gate, feedback, reuse, merge, or shutdown rules decide the next workflow action.
-
-Entering preemptible wait requires recording a wait intent before the `wait_agent` call. The wait intent is a wait set, not a scalar handle. Each wait-set entry must include:
-
-- worker label
-- `dispatch_agent_id`
-- runtime handle
-- entity path/id
-- stage name
-- blocked reason
-- collection state: `FO-uncollected` or `FO-collected`
-- source: fresh dispatch or same-handle reuse after `send_input`
-
-`Unresolved` means FO-uncollected, not necessarily still running. If a worker completes while the first officer is answering an interruption, that wait-set entry remains unresolved and FO-uncollected until the first officer resumes `wait_agent` on the same handle and collects/reconciles the completion evidence.
-
-Before or while waiting, communicate the wait/resume state in ordinary operator-facing prose: which wait-set entries are blocking the next orchestration step, that non-stopping captain input will be handled, and that waiting will resume afterward. Keep the wording natural for the current turn; Codex already provides the basic user interruption affordance, so do not make a precise instruction sentence part of the runtime contract.
-
-Call `wait_agent` for every FO-uncollected runtime handle in the wait set. For a plural wait set, pass and preserve all handles together; do not drop or replace a handle unless the wait intent is explicitly paused, superseded, or clarified with the captain.
-
-Wait attempt outcomes are:
-
-- `completed` — `wait_agent` returned completion evidence and the first officer reconciled the affected wait-set entries.
-- `timed_out` — the explicit wait budget expired without completion evidence.
-- `failed` — `wait_agent` or the worker result failed.
-- `preempted_by_user_input` — captain input interrupted the wait while one or more wait-set entries remained FO-uncollected.
-- `paused_by_user` — the captain told the first officer to pause, stop, cancel, or change away from the blocked workflow target.
-- `clarification_required` — the interruption revealed missing information required before waiting can continue.
-
-When non-stopping captain input arrives while any wait-set entry is FO-uncollected, mark the current wait attempt as `preempted_by_user_input`. Answer or handle the captain's input under ordinary first-officer rules, then resume `wait_agent` for every still-FO-uncollected entry in the same prior wait set unless the captain told you to pause or stop.
-
-If the captain's input dispatches additional worker work that is now part of the same blocked next step, update the wait set, report the new worker labels in user-facing prose, and record the new handles internally before waiting again. If the input creates a missing-information blocker, switch the outcome to `clarification_required` and do not pretend the first officer is still waiting.
-
-Completion notifications during the interruption are opportunistic evidence only. They do not schedule an autonomous first-officer turn, they do not replace resumed collection, and they do not make a wait-set entry `FO-collected`. The authoritative collection path remains resumed `wait_agent` on the same handle for each FO-uncollected entry.
+When you are waiting for ensigns because the next first-officer step is blocked, and the captain sends a non-stopping message, handle that input and then resume `wait_agent` for the same unresolved ensigns unless the captain says to pause or stop. If the input creates a clarification blocker, ask for the clarification instead of continuing to wait. Completion notifications that appear during the interruption are useful context, but do not replace the resumed `wait_agent` collection on the same worker handles.
 
 ## Codex Worker Assignment Fields
 

--- a/tests/test_agent_content.py
+++ b/tests/test_agent_content.py
@@ -186,57 +186,6 @@ def test_codex_runtime_docs_keep_interactive_workers_background_by_default():
     assert "wait immediately after dispatch" in text
 
 
-def test_codex_runtime_docs_define_preemptible_wait_mode_contract():
-    text = read_text("skills/first-officer/references/codex-first-officer-runtime.md")
-
-    assert "preemptible wait" in text.lower()
-    assert "background worker" in text.lower()
-    assert "post-wait completion handling" in text.lower()
-    assert re.search(
-        r"next orchestration step.*blocked|blocked.*next orchestration step",
-        text,
-        re.IGNORECASE | re.DOTALL,
-    )
-
-    for required in (
-        "worker label",
-        "dispatch_agent_id",
-        "runtime handle",
-        "entity path/id",
-        "stage name",
-        "blocked reason",
-        "FO-uncollected",
-        "fresh dispatch",
-        "same-handle reuse",
-    ):
-        assert required in text
-
-
-def test_codex_runtime_docs_define_preemptible_wait_continuity_and_outcomes():
-    text = read_text("skills/first-officer/references/codex-first-officer-runtime.md")
-    wait_section = section_text(text, "## Codex Preemptible Wait Mode", (r"^## ",))
-
-    assert re.search(r"unresolved.*FO-uncollected", wait_section, re.IGNORECASE | re.DOTALL)
-    assert re.search(r"opportunistic evidence only", wait_section, re.IGNORECASE)
-    assert re.search(r"autonomous first-officer turn", wait_section, re.IGNORECASE)
-    assert re.search(r"resum.*wait_agent.*same handle", wait_section, re.IGNORECASE | re.DOTALL)
-    assert re.search(
-        r"preempted_by_user_input.*resume `wait_agent`.*FO-uncollected",
-        wait_section,
-        re.IGNORECASE | re.DOTALL,
-    )
-
-    for outcome in (
-        "completed",
-        "timed_out",
-        "failed",
-        "preempted_by_user_input",
-        "paused_by_user",
-        "clarification_required",
-    ):
-        assert outcome in wait_section
-
-
 def test_codex_runtime_docs_state_coverage_limits_in_plain_language():
     """Contract-level check: the docs stay honest about what the harness can prove."""
     text = read_text("skills/first-officer/references/codex-first-officer-runtime.md")

--- a/tests/test_agent_content.py
+++ b/tests/test_agent_content.py
@@ -212,26 +212,19 @@ def test_codex_runtime_docs_define_preemptible_wait_mode_contract():
         assert required in text
 
 
-def test_codex_runtime_docs_define_preemptible_wait_status_and_outcomes():
+def test_codex_runtime_docs_define_preemptible_wait_continuity_and_outcomes():
     text = read_text("skills/first-officer/references/codex-first-officer-runtime.md")
     wait_section = section_text(text, "## Codex Preemptible Wait Mode", (r"^## ",))
 
-    assert (
-        "You can send a message and hit Esc to interrupt safely; I’ll process the additional "
-        "feedback and resume waiting for ensigns unless you tell me to pause or stop."
-    ) in wait_section
-    assert re.search(r"name every.*worker label|worker label.*every", wait_section, re.IGNORECASE | re.DOTALL)
-    assert re.search(r"raw .*handle|handle .*raw", wait_section, re.IGNORECASE | re.DOTALL)
-    assert re.search(r"ordinary wait-status prose.*not.*raw", wait_section, re.IGNORECASE | re.DOTALL)
     assert re.search(r"unresolved.*FO-uncollected", wait_section, re.IGNORECASE | re.DOTALL)
     assert re.search(r"opportunistic evidence only", wait_section, re.IGNORECASE)
     assert re.search(r"autonomous first-officer turn", wait_section, re.IGNORECASE)
     assert re.search(r"resum.*wait_agent.*same handle", wait_section, re.IGNORECASE | re.DOTALL)
-
-    status_example = re.search(r"```text\n(Waiting on .+?)\n```", wait_section, re.DOTALL)
-    assert status_example is not None
-    assert "item_" not in status_example.group(1)
-    assert "handle" not in status_example.group(1).lower()
+    assert re.search(
+        r"preempted_by_user_input.*resume `wait_agent`.*FO-uncollected",
+        wait_section,
+        re.IGNORECASE | re.DOTALL,
+    )
 
     for outcome in (
         "completed",

--- a/tests/test_agent_content.py
+++ b/tests/test_agent_content.py
@@ -174,25 +174,26 @@ def test_assembled_codex_skill_contract_uses_skill_relative_bootstrap_language()
     assert "bounded fallback" in text
 
 
-def test_codex_runtime_docs_keep_interactive_workers_background_by_default():
-    """Contract-level check: the runtime text describes the interactive wait policy."""
+def test_codex_runtime_docs_wait_immediately_after_fresh_dispatch():
+    """Contract-level check: fresh Codex dispatches enter preemptible wait mode."""
     t = TestRunner("agent content", keep_test_dir=False)
     text = assembled_agent_content(t, "first-officer", runtime="codex")
 
-    assert "interactive sessions" in text.lower()
-    assert "do not foreground `wait_agent` immediately after `spawn_agent`" in text
-    assert "explicitly asks to wait" in text
-    assert "bounded single-entity runs" in text
-    assert "wait immediately after dispatch" in text
+    assert "every fresh `spawn_agent` dispatch immediately becomes a preemptible wait" in text
+    assert "Esc/message interruption is safe" in text
+    assert "same unresolved handle" in text
+    assert "unless the captain says pause or stop" in text
+    assert "do not foreground `wait_agent` immediately after `spawn_agent`" not in text
+    assert "freshly dispatched worker running in the background" in text
 
 
 def test_codex_runtime_docs_state_coverage_limits_in_plain_language():
     """Contract-level check: the docs stay honest about what the harness can prove."""
     text = read_text("skills/first-officer/references/codex-first-officer-runtime.md")
 
-    assert "interactive sessions" in text.lower()
-    assert "background" in text.lower()
-    assert "bounded single-entity runs" in text.lower()
+    assert "fresh `spawn_agent` dispatch" in text
+    assert "preemptible wait" in text.lower()
+    assert "Esc or a captain message" in text
     assert "wait_agent" in text
 
 

--- a/tests/test_agent_content.py
+++ b/tests/test_agent_content.py
@@ -186,6 +186,64 @@ def test_codex_runtime_docs_keep_interactive_workers_background_by_default():
     assert "wait immediately after dispatch" in text
 
 
+def test_codex_runtime_docs_define_preemptible_wait_mode_contract():
+    text = read_text("skills/first-officer/references/codex-first-officer-runtime.md")
+
+    assert "preemptible wait" in text.lower()
+    assert "background worker" in text.lower()
+    assert "post-wait completion handling" in text.lower()
+    assert re.search(
+        r"next orchestration step.*blocked|blocked.*next orchestration step",
+        text,
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    for required in (
+        "worker label",
+        "dispatch_agent_id",
+        "runtime handle",
+        "entity path/id",
+        "stage name",
+        "blocked reason",
+        "FO-uncollected",
+        "fresh dispatch",
+        "same-handle reuse",
+    ):
+        assert required in text
+
+
+def test_codex_runtime_docs_define_preemptible_wait_status_and_outcomes():
+    text = read_text("skills/first-officer/references/codex-first-officer-runtime.md")
+    wait_section = section_text(text, "## Codex Preemptible Wait Mode", (r"^## ",))
+
+    assert (
+        "You can send a message and hit Esc to interrupt safely; I’ll process the additional "
+        "feedback and resume waiting for ensigns unless you tell me to pause or stop."
+    ) in wait_section
+    assert re.search(r"name every.*worker label|worker label.*every", wait_section, re.IGNORECASE | re.DOTALL)
+    assert re.search(r"raw .*handle|handle .*raw", wait_section, re.IGNORECASE | re.DOTALL)
+    assert re.search(r"ordinary wait-status prose.*not.*raw", wait_section, re.IGNORECASE | re.DOTALL)
+    assert re.search(r"unresolved.*FO-uncollected", wait_section, re.IGNORECASE | re.DOTALL)
+    assert re.search(r"opportunistic evidence only", wait_section, re.IGNORECASE)
+    assert re.search(r"autonomous first-officer turn", wait_section, re.IGNORECASE)
+    assert re.search(r"resum.*wait_agent.*same handle", wait_section, re.IGNORECASE | re.DOTALL)
+
+    status_example = re.search(r"```text\n(Waiting on .+?)\n```", wait_section, re.DOTALL)
+    assert status_example is not None
+    assert "item_" not in status_example.group(1)
+    assert "handle" not in status_example.group(1).lower()
+
+    for outcome in (
+        "completed",
+        "timed_out",
+        "failed",
+        "preempted_by_user_input",
+        "paused_by_user",
+        "clarification_required",
+    ):
+        assert outcome in wait_section
+
+
 def test_codex_runtime_docs_state_coverage_limits_in_plain_language():
     """Contract-level check: the docs stay honest about what the harness can prove."""
     text = read_text("skills/first-officer/references/codex-first-officer-runtime.md")

--- a/tests/test_codex_dispatch_immediate_wait.py
+++ b/tests/test_codex_dispatch_immediate_wait.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env -S uv run --with pytest python
+# /// script
+# requires-python = ">=3.10"
+# ///
+# ABOUTME: Live Codex regression for immediate preemptible waits after fresh dispatch.
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from test_lib import (  # noqa: E402
+    CodexLogParser,
+    git_add_commit,
+    run_codex_first_officer,
+    setup_fixture,
+)
+
+
+def _item_entries(log: CodexLogParser) -> list[tuple[int, dict]]:
+    entries: list[tuple[int, dict]] = []
+    for idx, entry in enumerate(log.json_entries):
+        if entry.get("type") != "item.completed":
+            continue
+        item = entry.get("item", {})
+        if isinstance(item, dict):
+            entries.append((idx, item))
+    return entries
+
+
+def _first_spawn_followed_by_wait(log: CodexLogParser) -> tuple[dict, dict | None, list[str]]:
+    entries = _item_entries(log)
+    for pos, (_, item) in enumerate(entries):
+        if item.get("type") != "collab_tool_call":
+            continue
+        if item.get("tool") not in {"spawn", "spawn_agent"}:
+            continue
+
+        handles = [str(handle) for handle in item.get("receiver_thread_ids") or []]
+        intervening_messages: list[str] = []
+        for _, later in entries[pos + 1:]:
+            if later.get("type") == "agent_message" and later.get("text"):
+                intervening_messages.append(str(later["text"]))
+                continue
+            if later.get("type") != "collab_tool_call":
+                return item, None, intervening_messages
+            if later.get("tool") not in {"wait", "wait_agent"}:
+                return item, None, intervening_messages
+            wait_handles = [str(handle) for handle in later.get("receiver_thread_ids") or []]
+            if handles and wait_handles == handles:
+                return item, later, intervening_messages
+            return item, None, intervening_messages
+
+        return item, None, intervening_messages
+
+    return {}, None, []
+
+
+def _has_preemptible_wait_status(messages: list[str]) -> bool:
+    text = "\n".join(messages).lower()
+    return (
+        bool(re.search(r"\besc\b|message|interrupt", text))
+        and "safe" in text
+        and "resume" in text
+        and "pause" in text
+        and "stop" in text
+    )
+
+
+@pytest.mark.live_codex
+@pytest.mark.serial
+def test_codex_fresh_dispatch_immediately_enters_preemptible_wait(test_project):
+    """A fresh Codex spawn immediately waits on the returned handle."""
+    t = test_project
+
+    print("--- Phase 1: Set up no-gate workflow fixture ---")
+    setup_fixture(t, "spike-no-gate", "dispatch-wait-pipeline")
+    git_add_commit(t.test_project_dir, "setup: dispatch immediate wait fixture")
+    t.check_cmd(
+        "status script runs without errors",
+        ["bash", "dispatch-wait-pipeline/status"],
+        cwd=t.test_project_dir,
+    )
+    print()
+
+    print("--- Phase 2: Run Codex first officer ---")
+    fo_exit = run_codex_first_officer(
+        t,
+        "dispatch-wait-pipeline",
+        run_goal=(
+            "Start the workflow in normal first-officer mode. "
+            "Dispatch the next ready task and report the resulting status."
+        ),
+        timeout_s=360,
+    )
+    t.check("Codex launcher exited cleanly", fo_exit == 0)
+    print()
+
+    print("--- Phase 3: Validate immediate preemptible wait after dispatch ---")
+    log = CodexLogParser(t.log_dir / "codex-fo-log.txt")
+    spawn_call, wait_call, status_messages = _first_spawn_followed_by_wait(log)
+
+    t.check("Codex FO made a fresh worker dispatch", bool(spawn_call))
+    spawn_handles = [str(handle) for handle in spawn_call.get("receiver_thread_ids") or []]
+    t.check("fresh dispatch returned runtime handle(s)", bool(spawn_handles))
+    t.check(
+        "first fresh dispatch is immediately followed by wait_agent on the same handle(s)",
+        bool(wait_call)
+        and [str(handle) for handle in wait_call.get("receiver_thread_ids") or []] == spawn_handles,
+    )
+    t.check(
+        "operator-facing wait status says Esc/message interruption is safe and will resume unless paused/stopped",
+        _has_preemptible_wait_status(status_messages),
+    )
+
+    t.finish()

--- a/tests/test_codex_packaged_agent_ids.py
+++ b/tests/test_codex_packaged_agent_ids.py
@@ -62,6 +62,20 @@ def test_exec_harness_invokes_first_officer_skill_by_name_with_minimal_prompt():
     assert "send_input" not in prompt
 
 
+def test_exec_harness_can_pin_first_officer_to_local_skill_path():
+    prompt = build_codex_first_officer_invocation_prompt(
+        "/tmp/example-workflow",
+        local_skill_path="/tmp/spacedock/skills/first-officer/SKILL.md",
+        local_plugin_root="/tmp/spacedock",
+    )
+
+    assert "spacedock:first-officer" in prompt
+    assert "/tmp/spacedock/skills/first-officer/SKILL.md" in prompt
+    assert "/tmp/spacedock/skills/commission/bin/status" in prompt
+    assert "wait_agent" not in prompt
+    assert "send_input" not in prompt
+
+
 def test_exec_harness_can_target_a_custom_logical_agent_id():
     prompt = build_codex_first_officer_invocation_prompt(
         "/tmp/example-workflow",

--- a/tests/test_gate_guardrail.py
+++ b/tests/test_gate_guardrail.py
@@ -145,7 +145,7 @@ def test_gate_guardrail(test_project, runtime, model, effort, request):
             "waiting-for-approval result is explicitly surfaced",
             bool(
                 re.search(
-                    r"waiting(?:[_\s-]+)for(?:[_\s-]+)approval",
+                    r"waiting(?:[_\s-]+)for(?:[_\s-]+)(?:human(?:[_\s-]+))?approval",
                     fo_text_output,
                     re.IGNORECASE,
                 )

--- a/tests/test_test_lib_helpers.py
+++ b/tests/test_test_lib_helpers.py
@@ -302,32 +302,6 @@ def test_codex_log_parser_detects_preempted_multi_handle_wait_resume(tmp_path):
                 "type": "collab_tool_call",
                 "tool": "wait",
                 "receiver_thread_ids": ["item_23", "item_42"],
-                "wait_intent": {
-                    "entries": [
-                        {
-                            "worker_label": "048-implementation/Ensign feedback cycle 2",
-                            "dispatch_agent_id": "spacedock:ensign",
-                            "runtime_handle": "item_23",
-                            "entity_path": "docs/plans/task-048.md",
-                            "entity_id": "048",
-                            "stage_name": "implementation",
-                            "blocked_reason": "blocked workflow state",
-                            "collection_state": "FO-uncollected",
-                            "source": "same-handle reuse",
-                        },
-                        {
-                            "worker_label": "054-implementation/Ensign",
-                            "dispatch_agent_id": "spacedock:ensign",
-                            "runtime_handle": "item_42",
-                            "entity_path": "docs/plans/task-054.md",
-                            "entity_id": "054",
-                            "stage_name": "implementation",
-                            "blocked_reason": "blocked workflow state",
-                            "collection_state": "FO-uncollected",
-                            "source": "fresh dispatch",
-                        },
-                    ]
-                },
             },
         },
         {
@@ -351,7 +325,7 @@ def test_codex_log_parser_detects_preempted_multi_handle_wait_resume(tmp_path):
             "item": {
                 "id": "notification_1",
                 "type": "agent_message",
-                "text": "Completion notification observed for item_23; still FO-uncollected until resumed wait_agent collects it.",
+                "text": "Completion notification observed for item_23; still unresolved until resumed wait_agent collects it.",
             },
         },
         {
@@ -377,10 +351,10 @@ def test_codex_log_parser_detects_preempted_multi_handle_wait_resume(tmp_path):
     log_path.write_text("\n".join(json.dumps(entry) for entry in entries))
 
     parser = CodexLogParser(log_path)
-    sequence = parser.preemptible_wait_sequences()[0]
+    sequence = parser.interrupted_wait_sequences()[0]
 
     assert sequence["initial_receiver_thread_ids"] == ["item_23", "item_42"]
-    assert sequence["initial_uncollected_thread_ids"] == ["item_23", "item_42"]
+    assert sequence["initial_unresolved_thread_ids"] == ["item_23", "item_42"]
     assert sequence["resumed_receiver_thread_ids"] == ["item_23", "item_42"]
     assert sequence["preemption_outcome"] == "preempted_by_user_input"
     assert sequence["user_interruption_texts"] == [
@@ -388,8 +362,8 @@ def test_codex_log_parser_detects_preempted_multi_handle_wait_resume(tmp_path):
     ]
     assert sequence["completion_notifications_before_resume"] == ["item_23"]
     assert sequence["collected_completed_thread_ids"] == ["item_23", "item_42"]
-    assert sequence["fo_collected_thread_ids"] == ["item_23", "item_42"]
-    assert sequence["still_uncollected_thread_ids"] == []
+    assert sequence["resolved_thread_ids"] == ["item_23", "item_42"]
+    assert sequence["still_unresolved_thread_ids"] == []
     assert sequence["dropped_thread_ids"] == []
     assert sequence["replacement_thread_ids"] == []
 

--- a/tests/test_test_lib_helpers.py
+++ b/tests/test_test_lib_helpers.py
@@ -284,6 +284,122 @@ def test_codex_log_parser_returns_only_agent_message_texts(tmp_path):
     ]
 
 
+def test_codex_log_parser_detects_preempted_multi_handle_wait_resume(tmp_path):
+    log_path = tmp_path / "codex-log.jsonl"
+    entries = [
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "msg_1",
+                "type": "agent_message",
+                "text": (
+                    "Waiting on `048-implementation/Ensign feedback cycle 2` and "
+                    "`054-implementation/Ensign` before I can advance the blocked "
+                    "workflow state. You can send a message and hit Esc to interrupt "
+                    "safely; I’ll process the additional feedback and resume waiting "
+                    "for ensigns unless you tell me to pause or stop."
+                ),
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "wait_1",
+                "type": "collab_tool_call",
+                "tool": "wait",
+                "receiver_thread_ids": ["item_23", "item_42"],
+                "wait_intent": {
+                    "entries": [
+                        {
+                            "worker_label": "048-implementation/Ensign feedback cycle 2",
+                            "dispatch_agent_id": "spacedock:ensign",
+                            "runtime_handle": "item_23",
+                            "entity": "048",
+                            "stage_name": "implementation",
+                            "blocked_reason": "blocked workflow state",
+                            "collection_state": "FO-uncollected",
+                        },
+                        {
+                            "worker_label": "054-implementation/Ensign",
+                            "dispatch_agent_id": "spacedock:ensign",
+                            "runtime_handle": "item_42",
+                            "entity": "054",
+                            "stage_name": "implementation",
+                            "blocked_reason": "blocked workflow state",
+                            "collection_state": "FO-uncollected",
+                        },
+                    ]
+                },
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "user_1",
+                "type": "user_message",
+                "text": "Before that finishes, can you clarify the gate wording?",
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "msg_2",
+                "type": "agent_message",
+                "text": "wait outcome: preempted_by_user_input; answering, then resuming the same wait set.",
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "notification_1",
+                "type": "agent_message",
+                "text": "Completion notification observed for item_23; still FO-uncollected until resumed wait_agent collects it.",
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "wait_2",
+                "type": "collab_tool_call",
+                "tool": "wait",
+                "receiver_thread_ids": ["item_23", "item_42"],
+                "agents_states": {
+                    "item_23": {
+                        "status": "completed",
+                        "message": "Stage report committed at abc1234.",
+                    },
+                    "item_42": {
+                        "status": "completed",
+                        "message": "Stage report committed at def5678.",
+                    },
+                },
+            },
+        },
+    ]
+    log_path.write_text("\n".join(json.dumps(entry) for entry in entries))
+
+    parser = CodexLogParser(log_path)
+    sequence = parser.preemptible_wait_sequences()[0]
+
+    assert sequence["initial_receiver_thread_ids"] == ["item_23", "item_42"]
+    assert sequence["resumed_receiver_thread_ids"] == ["item_23", "item_42"]
+    assert sequence["preemption_outcome"] == "preempted_by_user_input"
+    assert sequence["user_interruption_texts"] == [
+        "Before that finishes, can you clarify the gate wording?"
+    ]
+    assert sequence["completion_notifications_before_resume"] == ["item_23"]
+    assert sequence["collected_completed_thread_ids"] == ["item_23", "item_42"]
+    assert sequence["dropped_thread_ids"] == []
+    assert sequence["replacement_thread_ids"] == []
+
+    wait_status = parser.agent_message_texts()[0]
+    assert "048-implementation/Ensign feedback cycle 2" in wait_status
+    assert "054-implementation/Ensign" in wait_status
+    assert "blocked workflow state" in wait_status
+    assert "item_23" not in wait_status
+    assert "item_42" not in wait_status
+
+
 def test_isolated_claude_env_injects_oauth_token_when_token_file_present(monkeypatch, tmp_path):
     fake_home = tmp_path / "real-home"
     claude_dir = fake_home / ".claude"

--- a/tests/test_test_lib_helpers.py
+++ b/tests/test_test_lib_helpers.py
@@ -292,13 +292,7 @@ def test_codex_log_parser_detects_preempted_multi_handle_wait_resume(tmp_path):
             "item": {
                 "id": "msg_1",
                 "type": "agent_message",
-                "text": (
-                    "Waiting on `048-implementation/Ensign feedback cycle 2` and "
-                    "`054-implementation/Ensign` before I can advance the blocked "
-                    "workflow state. You can send a message and hit Esc to interrupt "
-                    "safely; I’ll process the additional feedback and resume waiting "
-                    "for ensigns unless you tell me to pause or stop."
-                ),
+                "text": "Waiting on the blocked implementation wait set before advancing.",
             },
         },
         {
@@ -314,19 +308,23 @@ def test_codex_log_parser_detects_preempted_multi_handle_wait_resume(tmp_path):
                             "worker_label": "048-implementation/Ensign feedback cycle 2",
                             "dispatch_agent_id": "spacedock:ensign",
                             "runtime_handle": "item_23",
-                            "entity": "048",
+                            "entity_path": "docs/plans/task-048.md",
+                            "entity_id": "048",
                             "stage_name": "implementation",
                             "blocked_reason": "blocked workflow state",
                             "collection_state": "FO-uncollected",
+                            "source": "same-handle reuse",
                         },
                         {
                             "worker_label": "054-implementation/Ensign",
                             "dispatch_agent_id": "spacedock:ensign",
                             "runtime_handle": "item_42",
-                            "entity": "054",
+                            "entity_path": "docs/plans/task-054.md",
+                            "entity_id": "054",
                             "stage_name": "implementation",
                             "blocked_reason": "blocked workflow state",
                             "collection_state": "FO-uncollected",
+                            "source": "fresh dispatch",
                         },
                     ]
                 },
@@ -382,6 +380,7 @@ def test_codex_log_parser_detects_preempted_multi_handle_wait_resume(tmp_path):
     sequence = parser.preemptible_wait_sequences()[0]
 
     assert sequence["initial_receiver_thread_ids"] == ["item_23", "item_42"]
+    assert sequence["initial_uncollected_thread_ids"] == ["item_23", "item_42"]
     assert sequence["resumed_receiver_thread_ids"] == ["item_23", "item_42"]
     assert sequence["preemption_outcome"] == "preempted_by_user_input"
     assert sequence["user_interruption_texts"] == [
@@ -389,15 +388,10 @@ def test_codex_log_parser_detects_preempted_multi_handle_wait_resume(tmp_path):
     ]
     assert sequence["completion_notifications_before_resume"] == ["item_23"]
     assert sequence["collected_completed_thread_ids"] == ["item_23", "item_42"]
+    assert sequence["fo_collected_thread_ids"] == ["item_23", "item_42"]
+    assert sequence["still_uncollected_thread_ids"] == []
     assert sequence["dropped_thread_ids"] == []
     assert sequence["replacement_thread_ids"] == []
-
-    wait_status = parser.agent_message_texts()[0]
-    assert "048-implementation/Ensign feedback cycle 2" in wait_status
-    assert "054-implementation/Ensign" in wait_status
-    assert "blocked workflow state" in wait_status
-    assert "item_23" not in wait_status
-    assert "item_42" not in wait_status
 
 
 def test_isolated_claude_env_injects_oauth_token_when_token_file_present(monkeypatch, tmp_path):


### PR DESCRIPTION
Interrupted Codex waits now resume on the same worker handles, preserving workflow continuity when the captain asks a side question.

## What changed
- Added concise Codex interrupted-wait runtime guidance.
- Added parser extraction for interrupted wait/resume sequences.
- Covered multi-handle wait resume with deterministic JSONL fixture.
- Updated task evidence through three validation cycles.

## Evidence
- Static suite: 512/512 passed.
- Targeted parser/content checks: 66/66 passed.

---
[216](/clkao/spacedock/blob/96b4af0e/docs/plans/codex-fo-preemptible-wait-mode.md)
Closes #148