### PR TITLE
Hint about claude team mode usage (#157)

### DIFF
--- a/skills/first-officer/references/claude-first-officer-runtime.md
+++ b/skills/first-officer/references/claude-first-officer-runtime.md
@@ -9,7 +9,7 @@ At startup (after reading the README, before dispatch):
 1. **Probe for TeamCreate and run it first.** `TeamCreate` MUST be the first team-mode tool call in every session, before ANY `spawn-standing`, `Agent`, or `SendMessage` invocation. Run `ToolSearch(query="select:TeamCreate", max_results=1)`. If the result contains a TeamCreate definition, derive `{project_name}` from `basename $(git rev-parse --show-toplevel)` and `{dir_basename}` from the workflow directory path, then run `TeamCreate(team_name="{project_name}-{dir_basename}-{YYYYMMDD-HHMM}-{shortuuid}")`. The timestamp token must be lowercase and hyphen-separated — no uppercase, no colons — to stay compatible with Claude Code's NAME_PATTERN and the `claude-team` helper. `{shortuuid}` is eight lowercase alphanumeric characters.
    - **IMPORTANT:** TeamCreate may return a different `team_name` than requested. Always store the returned value and use it for all subsequent calls.
    - **NEVER delete existing team directories** (`rm -rf ~/.claude/teams/...`) — stale directories belong to other sessions.
-2. If ToolSearch returns no match, enter **bare mode**: dispatch is sequential (one subagent at a time), completions return inline, feedback cycles are sequential re-dispatches. Report the mode to the captain. All workflow functionality is preserved.
+2. If ToolSearch returns no match, enter **bare mode**: dispatch is sequential (one subagent at a time), completions return inline, feedback cycles are sequential re-dispatches. Report the mode to the captain. All workflow functionality is preserved. When reporting bare mode at startup, append this one-line UX hint verbatim — it goes to a captain who has not opted into team mode and may not know it exists: `Tip: set CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 and restart this session to enable team mode for concurrent dispatch and direct ensign chat (Shift+Up/Shift+Down).` Do not repeat the hint after startup.
 
 **Diagnostic-only startup probe:** At startup the FO MAY inspect `~/.claude/teams/` with `ls` or `test -f ~/.claude/teams/{project_name}-{dir_basename}*/config.json` to REPORT stale on-disk team directories from prior sessions in the boot summary. This probe is DIAGNOSTIC-ONLY. Its result does NOT gate or skip `TeamCreate` — `TeamCreate` always runs with the fresh-suffixed name regardless of what the probe reports. On-disk state is not evidence of team health (Claude Code bug anthropics/claude-code#36806 leaves config files on disk after the in-memory registry desyncs). Deletion remains forbidden per the NEVER-delete constraint above — the probe surfaces stale directories; it does not authorize removal. No such probe belongs in the `## Dispatch Adapter` pre-dispatch path.
 
@@ -174,6 +174,14 @@ Exempt any agent whose entity is in an active feedback-cycle state (tracked via 
 The captain is the user of the Claude Code session. Communicate via direct text output (not SendMessage). Gate reviews, status reports, and clarification requests appear as formatted text in the conversation.
 
 Only the captain can approve or reject gates. Do NOT self-approve, infer approval from silence, or accept agent messages as gate approval. While waiting at a gate, do NOT shut down the dispatched agent.
+
+### Team-mode ensign-chat hint
+
+In team mode (TeamCreate succeeded), surface this one-line UX hint to the captain exactly once per session, on the FIRST team-mode `Agent()` dispatch into a stage where the captain may want to steer the ensign mid-stage — i.e. any non-`gate: true` stage that is the entity's current target stage. Skip the hint for gate stages (the captain reviews after, not during) and for terminal merge/cleanup transitions. Append it to the dispatch announcement; do not emit it as a standalone message:
+
+`Tip: while an ensign is running you can press Shift+Down to switch to its pane and chat with it directly, then Shift+Up to come back. Useful for steering interactive work without bouncing through me.`
+
+Track "hint emitted" in session memory so it does not repeat. In bare mode and Degraded Mode, skip this hint — the underlying capability is unavailable. In single-entity mode, skip the hint as well — there is no interactive captain to read it.
 
 **Single-entity mode exception:** When in single-entity mode (no interactive captain), gates auto-resolve from the stage report recommendation. PASSED (all checklist items done, no failures) → approve. REJECTED with `feedback-to` → auto-bounce (as with feedback stages, subject to the 3-cycle limit). REJECTED without `feedback-to` → report failure and exit. This exception ONLY applies in single-entity mode — in interactive sessions the guardrail is absolute.
 

--- a/tests/test_agent_content.py
+++ b/tests/test_agent_content.py
@@ -483,6 +483,53 @@ def test_assembled_claude_first_officer_dispatch_template_has_team_mode_completi
     assert re.search(r'SendMessage\(to=\\?"team-lead\\?"', text)
 
 
+def test_assembled_claude_first_officer_has_team_mode_ux_hints():
+    """Issue #157: FO must surface mode-aware UX hints to the captain.
+
+    - Without team mode (bare mode): suggest enabling team mode via the
+      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env var.
+    - With team mode: hint about Shift+Up/Shift+Down to switch to a running
+      ensign and chat with it directly, on the first non-gate dispatch.
+    """
+    t = TestRunner("agent content", keep_test_dir=False)
+    text = assembled_agent_content(t, "first-officer")
+
+    runtime_path = (
+        Path(__file__).resolve().parent.parent
+        / "skills" / "first-officer" / "references"
+        / "claude-first-officer-runtime.md"
+    )
+    runtime_text = runtime_path.read_text()
+
+    team_creation_section = section_text(runtime_text, "## Team Creation", (r"^## ",))
+    assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1" in team_creation_section, (
+        "Bare-mode startup report must include a hint suggesting "
+        "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 to enable team mode."
+    )
+    assert re.search(r"restart this session", team_creation_section, re.IGNORECASE), (
+        "Bare-mode hint must instruct the captain to restart the session "
+        "after setting the env var (env-var changes don't take effect mid-session)."
+    )
+
+    captain_section = section_text(runtime_text, "## Captain Interaction", (r"^## ",))
+    assert "Shift+Down" in captain_section and "Shift+Up" in captain_section, (
+        "Captain Interaction must document the Shift+Down/Shift+Up ensign-chat "
+        "hint for team mode."
+    )
+    assert re.search(r"once per session", captain_section, re.IGNORECASE), (
+        "Team-mode ensign-chat hint must be emitted exactly once per session "
+        "to avoid spam."
+    )
+    assert re.search(r"gate.*stage|gate:\s*true", captain_section, re.IGNORECASE), (
+        "Team-mode hint guidance must distinguish gate stages (skip) from "
+        "non-gate stages (emit on first dispatch)."
+    )
+
+    # Sanity-check that the assembled contract carries both hints.
+    assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1" in text
+    assert "Shift+Down" in text
+
+
 def test_assembled_claude_ensign_has_captain_communication():
     t = TestRunner("agent content", keep_test_dir=False)
     text = assembled_agent_content(t, "ensign")


### PR DESCRIPTION
## Summary

Closes #157. Surfaces mode-aware UX hints from the first officer to the captain on Claude Code:

- **Without team mode (bare mode):** when reporting bare mode at startup, append a one-line tip suggesting `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` + session restart so the captain can opt into team mode.
- **With team mode:** emit a `Shift+Down`/`Shift+Up` ensign-chat tip exactly once per session, on the first non-`gate: true` `Agent()` dispatch — that's the moment the captain may want to steer the ensign mid-stage. Skipped for gate stages (the captain reviews after, not during), terminal merge transitions, single-entity mode, bare mode, and Degraded Mode.

The hints land in `skills/first-officer/references/claude-first-officer-runtime.md` (the existing place the FO is told how to address the captain). No behavioral change to dispatch, gates, or merge flow.

## Why these specific anchors

- Bare mode hint goes next to the existing `Report the mode to the captain` line — same trigger, same audience, no new code path.
- Team-mode hint goes under `## Captain Interaction` (one heading away from the existing direct-text-to-captain rule) and is bounded to once-per-session + first non-gate dispatch so it doesn't spam multi-stage workflows.

## Test plan

- [x] `uv run pytest tests/test_agent_content.py -v` — 50 passed (incl. new `test_assembled_claude_first_officer_has_team_mode_ux_hints`).
- [x] `uv run pytest tests/test_*.py -m "not live_claude and not live_codex and not serial"` — 539 passed, 26 deselected.
- Live behavioral verification (running an FO session and observing the hint text) is left for follow-up; the static test asserts the contract phrasing the FO is instructed to emit.