### PR TITLE
Make claude-team stage-heading parser tolerate italic-wrapped parentheticals (#178)

### DIFF
--- a/docs/plans/claude-team-stage-heading-italic-parenthetical.md
+++ b/docs/plans/claude-team-stage-heading-italic-parenthetical.md
@@ -143,3 +143,20 @@ Regression guard: existing seven `TestExtractStageSubsection` tests must remain 
 ### Summary
 
 Reframed the ideation away from the original brittle regex-extension toward a two-direction approach: a permissive first-content-token extractor (Direction A) that survives any reasonable Markdown decoration, plus a fail-loud `ValueError` diagnostic (Direction B) integrated with `cmd_build` so unparseable-but-mentioned headings surface a structured error instead of silent fallthrough to break-glass. AC items are end-state properties with explicit `Verified by:` clauses; test plan covers both directions plus regression preservation of the seven existing #138/PR-145 tests. No prior stage report existed, so no feedback cycle marker was needed.
+
+## Stage Report: implementation
+
+- DONE: Replace `extract_stage_subsection` regex match with the permissive Direction A approach (strip decoration → check first content token equals stage name)
+  Implemented `_heading_tokens` + `_heading_first_token` helpers; `extract_stage_subsection` now matches when the heading's first content token equals `stage_name` after stripping `` ` *_~ `` and treating `(` / `[` as token terminators. Commit `c0e4b8f6`.
+- DONE: Add Direction B fail-loud path: raise `ValueError` with line number + raw heading + parsing requirement when stage name appears as a heading token but not the first one; return `None` when genuinely absent
+  Secondary scan uses `_heading_tokens` (token-level, not raw substring) so partial-name lookups like `wor` against `### \`work\`` still return `None`. Error message includes line number, `repr(heading)`, and the phrase "first content token". Commit `c0e4b8f6`.
+- DONE: Update `cmd_build` to catch `ValueError` from `extract_stage_subsection` and surface via `_build_error`
+  `try`/`except ValueError` wraps the call at `claude-team:269-273` and forwards `str(e)` to `_build_error`, giving the captain a structured stderr diagnostic with non-zero exit. Commit `c0e4b8f6`.
+- DONE: Add regression tests to `tests/test_claude_team.py::TestExtractStageSubsection` per entity test plan (8 new permissive-parser tests + 2 fail-loud) + E2E test in `TestBuildStageHeadingParentheticalE2E`
+  Added 11 unit tests (italic, underscore-italic, bold-name, bold-annotation, mixed-decoration, square-bracket, trailing-text, 4 parameterized real-world #178 cases, fail-loud-when-mentioned, return-None-when-absent) and 1 subprocess E2E test (`test_build_surfaces_unparseable_heading_diagnostic`). Existing 7 TestExtractStageSubsection tests + existing E2E test unchanged and green. Commit `2c5d7ca6`.
+- DONE: Local verification — `unset CLAUDECODE && uv run pytest tests/test_claude_team.py -v` and `make test-static`
+  `tests/test_claude_team.py`: 105 passed (22 in the two affected classes). `make test-static`: 553 passed, 26 deselected, 15 subtests passed in 28.87s.
+
+### Summary
+
+Implemented Direction A (permissive first-content-token extractor) and Direction B (fail-loud `ValueError` for headings that mention the stage name but don't parse) in `skills/commission/bin/claude-team`, plus `cmd_build` `try`/`except` to surface the diagnostic on stderr. Refined Direction B's substring check to operate on tokens rather than raw substring so the existing `test_rejects_partial_match` (`wor` against `### \`work\``) continued to return `None` instead of raising — only headings that contain the stage name as a real word now trigger fail-loud. All 7 prior `TestExtractStageSubsection` tests + the prior E2E test remain unchanged and green. Two commits per stage discipline: `c0e4b8f6` (source) and `2c5d7ca6` (tests).

--- a/docs/plans/claude-team-stage-heading-italic-parenthetical.md
+++ b/docs/plans/claude-team-stage-heading-italic-parenthetical.md
@@ -160,3 +160,23 @@ Reframed the ideation away from the original brittle regex-extension toward a tw
 ### Summary
 
 Implemented Direction A (permissive first-content-token extractor) and Direction B (fail-loud `ValueError` for headings that mention the stage name but don't parse) in `skills/commission/bin/claude-team`, plus `cmd_build` `try`/`except` to surface the diagnostic on stderr. Refined Direction B's substring check to operate on tokens rather than raw substring so the existing `test_rejects_partial_match` (`wor` against `### \`work\``) continued to return `None` instead of raising — only headings that contain the stage name as a real word now trigger fail-loud. All 7 prior `TestExtractStageSubsection` tests + the prior E2E test remain unchanged and green. Two commits per stage discipline: `c0e4b8f6` (source) and `2c5d7ca6` (tests).
+
+## Stage Report: validation
+
+- DONE: Run `make test-static` and `unset CLAUDECODE && uv run pytest tests/test_claude_team.py::TestExtractStageSubsection tests/test_claude_team.py::TestBuildStageHeadingParentheticalE2E -v` from the worktree; cite exit codes and pass/fail counts in the report.
+  `make test-static` → exit 0, 553 passed, 26 deselected, 15 subtests passed in 28.81s. Targeted run → exit 0, 22 passed in 0.11s (7 prior TestExtractStageSubsection + 13 new TestExtractStageSubsection + 2 TestBuildStageHeadingParentheticalE2E).
+- DONE: For each AC-1..AC-7 in the entity body, name the cited test from its `Verified by:` clause and confirm the run in step 1 covered it. Flag any AC whose cited test does not appear in the run output.
+  AC-1 → `test_matches_italic_wrapped_parenthetical`, `test_matches_underscore_italic_parenthetical`, `test_matches_bold_wrapped_name`, `test_matches_bold_annotation`, `test_matches_mixed_decoration`, `test_matches_square_bracket_annotation`, `test_matches_trailing_text_after_name` — all PASSED.
+  AC-2 → `test_raises_when_stage_mentioned_but_not_first_token` — PASSED.
+  AC-3 → `test_rejects_nonexistent_stage` — PASSED (also `test_returns_none_when_stage_truly_absent` PASSED).
+  AC-4 → `test_rejects_partial_match` — PASSED.
+  AC-5 → `TestBuildStageHeadingParentheticalE2E::test_build_surfaces_unparseable_heading_diagnostic` — PASSED.
+  AC-6 → `test_matches_real_world_178_examples` (4 parameterized cases: brainstorm, capture, pr-review, handoff) — all PASSED.
+  AC-7 → 7 prior TestExtractStageSubsection tests (`test_matches_backtick_bare_heading`, `test_matches_bare_heading`, `test_matches_backtick_heading_with_parenthetical`, `test_matches_bare_heading_with_parenthetical`, `test_matches_backtick_heading_with_arbitrary_parenthetical`, `test_rejects_nonexistent_stage`, `test_rejects_partial_match`) — all PASSED with no test changes.
+  No AC has a missing cited test.
+- DONE: Issue a PASSED or REJECTED recommendation. If REJECTED, name the failing AC and the missing or contradictory evidence.
+  PASSED.
+
+### Summary
+
+Validation cross-check: `make test-static` is green (553 passed) and the targeted `TestExtractStageSubsection` + `TestBuildStageHeadingParentheticalE2E` run is green (22 passed, 0 failures). Every AC-1..AC-7 has its cited `Verified by:` test present in the run output and passing — including the 7 regression-guard tests for AC-7 unchanged. Recommendation: PASSED.

--- a/skills/commission/bin/claude-team
+++ b/skills/commission/bin/claude-team
@@ -69,26 +69,73 @@ def _recent_team_evidence():
     return False
 
 
+_HEADING_DECORATION_CHARS = str.maketrans('', '', '`*_~')
+
+
+def _heading_tokens(line):
+    """Return the content tokens of a `### `-prefixed heading, or ``None``.
+
+    Strips Markdown inline decoration (`` ` ``, `*`, `_`, `~`) and treats
+    `(` and `[` as token terminators so trailing annotations like
+    `*(captain-interactive)*` or `[terminal]` do not merge with the name.
+    """
+    stripped = line.strip()
+    if not stripped.startswith('### '):
+        return None
+    rest = stripped[4:].strip()
+    rest = rest.translate(_HEADING_DECORATION_CHARS)
+    for ch in '([':
+        rest = rest.replace(ch, ' ')
+    return rest.split()
+
+
+def _heading_first_token(line):
+    """Return the first content token of a `### ` heading, or ``None``."""
+    tokens = _heading_tokens(line)
+    if not tokens:
+        return None
+    return tokens[0]
+
+
 def extract_stage_subsection(readme_path, stage_name):
     r"""Extract the full ### {stage_name} subsection from a workflow README.
 
-    Accepts backtick-quoted (`### \`work\``) and bare (`### work`) headings,
-    each optionally followed by a parenthetical annotation like
-    `### \`triaged\` (terminal)` — the annotation is informational; the
-    canonical truth source for terminal/middle/etc. is the YAML frontmatter.
+    Heading match is permissive: any `###` line whose first content token
+    (after stripping `` ` ``, `*`, `_`, `~` and treating `(` / `[` as token
+    terminators) equals ``stage_name`` is treated as a match. This survives
+    common Markdown decorations captains use for inline metadata: backticks,
+    italic (`*` / `_`), bold (`**` / `__`), parentheticals, square-bracket
+    annotations, and trailing em-dash text.
+
+    If no permissive match is found but some `###` line in the README mentions
+    the stage name as a substring, raise ``ValueError`` with line number, the
+    raw heading text, and the parsing requirement — this surfaces the
+    captain's malformed heading instead of silently returning ``None``.
+
+    Returns ``None`` only when no `###` line mentions the stage name at all
+    (genuinely missing stage).
     """
     with open(readme_path, 'r') as f:
         text = f.read()
     lines = text.splitlines()
-    heading_re = re.compile(
-        rf'^###\s+`?{re.escape(stage_name)}`?(?:\s+\([^)]*\))?\s*$'
-    )
     start = None
     for i, line in enumerate(lines):
-        if heading_re.match(line.strip()):
+        if _heading_first_token(line) == stage_name:
             start = i
             break
     if start is None:
+        for i, line in enumerate(lines):
+            tokens = _heading_tokens(line)
+            if tokens and stage_name in tokens:
+                stripped = line.strip()
+                raise ValueError(
+                    f"stage heading at line {i + 1} mentions '{stage_name}' "
+                    f"but does not parse as a stage heading: {stripped!r}. "
+                    f"The stage name must be the first content token of the "
+                    f"heading after stripping Markdown decoration "
+                    f"(backticks, *, _, ~) and treating '(' and '[' as "
+                    f"token terminators."
+                )
         return None
     end = len(lines)
     for i in range(start + 1, len(lines)):
@@ -266,7 +313,10 @@ def cmd_build(args):
         return _build_error(f"derived name '{derived_name}' contains invalid characters")
 
     # Extract stage subsection from README
-    stage_subsection = extract_stage_subsection(readme_path, stage)
+    try:
+        stage_subsection = extract_stage_subsection(readme_path, stage)
+    except ValueError as e:
+        return _build_error(str(e))
     if stage_subsection is None:
         return _build_error(f"stage '{stage}' heading not found in {readme_path}")
 

--- a/tests/test_claude_team.py
+++ b/tests/test_claude_team.py
@@ -1933,6 +1933,105 @@ class TestExtractStageSubsection:
         # "wor" is a prefix of "work" — must NOT match.
         assert mod.extract_stage_subsection(str(readme), "wor") is None
 
+    def _write_decorated(self, tmp_path, heading_line, body_line="Body."):
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            "# Workflow\n"
+            "\n"
+            "## Stages\n"
+            "\n"
+            f"{heading_line}\n"
+            "\n"
+            f"{body_line}\n"
+        )
+        return readme
+
+    def test_matches_italic_wrapped_parenthetical(self, tmp_path):
+        mod = _load_claude_team_lib()
+        readme = self._write_decorated(
+            tmp_path,
+            "### `brainstorm` *(captain-interactive — no ensign)*",
+        )
+        result = mod.extract_stage_subsection(str(readme), "brainstorm")
+        assert result is not None
+        assert result.startswith("### `brainstorm` *(captain-interactive — no ensign)*")
+
+    def test_matches_underscore_italic_parenthetical(self, tmp_path):
+        mod = _load_claude_team_lib()
+        readme = self._write_decorated(tmp_path, "### work _(initial)_")
+        result = mod.extract_stage_subsection(str(readme), "work")
+        assert result is not None
+        assert result.startswith("### work _(initial)_")
+
+    def test_matches_bold_wrapped_name(self, tmp_path):
+        mod = _load_claude_team_lib()
+        readme = self._write_decorated(tmp_path, "### **work**")
+        result = mod.extract_stage_subsection(str(readme), "work")
+        assert result is not None
+        assert result.startswith("### **work**")
+
+    def test_matches_bold_annotation(self, tmp_path):
+        mod = _load_claude_team_lib()
+        readme = self._write_decorated(tmp_path, "### name **(annotation)**")
+        result = mod.extract_stage_subsection(str(readme), "name")
+        assert result is not None
+        assert result.startswith("### name **(annotation)**")
+
+    def test_matches_mixed_decoration(self, tmp_path):
+        mod = _load_claude_team_lib()
+        readme = self._write_decorated(tmp_path, "### **`name`** *(annotation)*")
+        result = mod.extract_stage_subsection(str(readme), "name")
+        assert result is not None
+        assert result.startswith("### **`name`** *(annotation)*")
+
+    def test_matches_square_bracket_annotation(self, tmp_path):
+        mod = _load_claude_team_lib()
+        readme = self._write_decorated(tmp_path, "### name [terminal]")
+        result = mod.extract_stage_subsection(str(readme), "name")
+        assert result is not None
+        assert result.startswith("### name [terminal]")
+
+    def test_matches_trailing_text_after_name(self, tmp_path):
+        mod = _load_claude_team_lib()
+        readme = self._write_decorated(tmp_path, "### work — does the thing")
+        result = mod.extract_stage_subsection(str(readme), "work")
+        assert result is not None
+        assert result.startswith("### work — does the thing")
+
+    @pytest.mark.parametrize(
+        "heading,stage",
+        [
+            ("### `brainstorm` *(captain-interactive — no ensign)*", "brainstorm"),
+            ("### `capture` *(gate — rejection bounces to `iterate`)*", "capture"),
+            ("### `pr-review` *(fresh)*", "pr-review"),
+            (
+                "### `handoff` *(gate — rejection bounces to `pr-review`, terminal)*",
+                "handoff",
+            ),
+        ],
+    )
+    def test_matches_real_world_178_examples(self, tmp_path, heading, stage):
+        mod = _load_claude_team_lib()
+        readme = self._write_decorated(tmp_path, heading)
+        result = mod.extract_stage_subsection(str(readme), stage)
+        assert result is not None
+        assert result.startswith(heading)
+
+    def test_raises_when_stage_mentioned_but_not_first_token(self, tmp_path):
+        mod = _load_claude_team_lib()
+        readme = self._write_decorated(tmp_path, "### see also: `work`")
+        with pytest.raises(ValueError) as excinfo:
+            mod.extract_stage_subsection(str(readme), "work")
+        msg = str(excinfo.value)
+        assert "line 5" in msg
+        assert "see also: `work`" in msg
+        assert "first content token" in msg
+
+    def test_returns_none_when_stage_truly_absent(self, tmp_path):
+        mod = _load_claude_team_lib()
+        readme = self._write_decorated(tmp_path, "### something-else")
+        assert mod.extract_stage_subsection(str(readme), "work") is None
+
 
 class TestBuildStageHeadingParentheticalE2E:
     """#138/#212 AC-4: end-to-end subprocess repro of the issue body."""
@@ -1997,6 +2096,64 @@ class TestBuildStageHeadingParentheticalE2E:
         assert result.returncode == 0, f"stderr: {result.stderr}"
         out = json.loads(result.stdout)
         assert "Triage complete, entity is done." in out["prompt"]
+
+    def test_build_surfaces_unparseable_heading_diagnostic(self, tmp_path):
+        wf_dir = tmp_path / "workflow"
+        wf_dir.mkdir()
+        readme = wf_dir / "README.md"
+        readme.write_text(
+            "---\n"
+            "commissioned-by: spacedock@test\n"
+            "entity-label: task\n"
+            "stages:\n"
+            "  defaults:\n"
+            "    worktree: false\n"
+            "    concurrency: 2\n"
+            "  states:\n"
+            "    - name: new\n"
+            "      initial: true\n"
+            "    - name: work\n"
+            "      terminal: true\n"
+            "---\n"
+            "\n"
+            "# Workflow\n"
+            "\n"
+            "## Stages\n"
+            "\n"
+            "### `new`\n"
+            "\n"
+            "Seed.\n"
+            "\n"
+            "### see also: `work`\n"
+            "\n"
+            "Malformed heading body.\n"
+        )
+        entity = wf_dir / "sample.md"
+        entity.write_text(
+            "---\n"
+            "id: 001\n"
+            "title: Sample entity\n"
+            "status: work\n"
+            "---\n"
+            "\n"
+            "Body.\n"
+        )
+        inp = {
+            "schema_version": 1,
+            "entity_path": str(entity),
+            "workflow_dir": str(wf_dir),
+            "stage": "work",
+            "checklist": ["x"],
+            "team_name": None,
+            "feedback_context": None,
+            "scope_notes": None,
+            "bare_mode": True,
+            "is_feedback_reflow": False,
+        }
+        result = run_build(wf_dir, inp)
+        assert result.returncode != 0
+        assert "see also: `work`" in result.stderr
+        assert "first content token" in result.stderr
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make `claude-team build` accept italic-wrapped, bold-wrapped, and bracket-annotated stage headings instead of silently failing on them.

## What changed

- Replace the brittle `### \`stage\` (annotation)` regex with a permissive first-content-token extractor
- Add fail-loud `ValueError` when a heading mentions the stage name but cannot parse, surfacing line number and offending heading
- Wrap `cmd_build` to catch the new `ValueError` and route it through `_build_error` for stderr + non-zero exit
- Add 11 tests covering decoration variants, fail-loud paths, and a subprocess E2E for the cmd_build diagnostic

## Evidence

- `make test-static`: 553/553 passed
- `tests/test_claude_team.py::TestExtractStageSubsection` + `TestBuildStageHeadingParentheticalE2E`: 22/22 passed

---
[jaafh7xzz0va63rj6bgdgh3p](/clkao/spacedock/blob/9e429f3a/docs/plans/claude-team-stage-heading-italic-parenthetical.md)

Closes #178