### PR TITLE
status --set silently injects frontmatter into files whose first --- is a body separator

### DIFF
--- a/docs/plans/status-set-injects-frontmatter-when-first-fence-is-body-separator.md
+++ b/docs/plans/status-set-injects-frontmatter-when-first-fence-is-body-separator.md
@@ -149,3 +149,23 @@ Selected F1 (strict opening fence in `parse_frontmatter`) + F2 (defensive write 
 ### Summary
 
 Implemented F1+F2+F3 as one logical change pivoting on the shared `_has_opening_fence` predicate; total diff is +39 lines in `status` plus a 230-line test file. The only deviation from the spec was the assertion text in T-E2E-186 — the actual error path in `resolve_mutation_entity` produces `entity not found: <ref>` rather than `unknown reference: <ref>`; both prove the AC property (file untouched, non-zero exit, clear stderr), and the SHA256 byte-identity check is the load-bearing assertion. Full static suite green; commit c9c5f0d5 on branch `spacedock-ensign/status-set-injects-frontmatter-when-first-fence-is-body-separator`.
+
+## Stage Report: validation
+
+- DONE: Every AC (AC-1..AC-6) has its named tests rerun in the validator's session; results captured per-suite with `N/N passed` counts and AC-by-AC evidence.
+  Targeted file `tests/test_status_strict_opening_fence.py`: **11/11 passed** in 0.21s. Per-AC breakdown:
+  - **AC-1 (parser strict fence):** T-PARSE-1 `test_prose_before_first_fence_returns_empty` PASSED, T-PARSE-2 `test_leading_blank_lines_then_fence_parses` PASSED, T-PARSE-3 `test_leading_bom_then_fence_parses` PASSED, T-PARSE-4 `test_whitespace_only_first_line_is_content` PASSED.
+  - **AC-2 (write guard):** T-WRITE-1 `test_body_separator_only_raises_and_preserves_bytes` PASSED, T-WRITE-2 `test_pure_prose_no_fence_raises_and_preserves_bytes` PASSED.
+  - **AC-3 (active-scope discovery skip):** T-DISCOVER-1 `test_active_scope_skips_body_rule_file` PASSED, T-DISCOVER-2 `test_folder_form_index_without_fence_skipped` PASSED.
+  - **AC-4 (archived-scope discovery skip):** T-DISCOVER-3 `test_archived_scope_skips_body_rule_file` PASSED.
+  - **AC-5 (end-to-end issue #186):** T-E2E-186 `test_set_against_body_rule_file_fails_safely` PASSED.
+  - **AC-6 (regression):** T-E2E-VALID `test_set_against_valid_entity_still_works` PASSED.
+  Full repo offline suite via `make test-static`: **587 passed, 26 deselected, 15 subtests passed in 27.77s** — no pre-existing tests regressed.
+- DONE: The implementation's spec/reality drift on T-E2E-186 (asserted `entity not found: notes` instead of the spec's `unknown reference: notes`) is independently confirmed against the live `status` binary; if the AC's intent (non-zero exit, byte-identical file, slug-not-resolved diagnostic) is fully met the validator records that and treats the assertion text as a spec correction, not a defect.
+  Independent reproduction in `/tmp/drift-check`: invoked `python3 skills/commission/bin/status --set notes id=001` against a workflow with body-rule `notes.md`; live binary emitted `Error: entity not found: notes` on stderr and exit 1; `sha256sum` of `notes.md` was `b71cb89e26a99f6efd31f14e3d58fbcedd6b831c8ce9943420622880942462e3` both before and after the invocation (byte-identical). AC-5's three required properties — non-zero exit, slug-not-resolved diagnostic on stderr, byte-identical file via SHA256 — are all met. Recording as a spec correction: the actual error path in `resolve_mutation_entity` emits `entity not found: <ref>` rather than `unknown reference: <ref>`; the test assertion matches reality and the AC intent is fully verified.
+- DONE: PASSED or REJECTED recommendation with one-line rationale; if REJECTED, the rationale names the specific AC that failed.
+  **PASSED** — all six ACs verified by named tests (11/11 targeted tests green, full static suite 587/587 green, AC-5 spec-vs-reality drift independently confirmed against the live binary as a benign spec correction with full intent preserved).
+
+### Summary
+
+Validation reproduced every AC's named test, ran the full offline suite without regression, and independently verified the T-E2E-186 spec/reality drift against the live `status` binary — confirming `Error: entity not found: notes`, exit 1, and byte-identical SHA256 (`b71cb89e…`). Recommendation: **PASSED**. The deviation from the spec's `unknown reference:` wording is a spec correction (the actual `resolve_mutation_entity` "unknown" branch emits `entity not found: <ref>`), and all three load-bearing AC-5 properties are satisfied.

--- a/docs/plans/status-set-injects-frontmatter-when-first-fence-is-body-separator.md
+++ b/docs/plans/status-set-injects-frontmatter-when-first-fence-is-body-separator.md
@@ -136,3 +136,16 @@ Reviewer also confirmed:
 ### Summary
 
 Selected F1 (strict opening fence in `parse_frontmatter`) + F2 (defensive write check in `update_frontmatter`) + F3 (discovery skip in `discover_entity_files`); the four issue suggestions reduce to three implementation surfaces because slug pre-resolution already routes through discovery. Test plan combines four parser fixtures, two write-guard fixtures, three discovery-harness tests (active + folder-form + archived), and two end-to-end `--set` runs — all via the existing `tests/test_status_*.py` subprocess harness; no live LLM or worktree needed because the bug is fully reproducible at the `status` script boundary. Independent reviewer pass folded in three deltas (archive scope, AC-3 sharpening, whitespace-only first line) before gate.
+
+## Stage Report: implementation
+
+- DONE: F1, F2, and F3 share a single `_has_opening_fence(path)` predicate (defined once, called from `parse_frontmatter`, `update_frontmatter`, and `discover_entity_files`); the strictness contract is not duplicated three ways.
+  Predicate added at top of `skills/commission/bin/status` (above `parse_frontmatter`); called as a guard from all three surfaces (commit c9c5f0d5).
+- DONE: All 11 tests from the test plan (T-PARSE-1..4, T-WRITE-1/2, T-DISCOVER-1/2/3, T-E2E-186, T-E2E-VALID) added under `tests/test_status_*.py` and passing locally.
+  `tests/test_status_strict_opening_fence.py`: 11/11 passed. Note: T-E2E-186 asserts the actual error string `entity not found: notes` produced by `resolve_mutation_entity`'s `unknown` branch — the spec's `unknown reference: notes` was inaccurate about which error path fires; the AC's intent (non-zero exit + slug-not-resolved diagnostic + byte-identical file) is fully verified, including SHA256 before/after.
+- DONE: `make test-static` exits 0 — no pre-existing tests regressed by F1/F2/F3.
+  `587 passed, 26 deselected, 15 subtests passed in 27.71s`.
+
+### Summary
+
+Implemented F1+F2+F3 as one logical change pivoting on the shared `_has_opening_fence` predicate; total diff is +39 lines in `status` plus a 230-line test file. The only deviation from the spec was the assertion text in T-E2E-186 — the actual error path in `resolve_mutation_entity` produces `entity not found: <ref>` rather than `unknown reference: <ref>`; both prove the AC property (file untouched, non-zero exit, clear stderr), and the SHA256 byte-identity check is the load-bearing assertion. Full static suite green; commit c9c5f0d5 on branch `spacedock-ensign/status-set-injects-frontmatter-when-first-fence-is-body-separator`.

--- a/skills/commission/bin/status
+++ b/skills/commission/bin/status
@@ -93,13 +93,46 @@ import sys
 from datetime import datetime, timezone
 
 
+def _has_opening_fence(filepath):
+    """Return True iff the file's first non-empty, non-BOM line is exactly `---`.
+
+    Leading truly-empty lines (`\\n` only) are skipped before the check; a
+    whitespace-only line (e.g. `"   \\n"`) counts as content and disqualifies
+    the file. A leading UTF-8 BOM on the first line is ignored. Anything other
+    than an opening `---` fence at that position means the file has no
+    frontmatter — see issue #186 for the corruption this guards against.
+    """
+    try:
+        with open(filepath, 'r') as f:
+            first = True
+            for raw in f:
+                line = raw.rstrip('\n')
+                if first:
+                    if line.startswith('﻿'):
+                        line = line[1:]
+                    first = False
+                if line == '':
+                    continue
+                return line == '---'
+    except OSError:
+        return False
+    return False
+
+
 def parse_frontmatter(filepath):
     """Extract YAML frontmatter fields from a markdown file."""
     fields = {}
+    if not _has_opening_fence(filepath):
+        return fields
     in_fm = False
+    first = True
     with open(filepath, 'r') as f:
         for line in f:
             line = line.rstrip('\n')
+            if first:
+                if line.startswith('﻿'):
+                    line = line[1:]
+                first = False
             if line == '---':
                 if in_fm:
                     break
@@ -397,6 +430,8 @@ def discover_entity_files(directory):
                 continue
             if name.startswith('.'):
                 continue
+            if not _has_opening_fence(full):
+                continue
             slug = name[:-3]
             flat_paths[slug] = full
         elif os.path.isdir(full):
@@ -405,7 +440,7 @@ def discover_entity_files(directory):
             if name.startswith('.'):
                 continue
             index_path = os.path.join(full, 'index.md')
-            if os.path.isfile(index_path):
+            if os.path.isfile(index_path) and _has_opening_fence(index_path):
                 folder_paths[name] = index_path
 
     slugs = sorted(set(flat_paths) | set(folder_paths))
@@ -1437,6 +1472,9 @@ def parse_set_args(args):
 
 def update_frontmatter(filepath, updates):
     """Rewrite frontmatter fields in a file. Returns dict of updated fields."""
+    if not _has_opening_fence(filepath):
+        raise ValueError(f'No frontmatter found in {filepath}')
+
     with open(filepath, 'r') as f:
         content = f.read()
 

--- a/tests/test_status_strict_opening_fence.py
+++ b/tests/test_status_strict_opening_fence.py
@@ -1,0 +1,249 @@
+# ABOUTME: Tests for strict opening-fence detection in parse_frontmatter, update_frontmatter, and discover_entity_files.
+# ABOUTME: Guards issue #186 where a body horizontal rule was treated as YAML frontmatter and corrupted user prose.
+
+import hashlib
+import importlib.machinery
+import importlib.util
+import os
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import pytest
+
+from test_status_script import (
+    build_status_script,
+    make_pipeline,
+    run_status,
+    README_WITH_STAGES,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STATUS_SCRIPT = REPO_ROOT / "skills" / "commission" / "bin" / "status"
+
+
+def _load_status_module():
+    loader = importlib.machinery.SourceFileLoader("_status_lib_strict_fence", str(STATUS_SCRIPT))
+    spec = importlib.util.spec_from_file_location(
+        "_status_lib_strict_fence", str(STATUS_SCRIPT), loader=loader
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+status = _load_status_module()
+parse_frontmatter = status.parse_frontmatter
+update_frontmatter = status.update_frontmatter
+
+
+class TestParseFrontmatterStrictFence:
+    """AC-1: parse_frontmatter requires the first non-empty, non-BOM line to be `---`."""
+
+    def test_prose_before_first_fence_returns_empty(self, tmp_path):
+        """T-PARSE-1: prose first then `---` -> {}"""
+        f = tmp_path / "notes.md"
+        f.write_text(
+            "# My research notes\n"
+            "\n"
+            "Some prose here.\n"
+            "\n"
+            "---\n"
+            "\n"
+            "More prose after a horizontal rule.\n"
+        )
+        assert parse_frontmatter(str(f)) == {}
+
+    def test_leading_blank_lines_then_fence_parses(self, tmp_path):
+        """T-PARSE-2: leading blank lines (truly empty) before fence are allowed."""
+        f = tmp_path / "task.md"
+        f.write_text("\n\n---\nid: 001\n---\n\nbody\n")
+        assert parse_frontmatter(str(f)) == {"id": "001"}
+
+    def test_leading_bom_then_fence_parses(self, tmp_path):
+        """T-PARSE-3: BOM then `---` parses as if BOM were absent."""
+        f = tmp_path / "task.md"
+        f.write_text("﻿---\nid: 001\n---\n\nbody\n")
+        assert parse_frontmatter(str(f)) == {"id": "001"}
+
+    def test_whitespace_only_first_line_is_content(self, tmp_path):
+        """T-PARSE-4: a whitespace-only line is content, not blank — fence cannot follow."""
+        f = tmp_path / "task.md"
+        f.write_text("   \n---\nid: 001\n---\n\nbody\n")
+        assert parse_frontmatter(str(f)) == {}
+
+
+class TestUpdateFrontmatterWriteGuard:
+    """AC-2: update_frontmatter refuses to write when file lacks an opening fence."""
+
+    def test_body_separator_only_raises_and_preserves_bytes(self, tmp_path):
+        """T-WRITE-1: file whose first `---` is a body separator raises and is unchanged."""
+        f = tmp_path / "notes.md"
+        original = (
+            "# My research notes\n"
+            "\n"
+            "Some prose here.\n"
+            "\n"
+            "---\n"
+            "\n"
+            "More prose after a horizontal rule.\n"
+        )
+        f.write_text(original)
+        before = f.read_bytes()
+        with pytest.raises(ValueError, match=r"No frontmatter found in"):
+            update_frontmatter(str(f), [("id", "001")])
+        after = f.read_bytes()
+        assert before == after
+
+    def test_pure_prose_no_fence_raises_and_preserves_bytes(self, tmp_path):
+        """T-WRITE-2: file with no `---` at all raises and is unchanged."""
+        f = tmp_path / "prose.md"
+        original = "# Heading\n\nJust prose, no fences anywhere.\n"
+        f.write_text(original)
+        before = f.read_bytes()
+        with pytest.raises(ValueError, match=r"No frontmatter found in"):
+            update_frontmatter(str(f), [("id", "001")])
+        after = f.read_bytes()
+        assert before == after
+
+
+# Reproduction prose used in T-DISCOVER-* and T-E2E-186.
+NOTES_BODY_RULE = (
+    "# My research notes\n"
+    "\n"
+    "Some prose here.\n"
+    "\n"
+    "---\n"
+    "\n"
+    "More prose after a horizontal rule.\n"
+)
+
+
+def valid_entity(slug, id_):
+    return textwrap.dedent(f"""\
+        ---
+        id: {id_}
+        title: {slug}
+        status: backlog
+        ---
+
+        Description.
+        """)
+
+
+class TestDiscoveryStrictFence(unittest.TestCase):
+    """AC-3 / AC-4: discover_entity_files skips files that lack an opening fence."""
+
+    def setUp(self):
+        self._script_dir = tempfile.mkdtemp()
+        self.script_path = build_status_script(self._script_dir)
+
+    def tearDown(self):
+        os.unlink(self.script_path)
+        os.rmdir(self._script_dir)
+
+    def test_active_scope_skips_body_rule_file(self):
+        """T-DISCOVER-1: validate exits 0; default table lists valid only."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'valid.md': valid_entity('valid', '001'),
+                'notes.md': NOTES_BODY_RULE,
+            })
+
+            validate = run_status(tmpdir, '--validate', script_path=self.script_path)
+            self.assertEqual(validate.returncode, 0, validate.stderr)
+
+            default = run_status(tmpdir, script_path=self.script_path)
+            self.assertEqual(default.returncode, 0, default.stderr)
+            self.assertIn('valid', default.stdout)
+            self.assertNotIn('notes', default.stdout)
+
+    def test_folder_form_index_without_fence_skipped(self):
+        """T-DISCOVER-2: folder-form `slug/index.md` with body-rule first `---` is skipped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'valid.md': valid_entity('valid', '001'),
+            })
+            slug_dir = os.path.join(tmpdir, 'orphan')
+            os.makedirs(slug_dir)
+            with open(os.path.join(slug_dir, 'index.md'), 'w') as f:
+                f.write(NOTES_BODY_RULE)
+
+            default = run_status(tmpdir, script_path=self.script_path)
+            self.assertEqual(default.returncode, 0, default.stderr)
+            self.assertIn('valid', default.stdout)
+            self.assertNotIn('orphan', default.stdout)
+
+    def test_archived_scope_skips_body_rule_file(self):
+        """T-DISCOVER-3: --archived skips body-rule files but lists valid archived entities."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(
+                tmpdir,
+                README_WITH_STAGES,
+                entities={},
+                archived={
+                    'orphan.md': NOTES_BODY_RULE,
+                    'valid.md': valid_entity('valid', '001'),
+                },
+            )
+            archived = run_status(tmpdir, '--archived', script_path=self.script_path)
+            self.assertEqual(archived.returncode, 0, archived.stderr)
+            self.assertIn('valid', archived.stdout)
+            self.assertNotIn('orphan', archived.stdout)
+
+
+class TestEndToEndIssue186(unittest.TestCase):
+    """AC-5/AC-6: end-to-end --set against issue reproduction and a valid entity."""
+
+    def setUp(self):
+        self._script_dir = tempfile.mkdtemp()
+        self.script_path = build_status_script(self._script_dir)
+
+    def tearDown(self):
+        os.unlink(self.script_path)
+        os.rmdir(self._script_dir)
+
+    def test_set_against_body_rule_file_fails_safely(self):
+        """T-E2E-186: --set notes against body-rule notes.md fails non-zero, file unchanged."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'notes.md': NOTES_BODY_RULE,
+            })
+            notes_path = os.path.join(tmpdir, 'notes.md')
+            sha_before = hashlib.sha256(open(notes_path, 'rb').read()).hexdigest()
+
+            result = run_status(tmpdir, '--set', 'notes', 'id=001',
+                                script_path=self.script_path)
+            self.assertNotEqual(result.returncode, 0)
+            # Slug pre-resolution rejects the unknown ref; the exact error path
+            # is `resolve_mutation_entity` -> "Error: entity not found: <ref>".
+            # The AC's intent is satisfied: non-zero exit + slug-not-resolved
+            # diagnostic on stderr + zero file mutation (asserted via SHA256).
+            self.assertIn('entity not found: notes', result.stderr)
+
+            sha_after = hashlib.sha256(open(notes_path, 'rb').read()).hexdigest()
+            self.assertEqual(sha_before, sha_after,
+                             'notes.md must be byte-identical after rejected --set')
+
+    def test_set_against_valid_entity_still_works(self):
+        """T-E2E-VALID: --set against a properly-fenced entity rewrites status field."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'task.md': valid_entity('task', '001'),
+            })
+            result = run_status(tmpdir, '--set', 'task', 'status=ideation',
+                                script_path=self.script_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn('status:', result.stdout)
+            self.assertIn('-> ideation', result.stdout)
+
+            with open(os.path.join(tmpdir, 'task.md'), 'r') as f:
+                content = f.read()
+            self.assertIn('status: ideation', content)
+            self.assertIn('Description.', content)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(pytest.main([__file__, '-v']))


### PR DESCRIPTION
Prevent silent corruption of colocated markdown files whose first `---` is a body horizontal rule by enforcing strict opening-fence detection across the status parsers and discovery.

## What changed
- Add `_has_opening_fence` predicate as the single source for opening-fence detection.
- Reject `parse_frontmatter` reads when the first non-empty, non-BOM line is not `---`.
- Refuse `update_frontmatter` writes against files lacking a valid opening fence.
- Skip non-fenced `*.md` files in `discover_entity_files` across active and archived scopes.

## Evidence
- `tests/test_status_strict_opening_fence.py`: 11/11 passed (T-PARSE/T-WRITE/T-DISCOVER/T-E2E-186/T-E2E-VALID).
- `make test-static`: 587 passed, 0 regressions.

---
[m4](/clkao/spacedock/blob/fade4bbb/docs/plans/status-set-injects-frontmatter-when-first-fence-is-body-separator.md)

Closes #186