### PR TITLE
status binary refuses terminal advancement on rejected/abandoned entities when merge hook is registered, even when no PR is intended

### DIFF
--- a/docs/plans/status-refuses-terminal-on-rejected-entity-with-merge-hook.md
+++ b/docs/plans/status-refuses-terminal-on-rejected-entity-with-merge-hook.md
@@ -148,3 +148,15 @@ Picked shape 1 (verdict-keyed bypass), narrowed to the literal value `rejected` 
 
 ### Summary
 Implemented the verdict-rejected bypass as a two-line addition: a `current_verdict` resolve plus a `post_update_verdict` mirror, threaded into the existing merge-hook guard predicate. Five parser-level tests cover AC1-AC4 plus the symmetric AC3-already-PASSED case; full `make test-static` is green (582 passed). AC5 (E2E) is intentionally deferred per the dispatch.
+
+## Stage Report: validation
+
+- DONE: AC1-AC4 each rerun via the named tests in `tests/test_status_script.py::TestMergeHookTerminalGuard`; results captured per-AC with N/N passed; cross-check that each test's assertions actually prove the AC's stated end-state property.
+  19/19 PASSED in `TestMergeHookTerminalGuard` (0.68s). AC1 → `test_set_terminal_allowed_when_verdict_already_rejected` asserts exit 0 + `status=done` in fm. AC2 → `test_set_terminal_allowed_when_verdict_rejected_in_same_call` asserts exit 0 + status/verdict/completed all written. AC3 → `test_set_terminal_refused_when_verdict_passed` (1/1) asserts non-zero exit + 'merge hook' in stderr + status unchanged; reinforced by `test_set_status_done_refused_when_merge_hook_and_no_pr` (blank-verdict) and `test_set_terminal_refused_when_verdict_already_passed` (already-PASSED). AC4 → `test_set_verdict_rejected_alone_allowed_with_merge_hook` asserts exit 0 + verdict written on a non-terminal-status entity. Each test's assertions match the AC's end-state property (file-state + exit-code + stderr where named).
+- DONE: AC5 confirmed as deliberately deferred (skipped per implementation dispatch); AC6 (existing `tests/test_merge_hook_guardrail.py`) confirmed still passing in this run.
+  AC5 — implementation Stage Report records `SKIPPED: AC5 (E2E rejection-flow merge-hook fixture)` per dispatch instructions; no fixture staged. AC6 — `tests/test_merge_hook_guardrail.py::test_merge_hook_guardrail` 1/1 PASSED (325.03s). Full `make test-static` rerun: 582 passed, 26 deselected, 15 subtests passed (29.33s) — no regressions.
+- DONE: PASSED or REJECTED recommendation with one-line rationale; if REJECTED, name the specific AC that failed.
+  PASSED — all in-scope ACs (AC1-AC4, AC6) verified by named tests; AC5 deferred-by-design.
+
+### Summary
+All in-scope acceptance criteria verified against the named tests on commit 235770ce: `TestMergeHookTerminalGuard` 19/19 green, `test_merge_hook_guardrail.py` 1/1 green, full `make test-static` 582/0. AC5 is the live-E2E path the implementation explicitly deferred and is recorded as such, not a failure. Recommendation: PASSED.

--- a/docs/plans/status-refuses-terminal-on-rejected-entity-with-merge-hook.md
+++ b/docs/plans/status-refuses-terminal-on-rejected-entity-with-merge-hook.md
@@ -134,3 +134,17 @@ Per dispatch instructions, the staff-review trigger fires (touches `skills/commi
 ### Summary
 
 Picked shape 1 (verdict-keyed bypass), narrowed to the literal value `rejected` to avoid loosening the guard against blank-verdict misfires. The fix is a localized `post_update_verdict` resolution plus one condition in the existing merge-hook guard, with primary coverage at the parser level via five fixture tests and one E2E run on a new merge-hook-enabled rejection-flow fixture. Shapes 2 and 3 rejected on vocabulary-bloat and audit-clarity grounds respectively.
+
+## Stage Report: implementation
+
+- DONE: Implement the localized verdict-rejected bypass exactly as specified in the entity body's Implementation outline (resolve `post_update_verdict` mirroring `post_update_pr`; add the `post_update_verdict == 'rejected'` condition to the merge-hook guard at status:2347; mod-block guard untouched).
+  Commit 11e4f27c — `skills/commission/bin/status` resolves `current_verdict` from frontmatter, computes `post_update_verdict` mirroring the `post_update_pr` resolution, and adds `post_update_verdict != 'rejected'` to the merge-hook guard condition; mod-block guard at lines 2321-2340 is unchanged.
+- DONE: Add the five parser-level fixture tests on `TestMergeHookTerminalGuard` in `tests/test_status_script.py` per the test plan (T-1..T-5 covering AC1-AC4 plus the symmetric AC3-PASSED variant); all five pass locally.
+  Commit 11e4f27c — added `_write_entity_with_verdict` helper plus `test_set_terminal_allowed_when_verdict_already_rejected` (AC1), `test_set_terminal_allowed_when_verdict_rejected_in_same_call` (AC2), `test_set_terminal_refused_when_verdict_passed` (AC3), `test_set_verdict_rejected_alone_allowed_with_merge_hook` (AC4), `test_set_terminal_refused_when_verdict_already_passed` (AC3 symmetric); 19/19 in `TestMergeHookTerminalGuard` pass.
+- DONE: `make test-static` exits 0 — no pre-existing tests regressed; the existing `test_set_status_done_refused_when_merge_hook_and_no_pr` and `tests/test_merge_hook_guardrail.py` continue to pass.
+  582 passed, 26 deselected, 15 subtests passed; both named tests included in the green run.
+- SKIPPED: AC5 (E2E rejection-flow merge-hook fixture).
+  Per dispatch instructions, AC5 requires the live-claude harness and a new fixture; left for a separate task. No fixture staged — adding scaffolding without exercising it would clutter the worktree without independent verification.
+
+### Summary
+Implemented the verdict-rejected bypass as a two-line addition: a `current_verdict` resolve plus a `post_update_verdict` mirror, threaded into the existing merge-hook guard predicate. Five parser-level tests cover AC1-AC4 plus the symmetric AC3-already-PASSED case; full `make test-static` is green (582 passed). AC5 (E2E) is intentionally deferred per the dispatch.

--- a/docs/plans/status-set-should-validate-stage-name-values.md
+++ b/docs/plans/status-set-should-validate-stage-name-values.md
@@ -9,7 +9,7 @@ verdict:
 score: 0.55
 worktree: .worktrees/spacedock-ensign-status-set-should-validate-stage-name-values
 issue: "#189"
-pr:
+pr: #193
 mod-block: merge:pr-merge
 ---
 

--- a/skills/commission/bin/status
+++ b/skills/commission/bin/status
@@ -2330,6 +2330,7 @@ def main():
         current_fields = parse_frontmatter(entity_path)
         mod_block = current_fields.get('mod-block', '').strip()
         current_pr = current_fields.get('pr', '').strip()
+        current_verdict = current_fields.get('verdict', '').strip()
         clearing_mod_block = any(
             field == 'mod-block' and value == '' for field, value in updates
         )
@@ -2355,6 +2356,14 @@ def main():
         for field, value in updates:
             if field == 'pr':
                 post_update_pr = value.strip()
+
+        # Resolve the post-update verdict the same way; the merge-hook guard
+        # below treats the literal value 'rejected' as a captain-authoritative
+        # "this is not a ship" record and bypasses the hook requirement.
+        post_update_verdict = current_verdict
+        for field, value in updates:
+            if field == 'verdict':
+                post_update_verdict = value.strip()
 
         if (mod_block or clearing_mod_block) and not force:
             if is_terminal_update():
@@ -2382,7 +2391,8 @@ def main():
         # hook completion by requiring a non-empty pr, a set mod-block (hook
         # in flight), or --force. If none of those hold, the FO is trying to
         # skip the hook entirely — refuse so the hook cannot be bypassed.
-        if not force and is_terminal_update() and not mod_block and not post_update_pr:
+        if (not force and is_terminal_update() and not mod_block
+                and not post_update_pr and post_update_verdict != 'rejected'):
             merge_hooks = scan_mods(pipeline_dir).get('merge', [])
             if merge_hooks:
                 hook_list = ', '.join(merge_hooks)

--- a/tests/test_status_script.py
+++ b/tests/test_status_script.py
@@ -3308,6 +3308,100 @@ class TestMergeHookTerminalGuard(unittest.TestCase):
                                 script_path=self.script_path)
             self.assertEqual(result.returncode, 0, result.stderr)
 
+    def _write_entity_with_verdict(self, path, status, verdict):
+        with open(path, 'w') as f:
+            f.write(textwrap.dedent(f"""\
+                ---
+                id: 001
+                title: Task A
+                status: {status}
+                source:
+                started:
+                completed:
+                verdict: {verdict}
+                score: 0.80
+                worktree:
+                pr:
+                ---
+
+                Description.
+                """))
+
+    def test_set_terminal_allowed_when_verdict_already_rejected(self):
+        """AC1: verdict=rejected in frontmatter bypasses merge-hook guard on terminal --set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'task-a.md': entity('001', 'Task A', 'validation', '0.80'),
+            })
+            entity_path = os.path.join(tmpdir, 'task-a.md')
+            self._write_entity_with_verdict(entity_path, 'validation', 'rejected')
+            _add_merge_hook(tmpdir)
+            result = run_status(tmpdir, '--set', 'task-a', 'status=done', 'completed',
+                                script_path=self.script_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            fields = self._read_frontmatter(entity_path)
+            self.assertEqual(fields['status'], 'done')
+
+    def test_set_terminal_allowed_when_verdict_rejected_in_same_call(self):
+        """AC2: verdict=rejected set in same --set call bypasses merge-hook guard."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'task-a.md': entity('001', 'Task A', 'validation', '0.80'),
+            })
+            _add_merge_hook(tmpdir)
+            result = run_status(tmpdir, '--set', 'task-a',
+                                'status=done', 'verdict=rejected', 'completed',
+                                script_path=self.script_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            fields = self._read_frontmatter(os.path.join(tmpdir, 'task-a.md'))
+            self.assertEqual(fields['status'], 'done')
+            self.assertEqual(fields['verdict'], 'rejected')
+            self.assertNotEqual(fields['completed'], '')
+
+    def test_set_terminal_refused_when_verdict_passed(self):
+        """AC3: verdict=PASSED set in same --set call still triggers merge-hook refusal."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'task-a.md': entity('001', 'Task A', 'validation', '0.80'),
+            })
+            _add_merge_hook(tmpdir)
+            result = run_status(tmpdir, '--set', 'task-a',
+                                'status=done', 'verdict=PASSED',
+                                script_path=self.script_path)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('merge hook', result.stderr)
+            fields = self._read_frontmatter(os.path.join(tmpdir, 'task-a.md'))
+            self.assertEqual(fields['status'], 'validation')
+
+    def test_set_verdict_rejected_alone_allowed_with_merge_hook(self):
+        """AC4: verdict=rejected alone on a non-terminal-status entity bypasses guard."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'task-a.md': entity('001', 'Task A', 'validation', '0.80'),
+            })
+            _add_merge_hook(tmpdir)
+            result = run_status(tmpdir, '--set', 'task-a', 'verdict=rejected',
+                                script_path=self.script_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            fields = self._read_frontmatter(os.path.join(tmpdir, 'task-a.md'))
+            self.assertEqual(fields['verdict'], 'rejected')
+
+    def test_set_terminal_refused_when_verdict_already_passed(self):
+        """AC3 symmetric: verdict=PASSED already in frontmatter still refuses on terminal --set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_pipeline(tmpdir, README_WITH_STAGES, {
+                'task-a.md': entity('001', 'Task A', 'validation', '0.80'),
+            })
+            entity_path = os.path.join(tmpdir, 'task-a.md')
+            self._write_entity_with_verdict(entity_path, 'validation', 'PASSED')
+            _add_merge_hook(tmpdir)
+            result = run_status(tmpdir, '--set', 'task-a', 'status=done', 'completed',
+                                script_path=self.script_path)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('merge hook', result.stderr)
+            fields = self._read_frontmatter(entity_path)
+            self.assertEqual(fields['status'], 'validation')
+
     def test_set_terminal_allowed_without_merge_hook(self):
         """Workflow without merge hooks — terminal transition permitted freely."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Allow captains to terminalize rejected entities cleanly without `--force` when the workflow registers a merge hook, preserving the original ship-flow guard.

## What changed
- Resolve `post_update_verdict` mirroring `post_update_pr` from frontmatter plus the current update.
- Bypass the merge-hook terminal guard when `post_update_verdict == 'rejected'` (literal lowercase only).
- Leave the mod-block guard at lines 2321-2340 unchanged.
- Add 5 parser-level fixture tests on `TestMergeHookTerminalGuard` covering AC1–AC4 plus an AC3 symmetric `verdict=PASSED` variant.

## Evidence
- `tests/test_status_script.py::TestMergeHookTerminalGuard`: 19/19 passed.
- `tests/test_merge_hook_guardrail.py`: 1/1 passed (live, 325s) — original ship-flow guard still fires.
- `make test-static`: 582 passed, 0 regressions.

---
[84](/clkao/spacedock/blob/063f777a/docs/plans/status-refuses-terminal-on-rejected-entity-with-merge-hook.md)

Closes #188