### PR TITLE
docs(readme): lead with the problem Spacedock solves

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # Spacedock
 
-Spacedock runs agent work through defined stages, so you can delegate in batches and make only the calls that need your judgment.
+Hand an agent a multi-step job and it drifts, skips steps, or invents its own path. Hand it a workflow and it follows the workflow.
 
-The first officer coordinates the flow: it dispatches workers to advance each work item and surfaces approval-worthy decisions to you, the captain, so batches move forward without pulling you into every session.
+Spacedock runs agent work through stages you define. Each stage gets a fresh context, an explicit gate, and a structured report. Reviewers are allowed to push back. State lives outside the agent, so work survives the context limit and picks up the next session where it left off.
+
+We built Spacedock because we were there. We lived the pipelines that didn't finish, the reviewers that rubber-stamped, the work that died at the context limit, and the routines spread across too many tools. The tool is the way we wished agent work had been organized from the start.
 
 **You want Spacedock if:**
 
-- **You're a human tired of context-switching** between agent sessions to make approval decisions. Spacedock batches the decisions an agent wants to hand back to you and presents each with evidence, so you approve or redirect without re-loading context.
-- **You're an agent delegating repeatable work** and want a structured place to queue up approval-worthy decisions for your human without interrupting them for every tiny step.
+- **You delegate repeatable work to agents** (the same pipeline run on many inputs: code reviews, content drafts, outreach batches) and you want each run to finish, not stop halfway. Spacedock dispatches a fresh agent per stage, with an approval gate where your judgment actually matters.
+- **You don't trust single-agent output** on its own. Spacedock review stages are allowed to push back, with a 3-strikes escalation so you only see what the reviewer couldn't resolve.
+- **Your work spans days or weeks.** A blog draft, a launch strategy, a multi-week benchmark. Spacedock holds artifact state outside the agent, so the next session resumes instead of restarts.
 
 ## What's Different
 


### PR DESCRIPTION
## Summary

Rewrites the README opening so a reader instantly knows whether Spacedock is for them. The previous opening described what Spacedock does; this one leads with the pain it solves, names the mechanism that answers it, and gives three reader-state matches on distinct axes (shape / trust / time horizon).

## What changes

- **Opening hook** moves from "Spacedock runs agent work through defined stages..." (descriptive) to "Hand an agent a multi-step job and it drifts, skips steps, or invents its own path" (concrete pain, alpha-user language).
- **Mechanism paragraph** names how Spacedock answers it: stages with fresh context, explicit gates, structured reports, reviewers that push back, state outside the agent.
- **Origin sentence** is added in first-person plural: we lived the pipelines that didn't finish, the reviewers that rubber-stamped, the work that died at the context limit, the routines spread across too many tools.
- **"You want Spacedock if"** restructured from a 2-bullet "human / agent" framing into 3 reader-state bullets on three distinct axes:
  1. **Shape:** repeatable multi-step pipelines on many inputs
  2. **Trust:** single-agent output you can't verify on its face
  3. **Time horizon:** work that spans days or weeks

The rest of the README ("What's Different," "Quick Start," everything below) is untouched.

## Why now

The messaging is anchored in the alpha-interview synthesis at `recce-gtm/knowledge/customer-insight/interview-plans/alpha-interview-synthesis/alpha-problems.md` (7 universal problem clusters from the 9-alpha corpus). The clusters that drive each piece of the new copy:

- Cluster 5 (agents cannot follow full pipelines without scoping) → opening hook
- Cluster 1 (single-agent loops produce poor work without an external check, n=7) → trust bullet
- Cluster 2 (context pressure degrades agent quality, n=6) → mechanism paragraph
- Cluster 3 (state loss across sessions, n=3) → time-horizon bullet

## Test plan

- [ ] Render README on GitHub and check formatting (no broken bullets, no em dashes leaked)
- [ ] Read the opening cold and decide: does the pain land in the first 30 seconds?
- [ ] Verify the three axes don't overlap (shape, trust, time horizon stay distinct)
- [ ] Confirm the rest of the README still flows from the new opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)