### PR TITLE
fix(dispatch): split-root state-commit guidance on both branches (resolved state checkout)

### DIFF
--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -219,7 +219,10 @@ func runBuild(workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int
 
 	// Split-root: the README declares a state: checkout, so a worktree stage
 	// isolates CODE only — the entity body stays at the FO-passed entity_path.
-	splitRoot := workflowIsSplitRoot(workflowDir)
+	// stateCheckout is the resolved absolute state-checkout dir (workflowDir/<state>),
+	// the git repo where the entity body lives; "" when the workflow is single-root.
+	stateCheckout := splitRootStateCheckout(workflowDir)
+	splitRoot := stateCheckout != ""
 
 	// Rule 5: Feedback context required for feedback reflow.
 	if isFeedbackReflow && feedbackContext == "" {
@@ -301,8 +304,8 @@ func runBuild(workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int
 	// guidance applies to every stage, worktree or not: the worktree branch
 	// prepends CODE-directory/branch lines, a non-worktree stage emits the
 	// standalone guidance. The guidance carries the resolved absolute state
-	// checkout (workflowDir IS the state/entity dir under split root) and entity
-	// path — never literal {state_checkout}/{entity_path} brace tokens.
+	// checkout (workflowDir/<state>, the git repo holding the entity body) and
+	// entity path — never literal {state_checkout}/{entity_path} brace tokens.
 	var worktreeEntityPath string
 	if worktreePath != "" {
 		branch := fmt.Sprintf("%s/%s", workerKey, slug)
@@ -315,7 +318,7 @@ func runBuild(workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int
 					"code to main.\n"+
 					"%s",
 				worktreePath, worktreePath, branch,
-				stateCommitGuidance(workflowDir, entityPath)))
+				stateCommitGuidance(stateCheckout, entityPath)))
 		} else {
 			parts = append(parts, fmt.Sprintf(
 				"Your working directory is %s\n"+
@@ -325,7 +328,7 @@ func runBuild(workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int
 				worktreePath, worktreePath, branch))
 		}
 	} else if splitRoot {
-		parts = append(parts, stateCommitGuidance(workflowDir, entityPath))
+		parts = append(parts, stateCommitGuidance(stateCheckout, entityPath))
 	}
 
 	// 4. Entity-read instruction. Under split root the entity lives in the state

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -297,7 +297,12 @@ func runBuild(workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int
 			shlexQuote(workflowDir), shlexQuote(stage)),
 	}
 
-	// 3. Worktree instructions (conditional).
+	// 3. Worktree instructions (conditional). Under split root the state-commit
+	// guidance applies to every stage, worktree or not: the worktree branch
+	// prepends CODE-directory/branch lines, a non-worktree stage emits the
+	// standalone guidance. The guidance carries the resolved absolute state
+	// checkout (workflowDir IS the state/entity dir under split root) and entity
+	// path — never literal {state_checkout}/{entity_path} brace tokens.
 	var worktreeEntityPath string
 	if worktreePath != "" {
 		branch := fmt.Sprintf("%s/%s", workerKey, slug)
@@ -308,15 +313,9 @@ func runBuild(workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int
 					"Your git branch for CODE is %s. All CODE commits MUST be on "+
 					"this branch in the worktree. Do NOT switch branches or commit "+
 					"code to main.\n"+
-					"This workflow is split-root: the entity body and your stage report "+
-					"are NOT in the worktree. Write and commit them to the shared state "+
-					"checkout at the entity path below. Commit state path-scoped — "+
-					"`git -C {state_checkout} add {entity_path} && "+
-					"git -C {state_checkout} commit -m \"...\" -- {entity_path}` — "+
-					"never a bare `git add -A` or bare `git commit` in the state "+
-					"checkout (a bare commit cross-attributes a concurrent writer's "+
-					"staged entity). Retry on index.lock contention after a short wait.\n",
-				worktreePath, worktreePath, branch))
+					"%s",
+				worktreePath, worktreePath, branch,
+				stateCommitGuidance(workflowDir, entityPath)))
 		} else {
 			parts = append(parts, fmt.Sprintf(
 				"Your working directory is %s\n"+
@@ -325,6 +324,8 @@ func runBuild(workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int
 					"Do NOT switch branches or commit to main.\n",
 				worktreePath, worktreePath, branch))
 		}
+	} else if splitRoot {
+		parts = append(parts, stateCommitGuidance(workflowDir, entityPath))
 	}
 
 	// 4. Entity-read instruction. Under split root the entity lives in the state
@@ -417,6 +418,26 @@ func runBuild(workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int
 	}
 
 	return emitBuildJSON(stdout, out)
+}
+
+// stateCommitGuidance is the split-root state-commit instruction, shared by the
+// worktree and non-worktree branches so the wording lives in one place. It
+// substitutes the resolved absolute state checkout and entity paths into the
+// path-scoped commit command — never literal {state_checkout}/{entity_path}
+// brace tokens — and carries the concurrency-safe "never a bare git add -A"
+// rule that governs every split-root stage.
+func stateCommitGuidance(stateCheckout, entityPath string) string {
+	return fmt.Sprintf(
+		"This workflow is split-root: the entity body and your stage report "+
+			"live in the shared state checkout, not alongside the code. Write and "+
+			"commit them to the state checkout at the entity path below. Commit "+
+			"state path-scoped — "+
+			"`git -C %s add %s && "+
+			"git -C %s commit -m \"...\" -- %s` — "+
+			"never a bare `git add -A` or bare `git commit` in the state "+
+			"checkout (a bare commit cross-attributes a concurrent writer's "+
+			"staged entity). Retry on index.lock contention after a short wait.\n",
+		stateCheckout, entityPath, stateCheckout, entityPath)
 }
 
 // emitBuildJSON writes out as two-space-indented JSON with HTML escaping off and

--- a/internal/dispatch/build_parity_test.go
+++ b/internal/dispatch/build_parity_test.go
@@ -139,9 +139,11 @@ func TestBuildParityCrossProduct(t *testing.T) {
 			nativeBody := readDispatchBody(t, dispatchFilePathFromStdout(t, native.stdout))
 
 			assertParity(t, tc.name, native, oracle)
-			if nativeBody != rewriteOracleFetch(oracleBody) {
+			wantBody := stripStateCommitGuidance(rewriteOracleFetch(oracleBody))
+			gotBody := stripStateCommitGuidance(nativeBody)
+			if gotBody != wantBody {
 				t.Errorf("%s: dispatch body mismatch\n--- native ---\n%s\n--- oracle(rewritten) ---\n%s",
-					tc.name, nativeBody, rewriteOracleFetch(oracleBody))
+					tc.name, gotBody, wantBody)
 			}
 		})
 	}

--- a/internal/dispatch/build_statecommit_test.go
+++ b/internal/dispatch/build_statecommit_test.go
@@ -30,9 +30,12 @@ func TestStateCommitGuidanceResolvesPaths(t *testing.T) {
 			t.Setenv("HOME", home)
 			root := t.TempDir()
 
-			// Split root: the state checkout is the workflow dir; CODE (if any)
-			// lives in the worktree under root.
-			workflowDir := filepath.Join(root, "state-checkout")
+			// Split root: the workflow dir is the README/definition root; the
+			// README's `state: state-checkout` field diverges the entity/state
+			// checkout to workflowDir/state-checkout. CODE (if any) lives in the
+			// worktree under root.
+			workflowDir := root
+			stateCheckout := filepath.Join(workflowDir, "state-checkout")
 			writeFile(t, filepath.Join(workflowDir, "README.md"), readmeWorktree(true))
 
 			worktreeRel := ""
@@ -43,7 +46,7 @@ func TestStateCommitGuidanceResolvesPaths(t *testing.T) {
 				}
 			}
 
-			entityPath := filepath.Join(workflowDir, "thing", "index.md")
+			entityPath := filepath.Join(stateCheckout, "thing", "index.md")
 			writeFile(t, entityPath, entityFM("Thing", tc.stage, worktreeRel))
 
 			gitInit(t, root)
@@ -61,9 +64,11 @@ func TestStateCommitGuidanceResolvesPaths(t *testing.T) {
 			native := runNative(stdin, "build", "--workflow-dir", workflowDir)
 			body := readDispatchBody(t, dispatchFilePathFromStdout(t, native.stdout))
 
-			// POSITIVE: the resolved path-scoped state-commit command, both halves.
-			wantAdd := "git -C " + workflowDir + " add " + entityPath
-			wantCommit := "git -C " + workflowDir + " commit -m \"...\" -- " + entityPath
+			// POSITIVE: the resolved path-scoped state-commit command targets the
+			// resolved state checkout (workflowDir/state-checkout), not the bare
+			// workflow/definition dir, both halves.
+			wantAdd := "git -C " + stateCheckout + " add " + entityPath
+			wantCommit := "git -C " + stateCheckout + " commit -m \"...\" -- " + entityPath
 			if !strings.Contains(body, wantAdd) {
 				t.Errorf("%s: body missing resolved add command %q\n--- body ---\n%s",
 					tc.name, wantAdd, body)

--- a/internal/dispatch/build_statecommit_test.go
+++ b/internal/dispatch/build_statecommit_test.go
@@ -1,0 +1,87 @@
+// ABOUTME: Behavioral coverage for split-root state-commit guidance — both the
+// ABOUTME: worktree and non-worktree branches must emit resolved, brace-free paths.
+package dispatch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStateCommitGuidanceResolvesPaths pins both defects on the split-root
+// state-commit-guidance surface: a worktree stage AND a non-worktree stage must
+// each emit the path-scoped state-commit instruction with the resolved absolute
+// state-checkout and entity paths substituted in — and never a literal
+// {state_checkout} or {entity_path} brace token.
+func TestStateCommitGuidanceResolvesPaths(t *testing.T) {
+	cases := []struct {
+		name     string
+		worktree bool
+		stage    string
+	}{
+		{name: "worktree-stage", worktree: true, stage: "implementation"},
+		{name: "nonworktree-stage", worktree: false, stage: "backlog"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			root := t.TempDir()
+
+			// Split root: the state checkout is the workflow dir; CODE (if any)
+			// lives in the worktree under root.
+			workflowDir := filepath.Join(root, "state-checkout")
+			writeFile(t, filepath.Join(workflowDir, "README.md"), readmeWorktree(true))
+
+			worktreeRel := ""
+			if tc.worktree {
+				worktreeRel = ".worktrees/spacedock-ensign-thing"
+				if err := os.MkdirAll(filepath.Join(root, worktreeRel), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			entityPath := filepath.Join(workflowDir, "thing", "index.md")
+			writeFile(t, entityPath, entityFM("Thing", tc.stage, worktreeRel))
+
+			gitInit(t, root)
+
+			stdin := mergeStdin(map[string]any{
+				"schema_version": 2,
+				"entity_path":    entityPath,
+				"workflow_dir":   workflowDir,
+				"stage":          tc.stage,
+				"checklist":      []string{"- a", "- b"},
+				"team_name":      "fixture-team",
+				"bare_mode":      false,
+			}, nil)
+
+			native := runNative(stdin, "build", "--workflow-dir", workflowDir)
+			body := readDispatchBody(t, dispatchFilePathFromStdout(t, native.stdout))
+
+			// POSITIVE: the resolved path-scoped state-commit command, both halves.
+			wantAdd := "git -C " + workflowDir + " add " + entityPath
+			wantCommit := "git -C " + workflowDir + " commit -m \"...\" -- " + entityPath
+			if !strings.Contains(body, wantAdd) {
+				t.Errorf("%s: body missing resolved add command %q\n--- body ---\n%s",
+					tc.name, wantAdd, body)
+			}
+			if !strings.Contains(body, wantCommit) {
+				t.Errorf("%s: body missing resolved commit command %q\n--- body ---\n%s",
+					tc.name, wantCommit, body)
+			}
+
+			// NEGATIVE (the encoded failure): no literal brace tokens survive.
+			if strings.Contains(body, "{state_checkout}") {
+				t.Errorf("%s: body still carries literal {state_checkout}\n--- body ---\n%s",
+					tc.name, body)
+			}
+			if strings.Contains(body, "{entity_path}") {
+				t.Errorf("%s: body still carries literal {entity_path}\n--- body ---\n%s",
+					tc.name, body)
+			}
+		})
+	}
+}

--- a/internal/dispatch/helpers.go
+++ b/internal/dispatch/helpers.go
@@ -118,13 +118,20 @@ func isFile(path string) bool {
 	return err == nil && info.Mode().IsRegular()
 }
 
-// workflowIsSplitRoot reports whether the workflow README declares a state:
-// checkout. Matches workflow_is_split_root: false when the README is unreadable
-// or carries no non-empty state: field.
-func workflowIsSplitRoot(workflowDir string) bool {
+// splitRootStateCheckout returns the absolute state-checkout dir for a split-root
+// workflow, or "" when the workflow is single-root. Under split root the README
+// declares a state: checkout relative to the README/definition dir, so the
+// resolved state checkout is workflowDir/<state> — NOT workflowDir itself (which
+// is the definition dir where the state checkout is git-excluded). Returns "" when
+// the README is unreadable or carries no non-empty state: field.
+func splitRootStateCheckout(workflowDir string) string {
 	readmePath := filepath.Join(workflowDir, "README.md")
 	fm := status.ParseFrontmatter(readmePath)
-	return strings.TrimSpace(fm["state"]) != ""
+	state := strings.TrimSpace(fm["state"])
+	if state == "" {
+		return ""
+	}
+	return filepath.Join(workflowDir, state)
 }
 
 // recentTeamEvidence reports whether any ~/.claude/teams/*/config.json was

--- a/internal/dispatch/parity_harness_test.go
+++ b/internal/dispatch/parity_harness_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -81,6 +82,24 @@ func runNative(stdin string, args ...string) runResult {
 // non-fetch bytes can be byte-compared after carving out the one rewritten line.
 func rewriteOracleFetch(s string) string {
 	return strings.ReplaceAll(s, oracleFetchPrefix, nativeFetchPrefix)
+}
+
+// stateCommitGuidanceLine matches the split-root state-commit guidance sentence
+// (a single line ending in "after a short wait.\n"). The native emitter and the
+// Python oracle diverge here intentionally — the same documented divergence as
+// the fetch line: the oracle ships the gated literal-brace block (and emits
+// nothing at all for non-worktree split-root stages), while the native emitter
+// substitutes resolved absolute paths on both branches. The body-parity compare
+// strips this block from BOTH sides so the unchanged bytes still byte-match; the
+// diverged content is covered by build_statecommit_test.go instead.
+var stateCommitGuidanceLine = regexp.MustCompile(`This workflow is split-root: [^\n]*? after a short wait\.\n`)
+
+// stripStateCommitGuidance removes the diverged state-commit guidance line and
+// collapses the blank-line artifact left where it was removed, so a body with
+// the block and a body without it normalize to the same bytes.
+func stripStateCommitGuidance(s string) string {
+	s = stateCommitGuidanceLine.ReplaceAllString(s, "")
+	return regexp.MustCompile(`\n{3,}`).ReplaceAllString(s, "\n\n")
 }
 
 // assertParity compares the native run against the oracle run on all three

--- a/skills/ensign/references/ensign-shared-core.md
+++ b/skills/ensign/references/ensign-shared-core.md
@@ -25,9 +25,9 @@ Read the assignment context provided by the first officer. It defines:
 - `pr:` is the narrow mirrored exception and stays visible on `main` for startup/discovery.
 - Ordinary active-state writes must not land on `main` for worktree-backed entities.
 
-### Split-Root Worktree Contract
+### Split-Root State Contract
 
-When the workflow is split-root — the workflow README declares a `state:` checkout (e.g. `state: .spacedock-state`) — your worktree isolates **CODE only**. The entity body and your stage report do NOT live in the worktree; they live in the separate state checkout that the dispatch hands you as the entity path. Concretely:
+When the workflow is split-root — the workflow README declares a `state:` checkout (e.g. `state: .spacedock-state`) — the entity body and your stage report live in the separate state checkout that the dispatch hands you as the entity path, NOT alongside the code. This applies to every split-root stage. **If your stage has a worktree**, the worktree isolates **CODE only** and the entity/report stay in the state checkout. **If your stage has no worktree** (ideation, backlog), you run from the repo root and still write/commit the entity and report to the state checkout the dispatch named — the concurrency-safe commit rule below governs you too. Concretely:
 
 - Read, write, and commit the entity body and your stage report at the state-checkout entity path the dispatch gave you, never a worktree copy.
 - Code reads, writes, and commits stay under the worktree on its branch, exactly as the worktree instructions say.


### PR DESCRIPTION
Lands the **k6** entity (`dispatch-nonworktree-state-guidance`, id `k69e2gcvykjrc5354ty7kt3g`) onto `next` — completed, validated, and adversarially audited locally this session.

Fixes the split-root state-commit guidance the dispatch builder emits: factors a shared `stateCommitGuidance` helper, lifts it out of the worktree-only gate so **non-worktree** stages get it too, and binds the **resolved** state checkout (`workflowDir/<state>`, e.g. `docs/dev/.spacedock-state`) instead of `workflowDir` — so the emitted `git -C` targets the actual state repo on both branches. Companion de-frame of the ensign contract's split-root section. Parity stays green via a documented oracle-rewrite divergence.

Validated: offline `go test ./...` green (modulo the pre-existing env-only codex test); 1 feedback cycle (a state-checkout-binding bug caught by a parallel adversarial audit) then a clean re-validation + re-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)