### PR TITLE
feat: split-root ergonomics Phase A — absolute state path + boot backend surfacing + commission rule + single-root test

### DIFF
--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -139,6 +139,16 @@ func runBuild(workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int
 		return buildError(stderr, 1, "entity file not readable at '%s'", entityPath)
 	}
 
+	// Absolutize workflowDir against the process cwd once, so every downstream
+	// join — README path, splitRootStateCheckout, the fetch line's --workflow-dir,
+	// and the state-commit guidance — inherits an absolute, cwd-independent base.
+	// A worktree worker runs with its cwd inside .worktrees/…, where a relative
+	// emitted `git -C docs/dev/.spacedock-state` resolves nowhere; absolutizing
+	// here makes both halves of the emitted state-commit command absolute.
+	if abs, err := filepath.Abs(workflowDir); err == nil {
+		workflowDir = abs
+	}
+
 	// Rule 11: Workflow README readable.
 	readmePath := filepath.Join(workflowDir, "README.md")
 	if !isFile(readmePath) {

--- a/internal/dispatch/build_statecommit_test.go
+++ b/internal/dispatch/build_statecommit_test.go
@@ -9,6 +9,140 @@ import (
 	"testing"
 )
 
+// TestStateCommitPathAbsoluteFromRelativeWorkflowDir pins AC-0: a worktree-stage
+// dispatch built with a RELATIVE --workflow-dir must still emit an ABSOLUTE
+// `git -C <stateCheckout> add …` state-commit path. The worktree worker runs with
+// its cwd inside .worktrees/…, where a relative `git -C docs/dev/.spacedock-state`
+// resolves nowhere — so the emitted path must be cwd-independent. runBuild
+// absolutizes workflowDir against the process cwd, so the relative flag value
+// resolves to an absolute base for every downstream join.
+func TestStateCommitPathAbsoluteFromRelativeWorkflowDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := t.TempDir()
+
+	// Split-root workflow under root. Drive --workflow-dir as a RELATIVE path
+	// computed from the process cwd, so runBuild's filepath.Abs resolution is the
+	// thing under test. (t.Chdir is go1.24+; this module targets go1.22, so the
+	// relative spelling is derived rather than realized via a cwd change.)
+	workflowDir := filepath.Join(root, "wf")
+	stateCheckout := filepath.Join(workflowDir, "state-checkout")
+	writeFile(t, filepath.Join(workflowDir, "README.md"), readmeWorktree(true))
+
+	worktreeRel := ".worktrees/spacedock-ensign-thing"
+	if err := os.MkdirAll(filepath.Join(root, worktreeRel), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	entityPath := filepath.Join(stateCheckout, "thing", "index.md")
+	writeFile(t, entityPath, entityFM("Thing", "implementation", worktreeRel))
+
+	gitInit(t, root)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflowRel, err := filepath.Rel(cwd, workflowDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.IsAbs(workflowRel) {
+		t.Fatalf("derived workflow-dir spelling is not relative: %q", workflowRel)
+	}
+
+	stdin := mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    entityPath,
+		"workflow_dir":   workflowRel,
+		"stage":          "implementation",
+		"checklist":      []string{"- a", "- b"},
+		"team_name":      "fixture-team",
+		"bare_mode":      false,
+	}, nil)
+
+	native := runNative(stdin, "build", "--workflow-dir", workflowRel)
+	body := readDispatchBody(t, dispatchFilePathFromStdout(t, native.stdout))
+
+	// Pull the `git -C <path>` token out of the emitted state-commit command and
+	// assert it is absolute — a relative `git -C wf/state-checkout` is the defect.
+	const marker = "git -C "
+	idx := strings.Index(body, marker)
+	if idx < 0 {
+		t.Fatalf("body missing %q state-commit command\n--- body ---\n%s", marker, body)
+	}
+	rest := body[idx+len(marker):]
+	gitCPath := rest[:strings.IndexByte(rest, ' ')]
+	if !filepath.IsAbs(gitCPath) {
+		t.Errorf("emitted `git -C` path is not absolute: %q\n--- body ---\n%s", gitCPath, body)
+	}
+}
+
+// TestSingleRootNoStateCommitGuidance (AC-3) pins the single-root negative: a
+// workflow with NO state: field must emit NEITHER the "This workflow is
+// split-root" sentence NOR a `git -C` state-commit command — for both a worktree
+// stage and a non-worktree stage. The cross-product parity test strips the
+// guidance line before comparing, so only this dedicated negative guards against
+// a single-root guidance LEAK.
+func TestSingleRootNoStateCommitGuidance(t *testing.T) {
+	cases := []struct {
+		name     string
+		worktree bool
+		stage    string
+	}{
+		{name: "worktree-stage", worktree: true, stage: "implementation"},
+		{name: "nonworktree-stage", worktree: false, stage: "backlog"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			root := t.TempDir()
+
+			// Single root: no state: field, so the entity lives beside the README in
+			// the workflow dir and no state-commit guidance applies.
+			workflowDir := root
+			writeFile(t, filepath.Join(workflowDir, "README.md"), readmeWorktree(false))
+
+			worktreeRel := ""
+			if tc.worktree {
+				worktreeRel = ".worktrees/spacedock-ensign-thing"
+				if err := os.MkdirAll(filepath.Join(root, worktreeRel), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			entityPath := filepath.Join(workflowDir, "thing.md")
+			writeFile(t, entityPath, entityFM("Thing", tc.stage, worktreeRel))
+
+			gitInit(t, root)
+
+			stdin := mergeStdin(map[string]any{
+				"schema_version": 2,
+				"entity_path":    entityPath,
+				"workflow_dir":   workflowDir,
+				"stage":          tc.stage,
+				"checklist":      []string{"- a", "- b"},
+				"team_name":      "fixture-team",
+				"bare_mode":      false,
+			}, nil)
+
+			native := runNative(stdin, "build", "--workflow-dir", workflowDir)
+			body := readDispatchBody(t, dispatchFilePathFromStdout(t, native.stdout))
+
+			if strings.Contains(body, "This workflow is split-root") {
+				t.Errorf("%s: single-root body leaks the split-root guidance sentence\n--- body ---\n%s",
+					tc.name, body)
+			}
+			if strings.Contains(body, "git -C ") {
+				t.Errorf("%s: single-root body leaks a `git -C` state-commit command\n--- body ---\n%s",
+					tc.name, body)
+			}
+		})
+	}
+}
+
 // TestStateCommitGuidanceResolvesPaths pins both defects on the split-root
 // state-commit-guidance surface: a worktree stage AND a non-worktree stage must
 // each emit the path-scoped state-commit instruction with the resolved absolute

--- a/internal/status/boot.go
+++ b/internal/status/boot.go
@@ -174,6 +174,13 @@ type bootData struct {
 	dispatchable []dispatchable
 	teamPresent  bool
 	teamHint     string
+	// State backend: split-root when entityDir diverges from definitionDir (a
+	// non-empty README state: field), else single-root. The dirs are the absolute
+	// I/O spellings, so the FO reads the state checkout from boot with no inference.
+	stateBackend     string
+	definitionDir    string
+	entityDir        string
+	entityDirPresent bool
 }
 
 // gatherBoot runs every boot probe once and returns the result. NEXT_ID is
@@ -197,6 +204,17 @@ func gatherBoot(entities []*entity, stages []Stage, definitionDir, entityDir, gi
 	d.prStatus, d.prResults = checkPRStates(entities, stages, e)
 	d.dispatchable = computeDispatchable(entities, stages)
 	d.teamPresent, d.teamHint = probeTeamState(e)
+
+	d.definitionDir = definitionDir
+	d.entityDir = entityDir
+	if entityDir != definitionDir {
+		d.stateBackend = "split-root"
+	} else {
+		d.stateBackend = "single-root"
+	}
+	if info, err := os.Stat(entityDir); err == nil && info.IsDir() {
+		d.entityDirPresent = true
+	}
 	return d, nil
 }
 
@@ -275,5 +293,9 @@ func printBoot(w io.Writer, entities []*entity, stages []Stage, definitionDir, e
 		fmt.Fprintln(w, "present: false")
 		fmt.Fprintln(w, "hint: run TeamCreate before first team-mode dispatch (claude runtime supports it)")
 	}
+
+	// STATE_BACKEND
+	fmt.Fprintf(w, "STATE_BACKEND: %s (entity_dir: %s, present: %t)\n",
+		d.stateBackend, d.entityDir, d.entityDirPresent)
 	return nil
 }

--- a/internal/status/harness_test.go
+++ b/internal/status/harness_test.go
@@ -118,6 +118,20 @@ func asExitError(err error, target **exec.ExitError) bool {
 // the microsecond timestamp slips through un-normalized.
 var tsRe = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z`)
 
+// stateBackendLineRe matches the native-only STATE_BACKEND boot banner. The text
+// --boot adds it to surface the state backend for a human reading the boot, but
+// the Python oracle has no such line — the same kind of intentional native/oracle
+// divergence as the dispatch fetch-line and state-commit guidance. The boot-text
+// parity normalizers strip it from BOTH sides (the oracle never emits it) so the
+// shared sections still byte-match; the JSON form is covered by json_boot_test.go.
+var stateBackendLineRe = regexp.MustCompile(`STATE_BACKEND: [^\n]*\n`)
+
+// stripStateBackend removes the native-only STATE_BACKEND boot banner so a body
+// with it and the oracle body without it normalize to the same bytes.
+func stripStateBackend(s string) string {
+	return stateBackendLineRe.ReplaceAllString(s, "")
+}
+
 // sdB32Re matches a 24-char SD-B32 id token (the --next-id / NEXT_ID material),
 // used to normalize the non-deterministic id away for structural comparison.
 var sdB32Re = regexp.MustCompile(`\b[0-9a-hjkmnp-tv-z]{24}\b`)

--- a/internal/status/json_boot_test.go
+++ b/internal/status/json_boot_test.go
@@ -4,6 +4,7 @@ package status
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,9 +12,12 @@ import (
 
 // bootJSONKeys are the --boot --json top-level keys in their required order. The
 // FO parses --boot by key at startup, so order and presence are load-bearing.
+// The state-backend keys are appended AFTER team_state so every existing key's
+// relative order is preserved.
 var bootJSONKeys = []string{
 	"command", "mods", "id_style", "next_id", "min_prefix",
 	"orphans", "pr_state", "dispatchable", "team_state",
+	"state_backend", "definition_dir", "entity_dir", "entity_dir_present",
 }
 
 // TestBootJSONStructure (AC-1 oracle e) mirrors nextid_boot_test.go for the JSON
@@ -69,9 +73,28 @@ func TestBootJSONStructure(t *testing.T) {
 			Present string `json:"present"`
 			Hint    string `json:"hint"`
 		} `json:"team_state"`
+		StateBackend     string `json:"state_backend"`
+		DefinitionDir    string `json:"definition_dir"`
+		EntityDir        string `json:"entity_dir"`
+		EntityDirPresent string `json:"entity_dir_present"`
 	}
 	if err := json.Unmarshal([]byte(out), &boot); err != nil {
 		t.Fatalf("parse --boot --json: %v\n%s", err, out)
+	}
+
+	// State backend: the sdb32 fixture is single-root (no state: field), so the
+	// two roots converge and the backend reads single-root.
+	if boot.StateBackend != "single-root" {
+		t.Fatalf("state_backend = %q, want single-root (no state: field)", boot.StateBackend)
+	}
+	if boot.DefinitionDir != boot.EntityDir {
+		t.Fatalf("single-root definition_dir %q != entity_dir %q", boot.DefinitionDir, boot.EntityDir)
+	}
+	if !filepath.IsAbs(boot.DefinitionDir) {
+		t.Fatalf("definition_dir %q is not absolute", boot.DefinitionDir)
+	}
+	if boot.EntityDirPresent != "true" {
+		t.Fatalf("entity_dir_present = %q, want true (fixture dir exists)", boot.EntityDirPresent)
 	}
 
 	// Deterministic sections (env-independent on this fixture).
@@ -150,5 +173,72 @@ func TestBootJSONDispatchableMirrorsNext(t *testing.T) {
 				t.Fatalf("dispatchable[%d].%s differs: boot=%q next=%q", i, k, boot.Dispatchable[i][k], next.Dispatchable[i][k])
 			}
 		}
+	}
+}
+
+// bootStateFields is the state-backend slice of the --boot --json envelope.
+type bootStateFields struct {
+	StateBackend     string `json:"state_backend"`
+	DefinitionDir    string `json:"definition_dir"`
+	EntityDir        string `json:"entity_dir"`
+	EntityDirPresent string `json:"entity_dir_present"`
+}
+
+func bootStateOf(t *testing.T, root string) bootStateFields {
+	t.Helper()
+	out, errOut, code := runNative(t, root, pinnedEnv(t), "--workflow-dir", root, "--boot", "--json")
+	if code != 0 {
+		t.Fatalf("--boot --json exit=%d stderr=%q", code, errOut)
+	}
+	var b bootStateFields
+	if err := json.Unmarshal([]byte(out), &b); err != nil {
+		t.Fatalf("parse --boot --json: %v\n%s", err, out)
+	}
+	return b
+}
+
+// TestBootJSONStateBackendSplitRoot (AC-1) asserts a split-root workflow names
+// its split state checkout in --boot --json: state_backend split-root, entity_dir
+// ends in the state path, is absolute, and diverges from definition_dir.
+func TestBootJSONStateBackendSplitRoot(t *testing.T) {
+	def, _ := buildSplitRoot(t, splitRootReadme, map[string]string{
+		"add-login.md": "---\nstatus: ideation\n---\n",
+	})
+
+	b := bootStateOf(t, def)
+	if b.StateBackend != "split-root" {
+		t.Fatalf("state_backend = %q, want split-root", b.StateBackend)
+	}
+	if b.DefinitionDir == b.EntityDir {
+		t.Fatalf("split-root definition_dir == entity_dir (%q); roots must diverge", b.EntityDir)
+	}
+	if !filepath.IsAbs(b.EntityDir) {
+		t.Fatalf("entity_dir %q is not absolute", b.EntityDir)
+	}
+	if filepath.Base(b.EntityDir) != ".spacedock-state" {
+		t.Fatalf("entity_dir %q does not end in the state path .spacedock-state", b.EntityDir)
+	}
+	if b.EntityDirPresent != "true" {
+		t.Fatalf("entity_dir_present = %q, want true (state dir exists)", b.EntityDirPresent)
+	}
+}
+
+// TestBootJSONStateBackendEntityDirAbsent (AC-1 diagnostic) asserts the
+// absent-state-checkout case is observable: a split-root workflow whose state
+// dir does NOT exist on disk reports entity_dir_present false, so the FO can
+// distinguish a 2nd-host un-bootstrapped checkout from an empty workflow.
+func TestBootJSONStateBackendEntityDirAbsent(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte(splitRootReadme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately do NOT create the .spacedock-state dir.
+
+	b := bootStateOf(t, root)
+	if b.StateBackend != "split-root" {
+		t.Fatalf("state_backend = %q, want split-root", b.StateBackend)
+	}
+	if b.EntityDirPresent != "false" {
+		t.Fatalf("entity_dir_present = %q, want false (state dir absent)", b.EntityDirPresent)
 	}
 }

--- a/internal/status/json_commands.go
+++ b/internal/status/json_commands.go
@@ -186,6 +186,14 @@ func bootJSON(d *bootData) *jsonObj {
 	}
 	out.setValue("team_state", team)
 
+	// State backend keys, appended AFTER team_state so the FO's key-order parse of
+	// every prior key is preserved. entity_dir_present is the string "true"/"false"
+	// matching team_state.present's string-bool convention.
+	out.set("state_backend", d.stateBackend)
+	out.set("definition_dir", d.definitionDir)
+	out.set("entity_dir", d.entityDir)
+	out.set("entity_dir_present", strconv.FormatBool(d.entityDirPresent))
+
 	return out
 }
 

--- a/internal/status/native_read_test.go
+++ b/internal/status/native_read_test.go
@@ -113,8 +113,8 @@ func TestNativeBootMatchesOracle(t *testing.T) {
 	if oracleCode != 0 {
 		t.Fatalf("oracle --boot exit=%d", oracleCode)
 	}
-	normNative := sdB32Re.ReplaceAllString(normalize(nativeOut, root), "<ID>")
-	normOracle := sdB32Re.ReplaceAllString(normalize(oracleOut, root), "<ID>")
+	normNative := sdB32Re.ReplaceAllString(stripStateBackend(normalize(nativeOut, root)), "<ID>")
+	normOracle := sdB32Re.ReplaceAllString(stripStateBackend(normalize(oracleOut, root)), "<ID>")
 	if normNative != normOracle {
 		t.Fatalf("--boot parity mismatch\n--- native ---\n%s\n--- oracle ---\n%s", normNative, normOracle)
 	}

--- a/internal/status/zz_independent_parity_test.go
+++ b/internal/status/zz_independent_parity_test.go
@@ -97,6 +97,10 @@ var indTSRe = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z`)
 
 func indNormalize(s, root string) string {
 	s = indTSRe.ReplaceAllString(s, "<TS>")
+	// Strip the native-only STATE_BACKEND boot banner (the oracle has no such
+	// line) — the same documented native/oracle divergence the in-tree harness
+	// strips; the backend keys are byte-pinned in json_boot_test.go instead.
+	s = stripStateBackend(s)
 	if root != "" {
 		if real, err := filepath.EvalSymlinks(root); err == nil && real != root {
 			s = strings.ReplaceAll(s, real, "<ROOT>")

--- a/skills/commission/SKILL.md
+++ b/skills/commission/SKILL.md
@@ -274,6 +274,13 @@ Craft thoughtful, mission-specific content for each stage definition. The inputs
 
 Do NOT include a Scoring Rubric section by default. Scoring uses a simple 0.0–1.0 float — no rubric needed. If {captain} explicitly asks for a multi-dimension rubric, include a Scoring Rubric section documenting their chosen dimensions.
 
+**State backend (`state:` field).** Decide where the workflow's mutable entity state lives:
+
+- **Split-root** (`state: .spacedock-state` in the README frontmatter): use when the workflow is embedded in a code repo whose PRs you care about. The README (the living spec) stays on your code branch; the mutable entity state lives in a separate `.spacedock-state` checkout, so routine stage transitions never churn the code branch and never collide with a feature PR.
+- **Single-root** (omit `state:`): use for a standalone workflow that is not embedded in a code repo you ship from — the entities live beside the README in the same directory.
+
+If you choose split-root, also set up the `.spacedock-state` checkout (and, for collaboration/resume, declare its remote).
+
 Use this template structure, filling in all `{variables}` from the design phase:
 
 ````markdown

--- a/skills/integration/skill_text_test.go
+++ b/skills/integration/skill_text_test.go
@@ -106,6 +106,30 @@ func TestNoPRMergeOrModBehaviorIntroduced(t *testing.T) {
 	}
 }
 
+// TestCommissionStateBackendDecisionRule locks AC-2: the commission SKILL.md
+// carries the split-root-vs-single-root state-backend decision rule, so a newly
+// commissioned workflow no longer defaults to single-root with no guidance. The
+// three load-bearing fragments are the split-root frontmatter spelling, the
+// split-root trigger phrase, and the single-root "omit" guidance.
+func TestCommissionStateBackendDecisionRule(t *testing.T) {
+	p := filepath.Join(skillsRoot(t), "commission", "SKILL.md")
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read commission SKILL.md: %v", err)
+	}
+	skill := string(b)
+
+	for _, frag := range []string{
+		"state: .spacedock-state",
+		"embedded in a code repo whose PRs you care about",
+		"omit `state:`",
+	} {
+		if !strings.Contains(skill, frag) {
+			t.Errorf("commission SKILL.md missing state-backend decision-rule fragment %q", frag)
+		}
+	}
+}
+
 // sectionAfter returns the body of the markdown section beginning at the line
 // equal to heading, up to (but excluding) the next top-level `## ` heading, or
 // "" when the heading is absent. Used to scope an assertion to one section.


### PR DESCRIPTION
Lands **Phase A** (`split-root-ergonomics-and-remote-model`, id `5baenph5sbcrx7mhv3qbbjbn`) onto next — validated + adversarially audited locally. A0: absolutize workflowDir in runBuild (cwd-independent state-commit path). A1: surface state_backend/definition_dir/entity_dir/entity_dir_present in `status --boot --json`. A2: commission split-vs-single decision rule. A3: single-root no-guidance negative test. Offline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)