### PR TITLE
fix(contract,init): actionable predates-contract remedy + make init upgrade a stale plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ go build -o spacedock ./cmd/spacedock
 `--plugin-dir` loads the repo's own vendored `spacedock:first-officer` /
 `spacedock:ensign` skills and relaxes the contract gate.
 
+**Upgrade a stale plugin** — when `spacedock doctor` reports your installed
+plugin is out of date (predates this binary's contract), reinstall it:
+
+```bash
+spacedock init --host claude
+```
+
+`spacedock init` reinstalls from `spacedock-dev/spacedock@next`, replacing a
+stale already-installed plugin (it uninstalls before installing, since a plain
+`plugin install` no-ops when the plugin is already present).
+
 [safehouse](https://agent-safehouse.dev) is a separate runtime dependency for
 sandboxed launches — not installed by either lane. A `.safehouse` profile in the
 working directory (or the `--safehouse` / `--safehouse-<key>=…` flags) wraps the

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -204,19 +204,30 @@ func (execHost) Launch(argv []string) error {
 	return syscall.Exec(bin, argv, os.Environ())
 }
 
-// Install shells the host plugin marketplace add + install pair. The marketplace
-// source is pinned to branch via @ref (Claude) when set. Codex installs are not
-// shelled here — runInit emits the documented prose for that host.
+// installArgvSequence is the 3-command upgrade shape `Install` issues: pin the
+// marketplace source (@ref when a branch is set), uninstall the existing
+// spacedock@spacedock, then install it fresh. The uninstall step is what moves a
+// stale already-installed plugin off — plain `plugin install` no-ops when the
+// plugin is already installed. uninstall is itself a no-op on a fresh box, so the
+// sequence is safe on first install.
+func installArgvSequence(source, branch string) [][]string {
+	return [][]string{
+		{"plugin", "marketplace", "add", marketplaceAddArg(source, branch)},
+		{"plugin", "uninstall", "spacedock@spacedock"},
+		{"plugin", "install", "spacedock@spacedock"},
+	}
+}
+
+// Install shells the host plugin upgrade sequence (marketplace add + uninstall +
+// install). The marketplace source is pinned to branch via @ref (Claude) when
+// set. Codex installs are not shelled here — runInit emits the documented prose
+// for that host.
 func (execHost) Install(host, source, branch string) (string, error) {
 	if host != "claude" {
 		return "", fmt.Errorf("programmatic install is only supported for claude; codex install is documented prose")
 	}
-	marketplaceArg := marketplaceAddArg(source, branch)
 	var sb strings.Builder
-	for _, args := range [][]string{
-		{"plugin", "marketplace", "add", marketplaceArg},
-		{"plugin", "install", "spacedock@spacedock"},
-	} {
+	for _, args := range installArgvSequence(source, branch) {
 		cmd := exec.Command(host, args...)
 		out, err := cmd.CombinedOutput()
 		sb.Write(out)

--- a/internal/cli/init_devbranch_test.go
+++ b/internal/cli/init_devbranch_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"reflect"
 	"testing"
 )
 
@@ -45,5 +46,31 @@ func TestMarketplaceAddArgvCarriesRef(t *testing.T) {
 	}
 	if got := marketplaceAddArg("spacedock-dev/spacedock", ""); got != "spacedock-dev/spacedock" {
 		t.Errorf("marketplaceAddArg without branch = %q, want bare source", got)
+	}
+}
+
+// TestInstallArgvSequence locks AC-2: execHost.Install issues the 3-command
+// upgrade shape — marketplace add (with the @ref pin), then `plugin uninstall
+// spacedock@spacedock`, then `plugin install spacedock@spacedock`, in that order.
+// The uninstall step is what moves a stale already-installed plugin off (plain
+// install no-ops on it); uninstall is itself a no-op on a fresh box. With an
+// empty branch the marketplace arg is the bare source.
+func TestInstallArgvSequence(t *testing.T) {
+	wantWithBranch := [][]string{
+		{"plugin", "marketplace", "add", "spacedock-dev/spacedock@next"},
+		{"plugin", "uninstall", "spacedock@spacedock"},
+		{"plugin", "install", "spacedock@spacedock"},
+	}
+	if got := installArgvSequence("spacedock-dev/spacedock", "next"); !reflect.DeepEqual(got, wantWithBranch) {
+		t.Errorf("installArgvSequence(branch=next) = %v, want %v", got, wantWithBranch)
+	}
+
+	wantBareSource := [][]string{
+		{"plugin", "marketplace", "add", "spacedock-dev/spacedock"},
+		{"plugin", "uninstall", "spacedock@spacedock"},
+		{"plugin", "install", "spacedock@spacedock"},
+	}
+	if got := installArgvSequence("spacedock-dev/spacedock", ""); !reflect.DeepEqual(got, wantBareSource) {
+		t.Errorf("installArgvSequence(no branch) = %v, want %v", got, wantBareSource)
 	}
 }

--- a/internal/cli/upgrade_from_stale_test.go
+++ b/internal/cli/upgrade_from_stale_test.go
@@ -1,0 +1,117 @@
+// ABOUTME: AC-3 live upgrade-from-stale smoke — a real isolated-CLAUDE_CONFIG_DIR
+// ABOUTME: install of a stale (no requires-contract) plugin, then the 3-command upgrade to green.
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/contract"
+)
+
+// TestUpgradeFromStaleMovesToGreen is the load-bearing AC-3 proof: a plugin
+// installed from a stale marketplace (no requires-contract, the 0.12.1 shape)
+// resolves to the plugin-predates-contract verdict (exit 1, the dead-end the
+// captain hit); running the 3-command installArgvSequence against an upgraded
+// marketplace (requires-contract >=1,<2) then leaves doctor reporting compatible
+// (exit 0). This proves plain `plugin install` no-ops on an already-installed
+// plugin and the inserted `plugin uninstall` is what moves the stale install off.
+// Skips when `claude` is not on PATH; a real install kept hermetic by env
+// isolation, not a mock — mirrors TestClaudePluginInstallIsHostNative.
+func TestUpgradeFromStaleMovesToGreen(t *testing.T) {
+	claudeBin, err := exec.LookPath("claude")
+	if err != nil {
+		t.Skip("claude not on PATH; upgrade-from-stale smoke requires the host CLI")
+	}
+
+	tmp := t.TempDir()
+	staleMarketplace := buildStaleMarketplace(t, tmp)
+	upgradedMarketplace := buildLocalMarketplace(t, filepath.Join(tmp, "upgraded"))
+	configDir := filepath.Join(tmp, "config")
+	cacheDir := filepath.Join(tmp, "cache")
+	mustMkdir(t, configDir)
+	mustMkdir(t, cacheDir)
+
+	env := append(os.Environ(),
+		"CLAUDE_CONFIG_DIR="+configDir,
+		"CLAUDE_CODE_PLUGIN_CACHE_DIR="+cacheDir,
+	)
+
+	// Seed the stale install: marketplace add + install, the 0.12.1 shape.
+	runHost(t, claudeBin, env, "plugin", "marketplace", "add", staleMarketplace)
+	runHost(t, claudeBin, env, "plugin", "install", "spacedock@spacedock")
+
+	// The stale install resolves to the predates-contract verdict (exit 1) — the
+	// dead-end this entity fixes.
+	staleManifest := resolveClaudeManifestEnv(t, claudeBin, env)
+	staleVerdict := contract.ManifestVerdict(staleManifest, "claude", "next")
+	if staleVerdict.Verdict != contract.PluginPredatesContract {
+		t.Fatalf("stale install verdict = %v, want plugin-predates-contract (message=%q)", staleVerdict.Verdict, staleVerdict.Message)
+	}
+
+	// Upgrade via the committed 3-command shape. Plain `plugin install` would
+	// no-op here (the plugin is already installed); the inserted uninstall is what
+	// moves it. Run the exact argv installArgvSequence emits.
+	for _, args := range installArgvSequence(upgradedMarketplace, "") {
+		runHost(t, claudeBin, env, args...)
+	}
+
+	// Doctor now reports compatible (exit 0) — the install moved off the stale plugin.
+	upgradedManifest := resolveClaudeManifestEnv(t, claudeBin, env)
+	upgradedVerdict := contract.ManifestVerdict(upgradedManifest, "claude", "next")
+	if upgradedVerdict.Verdict != contract.Compatible {
+		t.Fatalf("after upgrade, verdict = %v, want compatible (message=%q)", upgradedVerdict.Verdict, upgradedVerdict.Message)
+	}
+}
+
+// buildStaleMarketplace writes a local-path marketplace whose plugin manifest has
+// NO requires-contract field — the 0.12.1 shape that predates the contract
+// mechanism. Returns the marketplace directory.
+func buildStaleMarketplace(t *testing.T, root string) string {
+	t.Helper()
+	marketplace := filepath.Join(root, "stale")
+	plugin := filepath.Join(marketplace, "spacedock")
+	mustMkdir(t, filepath.Join(marketplace, ".claude-plugin"))
+	mustMkdir(t, filepath.Join(plugin, ".claude-plugin"))
+	mustMkdir(t, filepath.Join(plugin, "skills", "demo"))
+
+	mustWrite(t, filepath.Join(marketplace, ".claude-plugin", "marketplace.json"), `{
+  "name": "spacedock",
+  "owner": { "name": "CL Kao" },
+  "plugins": [
+    { "name": "spacedock", "source": "./spacedock", "description": "test", "category": "workflow" }
+  ]
+}
+`)
+	mustWrite(t, filepath.Join(plugin, ".claude-plugin", "plugin.json"), `{ "name": "spacedock", "version": "0.12.1", "skills": "./skills/" }
+`)
+	mustWrite(t, filepath.Join(plugin, "skills", "demo", "SKILL.md"), "---\nname: demo\ndescription: demo skill\n---\ndemo\n")
+	return marketplace
+}
+
+// resolveClaudeManifestEnv resolves the installed spacedock@spacedock manifest
+// path under an isolated env, mirroring execHost.resolveClaudeManifest but with
+// the test's env applied.
+func resolveClaudeManifestEnv(t *testing.T, claudeBin string, env []string) string {
+	t.Helper()
+	cmd := exec.Command(claudeBin, "plugin", "list", "--json")
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("claude plugin list --json: %v", err)
+	}
+	var entries []pluginListEntry
+	if err := json.Unmarshal(out, &entries); err != nil {
+		t.Fatalf("parse plugin list --json: %v\n%s", err, out)
+	}
+	for _, e := range entries {
+		if e.ID == "spacedock@spacedock" && e.InstallPath != "" {
+			return filepath.Join(e.InstallPath, manifestSubpath("claude"))
+		}
+	}
+	t.Fatalf("spacedock@spacedock not resolved in:\n%s", out)
+	return ""
+}

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -37,6 +37,12 @@ const (
 	// host. Distinct, non-fatal-by-default; reported rather than asserting
 	// compatibility.
 	NoPluginFound
+	// PluginPredatesContract means the manifest has no requires-contract field at
+	// all: the installed plugin predates the contract mechanism. Kin to
+	// too-old-plugin, but with no range to name; remedy reinstalls via
+	// `spacedock init` and omits the `plugin update` fallback (which no-ops on a
+	// stale install).
+	PluginPredatesContract
 )
 
 // String renders the verdict's stable kebab-case token (the oracle string AC-1
@@ -53,6 +59,8 @@ func (v Verdict) String() string {
 		return "malformed-range"
 	case NoPluginFound:
 		return "no-plugin-found"
+	case PluginPredatesContract:
+		return "plugin-predates-contract"
 	default:
 		return "unknown"
 	}
@@ -110,6 +118,12 @@ func Compare(c int, raw, host, branch string) Result {
 // compareWithManifest is Compare with an optional manifest path woven into the
 // malformed-range message so a packaging bug names the offending file.
 func compareWithManifest(c int, raw, host, branch, manifestPath string) Result {
+	if strings.TrimSpace(raw) == "" {
+		return Result{
+			Verdict: PluginPredatesContract,
+			Message: pluginPredatesContractRemedy(host, branch),
+		}
+	}
 	lo, hi, err := ParseRange(raw)
 	if err != nil {
 		loc := manifestPath
@@ -168,6 +182,24 @@ func tooOldPluginRemedy(c int, rangeStr, host string) string {
 		"too-old-plugin: your installed plugin (needs %s) predates this binary (contract %d). "+
 			"Update it: spacedock init --host %s (or '%s plugin update spacedock').",
 		rangeStr, c, host, host)
+}
+
+// pluginPredatesContractRemedy is the pinned remedy for an installed plugin that
+// predates the contract mechanism (no requires-contract field). It names the
+// `spacedock init` one-liner — never raw `<host> plugin` commands — and omits the
+// `plugin update` fallback, which no-ops on a stale already-installed plugin. The
+// host is parameterized; the optional pre-release branch suffixes the reinstall
+// source so a dev install reflects the branch (the default release path omits it).
+func pluginPredatesContractRemedy(host, branch string) string {
+	source := "spacedock-dev/spacedock"
+	if branch != "" {
+		source += "@" + branch
+	}
+	return fmt.Sprintf(
+		"plugin-predates-contract: your installed Spacedock plugin is out of date "+
+			"(predates this binary's contract). Upgrade it: spacedock init --host %s "+
+			"(reinstalls from %s).",
+		host, source)
 }
 
 // noPluginMessage is the pinned no-plugin-found report for a host. Not a

--- a/internal/contract/contract_test.go
+++ b/internal/contract/contract_test.go
@@ -78,7 +78,7 @@ func TestCompare(t *testing.T) {
 		{"too-old-plugin-at-hi", 2, ">=1,<2", TooOldPlugin, "too-old-plugin"},
 		{"too-old-plugin-above-hi", 5, ">=1,<2", TooOldPlugin, "too-old-plugin"},
 		{"malformed", 1, ">=1", MalformedRange, "malformed contract range"},
-		{"malformed-empty", 1, "", MalformedRange, "malformed contract range"},
+		{"predates-contract-empty", 1, "", PluginPredatesContract, "spacedock init --host claude"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -118,6 +118,48 @@ func TestCompareMessageShape(t *testing.T) {
 		if !strings.Contains(res.Message, "Run `spacedock doctor`") {
 			t.Errorf("Compare(%d,%q) message missing doctor pointer: %q", c.contract, c.raw, res.Message)
 		}
+	}
+}
+
+// TestPluginPredatesContractRemedy locks the new verdict for an absent/empty
+// requires-contract: it names the `spacedock init --host <host>` one-liner,
+// reflects the dev branch (@next) when set, and OMITS the `plugin update`
+// fallback that reusing too-old-plugin would drag in (that fallback no-ops on a
+// stale install). A whitespace-only value routes here too; a non-empty
+// unparseable value still reads as a packaging bug.
+func TestPluginPredatesContractRemedy(t *testing.T) {
+	for _, raw := range []string{"", "   "} {
+		res := Compare(1, raw, "claude", "next")
+		if res.Verdict != PluginPredatesContract {
+			t.Fatalf("Compare(1,%q) verdict = %v, want plugin-predates-contract", raw, res.Verdict)
+		}
+		if !strings.Contains(res.Message, "spacedock init --host claude") {
+			t.Errorf("predates-contract remedy missing init one-liner: %q", res.Message)
+		}
+		if !strings.Contains(res.Message, "@next") {
+			t.Errorf("predates-contract remedy missing @next branch: %q", res.Message)
+		}
+		if strings.Contains(res.Message, "plugin update") {
+			t.Errorf("predates-contract remedy must omit the no-op `plugin update` fallback: %q", res.Message)
+		}
+	}
+
+	// With no dev branch, the remedy is the clean release one-liner (no @suffix).
+	plain := Compare(1, "", "claude", "")
+	if strings.Contains(plain.Message, "@next") {
+		t.Errorf("predates-contract remedy with no branch should omit @next: %q", plain.Message)
+	}
+	if !strings.Contains(plain.Message, "spacedock init --host claude") {
+		t.Errorf("predates-contract remedy with no branch missing init one-liner: %q", plain.Message)
+	}
+
+	// A non-empty unparseable value is still a packaging bug, not predates-contract.
+	bug := Compare(1, ">=1", "claude", "next")
+	if bug.Verdict != MalformedRange {
+		t.Fatalf("Compare(1,%q) verdict = %v, want malformed-range", ">=1", bug.Verdict)
+	}
+	if !strings.Contains(bug.Message, "This is a packaging bug") {
+		t.Errorf("non-empty malformed should keep the packaging-bug message: %q", bug.Message)
 	}
 }
 

--- a/internal/contract/doctor.go
+++ b/internal/contract/doctor.go
@@ -17,7 +17,8 @@ var errNoManifest = errors.New("manifest not found")
 // readRequiresContract reads a plugin manifest JSON and returns its
 // requires-contract string. A missing file yields errNoManifest; an absent
 // requires-contract field yields an empty string (which Compare classifies as
-// malformed-range, since the field is required for a published plugin).
+// plugin-predates-contract — the installed plugin predates the contract
+// mechanism — and routes to the actionable `spacedock init` upgrade remedy).
 func readRequiresContract(manifestPath string) (string, error) {
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {


### PR DESCRIPTION
A first run on a stale (pre-`requires-contract`) Spacedock plugin dead-ended with a misleading "packaging bug" error, and `spacedock init` silently no-op'd instead of upgrading it. This gives a stale install a clear, working path to green.

## What changed
- **Contract gate:** an absent/empty `requires-contract` now yields a distinct `plugin-predates-contract` verdict with an actionable remedy — `spacedock init --host claude` (branch-parameterized `@next`, no broken `plugin update` fallback) — instead of the dead-end "packaging bug" message. A genuinely non-empty malformed range still reads as a packaging bug.
- **init upgrade:** `execHost.Install` now issues `marketplace add … → uninstall spacedock@spacedock → install spacedock@spacedock` (extracted to `installArgvSequence`), so an already-installed stale plugin is replaced rather than no-op'd.

## Evidence
- `TestCompare` / `TestPluginPredatesContractRemedy` — empty/whitespace → new verdict + `spacedock init` remedy; non-empty malformed → unchanged packaging-bug.
- `TestInstallArgvSequence` — exact 3-vector argv (add @ref / uninstall / install), with and without a branch pin.
- `TestUpgradeFromStaleMovesToGreen` — **live** isolated `CLAUDE_CONFIG_DIR`: seed a 0.12.1-shape (no `requires-contract`) install → `plugin-predates-contract` (exit 1) → run the 3-command argv → `doctor` Compatible (exit 0).
- `go test ./...` green; `CONTRACT_VERSION` unchanged.

---
audit: `38` · spacedock-dev/spacedock
