### PR TITLE
feat(cli): cobra migration — grouped jargon-free help, install rename, Option-2 passthrough

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/spacedock-dev/spacedock
 
 go 1.22
+
+require (
+	github.com/spf13/cobra v1.10.1
+	github.com/spf13/pflag v1.0.9
+)
+
+require github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,14 +1,17 @@
-// ABOUTME: Command routing, usage text, and exit-code behavior for spacedock.
-// ABOUTME: status forwards argv verbatim to the status.Runner seam.
+// ABOUTME: cobra command tree, grouped help, and exit-code behavior for spacedock.
+// ABOUTME: status/dispatch forward argv verbatim; claude/codex use the Option-2 grammar.
 package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/spf13/cobra"
 
 	"github.com/spacedock-dev/spacedock/internal/contract"
 	"github.com/spacedock-dev/spacedock/internal/dispatch"
@@ -23,6 +26,9 @@ import (
 // overwritten by the git-describe tag on a stamped release build.
 var Version = "0.19.0"
 
+// tagline is the one-line product description rendered as the first help line.
+const tagline = "spacedock — agentic workflow launcher"
+
 // Run is the process entry point. status is routed to the native Go runner,
 // which composes the definition root (README) and the entity root (the README's
 // state: dir) itself; all other commands are handled directly. The vendored
@@ -32,42 +38,260 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 }
 
 // run is the injectable core. It depends only on the status.Runner interface,
-// never on the vendored script or any exec detail, so AC-4's fake-runner test
-// can drive the status path with pinned env/cwd.
+// never on the vendored script or any exec detail, so the fake-runner tests can
+// drive the status path with pinned env/cwd. cobra is wired INSIDE run so the
+// package's public surface (Run) and the exit-code contract are unchanged: the
+// command tree captures env/dir/stdin/stdout/stderr/runner in its RunE closures.
 func run(ctx context.Context, args []string, env []string, dir string, stdin io.Reader, stdout io.Writer, stderr io.Writer, runner status.Runner) int {
-	if len(args) == 0 {
-		printUsage(stdout)
-		return 0
+	root := newRootCommand(ctx, env, dir, stdin, stdout, stderr, runner)
+	root.SetArgs(args)
+	if err := root.Execute(); err != nil {
+		return exitCodeFor(err)
 	}
+	return 0
+}
 
-	switch args[0] {
-	case "-h", "--help", "help":
-		printUsage(stdout)
-		return 0
-	case "--version", "version":
-		fmt.Fprintf(stdout, "spacedock %s (contract %d)\n", Version, contract.CONTRACT_VERSION)
-		return 0
-	case "status":
-		return runStatus(ctx, args[1:], env, dir, stdin, stdout, stderr, runner)
-	case "dispatch":
-		return dispatch.Run(args[1:], stdin, stdout, stderr)
-	case "claude":
-		applyDevBranchOverride(env)
-		return runClaude(ctx, args[1:], dir, execHost{}, exec.LookPath, stdout, stderr)
-	case "codex":
-		applyDevBranchOverride(env)
-		return runCodex(ctx, args[1:], dir, execHost{}, exec.LookPath, stdout, stderr)
-	case "init":
-		applyDevBranchOverride(env)
-		return runInit(ctx, args[1:], execHost{}, stdout, stderr)
-	case "doctor":
-		applyDevBranchOverride(env)
-		return runDoctor(ctx, args[1:], execHost{}, stdout, stderr)
-	default:
-		fmt.Fprintf(stderr, "unknown command: %s\n", args[0])
-		printUsage(stderr)
-		return 2
+// exitCodeError carries an explicit process exit code out of a RunE so the
+// command tree can preserve the hand-rolled router's exit-code contract (status
+// exit-1 surfacing, the front-door fail-fast exit 1) through cobra's single error
+// return. cobra's own command-resolution errors (unknown command, unknown flag)
+// carry no code and map to exit 2.
+type exitCodeError struct{ code int }
+
+func (e exitCodeError) Error() string { return fmt.Sprintf("exit %d", e.code) }
+
+// exitCodeFor maps an Execute error to a process exit code. An explicit
+// exitCodeError carries its own code (RunE already wrote any diagnostic); every
+// other error is a cobra command/flag-resolution failure, which exits 2 to match
+// the hand-rolled router's unknown-command contract (TestUnknownCommand).
+func exitCodeFor(err error) int {
+	var ec exitCodeError
+	if errors.As(err, &ec) {
+		return ec.code
 	}
+	return 2
+}
+
+// newRootCommand assembles the cobra tree. The root owns the grouped jargon-free
+// help (AC-1) and the explicit `--version` handler with the `(contract N)` token
+// (AC-5). SilenceErrors/SilenceUsage hand all output and exit-code control to this
+// package: cobra never prints its own error or usage, so the unknown-command path
+// emits the pinned message and exits 2 (the root RunE below), and the help is
+// rendered solely by printHelp.
+func newRootCommand(ctx context.Context, env []string, dir string, stdin io.Reader, stdout, stderr io.Writer, runner status.Runner) *cobra.Command {
+	versionFlag := false
+
+	root := &cobra.Command{
+		Use:               "spacedock",
+		SilenceErrors:     true,
+		SilenceUsage:      true,
+		Args:              cobra.ArbitraryArgs,
+		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if versionFlag {
+				printVersion(stdout)
+				return nil
+			}
+			// No subcommand and no recognized flag: an unknown command token
+			// (e.g. `spacedock bogus`) exits 2 with the pinned message; bare
+			// `spacedock` renders the grouped help.
+			if len(args) > 0 {
+				return unknownCommand(args[0], stderr)
+			}
+			printHelp(stdout)
+			return nil
+		},
+	}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.Flags().BoolVar(&versionFlag, "version", false, "Print the spacedock version and contract level")
+	root.SetHelpFunc(func(*cobra.Command, []string) { printHelp(stdout) })
+
+	root.AddGroup(
+		&cobra.Group{ID: "launch", Title: "Launch"},
+		&cobra.Group{ID: "setup", Title: "Setup"},
+		&cobra.Group{ID: "workflow", Title: "Workflow"},
+	)
+
+	root.AddCommand(
+		newClaudeCommand(ctx, env, dir, stdout, stderr),
+		newCodexCommand(ctx, env, dir, stdout, stderr),
+		newInstallCommand(ctx, env, stdout, stderr),
+		newDoctorCommand(ctx, env, stdout, stderr),
+		newStatusCommand(ctx, env, dir, stdin, stdout, stderr, runner),
+		newDispatchCommand(stdin, stdout, stderr),
+	)
+	return root
+}
+
+// newClaudeCommand wires `spacedock claude`. Flag parsing is disabled at the cobra
+// layer so the post-subcommand argv reaches runClaude verbatim — runClaude owns the
+// Option-2 grammar via parseFrontDoorArgs (ArgsLenAtDash). The flags are declared
+// only so `--help` renders them (AC-4); `-h`/`--help` is intercepted here because
+// DisableFlagParsing routes it to RunE rather than cobra's own help.
+func newClaudeCommand(ctx context.Context, env []string, dir string, stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "claude [task] [-- claude-flags]",
+		Short:              "Start Claude Code as your Spacedock first officer",
+		GroupID:            "launch",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if wantsHelp(args) {
+				return cmd.Help()
+			}
+			applyDevBranchOverride(env)
+			if code := runClaude(ctx, args, dir, execHost{}, exec.LookPath, stdout, stderr); code != 0 {
+				return exitCodeError{code}
+			}
+			return nil
+		},
+	}
+	setFrontDoorHelp(cmd, "claude", stdout)
+	return cmd
+}
+
+// newCodexCommand mirrors newClaudeCommand for `spacedock codex`.
+func newCodexCommand(ctx context.Context, env []string, dir string, stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "codex [task] [-- codex-flags]",
+		Short:              "Start Codex as your Spacedock first officer",
+		GroupID:            "launch",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if wantsHelp(args) {
+				return cmd.Help()
+			}
+			applyDevBranchOverride(env)
+			if code := runCodex(ctx, args, dir, execHost{}, exec.LookPath, stdout, stderr); code != 0 {
+				return exitCodeError{code}
+			}
+			return nil
+		},
+	}
+	setFrontDoorHelp(cmd, "codex", stdout)
+	return cmd
+}
+
+// newInstallCommand wires `spacedock install` (the renamed `init`). Behavior is
+// unchanged from init: install the per-host plugin then run doctor (claude), or
+// emit the documented codex add prose. DisableFlagParsing keeps the post-subcommand
+// argv verbatim for the existing hand-parsed runInit (so `--host`/`--check` parse
+// exactly as before); `-h`/`--help` is intercepted here.
+func newInstallCommand(ctx context.Context, env []string, stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "install [--host claude|codex] [--check]",
+		Short:              "Install the Spacedock plugin for a host, then check it",
+		GroupID:            "setup",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if wantsHelp(args) {
+				return cmd.Help()
+			}
+			applyDevBranchOverride(env)
+			if code := runInit(ctx, args, execHost{}, stdout, stderr); code != 0 {
+				return exitCodeError{code}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().String("host", "claude", "Host to install the plugin for (claude or codex)")
+	cmd.Flags().Bool("check", false, "Run the compatibility report without installing")
+	setSetupHelp(cmd, stdout, `
+Examples:
+  spacedock install
+  spacedock install --host codex
+  spacedock install --check
+`)
+	return cmd
+}
+
+// newDoctorCommand wires `spacedock doctor` with its existing hand-parsed
+// `--host`/`--plugin-manifest` handling preserved verbatim.
+func newDoctorCommand(ctx context.Context, env []string, stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "doctor [--host claude|codex]",
+		Short:              "Check the installed plugin and this binary are compatible",
+		GroupID:            "setup",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if wantsHelp(args) {
+				return cmd.Help()
+			}
+			applyDevBranchOverride(env)
+			if code := runDoctor(ctx, args, execHost{}, stdout, stderr); code != 0 {
+				return exitCodeError{code}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().String("host", "claude", "Host to check (claude or codex)")
+	cmd.Flags().String("plugin-manifest", "", "Read this manifest directly instead of resolving the installed plugin")
+	setSetupHelp(cmd, stdout, `
+Examples:
+  spacedock doctor
+  spacedock doctor --host codex
+`)
+	return cmd
+}
+
+// newStatusCommand reparents `spacedock status` under cobra with flag parsing
+// disabled, so its post-subcommand argv forwards VERBATIM to runStatus exactly as
+// the hand-rolled router did — cobra never consumes, reorders, or validates a
+// status flag (AC-5).
+func newStatusCommand(ctx context.Context, env []string, dir string, stdin io.Reader, stdout, stderr io.Writer, runner status.Runner) *cobra.Command {
+	return &cobra.Command{
+		Use:                "status [args]",
+		Short:              "Show or update workflow state",
+		GroupID:            "workflow",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if code := runStatus(ctx, args, env, dir, stdin, stdout, stderr, runner); code != 0 {
+				return exitCodeError{code}
+			}
+			return nil
+		},
+	}
+}
+
+// newDispatchCommand reparents `spacedock dispatch` under cobra with flag parsing
+// disabled, forwarding its post-subcommand argv verbatim to dispatch.Run (AC-5).
+func newDispatchCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:                "dispatch build | show-stage-def",
+		Short:              "Build worker dispatch artifacts",
+		GroupID:            "workflow",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if code := dispatch.Run(args, stdin, stdout, stderr); code != 0 {
+				return exitCodeError{code}
+			}
+			return nil
+		},
+	}
+}
+
+// wantsHelp reports whether the operator asked for command help. Commands with
+// DisableFlagParsing receive `-h`/`--help` as ordinary args, so each RunE checks
+// for it before doing work. Only a leading help token counts: a `--help` after
+// `--` is host passthrough, not a request for spacedock's help.
+func wantsHelp(args []string) bool {
+	for _, a := range args {
+		if a == "--" {
+			return false
+		}
+		if a == "-h" || a == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+// unknownCommand writes the pinned unknown-command diagnostic plus the grouped
+// help to stderr and returns the exit-2 carrier.
+func unknownCommand(name string, stderr io.Writer) error {
+	fmt.Fprintf(stderr, "unknown command: %s\n", name)
+	printHelp(stderr)
+	return exitCodeError{2}
 }
 
 // runStatus forwards the post-"status" argv verbatim to the runner and returns
@@ -114,29 +338,10 @@ func cwd() string {
 	return dir
 }
 
-func printUsage(w io.Writer) {
-	fmt.Fprint(w, `spacedock is the Spacedock v1 launcher.
-
-Usage:
-  spacedock claude [args...]                          version-gate then launch claude --agent spacedock:first-officer
-  spacedock codex [args...]                           version-gate then launch codex with the spacedock:first-officer skill
-  spacedock init [--host claude|codex] [--check]      install the per-host plugin, then run doctor
-  spacedock doctor [--host claude|codex] [--plugin-manifest PATH]
-  spacedock status [args...]
-  spacedock dispatch build --workflow-dir DIR
-  spacedock dispatch show-stage-def --workflow-dir DIR --stage STAGE
-  spacedock --version
-  spacedock --help
-
-claude/codex are the host front doors: they version-gate against the installed
-plugin's requires-contract and fail fast on a mismatch before launching. Append a
-task with a -- fence (spacedock claude -- "the task"); host flags go before the
-fence and forward verbatim. Sandbox knobs: --safehouse forces the safehouse wrap,
---safehouse-enable=KEY[,KEY], --safehouse-add-dirs=PATH, --safehouse-add-dirs-ro=PATH.
-A --plugin-dir launch loads the local checkout and relaxes the contract gate.
-init installs the per-host plugin via the host plugin mechanism (no skill-file copies).
-doctor reports the compatibility verdict against the binary's CONTRACT_VERSION.
-status forwards its arguments to the workflow status command.
-dispatch assembles ensign dispatch artifacts (build, show-stage-def).
-`)
+// printVersion emits the version line with the contract token. The token is
+// load-bearing: the FO/ensign skills read `(contract N)` from `spacedock
+// --version`, so cobra's auto version-flag (a bare version string, plus a command
+// row in help) is deliberately NOT used.
+func printVersion(w io.Writer) {
+	fmt.Fprintf(w, "spacedock %s (contract %d)\n", Version, contract.CONTRACT_VERSION)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,21 +9,74 @@ import (
 	"github.com/spacedock-dev/spacedock/internal/contract"
 )
 
-func TestHelp(t *testing.T) {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
+// TestTopLevelHelpGroupedJargonFree pins AC-1: `--help` renders the tagline, the
+// three group headers in order, the six grouped command names with terse
+// one-liners, and a single footer pointing at per-command help + --version. The
+// banned internal jargon (`front door`, `contract-gated`, `META`) is absent, and
+// neither `--version` nor `--help` appears as its own command row (they live in
+// the footer). The render goes to stdout with exit 0 and empty stderr.
+func TestTopLevelHelpGroupedJargonFree(t *testing.T) {
+	var stdout, stderr bytes.Buffer
 	code := Run([]string{"--help"}, &stdout, &stderr)
 
 	if code != 0 {
 		t.Fatalf("Run returned %d, want 0", code)
 	}
-	if !strings.Contains(stdout.String(), "Usage:") {
-		t.Fatalf("help output missing Usage: %q", stdout.String())
-	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
+	out := stdout.String()
+
+	for _, want := range []string{
+		"spacedock — agentic workflow launcher",
+		"Launch", "Setup", "Workflow",
+		"claude", "codex", "install", "doctor", "status", "dispatch",
+		`Run "spacedock <command> --help" for details.`,
+		"--version prints the version.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("top-level help missing %q:\n%s", want, out)
+		}
+	}
+
+	for _, banned := range []string{"front door", "contract-gated", "META"} {
+		if strings.Contains(out, banned) {
+			t.Errorf("top-level help carried banned jargon %q:\n%s", banned, out)
+		}
+	}
+
+	// The group headers appear in the captain-approved order.
+	iLaunch := strings.Index(out, "Launch")
+	iSetup := strings.Index(out, "Setup")
+	iWorkflow := strings.Index(out, "Workflow")
+	if !(iLaunch < iSetup && iSetup < iWorkflow) {
+		t.Errorf("group headers out of order: Launch=%d Setup=%d Workflow=%d", iLaunch, iSetup, iWorkflow)
+	}
+}
+
+// TestTopLevelHelpFormsAreIdentical pins AC-1's invariant that bare `spacedock`,
+// `-h`, and the `help` subcommand render byte-identical output to `--help`.
+func TestTopLevelHelpFormsAreIdentical(t *testing.T) {
+	ref := helpStdout(t, "--help")
+	for _, form := range [][]string{nil, {"-h"}, {"help"}} {
+		got := helpStdout(t, form...)
+		if got != ref {
+			t.Errorf("help form %v output differs from --help:\n--- form ---\n%s\n--- --help ---\n%s", form, got, ref)
+		}
+	}
+}
+
+func helpStdout(t *testing.T, args ...string) string {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := Run(args, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run(%v) = %d, want 0 (stderr=%q)", args, code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("Run(%v) stderr = %q, want empty", args, stderr.String())
+	}
+	return stdout.String()
 }
 
 func TestVersion(t *testing.T) {

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -58,13 +58,13 @@ func gateHost(ops hostOps, host string, stderr io.Writer) (ok bool) {
 	if err != nil {
 		fmt.Fprintf(stderr,
 			"Spacedock: could not resolve the installed %s plugin (%v). "+
-				"Run `spacedock doctor` or `spacedock init --host %s`.\n", host, err, host)
+				"Run `spacedock doctor` or `spacedock install --host %s`.\n", host, err, host)
 		return false
 	}
 	if manifestPath == "" {
 		fmt.Fprintf(stderr,
 			"Spacedock: no installed %s plugin found. "+
-				"Run `spacedock init --host %s` (or `spacedock claude --skip-contract-check` to bootstrap).\n", host, host)
+				"Run `spacedock install --host %s` (or `spacedock claude --skip-contract-check` to bootstrap).\n", host, host)
 		return false
 	}
 	res := contract.ManifestVerdict(manifestPath, host, devBranch)
@@ -74,7 +74,7 @@ func gateHost(ops hostOps, host string, stderr io.Writer) (ok bool) {
 	if res.Verdict == contract.NoPluginFound {
 		fmt.Fprintf(stderr,
 			"Spacedock: the installed %s plugin reported a manifest path that does not exist (%s). "+
-				"Run `spacedock init --host %s` (or `spacedock claude --skip-contract-check` to bootstrap).\n",
+				"Run `spacedock install --host %s` (or `spacedock claude --skip-contract-check` to bootstrap).\n",
 			host, manifestPath, host)
 		return false
 	}

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/spf13/pflag"
+
 	"github.com/spacedock-dev/spacedock/internal/contract"
 	"github.com/spacedock-dev/spacedock/internal/safehouse"
 )
@@ -93,7 +95,7 @@ func gateHost(ops hostOps, host string, stderr io.Writer) (ok bool) {
 // the installed plugin). `lookPath` resolves the safehouse binary (default
 // exec.LookPath; injected so tests pin not-found).
 func runClaude(ctx context.Context, args []string, dir string, ops hostOps, lookPath func(string) (string, error), stdout, stderr io.Writer) int {
-	fd, err := splitFrontDoorArgs(args)
+	fd, err := parseFrontDoorArgs(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "spacedock claude: %v\n", err)
 		return 1
@@ -199,7 +201,7 @@ const codexBootstrapPrompt = "You totally got this. Take your time. I love you. 
 // `--plugin-dir`. `lookPath` resolves the safehouse binary (default exec.LookPath;
 // injected so tests pin not-found).
 func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookPath func(string) (string, error), stdout, stderr io.Writer) int {
-	fd, err := splitFrontDoorArgs(args)
+	fd, err := parseFrontDoorArgs(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "spacedock codex: %v\n", err)
 		return 1
@@ -268,38 +270,81 @@ type frontDoorArgs struct {
 	skipCheck bool
 }
 
-const safehouseKnobPrefix = "--safehouse-"
+// frontDoorFlags binds the spacedock-owned front-door flags onto a pflag.FlagSet
+// so cobra owns their vocabulary natively: the three value-taking safehouse knobs
+// are StringArray (accept both `--flag value` and `--flag=value`, accumulate on
+// repeat), and the bare `--safehouse`/`--skip-contract-check` are Bool. The
+// returned pointers are read back by parseFrontDoorArgs after Parse. The same
+// binding feeds the per-command cobra help (AC-4), so the help and the parser
+// never drift.
+type frontDoorFlags struct {
+	safehouse *bool
+	skipCheck *bool
+	enable    *[]string
+	addDirs   *[]string
+	addDirsRO *[]string
+}
 
-// splitFrontDoorArgs parses the front-door grammar in one pass. Front-door flags
-// (`--skip-contract-check`, the bare `--safehouse`, and `--safehouse-<key>=…`
-// knobs) are consumed wherever they appear and never forwarded to the host. The
-// `--` fence convention (captain decision on OPEN-LP1) splits the rest: tokens
-// BEFORE the fence are host passthrough (value-taking host flags ride here and
-// forward verbatim); the bare text AFTER the fence is the launch-prompt task.
-// Without a fence everything is host passthrough and there is no task. The
-// `--safehouse-` knob keys are validated by safehouse.TranslateFlags at launch;
-// here a knob is only de-prefixed and collected.
-func splitFrontDoorArgs(args []string) (fd frontDoorArgs, err error) {
-	fenced := false
-	var taskTokens []string
-	for _, a := range args {
-		switch {
-		case a == "--skip-contract-check":
-			fd.skipCheck = true
-		case a == "--safehouse":
-			fd.forceSafehouse = true
-		case strings.HasPrefix(a, safehouseKnobPrefix):
-			fd.safehouseFlags = append(fd.safehouseFlags, strings.TrimPrefix(a, safehouseKnobPrefix))
-		case a == "--" && !fenced:
-			// The first `--` is the fence: host flags end, the task begins.
-			fenced = true
-		case fenced:
-			taskTokens = append(taskTokens, a)
-		default:
-			fd.passthrough = append(fd.passthrough, a)
-		}
+func bindFrontDoorFlags(fs *pflag.FlagSet) frontDoorFlags {
+	return frontDoorFlags{
+		safehouse: fs.Bool("safehouse", false,
+			"Force the safehouse sandbox wrap even without a .safehouse profile in the directory"),
+		skipCheck: fs.Bool("skip-contract-check", false,
+			"Bypass the contract gate and launch without resolving the installed plugin (bootstrap)"),
+		enable: fs.StringArray("safehouse-enable", nil,
+			"Enable a safehouse capability (KEY[,KEY]); repeatable; e.g. --safehouse-enable ssh,docker"),
+		addDirs: fs.StringArray("safehouse-add-dirs", nil,
+			"Grant safehouse read-write access to a directory; repeatable"),
+		addDirsRO: fs.StringArray("safehouse-add-dirs-ro", nil,
+			"Grant safehouse read-only access to a directory; repeatable"),
 	}
-	if fenced {
+}
+
+// parseFrontDoorArgs parses the Option-2 front-door grammar in one pass via a
+// pflag.FlagSet. cobra owns the spacedock flags wherever they appear before `--`;
+// the non-flag positionals before `--` join (single space) into the launch task;
+// everything after `--` forwards verbatim to the host as passthrough. This is the
+// grammar inversion: host flags now ride AFTER `--`, the task before — the prompt
+// is always spacedock-constructed and never adjacent to a value-taking host flag,
+// so no dangling host flag can swallow it. The collected safehouse-knob values are
+// re-prefixed to the `key=value` token form safehouse.TranslateFlags owns, so the
+// safehouse vocabulary (the comma-split on enable, the unknown-key error) is
+// unchanged — the space-form bug dies because cobra consumes the value as the
+// flag's argument instead of leaking it to passthrough.
+func parseFrontDoorArgs(args []string) (fd frontDoorArgs, err error) {
+	fs := pflag.NewFlagSet("spacedock-front-door", pflag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	flags := bindFrontDoorFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return frontDoorArgs{}, err
+	}
+
+	fd.forceSafehouse = *flags.safehouse
+	fd.skipCheck = *flags.skipCheck
+	for _, v := range *flags.enable {
+		fd.safehouseFlags = append(fd.safehouseFlags, "enable="+v)
+	}
+	for _, v := range *flags.addDirs {
+		fd.safehouseFlags = append(fd.safehouseFlags, "add-dirs="+v)
+	}
+	for _, v := range *flags.addDirsRO {
+		fd.safehouseFlags = append(fd.safehouseFlags, "add-dirs-ro="+v)
+	}
+
+	// ArgsLenAtDash is the count of positionals seen before `--` (or -1 when no
+	// `--` was given). Without a `--`, every positional is the task and nothing
+	// forwards. With a `--`, the pre-dash positionals join into the task and the
+	// post-dash positionals forward verbatim as host passthrough.
+	positionals := fs.Args()
+	dash := fs.ArgsLenAtDash()
+	var taskTokens []string
+	if dash < 0 {
+		taskTokens = positionals
+	} else {
+		taskTokens = positionals[:dash]
+		fd.passthrough = positionals[dash:]
+	}
+	if len(taskTokens) > 0 {
 		fd.task = strings.Join(taskTokens, " ")
 		fd.hasTask = true
 	}

--- a/internal/cli/frontdoor_parse_test.go
+++ b/internal/cli/frontdoor_parse_test.go
@@ -1,15 +1,16 @@
-// ABOUTME: Table test for splitFrontDoorArgs — the front-door grammar that pulls
-// ABOUTME: --skip-contract-check/--safehouse(-*) and the post-fence task off args.
+// ABOUTME: Table test for parseFrontDoorArgs — the Option-2 grammar that takes the
+// ABOUTME: task before --, host flags after --, and the safehouse/skip knobs anywhere.
 package cli
 
 import "testing"
 
-// TestSplitFrontDoorArgs pins the front-door grammar (LP-1 fence convention +
-// cycle-2 safehouse knobs). Host value-taking flags ride before the `--` fence
-// and forward verbatim; the task is the bare text AFTER the fence; the
-// front-door flags (--skip-contract-check, bare --safehouse, --safehouse-<key>=)
-// are consumed wherever they appear and never forwarded.
-func TestSplitFrontDoorArgs(t *testing.T) {
+// TestParseFrontDoorArgs pins the Option-2 front-door grammar (AC-3 + AC-6). The
+// task is the joined non-flag positionals BEFORE `--`; host value-taking flags
+// ride AFTER `--` and forward verbatim as passthrough; the spacedock-owned flags
+// (--skip-contract-check, --safehouse, the three repeatable --safehouse-* knobs)
+// are consumed wherever they appear before `--` in BOTH space and equals form and
+// are never forwarded.
+func TestParseFrontDoorArgs(t *testing.T) {
 	cases := []struct {
 		name           string
 		args           []string
@@ -22,21 +23,27 @@ func TestSplitFrontDoorArgs(t *testing.T) {
 	}{
 		{name: "bare"},
 		{
-			name:    "fenced-task",
-			args:    []string{"--", "do the thing"},
+			name:    "task-positional",
+			args:    []string{"do the thing"},
 			task:    "do the thing",
 			hasTask: true,
 		},
 		{
-			name:        "host-flag-then-fenced-task",
-			args:        []string{"--plugin-dir", "/p", "--", "do the thing"},
+			name:    "multi-word-task-joins",
+			args:    []string{"do", "the", "thing"},
+			task:    "do the thing",
+			hasTask: true,
+		},
+		{
+			name:        "task-then-fenced-host-flag",
+			args:        []string{"do the thing", "--", "--plugin-dir", "/p"},
 			passthrough: []string{"--plugin-dir", "/p"},
 			task:        "do the thing",
 			hasTask:     true,
 		},
 		{
-			name:        "no-fence-all-passthrough",
-			args:        []string{"--model", "gpt-x"},
+			name:        "host-flags-after-fence-no-task",
+			args:        []string{"--", "--model", "gpt-x"},
 			passthrough: []string{"--model", "gpt-x"},
 		},
 		{
@@ -50,29 +57,29 @@ func TestSplitFrontDoorArgs(t *testing.T) {
 			forceSafehouse: true,
 		},
 		{
-			name:           "safehouse-knob-deprefixed",
+			name:           "safehouse-knob-equals-form",
 			args:           []string{"--safehouse-enable=docker"},
 			safehouseFlags: []string{"enable=docker"},
 		},
 		{
-			name:           "knob-after-fence-still-consumed",
-			args:           []string{"--", "--safehouse-enable=ssh", "task text"},
-			safehouseFlags: []string{"enable=ssh"},
-			task:           "task text",
-			hasTask:        true,
+			name:           "safehouse-knob-space-form",
+			args:           []string{"--safehouse-enable", "docker"},
+			safehouseFlags: []string{"enable=docker"},
 		},
 		{
-			name:    "fenced-empty-task-string-counts",
-			args:    []string{"--", ""},
-			task:    "",
-			hasTask: true,
+			name:           "knob-and-task-and-fenced-host-flags",
+			args:           []string{"--safehouse-enable=ssh", "task text", "--", "--model", "x"},
+			safehouseFlags: []string{"enable=ssh"},
+			passthrough:    []string{"--model", "x"},
+			task:           "task text",
+			hasTask:        true,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			fd, err := splitFrontDoorArgs(tc.args)
+			fd, err := parseFrontDoorArgs(tc.args)
 			if err != nil {
-				t.Fatalf("splitFrontDoorArgs(%v) err = %v, want nil", tc.args, err)
+				t.Fatalf("parseFrontDoorArgs(%v) err = %v, want nil", tc.args, err)
 			}
 			if !equalArgv(fd.passthrough, tc.passthrough) {
 				t.Errorf("passthrough = %v, want %v", fd.passthrough, tc.passthrough)

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -108,7 +109,7 @@ func TestClaudeFrontDoorUnresolvableManifestFailsFast(t *testing.T) {
 	if fake.launchedArg != nil {
 		t.Fatalf("launch seam invoked with unresolvable manifest: %v", fake.launchedArg)
 	}
-	if !strings.Contains(stderr.String(), "spacedock doctor") && !strings.Contains(stderr.String(), "spacedock init") {
+	if !strings.Contains(stderr.String(), "spacedock doctor") && !strings.Contains(stderr.String(), "spacedock install") {
 		t.Fatalf("stderr missing actionable remedy pointer: %q", stderr.String())
 	}
 }
@@ -131,8 +132,56 @@ func TestClaudeFrontDoorNonEmptyMissingManifestFailsFast(t *testing.T) {
 	if fake.launchedArg != nil {
 		t.Fatalf("launch seam invoked with a missing manifest: %v", fake.launchedArg)
 	}
-	if !strings.Contains(stderr.String(), "spacedock doctor") && !strings.Contains(stderr.String(), "spacedock init") {
+	if !strings.Contains(stderr.String(), "spacedock doctor") && !strings.Contains(stderr.String(), "spacedock install") {
 		t.Fatalf("stderr missing actionable remedy pointer: %q", stderr.String())
+	}
+}
+
+// TestGateRemedyNamesLiveInstallCommand: every gateHost remedy must point at a
+// command the binary actually recognizes. After the init->install rename a user
+// who hits the gate and is told to "run spacedock init --host …" runs a command
+// that now exits 2 (unknown command). Drive each remedy branch (resolve error,
+// no plugin, missing manifest) and assert the printed remedy names `spacedock
+// install` and never `spacedock init`; then prove the named command resolves by
+// feeding it through cli.Run and asserting it is not the unknown-command exit 2.
+func TestGateRemedyNamesLiveInstallCommand(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-dir", ".claude-plugin", "plugin.json")
+	cases := []struct {
+		name string
+		fake *fakeHost
+	}{
+		{"resolve error", &fakeHost{resolveErr: errors.New("host CLI failed")}},
+		{"no plugin", &fakeHost{manifest: ""}},
+		{"missing manifest", &fakeHost{manifest: missing}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			if ok := gateHost(tc.fake, "claude", &stderr); ok {
+				t.Fatalf("gateHost = ok, want denied for %s", tc.name)
+			}
+			remedy := stderr.String()
+			if !strings.Contains(remedy, "spacedock install") {
+				t.Fatalf("remedy does not name the live install command: %q", remedy)
+			}
+			if strings.Contains(remedy, "spacedock init") {
+				t.Fatalf("remedy names the removed init command (exits 2): %q", remedy)
+			}
+		})
+	}
+
+	// The command the remedy names must resolve in the live command tree. cobra's
+	// Find returns the matched command for a registered name and falls back to the
+	// root for an unknown one — so `install` must resolve to a non-root command
+	// while the removed `init` must fall back to root (the unknown-command path
+	// that exits 2). Resolution is deterministic and touches no host CLI.
+	var stdout, stderr bytes.Buffer
+	root := newRootCommand(context.Background(), nil, t.TempDir(), nil, &stdout, &stderr, &fakeRunner{})
+	if cmd, _, err := root.Find([]string{"install"}); err != nil || cmd == root {
+		t.Fatalf("`install` did not resolve to a registered command (cmd=%v, err=%v)", cmd.Name(), err)
+	}
+	if cmd, _, _ := root.Find([]string{"init"}); cmd != root {
+		t.Fatalf("`init` resolved to a command (%v) — the removed verb must fall back to the unknown-command path", cmd.Name())
 	}
 }
 

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -63,7 +63,7 @@ func TestClaudeFrontDoorLaunchesOnCompatible(t *testing.T) {
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
-	code := runClaude(context.Background(), []string{"-p", "do the thing"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+	code := runClaude(context.Background(), []string{"--", "-p", "do the thing"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
 
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
@@ -163,7 +163,7 @@ func TestCodexFrontDoorLaunchesOnCompatible(t *testing.T) {
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
-	code := runCodex(context.Background(), []string{"-m", "gpt-x"}, dir, fake, lookFound, &stdout, &stderr)
+	code := runCodex(context.Background(), []string{"--", "-m", "gpt-x"}, dir, fake, lookFound, &stdout, &stderr)
 
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,0 +1,99 @@
+// ABOUTME: Grouped jargon-free top-level help and the per-command help renderers.
+// ABOUTME: Renders the Launch/Setup/Workflow groups, terse one-liners, and footer.
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// topLevelHelp is the grouped, jargon-free, META-free top-level help (AC-1). The
+// command list is hand-rendered (not cobra's default `Available Commands` block)
+// so the three groups carry terse aligned one-liners and the footer holds
+// `--version` and the per-command help pointer instead of dedicated command rows.
+// No internal jargon (`front door`, `contract-gated`, `META`) appears.
+const topLevelHelp = tagline + `
+
+Launch
+  claude  [task] [-- claude-flags]   Start Claude Code as your Spacedock first officer
+  codex   [task] [-- codex-flags]    Start Codex as your Spacedock first officer
+Setup
+  install  [--host claude|codex]     Install the Spacedock plugin for a host, then check it
+  doctor   [--host claude|codex]     Check the installed plugin and this binary are compatible
+Workflow
+  status    [args]                   Show or update workflow state
+  dispatch  build | show-stage-def   Build worker dispatch artifacts
+
+Run "spacedock <command> --help" for details.  ·  --version prints the version.
+`
+
+func printHelp(w io.Writer) {
+	fmt.Fprint(w, topLevelHelp)
+}
+
+// setFrontDoorHelp installs a per-command help renderer for claude/codex (AC-4):
+// the sandbox knobs, --skip-contract-check, --plugin-dir, the `--` host-flag
+// forwarding explanation, and an Examples block. The flags are declared on the
+// command (declareFrontDoorHelpFlags) only so FlagUsages renders them — the real
+// parsing is parseFrontDoorArgs's. A per-command HelpFunc is set so the root's
+// grouped HelpFunc is not inherited (cobra walks to the parent only when a child
+// has none).
+func setFrontDoorHelp(cmd *cobra.Command, host string, w io.Writer) {
+	declareFrontDoorHelpFlags(cmd)
+	cmd.SetHelpFunc(func(c *cobra.Command, _ []string) {
+		fmt.Fprint(w, tagline+`
+
+Usage:
+  spacedock `+host+` [task] [spacedock-flags] [-- `+host+`-flags]
+
+Start `+hostTitle(host)+` as your Spacedock first officer. The optional task is the
+launch prompt; everything after -- forwards verbatim to `+host+`.
+
+A --plugin-dir launch (after --) loads a local plugin checkout and relaxes the
+contract gate, so it does not require a prior "spacedock install".
+
+Flags:
+`)
+		fmt.Fprint(w, c.Flags().FlagUsages())
+		fmt.Fprint(w, `
+Forwarding:
+  Tokens before -- are spacedock's (the task + the flags above). Tokens after --
+  forward verbatim to `+host+`, e.g. `+host+` model/session flags and --plugin-dir.
+
+Examples:
+  spacedock `+host+`
+  spacedock `+host+` "review the open PRs"
+  spacedock `+host+` --safehouse-add-dirs ~/scratch -- --plugin-dir ./checkout
+`)
+	})
+}
+
+// setSetupHelp installs a per-command help renderer for install/doctor: the
+// command's own flags and an Examples block. A per-command HelpFunc is set so the
+// root's grouped HelpFunc is not inherited.
+func setSetupHelp(cmd *cobra.Command, w io.Writer, examples string) {
+	cmd.SetHelpFunc(func(c *cobra.Command, _ []string) {
+		fmt.Fprintf(w, "%s\n\nUsage:\n  spacedock %s\n\nFlags:\n", c.Short, c.Use)
+		fmt.Fprint(w, c.Flags().FlagUsages())
+		fmt.Fprint(w, examples)
+	})
+}
+
+// declareFrontDoorHelpFlags registers the spacedock-owned front-door flags onto a
+// command's flag set purely so `--help` renders them (AC-4). The flags are never
+// parsed by cobra here (the command has DisableFlagParsing); parseFrontDoorArgs
+// owns the real parsing. bindFrontDoorFlags is the single source for the flag set
+// so the help and the parser never drift.
+func declareFrontDoorHelpFlags(cmd *cobra.Command) {
+	bindFrontDoorFlags(cmd.Flags())
+}
+
+// hostTitle returns the display name for the host in help prose.
+func hostTitle(host string) string {
+	if host == "codex" {
+		return "Codex"
+	}
+	return "Claude Code"
+}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -1,0 +1,55 @@
+// ABOUTME: AC-4 per-command help coverage — claude/codex/install --help carry the
+// ABOUTME: sandbox knobs, --plugin-dir, the -- forwarding note, and an Examples block.
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestFrontDoorHelpCarriesDetail pins AC-4: `spacedock claude --help` and
+// `spacedock codex --help` render (exit 0) the sandbox knobs, --skip-contract-check,
+// --plugin-dir, the `--` host-flag forwarding note, and an Examples block.
+func TestFrontDoorHelpCarriesDetail(t *testing.T) {
+	for _, host := range []string{"claude", "codex"} {
+		t.Run(host, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{host, "--help"}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+			}
+			out := stdout.String()
+			for _, want := range []string{
+				"--safehouse",
+				"--safehouse-enable",
+				"--safehouse-add-dirs",
+				"--safehouse-add-dirs-ro",
+				"--skip-contract-check",
+				"--plugin-dir",
+				"forward verbatim",
+				"Examples:",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("%s --help missing %q:\n%s", host, want, out)
+				}
+			}
+		})
+	}
+}
+
+// TestInstallHelpDocumentsHostAndCheck pins AC-4 for the setup verb: `spacedock
+// install --help` documents --host and --check.
+func TestInstallHelpDocumentsHostAndCheck(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"install", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"--host", "--check", "Examples:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("install --help missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/launch_parity_test.go
+++ b/internal/cli/launch_parity_test.go
@@ -174,13 +174,14 @@ func TestUnknownSafehouseKeyErrors(t *testing.T) {
 	}
 }
 
-// LP-AC-1: a fenced trailing task becomes base + " " + task as the LAST inner
-// token; bare → base exactly; a host flag before the fence still forwards.
+// LP-AC-1 (Option-2 grammar): a task positional (BEFORE any `--`) becomes
+// base + " " + task as the LAST inner token; bare → base exactly; a host flag
+// AFTER the `--` still forwards verbatim, with the task riding before the fence.
 func TestFenceTaskPromptOverride(t *testing.T) {
-	t.Run("claude-fenced-task", func(t *testing.T) {
+	t.Run("claude-task-positional", func(t *testing.T) {
 		fake := &fakeHost{manifest: compatibleManifest(t)}
 		var stdout, stderr bytes.Buffer
-		code := runClaude(context.Background(), []string{"--", "do the thing"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+		code := runClaude(context.Background(), []string{"do the thing"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
@@ -201,10 +202,10 @@ func TestFenceTaskPromptOverride(t *testing.T) {
 			t.Fatalf("last token = %q, want bare base prompt (no trailing space)", last)
 		}
 	})
-	t.Run("claude-host-flag-before-fence", func(t *testing.T) {
+	t.Run("claude-task-before-fenced-host-flag", func(t *testing.T) {
 		fake := &fakeHost{manifest: compatibleManifest(t)}
 		var stdout, stderr bytes.Buffer
-		code := runClaude(context.Background(), []string{"--model", "gpt-x", "--", "do the thing"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+		code := runClaude(context.Background(), []string{"do the thing", "--", "--model", "gpt-x"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
@@ -213,10 +214,10 @@ func TestFenceTaskPromptOverride(t *testing.T) {
 			t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
 		}
 	})
-	t.Run("codex-fenced-task", func(t *testing.T) {
+	t.Run("codex-task-positional", func(t *testing.T) {
 		fake := &fakeHost{manifest: compatibleManifest(t)}
 		var stdout, stderr bytes.Buffer
-		code := runCodex(context.Background(), []string{"--", "do the thing"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+		code := runCodex(context.Background(), []string{"do the thing"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
@@ -232,7 +233,7 @@ func TestCodexResumeSubcommandSuppressesPrompt(t *testing.T) {
 	t.Run("resume-no-prompt", func(t *testing.T) {
 		fake := &fakeHost{manifest: compatibleManifest(t)}
 		var stdout, stderr bytes.Buffer
-		code := runCodex(context.Background(), []string{"resume", "abc-123"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+		code := runCodex(context.Background(), []string{"--", "resume", "abc-123"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
@@ -266,7 +267,7 @@ func TestPluginDirRelaxesGate(t *testing.T) {
 	t.Run("claude-relaxes-on-failing-manifest", func(t *testing.T) {
 		fake := &fakeHost{manifest: tooOldBinaryManifest(t)} // gate would FAIL
 		var stdout, stderr bytes.Buffer
-		code := runClaude(context.Background(), []string{"--plugin-dir", "/a", "--plugin-dir", "/b"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+		code := runClaude(context.Background(), []string{"--", "--plugin-dir", "/a", "--plugin-dir", "/b"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (--plugin-dir relaxes the gate); stderr=%q", code, stderr.String())
 		}
@@ -278,7 +279,7 @@ func TestPluginDirRelaxesGate(t *testing.T) {
 	t.Run("codex-relaxes-on-failing-manifest", func(t *testing.T) {
 		fake := &fakeHost{manifest: tooOldBinaryManifest(t)}
 		var stdout, stderr bytes.Buffer
-		code := runCodex(context.Background(), []string{"--plugin-dir", "/a"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+		code := runCodex(context.Background(), []string{"--", "--plugin-dir", "/a"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (--plugin-dir relaxes the gate); stderr=%q", code, stderr.String())
 		}

--- a/internal/cli/plugin_dir_frontdoor_test.go
+++ b/internal/cli/plugin_dir_frontdoor_test.go
@@ -43,9 +43,11 @@ func (h *resolveErrHost) ResolveManifest(string) (string, error) {
 // task-bearing prompt appended LAST, and NO contract-gate rejection — proving the
 // manifest this entity vendors flows through the dev lane. The host's
 // ResolveManifest is wired to fail; a launch on exit 0 with the FO seam present
-// proves the gate was relaxed (ResolveManifest never consulted). Because the
-// prompt is always the last spacedock-built token and --plugin-dir rides in the
-// post-`--` passthrough, the prompt is structurally unswallowable (AC-3).
+// proves the gate was relaxed (ResolveManifest never consulted). The prompt is
+// always the last spacedock-built token and --plugin-dir rides in the post-`--`
+// passthrough with its value bound, so the host never binds the prompt here
+// (AC-3). The narrow limit — a dangling value-taking flag as the FINAL passthrough
+// token — is covered by TestDanglingValueTakingHostFlagStillSwallows.
 func TestDevLanePluginDirReachesLaunchSeam(t *testing.T) {
 	repo := vendoredRepoRoot(t)
 	host := &resolveErrHost{}
@@ -68,8 +70,44 @@ func TestDevLanePluginDirReachesLaunchSeam(t *testing.T) {
 		t.Fatalf("launch argv = %v, want %v", host.launchedArg, want)
 	}
 	// The last token is the spacedock-built prompt, and --plugin-dir <repo> rides
-	// before it in passthrough — no dangling host flag is adjacent to the prompt.
+	// before it in passthrough with its value bound — the prompt is never adjacent
+	// to a value-starved host flag.
 	if last := host.launchedArg[len(host.launchedArg)-1]; last != wantBootstrapPrompt+" do the thing" {
-		t.Fatalf("last token = %q, want the spacedock prompt (must be unswallowable)", last)
+		t.Fatalf("last token = %q, want the spacedock prompt", last)
+	}
+}
+
+// TestDanglingValueTakingHostFlagStillSwallows pins the ACCURATE AC-3 property and
+// its honest limitation. The invariant the Option-2 grammar guarantees is narrow:
+// the spacedock prompt is ALWAYS the last assembled host-argv token and ALWAYS
+// spacedock-constructed (never sourced from a host token). It is NOT a structural
+// guarantee that the host can never bind the prompt: a user who dangles a
+// value-taking host flag as the FINAL post-`--` passthrough token (`-- --plugin-dir`
+// with no value) places that flag immediately before the prompt, so the host's
+// own parser binds the prompt as the flag's value. This is byte-identical to
+// origin/next and is a user error (the user gave a value-taking flag no value),
+// not a regression introduced by this change. The test proves both halves: the
+// prompt is still the last spacedock-built token (our invariant holds), and the
+// dangling flag is the one immediately before it (the host-side consequence).
+func TestDanglingValueTakingHostFlagStillSwallows(t *testing.T) {
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), []string{"do the thing", "--", "--plugin-dir"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	argv := fake.launchedArg
+	wantPrompt := wantBootstrapPrompt + " do the thing"
+	// Our invariant: the prompt is the last token and spacedock-constructed.
+	if last := argv[len(argv)-1]; last != wantPrompt {
+		t.Fatalf("last token = %q, want the spacedock prompt (the always-last invariant must hold)", last)
+	}
+	// The honest limitation: a dangling value-taking flag sits right before the
+	// prompt, so the host parser will bind the prompt as that flag's value. This is
+	// a user error identical to origin/next, NOT a structural impossibility.
+	if before := argv[len(argv)-2]; before != "--plugin-dir" {
+		t.Fatalf("token before prompt = %q, want the dangling --plugin-dir (the host would bind the prompt as its value)", before)
 	}
 }

--- a/internal/cli/plugin_dir_frontdoor_test.go
+++ b/internal/cli/plugin_dir_frontdoor_test.go
@@ -37,19 +37,21 @@ func (h *resolveErrHost) ResolveManifest(string) (string, error) {
 	return "", errors.New("ResolveManifest must not be called on the --plugin-dir dev lane")
 }
 
-// TestDevLanePluginDirReachesLaunchSeam locks AC-2(a): `spacedock claude
-// --plugin-dir <vendored-repo> -- "task"` reaches the launch seam with the inner
-// argv beginning `claude --agent spacedock:first-officer`, the fenced task
-// appended, and NO contract-gate rejection — proving the manifest this entity
-// vendors flows through the dev lane. The host's ResolveManifest is wired to
-// fail; a launch on exit 0 with the FO seam present proves the gate was relaxed
-// (ResolveManifest never consulted).
+// TestDevLanePluginDirReachesLaunchSeam locks AC-2(a) under the Option-2 grammar:
+// `spacedock claude "task" -- --plugin-dir <vendored-repo>` reaches the launch
+// seam with the inner argv beginning `claude --agent spacedock:first-officer`, the
+// task-bearing prompt appended LAST, and NO contract-gate rejection — proving the
+// manifest this entity vendors flows through the dev lane. The host's
+// ResolveManifest is wired to fail; a launch on exit 0 with the FO seam present
+// proves the gate was relaxed (ResolveManifest never consulted). Because the
+// prompt is always the last spacedock-built token and --plugin-dir rides in the
+// post-`--` passthrough, the prompt is structurally unswallowable (AC-3).
 func TestDevLanePluginDirReachesLaunchSeam(t *testing.T) {
 	repo := vendoredRepoRoot(t)
 	host := &resolveErrHost{}
 	var stdout, stderr bytes.Buffer
 
-	code := runClaude(context.Background(), []string{"--plugin-dir", repo, "--", "do the thing"}, t.TempDir(), host, lookFound, &stdout, &stderr)
+	code := runClaude(context.Background(), []string{"do the thing", "--", "--plugin-dir", repo}, t.TempDir(), host, lookFound, &stdout, &stderr)
 
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (--plugin-dir <repo> must relax the gate); stderr=%q", code, stderr.String())
@@ -64,5 +66,10 @@ func TestDevLanePluginDirReachesLaunchSeam(t *testing.T) {
 	}
 	if !equalArgv(host.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", host.launchedArg, want)
+	}
+	// The last token is the spacedock-built prompt, and --plugin-dir <repo> rides
+	// before it in passthrough — no dangling host flag is adjacent to the prompt.
+	if last := host.launchedArg[len(host.launchedArg)-1]; last != wantBootstrapPrompt+" do the thing" {
+		t.Fatalf("last token = %q, want the spacedock prompt (must be unswallowable)", last)
 	}
 }

--- a/internal/cli/safehouse_frontdoor_test.go
+++ b/internal/cli/safehouse_frontdoor_test.go
@@ -40,7 +40,7 @@ func TestClaudeSafehousePresentWrapsArgv(t *testing.T) {
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
-	code := runClaude(context.Background(), []string{"--foo"}, dir, fake, lookFound, &stdout, &stderr)
+	code := runClaude(context.Background(), []string{"--", "--foo"}, dir, fake, lookFound, &stdout, &stderr)
 
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
@@ -79,7 +79,7 @@ func TestClaudeNoSafehouseLaunchesPlain(t *testing.T) {
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
-	code := runClaude(context.Background(), []string{"--foo"}, dir, fake, lookFound, &stdout, &stderr)
+	code := runClaude(context.Background(), []string{"--", "--foo"}, dir, fake, lookFound, &stdout, &stderr)
 
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
@@ -156,7 +156,7 @@ func TestCodexSafehousePresentWrapsArgv(t *testing.T) {
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
-	code := runCodex(context.Background(), []string{"--foo"}, dir, fake, lookFound, &stdout, &stderr)
+	code := runCodex(context.Background(), []string{"--", "--foo"}, dir, fake, lookFound, &stdout, &stderr)
 
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
@@ -201,7 +201,7 @@ func TestCodexNoSafehouseLaunchesPlainNoBypass(t *testing.T) {
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
-	code := runCodex(context.Background(), []string{"--foo"}, dir, fake, lookFound, &stdout, &stderr)
+	code := runCodex(context.Background(), []string{"--", "--foo"}, dir, fake, lookFound, &stdout, &stderr)
 
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
@@ -285,7 +285,7 @@ func TestClaudeResumeFamilySuppressesBootstrapPrompt(t *testing.T) {
 			fake := &fakeHost{manifest: compatibleManifest(t)}
 			var stdout, stderr bytes.Buffer
 
-			code := runClaude(context.Background(), []string{tc.arg}, dir, fake, lookFound, &stdout, &stderr)
+			code := runClaude(context.Background(), []string{"--", tc.arg}, dir, fake, lookFound, &stdout, &stderr)
 
 			if code != 0 {
 				t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())

--- a/internal/cli/safehouse_frontdoor_test.go
+++ b/internal/cli/safehouse_frontdoor_test.go
@@ -114,7 +114,7 @@ func TestClaudePluginGateShortCircuitsBeforeSafehouse(t *testing.T) {
 	if fake.launchedArg != nil {
 		t.Fatalf("Launch invoked despite plugin-gate failure: %v", fake.launchedArg)
 	}
-	if !strings.Contains(stderr.String(), "spacedock init") && !strings.Contains(stderr.String(), "spacedock doctor") {
+	if !strings.Contains(stderr.String(), "spacedock install") && !strings.Contains(stderr.String(), "spacedock doctor") {
 		t.Fatalf("stderr missing plugin-gate remedy: %q", stderr.String())
 	}
 	if strings.Contains(stderr.String(), ".safehouse profile") {
@@ -237,7 +237,7 @@ func TestCodexPluginGateShortCircuitsBeforeSafehouse(t *testing.T) {
 	if fake.launchedArg != nil {
 		t.Fatalf("Launch invoked despite plugin-gate failure: %v", fake.launchedArg)
 	}
-	if !strings.Contains(stderr.String(), "spacedock init") && !strings.Contains(stderr.String(), "spacedock doctor") {
+	if !strings.Contains(stderr.String(), "spacedock install") && !strings.Contains(stderr.String(), "spacedock doctor") {
 		t.Fatalf("stderr missing plugin-gate remedy: %q", stderr.String())
 	}
 	if strings.Contains(stderr.String(), ".safehouse profile") {

--- a/internal/cli/safehouse_knob_test.go
+++ b/internal/cli/safehouse_knob_test.go
@@ -1,0 +1,115 @@
+// ABOUTME: AC-6 sandbox-knob parsing — space/equals/repeat forms produce the same
+// ABOUTME: safehouse extra argv, the reported space-form bug leaks nothing, bad value errors.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/safehouse"
+)
+
+// TestSafehouseKnobFormsEquivalent pins AC-6: each value-taking knob accepts the
+// space form, the equals form, and repeats — all producing the same safehouse
+// `extra` argv. The equivalence is asserted through the full chain
+// parseFrontDoorArgs → safehouse.TranslateFlags, which is what the launcher feeds.
+func TestSafehouseKnobFormsEquivalent(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		wantExtra []string
+	}{
+		{"enable-equals", []string{"--safehouse-enable=docker"}, []string{"--enable=docker"}},
+		{"enable-space", []string{"--safehouse-enable", "docker"}, []string{"--enable=docker"}},
+		{"enable-comma-split", []string{"--safehouse-enable=ssh,docker"}, []string{"--enable=ssh", "--enable=docker"}},
+		{"enable-repeat-accumulates", []string{"--safehouse-enable", "ssh", "--safehouse-enable", "docker"}, []string{"--enable=ssh", "--enable=docker"}},
+		{"add-dirs-equals", []string{"--safehouse-add-dirs=/a"}, []string{"--add-dirs=/a"}},
+		{"add-dirs-space", []string{"--safehouse-add-dirs", "/a"}, []string{"--add-dirs=/a"}},
+		{"add-dirs-repeat", []string{"--safehouse-add-dirs", "/a", "--safehouse-add-dirs", "/b"}, []string{"--add-dirs=/a", "--add-dirs=/b"}},
+		{"add-dirs-ro-space", []string{"--safehouse-add-dirs-ro", "/c"}, []string{"--add-dirs-ro=/c"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fd, err := parseFrontDoorArgs(tc.args)
+			if err != nil {
+				t.Fatalf("parseFrontDoorArgs(%v) err = %v", tc.args, err)
+			}
+			extra, err := safehouse.TranslateFlags(fd.safehouseFlags)
+			if err != nil {
+				t.Fatalf("TranslateFlags(%v) err = %v", fd.safehouseFlags, err)
+			}
+			if !equalArgv(extra, tc.wantExtra) {
+				t.Fatalf("extra = %v, want %v", extra, tc.wantExtra)
+			}
+		})
+	}
+}
+
+// TestSafehouseAddDirsSpaceFormNoLeak is the regression for the captain-reported
+// bug: `--safehouse-add-dirs ~/a --safehouse-add-dirs ~/b` (space form) used to
+// fail with `malformed flag` and leak the paths into host passthrough. In the end
+// state cobra captures each value into two `--add-dirs=` entries in the safehouse
+// extra slot, and the paths appear NOWHERE in the host argv (they are not host
+// passthrough). Driven through runClaude to the recorded launch.
+func TestSafehouseAddDirsSpaceFormNoLeak(t *testing.T) {
+	dir := safehouseFixtureDir(t)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(),
+		[]string{"--safehouse-add-dirs", "/home/a", "--safehouse-add-dirs", "/home/b"},
+		dir, fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	want := []string{"safehouse", "--trust-workdir-config", "--add-dirs=/home/a", "--add-dirs=/home/b", "--",
+		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
+	if !equalArgv(fake.launchedArg, want) {
+		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
+	}
+	// The paths ride in the safehouse extra slot (before the inner `--`), never as
+	// host passthrough adjacent to the inner claude argv.
+	dash := -1
+	for i, tok := range fake.launchedArg {
+		if tok == "--" {
+			dash = i
+			break
+		}
+	}
+	if dash < 0 {
+		t.Fatalf("no safehouse `--` separator in argv: %v", fake.launchedArg)
+	}
+	for _, tok := range fake.launchedArg[dash:] {
+		if tok == "/home/a" || tok == "/home/b" || strings.HasPrefix(tok, "--safehouse-add-dirs") {
+			t.Fatalf("a knob path/token leaked past the safehouse `--` into host passthrough: %v", fake.launchedArg)
+		}
+	}
+}
+
+// TestSafehouseBadValueNamesKnob pins AC-6's clear-error end state: a genuinely
+// bad knob value surfaces a knob-named error, not the internal `malformed flag`
+// text. An unknown safehouse key is the representative bad value; the error names
+// the knob (`--safehouse-bogus`) and Launch is never reached.
+func TestSafehouseBadValueNamesKnob(t *testing.T) {
+	dir := safehouseFixtureDir(t)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), []string{"--safehouse-bogus=x"}, dir, fake, lookFound, &stdout, &stderr)
+
+	if code == 0 {
+		t.Fatalf("exit = 0, want non-zero for a bad knob value")
+	}
+	if fake.launchedArg != nil {
+		t.Fatalf("Launch invoked on a bad knob value: %v", fake.launchedArg)
+	}
+	if !strings.Contains(stderr.String(), "--safehouse-bogus") {
+		t.Fatalf("error does not name the knob --safehouse-bogus: %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "malformed flag") {
+		t.Fatalf("error leaked the internal malformed-flag text: %q", stderr.String())
+	}
+}

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -176,11 +176,11 @@ func tooOldBinaryRemedy(c int, rangeStr, branch string) string {
 }
 
 // tooOldPluginRemedy is the pinned too-old-plugin remedy line, parameterized by
-// the detected host for the init/update hint.
+// the detected host for the install/update hint.
 func tooOldPluginRemedy(c int, rangeStr, host string) string {
 	return fmt.Sprintf(
 		"too-old-plugin: your installed plugin (needs %s) predates this binary (contract %d). "+
-			"Update it: spacedock init --host %s (or '%s plugin update spacedock').",
+			"Update it: spacedock install --host %s (or '%s plugin update spacedock').",
 		rangeStr, c, host, host)
 }
 
@@ -207,6 +207,6 @@ func pluginPredatesContractRemedy(host, branch string) string {
 // by the caller's policy.
 func noPluginMessage(host string) string {
 	return fmt.Sprintf(
-		"no installed Spacedock plugin found for host %s. Install it: spacedock init --host %s.",
+		"no installed Spacedock plugin found for host %s. Install it: spacedock install --host %s.",
 		host, host)
 }

--- a/internal/contract/contract_test.go
+++ b/internal/contract/contract_test.go
@@ -164,13 +164,18 @@ func TestPluginPredatesContractRemedy(t *testing.T) {
 }
 
 // TestCompareHostSubstitution verifies the host parameter is woven into the
-// too-old-plugin remedy (the only place an init/update host appears).
+// too-old-plugin remedy (the only place an install/update host appears). The
+// remedy must name the live `spacedock install` command, not the removed `init`
+// (which now exits 2) — the remedy a user hits at the gate must run.
 func TestCompareHostSubstitution(t *testing.T) {
 	for _, host := range []string{"claude", "codex"} {
 		res := Compare(2, ">=1,<2", host, "")
-		want := "spacedock init --host " + host
+		want := "spacedock install --host " + host
 		if !strings.Contains(res.Message, want) {
 			t.Errorf("too-old-plugin remedy for host %q missing %q: %q", host, want, res.Message)
+		}
+		if strings.Contains(res.Message, "spacedock init") {
+			t.Errorf("too-old-plugin remedy for host %q names the removed init command: %q", host, res.Message)
 		}
 	}
 }


### PR DESCRIPTION
Migrate the CLI to cobra for a grouped, jargon-free `--help` and a predictable launch grammar where the spacedock prompt is never swallowed by passthrough flags.

## What changed
- Migrate `internal/cli` dispatch from hand-rolled parsing to cobra.
- Group `spacedock --help` into Launch/Setup/Workflow; drop jargon (`front door`, `contract-gated`, META).
- Rename `init` → `install`; `init` now exits 2 as an unknown command.
- Adopt Option-2 passthrough: the spacedock prompt is always the last host-argv token; `--plugin-dir` rides post-`--`.
- Name every contract-gate remedy after the live `install` command, not the removed `init`.

## Evidence
- `go test ./...`: 524/525 passed (sole failure is the pre-existing env-gated codex-host resolver test, unrelated to this diff).
- Independent adversarial audit on a detached checkout: all 6 ACs reproduced; the one finding (gate remedies named the removed `init`) fixed and re-validated.

## Review guidance
Focus on `internal/cli/frontdoor.go` argv assembly (prompt-always-last) and the `cli.Run` seam/exit-code contract — both verified unchanged.

---
[z0](/spacedock-dev/spacedock/blob/spacedock-state/dev/cli-cobra-redesign/index.md)
