### PR TITLE
feat(cli): workflow auto-discovery + actionable errors + new/completion verbs

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -119,6 +119,8 @@ func newRootCommand(ctx context.Context, env []string, dir string, stdin io.Read
 		newInstallCommand(ctx, env, stdout, stderr),
 		newDoctorCommand(ctx, env, stdout, stderr),
 		newStatusCommand(ctx, env, dir, stdin, stdout, stderr, runner),
+		newNewCommand(ctx, env, dir, stdin, stdout, stderr, runner),
+		newCompletionCommand(stdout, stderr),
 		newDispatchCommand(stdin, stdout, stderr),
 	)
 	return root
@@ -253,6 +255,55 @@ func newStatusCommand(ctx context.Context, env []string, dir string, stdin io.Re
 	}
 }
 
+// newNewCommand wires `spacedock new [--folder] SLUG` as a pure alias for
+// `status --new`: the post-subcommand argv (the optional --folder plus the slug)
+// is prefixed with --new and forwarded verbatim to runStatus, so the body is read
+// from stdin and the existing runNew atomic-create path is reused unchanged. With
+// the discovery walk-up, `new` run inside a workflow needs no --workflow-dir.
+// DisableFlagParsing keeps --folder reaching the runner intact (AC-3).
+func newNewCommand(ctx context.Context, env []string, dir string, stdin io.Reader, stdout, stderr io.Writer, runner status.Runner) *cobra.Command {
+	return &cobra.Command{
+		Use:                "new [--folder] SLUG",
+		Short:              "Create an entity from a stdin body (auto-discovers the workflow)",
+		GroupID:            "workflow",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if wantsHelp(args) {
+				return cmd.Help()
+			}
+			aliased := append([]string{"--new"}, args...)
+			if code := runStatus(ctx, aliased, env, dir, stdin, stdout, stderr, runner); code != 0 {
+				return exitCodeError{code}
+			}
+			return nil
+		},
+	}
+}
+
+// newCompletionCommand wires `spacedock completion bash|zsh`, emitting a static
+// completion script to stdout (exit 0). An unknown or missing shell prints the
+// named usage error and returns 2 — the CLI-layer usage-error code, matching the
+// unknown-command path. The static script (no dynamic slug completion: YAGNI)
+// replaces cobra's default completion command, which is disabled at the root via
+// CompletionOptions.DisableDefaultCmd (AC-3).
+func newCompletionCommand(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:                "completion bash|zsh",
+		Short:              "Print a bash or zsh completion script",
+		GroupID:            "workflow",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if wantsHelp(args) {
+				return cmd.Help()
+			}
+			if code := runCompletion(args, stdout, stderr); code != 0 {
+				return exitCodeError{code}
+			}
+			return nil
+		},
+	}
+}
+
 // newDispatchCommand reparents `spacedock dispatch` under cobra with flag parsing
 // disabled, forwarding its post-subcommand argv verbatim to dispatch.Run (AC-5).
 func newDispatchCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
@@ -345,3 +396,66 @@ func cwd() string {
 func printVersion(w io.Writer) {
 	fmt.Fprintf(w, "spacedock %s (contract %d)\n", Version, contract.CONTRACT_VERSION)
 }
+
+// runCompletion emits a static shell-completion script for bash or zsh to
+// stdout (exit 0). An unknown or missing shell prints the named usage error to
+// stderr and returns 2 — the CLI-layer usage-error code, consistent with the
+// unknown-command path, since completion is handled in-package and never reaches
+// the native runner.
+func runCompletion(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "Error: completion requires a shell: bash or zsh")
+		return 2
+	}
+	switch args[0] {
+	case "bash":
+		fmt.Fprint(stdout, bashCompletion)
+		return 0
+	case "zsh":
+		fmt.Fprint(stdout, zshCompletion)
+		return 0
+	default:
+		fmt.Fprintln(stderr, "Error: completion requires a shell: bash or zsh")
+		return 2
+	}
+}
+
+// bashCompletion completes the top-level verbs and the common status flags. It
+// is intentionally static (no dynamic slug completion): YAGNI.
+const bashCompletion = `# spacedock bash completion
+_spacedock() {
+  local cur prev verbs status_flags
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  verbs="claude codex install doctor status new completion dispatch --version --help"
+  status_flags="--workflow-dir --next --next-id --boot --validate --archived --json --quiet --new --folder --set --where --archive --resolve --short-id --discover --root"
+  if [ "$COMP_CWORD" -eq 1 ]; then
+    COMPREPLY=( $(compgen -W "$verbs" -- "$cur") )
+    return 0
+  fi
+  case "${COMP_WORDS[1]}" in
+    status) COMPREPLY=( $(compgen -W "$status_flags" -- "$cur") ) ;;
+    completion) COMPREPLY=( $(compgen -W "bash zsh" -- "$cur") ) ;;
+  esac
+}
+complete -F _spacedock spacedock
+`
+
+// zshCompletion completes the top-level verbs and the common status flags.
+const zshCompletion = `#compdef spacedock
+# spacedock zsh completion
+_spacedock() {
+  local -a verbs status_flags
+  verbs=(claude codex install doctor status new completion dispatch --version --help)
+  status_flags=(--workflow-dir --next --next-id --boot --validate --archived --json --quiet --new --folder --set --where --archive --resolve --short-id --discover --root)
+  if (( CURRENT == 2 )); then
+    compadd -- $verbs
+    return
+  fi
+  case "${words[2]}" in
+    status) compadd -- $status_flags ;;
+    completion) compadd -- bash zsh ;;
+  esac
+}
+_spacedock "$@"
+`

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -23,8 +23,10 @@ Setup
   install  [--host claude|codex]     Install the Spacedock plugin for a host, then check it
   doctor   [--host claude|codex]     Check the installed plugin and this binary are compatible
 Workflow
-  status    [args]                   Show or update workflow state
-  dispatch  build | show-stage-def   Build worker dispatch artifacts
+  status      [args]                 Show or update workflow state
+  new         [--folder] SLUG        Create an entity from a stdin body (auto-discovers the workflow)
+  completion  bash|zsh               Print a bash or zsh completion script
+  dispatch    build | show-stage-def Build worker dispatch artifacts
 
 Run "spacedock <command> --help" for details.  ·  --version prints the version.
 `

--- a/internal/cli/verbs_test.go
+++ b/internal/cli/verbs_test.go
@@ -1,0 +1,113 @@
+// ABOUTME: AC-3 verb tests — `new` aliases status --new through discovery, and
+// ABOUTME: `completion <shell>` emits a script (exit 0) or names the usage error.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+const newEntityBody = "---\ntitle: Minted via new\nstatus: ideation\nscore: \"0.30\"\nsource: roadmap\n---\n# Minted via new\n"
+
+// TestNewVerbMintsInDiscoveredWorkflow (AC-3) runs `spacedock new <slug>` with a
+// body on stdin from a cwd inside a commissioned workflow (NO --workflow-dir),
+// and asserts the alias reaches runNew: minted-id narration on stdout, the
+// entity file exists, and --validate is clean.
+func TestNewVerbMintsInDiscoveredWorkflow(t *testing.T) {
+	def := t.TempDir()
+	writeFile(t, filepath.Join(def, "README.md"), "---\ncommissioned-by: spacedock@1\nid-style: slug\nstages:\n  states:\n    - name: ideation\n      initial: true\n    - name: done\n      terminal: true\n---\n# WF\n")
+
+	env := []string{"USER=pinned", "PATH=" + os.Getenv("PATH")}
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"new", "minted-task"}, env, def, strings.NewReader(newEntityBody), &stdout, &stderr, &status.NativeRunner{})
+	if code != 0 {
+		t.Fatalf("new exit=%d stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "id=") {
+		t.Fatalf("new stdout = %q, want minted-id narration", stdout.String())
+	}
+	if !isFile(filepath.Join(def, "minted-task.md")) {
+		t.Fatalf("new did not create the entity file")
+	}
+
+	// --validate clean immediately after, proving a complete entity was minted.
+	var vout, verr bytes.Buffer
+	vcode := run(context.Background(), []string{"status", "--workflow-dir", def, "--validate"}, env, def, nil, &vout, &verr, &status.NativeRunner{})
+	if vcode != 0 || strings.TrimSpace(vout.String()) != "VALID" {
+		t.Fatalf("post-new validate exit=%d out=%q err=%q", vcode, vout.String(), verr.String())
+	}
+}
+
+// TestNewVerbFolderForm proves `new --folder <slug>` threads the --folder flag
+// to the runner's folder-form create path.
+func TestNewVerbFolderForm(t *testing.T) {
+	def := t.TempDir()
+	writeFile(t, filepath.Join(def, "README.md"), "---\ncommissioned-by: spacedock@1\nid-style: slug\nstages:\n  states:\n    - name: ideation\n      initial: true\n    - name: done\n      terminal: true\n---\n# WF\n")
+
+	env := []string{"USER=pinned", "PATH=" + os.Getenv("PATH")}
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"new", "--folder", "foldered"}, env, def, strings.NewReader(newEntityBody), &stdout, &stderr, &status.NativeRunner{})
+	if code != 0 {
+		t.Fatalf("new --folder exit=%d stderr=%q", code, stderr.String())
+	}
+	if !isFile(filepath.Join(def, "foldered", "index.md")) {
+		t.Fatalf("new --folder did not create folder-form entity")
+	}
+}
+
+// TestCompletionShells (AC-3) covers the completion verb's exit-code contract.
+func TestCompletionShells(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh"} {
+		var stdout, stderr bytes.Buffer
+		code := Run([]string{"completion", shell}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("completion %s exit=%d stderr=%q", shell, code, stderr.String())
+		}
+		for _, verb := range []string{"status", "new", "completion"} {
+			if !strings.Contains(stdout.String(), verb) {
+				t.Fatalf("completion %s script missing verb %q:\n%s", shell, verb, stdout.String())
+			}
+		}
+	}
+
+	// Missing shell and unknown shell both exit 2 with the named usage error.
+	for _, args := range [][]string{{"completion"}, {"completion", "fish"}} {
+		var stdout, stderr bytes.Buffer
+		code := Run(args, &stdout, &stderr)
+		if code != 2 {
+			t.Fatalf("%v exit=%d, want 2 (stderr=%q)", args, code, stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "completion requires a shell: bash or zsh") {
+			t.Fatalf("%v stderr = %q, want named usage error", args, stderr.String())
+		}
+	}
+}
+
+// TestHelpListsNewVerbs (AC-3) asserts the grouped --help lists both new verbs
+// under the Workflow group with their one-liners, in the cobra help structure.
+func TestHelpListsNewVerbs(t *testing.T) {
+	var stdout bytes.Buffer
+	Run([]string{"--help"}, &stdout, &bytes.Buffer{})
+	out := stdout.String()
+	for _, want := range []string{
+		"new",
+		"Create an entity from a stdin body",
+		"completion",
+		"Print a bash or zsh completion script",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("--help missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func isFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}

--- a/internal/status/discover_walkup.go
+++ b/internal/status/discover_walkup.go
@@ -1,0 +1,68 @@
+// ABOUTME: Walk-up workflow discovery and state-checkout detection — find the
+// ABOUTME: enclosing commissioned workflow, or name a misdirected state checkout.
+package status
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// discoverWorkflowDir walks up from startDir to the nearest ancestor whose
+// README.md frontmatter declares a `commissioned-by: spacedock@` field, the
+// same predicate discoverWorkflows uses to recognize a workflow. The first
+// match on the way up wins — when workflows are nested, this resolves to the
+// innermost enclosing workflow. Returns (dir, true) on a match, ("", false) at
+// the filesystem root with no match.
+func discoverWorkflowDir(startDir string) (string, bool) {
+	d, err := filepath.Abs(startDir)
+	if err != nil {
+		d = startDir
+	}
+	for {
+		readme := filepath.Join(d, "README.md")
+		if isRegularFile(readme) {
+			fields := ParseFrontmatter(readme)
+			if strings.HasPrefix(fields["commissioned-by"], "spacedock@") {
+				return d, true
+			}
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			return "", false
+		}
+		d = parent
+	}
+}
+
+// stateCheckoutParent reports whether pointedDir is the state checkout of an
+// enclosing workflow. It walks up from pointedDir; at each ancestor A it reads
+// A/README.md's `state:` field, and if that field's cleaned, non-escaping value
+// resolves to the same realpath as pointedDir, A is the definition dir. This
+// reuses the same `state:` validation rules as resolveRoots (reject absolute /
+// `..`-escaping). Returns (defDir, true) on a match, ("", false) otherwise.
+func stateCheckoutParent(pointedDir string) (string, bool) {
+	target := realpathOf(pointedDir)
+	d, err := filepath.Abs(pointedDir)
+	if err != nil {
+		d = pointedDir
+	}
+	for {
+		readme := filepath.Join(d, "README.md")
+		if isRegularFile(readme) {
+			stateValue := strings.TrimSpace(ParseFrontmatter(readme)["state"])
+			if stateValue != "" && !filepath.IsAbs(stateValue) {
+				cleaned := filepath.Clean(stateValue)
+				if cleaned != ".." && !strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+					if realpathOf(filepath.Join(d, cleaned)) == target {
+						return d, true
+					}
+				}
+			}
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			return "", false
+		}
+		d = parent
+	}
+}

--- a/internal/status/discover_walkup_test.go
+++ b/internal/status/discover_walkup_test.go
@@ -1,0 +1,87 @@
+// ABOUTME: Walk-up discovery + state-checkout detection tests — discoverWorkflowDir
+// ABOUTME: finds the enclosing workflow; stateCheckoutParent names a misdirected dir.
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDiscoverWorkflowDirWalksUp proves discoverWorkflowDir finds the nearest
+// ancestor whose README is commissioned, starting from a deep cwd.
+func TestDiscoverWorkflowDirWalksUp(t *testing.T) {
+	def, state := buildSplitRoot(t, splitRootReadme, map[string]string{
+		"add-login.md": "---\nstatus: ideation\n---\n",
+	})
+	deep := filepath.Join(state, "add-login", "reports")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := discoverWorkflowDir(deep)
+	if !ok {
+		t.Fatalf("discoverWorkflowDir(%q) = ok false, want true", deep)
+	}
+	if realpathOf(got) != realpathOf(def) {
+		t.Fatalf("discoverWorkflowDir(%q) = %q, want %q", deep, got, def)
+	}
+}
+
+// TestDiscoverWorkflowDirMiss proves a tree with no commissioned README yields
+// ok false.
+func TestDiscoverWorkflowDirMiss(t *testing.T) {
+	dir := t.TempDir()
+	deep := filepath.Join(dir, "a", "b")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := discoverWorkflowDir(deep); ok {
+		t.Fatalf("discoverWorkflowDir(%q) = ok true, want false (no commissioned README)", deep)
+	}
+}
+
+// TestDiscoverWorkflowDirInnermostWins is the M-1 nested-workflow resolution
+// test: when two commissioned workflows are nested, the walk-up resolves to the
+// INNER one (first match wins on the way up).
+func TestDiscoverWorkflowDirInnermostWins(t *testing.T) {
+	outer := t.TempDir()
+	writeFile(t, filepath.Join(outer, "README.md"), splitRootReadme)
+	inner := filepath.Join(outer, "sub", "inner")
+	writeFile(t, filepath.Join(inner, "README.md"), splitRootReadme)
+	deep := filepath.Join(inner, "a", "b")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := discoverWorkflowDir(deep)
+	if !ok {
+		t.Fatalf("discoverWorkflowDir(%q) = ok false, want true", deep)
+	}
+	if realpathOf(got) != realpathOf(inner) {
+		t.Fatalf("discoverWorkflowDir(%q) = %q, want innermost %q (first match wins)", deep, got, inner)
+	}
+}
+
+// TestStateCheckoutParentDetects proves stateCheckoutParent walks up from a
+// state checkout to the definition dir whose README declares state: pointing
+// back at it.
+func TestStateCheckoutParentDetects(t *testing.T) {
+	def, state := buildSplitRoot(t, splitRootReadme, map[string]string{
+		"add-login.md": "---\nstatus: ideation\n---\n",
+	})
+	got, ok := stateCheckoutParent(state)
+	if !ok {
+		t.Fatalf("stateCheckoutParent(%q) = ok false, want true", state)
+	}
+	if realpathOf(got) != realpathOf(def) {
+		t.Fatalf("stateCheckoutParent(%q) = %q, want def dir %q", state, got, def)
+	}
+}
+
+// TestStateCheckoutParentMiss proves an ordinary dir with no enclosing state:
+// README yields ok false.
+func TestStateCheckoutParentMiss(t *testing.T) {
+	dir := t.TempDir()
+	if _, ok := stateCheckoutParent(dir); ok {
+		t.Fatalf("stateCheckoutParent(%q) = ok true, want false", dir)
+	}
+}

--- a/internal/status/discovery_dispatch_test.go
+++ b/internal/status/discovery_dispatch_test.go
@@ -1,0 +1,143 @@
+// ABOUTME: AC-1/AC-2 dispatch tests — no-flag discovery renders the enclosing
+// ABOUTME: workflow; no-workflow / state-checkout misdirection yield named errors.
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	noWorkflowErr        = "Error: no Spacedock workflow here — pass --workflow-dir or run inside a workflow\n"
+	stateCheckoutErrHead = "Error: this is a state checkout; point --workflow-dir at the definition dir (the one whose README declares state:): "
+)
+
+// TestDiscoveryRendersEnclosingWorkflow (AC-1) runs with NO --workflow-dir from
+// a deep cwd inside a commissioned workflow and asserts the workflow renders,
+// stage-ordered, exit 0.
+func TestDiscoveryRendersEnclosingWorkflow(t *testing.T) {
+	def, state := buildSplitRoot(t, splitRootReadme, map[string]string{
+		"add-login.md":         "---\nstatus: implementation\n---\n",
+		"refactor-dispatch.md": "---\nstatus: ideation\n---\n",
+	})
+	deep := filepath.Join(state, "add-login", "reports")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	env := pinnedEnv(t)
+
+	out, stderr, code := runNative(t, deep, env)
+	if code != 0 {
+		t.Fatalf("no-flag discovery exit=%d stderr=%q", code, stderr)
+	}
+	_ = def
+	slugs := tableSlugs(t, out)
+	if !equalStrings(slugs, []string{"refactor-dispatch", "add-login"}) {
+		t.Fatalf("slugs = %v, want stage-ordered [refactor-dispatch add-login]\n%s", slugs, out)
+	}
+}
+
+// TestNoWorkflowHereError (AC-1/AC-2) runs with no --workflow-dir from an
+// empty, non-enclosed tempdir and asserts the exact no-workflow stderr, exit 1.
+func TestNoWorkflowHereError(t *testing.T) {
+	empty := t.TempDir()
+	env := pinnedEnv(t)
+
+	out, stderr, code := runNative(t, empty, env)
+	if code != 1 {
+		t.Fatalf("no-workflow exit=%d, want 1 (stdout=%q stderr=%q)", code, out, stderr)
+	}
+	if stderr != noWorkflowErr {
+		t.Fatalf("stderr = %q, want %q", stderr, noWorkflowErr)
+	}
+}
+
+// TestStateCheckoutPointedAtError (AC-2, M-9 + M-4) materializes a split-root
+// with sd-b32 entities and NO state README, points --workflow-dir AT the state
+// checkout under --validate, and asserts the named state-checkout error (ending
+// in the def dir), exit 1, with the pre-change `non-numeric sequential id`
+// symptom GONE.
+func TestStateCheckoutPointedAtError(t *testing.T) {
+	readme := `---
+commissioned-by: spacedock@1
+id-style: sd-b32
+state: .spacedock-state
+stages:
+  states:
+    - name: ideation
+      initial: true
+    - name: done
+      terminal: true
+---
+
+# SD-B32 Split-Root
+`
+	def, state := buildSplitRoot(t, readme, map[string]string{
+		"alpha.md": "---\nid: c0p9v8u7t6s5r4q3p2n1m0kj\nstatus: ideation\n---\n",
+		"beta.md":  "---\nid: 9z8y7x6w5v4u3t2s1r0qp0nm\nstatus: ideation\n---\n",
+	})
+	env := pinnedEnv(t)
+
+	// Guard: the state checkout carries no README of its own (M-9 — only then
+	// does sd-b32 default to sequential and surface the misdiagnosis symptom).
+	if _, err := os.Lstat(filepath.Join(state, "README.md")); !os.IsNotExist(err) {
+		t.Fatalf("state checkout must have no README.md, lstat err=%v", err)
+	}
+
+	// M-4: the regression assertion only fires under --validate, so pin that
+	// command context.
+	out, stderr, code := runNative(t, def, env, "--workflow-dir", state, "--validate")
+	if code != 1 {
+		t.Fatalf("state-checkout --validate exit=%d, want 1 (stdout=%q stderr=%q)", code, out, stderr)
+	}
+	if !strings.HasPrefix(stderr, stateCheckoutErrHead) {
+		t.Fatalf("stderr = %q, want prefix %q", stderr, stateCheckoutErrHead)
+	}
+	if !strings.HasSuffix(strings.TrimRight(stderr, "\n"), def) {
+		t.Fatalf("stderr = %q, want it to end in the def dir %q", stderr, def)
+	}
+	// Regression guard: the pre-change symptom must be gone.
+	if strings.Contains(stderr, "non-numeric sequential id") {
+		t.Fatalf("stderr still contains the pre-change symptom:\n%s", stderr)
+	}
+}
+
+// TestExplicitWorkflowDirSkipsDiscovery proves an explicit --workflow-dir at a
+// commissioned workflow is used verbatim and discovery is not consulted: the
+// run renders the explicit workflow even though cwd is an unrelated empty dir.
+func TestExplicitWorkflowDirSkipsDiscovery(t *testing.T) {
+	def, _ := buildSplitRoot(t, splitRootReadme, map[string]string{
+		"add-login.md": "---\nstatus: ideation\n---\n",
+	})
+	unrelated := t.TempDir()
+	env := pinnedEnv(t)
+
+	out, stderr, code := runNative(t, unrelated, env, "--workflow-dir", def)
+	if code != 0 {
+		t.Fatalf("explicit --workflow-dir exit=%d stderr=%q", code, stderr)
+	}
+	if got := sortedCopy(tableSlugs(t, out)); !equalStrings(got, []string{"add-login"}) {
+		t.Fatalf("slugs = %v, want [add-login]\n%s", got, out)
+	}
+}
+
+// TestExplicitEmptyDirUnchanged proves the design's deliberate choice: an
+// explicit --workflow-dir at an empty non-workflow dir is NOT reclassified as a
+// no-workflow error — it falls through to today's empty-table behavior (exit 0).
+func TestExplicitEmptyDirUnchanged(t *testing.T) {
+	empty := t.TempDir()
+	env := pinnedEnv(t)
+
+	out, stderr, code := runNative(t, empty, env, "--workflow-dir", empty)
+	if code != 0 {
+		t.Fatalf("explicit empty-dir exit=%d, want 0 (unchanged) stderr=%q", code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("explicit empty-dir stderr = %q, want empty (no reclassification)", stderr)
+	}
+	if !strings.Contains(out, "ID") || !strings.Contains(out, "SLUG") {
+		t.Fatalf("explicit empty-dir should render an empty table header:\n%s", out)
+	}
+}

--- a/internal/status/native_runner.go
+++ b/internal/status/native_runner.go
@@ -55,12 +55,15 @@ func dispatch(args []string, dir string, e env, stdin io.Reader, stdout, stderr 
 	// verbatim and discovery is skipped, preserving every explicit invocation. With
 	// neither, walk up from the request dir to the enclosing commissioned workflow;
 	// a miss is the named no-workflow error (replacing today's empty-table /
-	// "no stages block" fallback for the no-flag path only).
+	// "no stages block" fallback for the no-flag path only). A --root invocation is
+	// exempt: the cross-workflow --root --resolve path takes its workflows from the
+	// explicit root and never consumes a cwd workflow, so discovery must not gate it
+	// (mirrors the --discover early-return exemption above).
 	pipelineDir := workflowDir
 	if pipelineDir == "" {
 		pipelineDir = e.get("PIPELINE_DIR")
 	}
-	if pipelineDir == "" {
+	if pipelineDir == "" && rootPath == "" {
 		if discovered, ok := discoverWorkflowDir(dir); ok {
 			pipelineDir = discovered
 		} else {
@@ -144,9 +147,12 @@ func dispatch(args []string, dir string, e env, stdin io.Reader, stdout, stderr 
 	// (a dir with no own commissioned README) whose enclosing definition dir
 	// declares state: back at it, name the real problem rather than emit the
 	// downstream id/stage symptoms. Fires only for the detected state-checkout
-	// case; an arbitrary non-workflow explicit dir falls through unchanged.
+	// case; an arbitrary non-workflow explicit dir falls through unchanged. A
+	// --root invocation is exempt for the same reason discovery is: the --root
+	// path never consumes roots, and its cwd-derived definitionDir must not be
+	// reinterpreted as a misdirected --workflow-dir.
 	defReadme := filepath.Join(roots.definitionDir, "README.md")
-	if !(isRegularFile(defReadme) && strings.HasPrefix(ParseFrontmatter(defReadme)["commissioned-by"], "spacedock@")) {
+	if rootPath == "" && !(isRegularFile(defReadme) && strings.HasPrefix(ParseFrontmatter(defReadme)["commissioned-by"], "spacedock@")) {
 		if defDir, ok := stateCheckoutParent(roots.definitionDir); ok {
 			return errExit(stderr, "this is a state checkout; point --workflow-dir at the definition dir (the one whose README declares state:): "+defDir)
 		}

--- a/internal/status/native_runner.go
+++ b/internal/status/native_runner.go
@@ -51,11 +51,21 @@ func dispatch(args []string, dir string, e env, stdin io.Reader, stdout, stderr 
 		return errExit(stderr, err.Error())
 	}
 
-	// The native runner requires --workflow-dir (there is no embedded-script
-	// dirname(__file__) fallback). PIPELINE_DIR remains an accepted source.
+	// Resolution precedence: an explicit --workflow-dir (or PIPELINE_DIR) is used
+	// verbatim and discovery is skipped, preserving every explicit invocation. With
+	// neither, walk up from the request dir to the enclosing commissioned workflow;
+	// a miss is the named no-workflow error (replacing today's empty-table /
+	// "no stages block" fallback for the no-flag path only).
 	pipelineDir := workflowDir
 	if pipelineDir == "" {
 		pipelineDir = e.get("PIPELINE_DIR")
+	}
+	if pipelineDir == "" {
+		if discovered, ok := discoverWorkflowDir(dir); ok {
+			pipelineDir = discovered
+		} else {
+			return errExit(stderr, "no Spacedock workflow here — pass --workflow-dir or run inside a workflow")
+		}
 	}
 
 	setResult, err := parseSetArgs(args)
@@ -128,6 +138,18 @@ func dispatch(args []string, dir string, e env, stdin io.Reader, stdout, stderr 
 	roots, err := resolveRoots(pipelineDir, dir)
 	if err != nil {
 		return errExit(stderr, err.Error())
+	}
+
+	// State-checkout misdirection: when --workflow-dir points at a state checkout
+	// (a dir with no own commissioned README) whose enclosing definition dir
+	// declares state: back at it, name the real problem rather than emit the
+	// downstream id/stage symptoms. Fires only for the detected state-checkout
+	// case; an arbitrary non-workflow explicit dir falls through unchanged.
+	defReadme := filepath.Join(roots.definitionDir, "README.md")
+	if !(isRegularFile(defReadme) && strings.HasPrefix(ParseFrontmatter(defReadme)["commissioned-by"], "spacedock@")) {
+		if defDir, ok := stateCheckoutParent(roots.definitionDir); ok {
+			return errExit(stderr, "this is a state checkout; point --workflow-dir at the definition dir (the one whose README declares state:): "+defDir)
+		}
 	}
 
 	// --new atomic create.

--- a/internal/status/root_resolve_discovery_test.go
+++ b/internal/status/root_resolve_discovery_test.go
@@ -1,0 +1,98 @@
+// ABOUTME: A-1 regression — discovery must not gate the --root --resolve and
+// ABOUTME: plain --resolve paths, which resolve without an enclosing cwd workflow.
+package status
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// commissionedSeqREADME is a commissioned slug-style README so discoverWorkflows
+// recognizes the workflow for the --root cross-workflow resolve path.
+const commissionedSeqREADME = `---
+commissioned-by: spacedock@1
+id-style: slug
+stages:
+  states:
+    - name: backlog
+      initial: true
+    - name: done
+      terminal: true
+---
+
+# WFA
+`
+
+// TestRootResolveSkipsDiscovery is the A-1 BLOCKER regression: `status --root
+// <root> --resolve 'wfa::shared-task'` from a NON-enclosed cwd must exit 0 and
+// resolve the entity. The --root path never consumes the cwd workflow, so the
+// discovery gate must not hard-error it. Pre-fix this regressed to exit 1 with
+// the no-workflow error.
+func TestRootResolveSkipsDiscovery(t *testing.T) {
+	root := t.TempDir()
+	writeAll(t, root, map[string]string{
+		"wfa/README.md":      commissionedSeqREADME,
+		"wfa/shared-task.md": "---\nstatus: backlog\n---\n# Shared\n",
+	})
+	gitInit(t, root)
+
+	// cwd is an unrelated, non-enclosed empty tempdir — no workflow above it.
+	nonEnclosed := t.TempDir()
+	env := pinnedEnv(t)
+
+	out, stderr, code := runNative(t, nonEnclosed, env, "--root", root, "--resolve", "wfa::shared-task")
+	if code != 0 {
+		t.Fatalf("--root --resolve exit=%d, want 0 (stdout=%q stderr=%q)", code, out, stderr)
+	}
+	if strings.Contains(stderr, "no Spacedock workflow here") {
+		t.Fatalf("--root --resolve must not hit the no-workflow gate; stderr=%q", stderr)
+	}
+	// path= is realpath-derived (discoverWorkflows canonicalizes the root), so
+	// assert on the slug and the entity's file location rather than a raw prefix.
+	if !strings.Contains(out, "slug=shared-task") ||
+		!strings.Contains(out, filepath.Join("wfa", "shared-task.md")) {
+		t.Fatalf("--root --resolve output = %q, want it to resolve shared-task under wfa/", out)
+	}
+}
+
+// TestRootResolveUnqualifiedSkipsDiscovery covers the unqualified --root
+// --resolve form (no wf:: prefix) from a non-enclosed cwd: it scans all
+// workflows under root and must likewise skip the discovery gate.
+func TestRootResolveUnqualifiedSkipsDiscovery(t *testing.T) {
+	root := t.TempDir()
+	writeAll(t, root, map[string]string{
+		"wfa/README.md":      commissionedSeqREADME,
+		"wfa/shared-task.md": "---\nstatus: backlog\n---\n# Shared\n",
+	})
+	gitInit(t, root)
+	nonEnclosed := t.TempDir()
+	env := pinnedEnv(t)
+
+	out, stderr, code := runNative(t, nonEnclosed, env, "--root", root, "--resolve", "shared-task")
+	if code != 0 {
+		t.Fatalf("unqualified --root --resolve exit=%d, want 0 (stderr=%q)", code, stderr)
+	}
+	if !strings.Contains(out, "slug=shared-task") {
+		t.Fatalf("unqualified --root --resolve output = %q, want shared-task resolved", out)
+	}
+}
+
+// TestPlainResolveFromNonWorkflowEmitsNoWorkflow pins the polish-item decision:
+// a plain `--resolve <ref>` (no --root, no --workflow-dir) from a non-enclosed
+// cwd resolves via discovery, so a non-workflow cwd yields the named
+// no-workflow error (exit 1) — the more actionable message — rather than the
+// prior "unknown reference". This path DOES require a workflow, so the change is
+// intended and kept.
+func TestPlainResolveFromNonWorkflowEmitsNoWorkflow(t *testing.T) {
+	nonEnclosed := t.TempDir()
+	env := pinnedEnv(t)
+
+	out, stderr, code := runNative(t, nonEnclosed, env, "--resolve", "anything")
+	if code != 1 {
+		t.Fatalf("plain --resolve from non-workflow exit=%d, want 1 (stdout=%q stderr=%q)", code, out, stderr)
+	}
+	if stderr != noWorkflowErr {
+		t.Fatalf("plain --resolve stderr = %q, want the no-workflow error %q", stderr, noWorkflowErr)
+	}
+}


### PR DESCRIPTION
Make `spacedock` discoverable and forgiving: auto-discover the enclosing workflow, replace misleading errors with the actual fix, and add `new` + `completion` verbs.

## What changed
- Add workflow auto-discovery: walk up to the enclosing `commissioned-by: spacedock@` README when `--workflow-dir` is omitted.
- Replace the misleading state-checkout and no-workflow errors with actionable messages that name the real fix.
- Add `spacedock new` (auto-discovering alias) and `spacedock completion <shell>` as cobra Workflow-group verbs.
- Exempt `--root` from the discovery gate so `--root --resolve` cross-workflow lookups keep working.

## Evidence
- `go test ./...`: 554/555 passed (sole failure is the pre-existing env-gated codex-host resolver test, untouched by this diff).
- Validated across 3 cycles + an independent adversarial detached-checkout audit; the `--workflow-dir` resolution re-interpretation got a 9-case adversarial guard probe (no over/under-correction).

## Review guidance
The resolution re-interpretation lives in `internal/status/native_runner.go` (discovery + state-checkout gates, both exempted when `--root`/`--workflow-dir` is set).

---
[xd](/spacedock-dev/spacedock/blob/spacedock-state/dev/cli-ergonomics/index.md)
