### PR TITLE
ci(next-publish): deliberate workflow_dispatch trigger (stop per-merge marketplace bumps)

### DIFF
--- a/.github/workflows/next-publish.yml
+++ b/.github/workflows/next-publish.yml
@@ -1,17 +1,12 @@
-# Bumps the marketplace entry's calendar version on each `next` publish (AC-2d).
+# Bumps the marketplace entry's calendar version on a deliberate `next` publish.
 # The calendar key (`0.0.YYYYMMDDNN`) is the `claude plugin update` re-pull key:
 # bumping it is the ONLY thing that makes `update` re-pull the moving `next`
-# branch. Tied to the CI that publishes `next` so it cannot be forgotten.
+# branch. Triggered manually (`workflow_dispatch`) — run it when you want `@next`
+# marketplace installers to re-pull, not on every push.
 name: next-publish
 
 on:
-  push:
-    branches:
-      - next
-    # The bump commit only touches marketplace.json; ignoring that path stops the
-    # bump from re-triggering itself in a loop.
-    paths-ignore:
-      - ".claude-plugin/marketplace.json"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Why
The `next-publish` workflow fired on every push to `next`, auto-bumping the marketplace calendar version (`0.0.YYYYMMDDNN`) and producing a bot "bump marketplace calendar version" commit per push — noise on `next`.

That calendar key is only the re-pull key for `claude plugin update spacedock@next` from the marketplace. The primary dev workflow uses `--plugin-dir`, which bypasses the marketplace entirely, so the bump does not need to fire on every merge — only on a deliberate `@next` publish.

## What changed
- `on:` trigger: `push: branches: [next]` → `workflow_dispatch:` (manual only).
- Removed the now-unnecessary `paths-ignore: [.claude-plugin/marketplace.json]` self-loop guard (no self-trigger possible under `workflow_dispatch`).
- Header comment updated to reflect the deliberate cadence; still explains the calendar key is the `claude plugin update` re-pull key.
- `permissions: contents: write` and the entire `bump-calendar` job (`go run ./cmd/spacedock-release bump-calendar`, commit, push `next`) are unchanged.

## How to publish now
Run the workflow manually (Actions → next-publish → Run workflow, or `gh workflow run next-publish.yml --ref next`) when you want `@next` marketplace installers to re-pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)