### PR TITLE
feat(claudeteam): host-neutrality seam — relocate ~/.claude team-state reads behind an injected probe

### DIFF
--- a/internal/claudeteam/claudeteam.go
+++ b/internal/claudeteam/claudeteam.go
@@ -1,0 +1,79 @@
+// ABOUTME: The Claude runtime seam — owns the ~/.claude/teams reads behind a
+// ABOUTME: host-supplied TeamStateProbe plus the boot hint + bare-mode advisory text.
+package claudeteam
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// teamStateWindow is the lookback for "recent team-runtime evidence": a
+// ~/.claude/teams/*/config.json touched inside this window means a Claude team
+// session is live. The boot TEAM_STATE and the build bare-mode advisory share it.
+const teamStateWindow = 30 * time.Minute
+
+// PresentFalseHint is the boot TEAM_STATE present:false hint the Claude seam
+// supplies. It names a Claude-only tool (TeamCreate), so it lives here, not in
+// the generic internal/status renderer — the generic renderer reads it only when
+// a probe is wired, and emits a host-neutral line when the probe is nil.
+const PresentFalseHint = "run TeamCreate before first team-mode dispatch (claude runtime supports it)"
+
+// TeamStateProbe reports recent local team-runtime evidence over the shared
+// ~/.claude/teams read. present drives the boot TEAM_STATE present field; hint is
+// the boot present:true hint line; recent drives the build bare-mode advisory
+// gate. now is injected so the 30-minute window is testable. internal/status and
+// internal/dispatch take this as a value (nil on a non-Claude host) so their
+// source carries no ~/.claude read.
+type TeamStateProbe func(home string, now time.Time) (present bool, hint string, recent bool)
+
+// Probe is the concrete Claude implementation: it scans ~/.claude/teams/*/config.json
+// mtimes under home for the newest one inside the 30-minute window. present and
+// recent both report whether such a config exists; hint names the newest team
+// directory on the present path. home is the resolved HOME (the caller keeps HOME
+// resolution generic; only this ~/.claude read is Claude-specific). The Claude CLI
+// front door wires claudeteam.Probe; Codex/bare wire nil.
+func Probe(home string, now time.Time) (present bool, hint string, recent bool) {
+	teamsDir := filepath.Join(home, ".claude", "teams")
+	info, err := os.Stat(teamsDir)
+	if err != nil || !info.IsDir() {
+		return false, "", false
+	}
+	entries, err := os.ReadDir(teamsDir)
+	if err != nil {
+		return false, "", false
+	}
+	cutoff := now.Add(-teamStateWindow)
+	var newest string
+	var newestMtime time.Time
+	for _, ent := range entries {
+		cfg := filepath.Join(teamsDir, ent.Name(), "config.json")
+		st, err := os.Stat(cfg)
+		if err != nil || !st.Mode().IsRegular() {
+			continue
+		}
+		if st.ModTime().After(newestMtime) {
+			newestMtime = st.ModTime()
+			newest = ent.Name()
+		}
+	}
+	if newest != "" && !newestMtime.Before(cutoff) {
+		return true, "recent team directory: " + newest, true
+	}
+	return false, "", false
+}
+
+// BareModeAdvisory writes the bare-mode dispatch warning to w. It names a
+// Claude-only bootstrap tool (TeamCreate) and the ~/.claude/teams path, so the
+// text lives in the Claude seam, not in the generic internal/dispatch build path.
+// The generic build path calls this only when a Claude probe is wired AND reports
+// no recent evidence; a nil-probe (Codex/bare) host emits no advisory at all.
+func BareModeAdvisory(w io.Writer) {
+	fmt.Fprintln(w,
+		"WARN: bare_mode dispatch with no recent TeamCreate evidence "+
+			"(no ~/.claude/teams/*/config.json modified in the last 30 minutes). "+
+			"If you intend teams mode, run ToolSearch select:TeamCreate and TeamCreate first. "+
+			"If bare is intentional, this warning can be ignored.")
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 	"github.com/spacedock-dev/spacedock/internal/contract"
 	"github.com/spacedock-dev/spacedock/internal/dispatch"
 	"github.com/spacedock-dev/spacedock/internal/status"
@@ -34,7 +35,13 @@ const tagline = "spacedock — agentic workflow launcher"
 // state: dir) itself; all other commands are handled directly. The vendored
 // Python runner stays selectable through the injectable run() core.
 func Run(args []string, stdout io.Writer, stderr io.Writer) int {
-	return run(context.Background(), args, os.Environ(), cwd(), os.Stdin, stdout, stderr, &status.NativeRunner{})
+	// The native binary is the Claude runtime's companion: the Claude first officer
+	// invokes `spacedock status --boot` and `spacedock dispatch build` directly, so
+	// the workflow surface is wired with the Claude team-state probe. claudeteam owns
+	// the ~/.claude read; status/dispatch take it as an opaque value. A non-Claude
+	// runtime entry point wires nil (host-neutral present:false / no bare-mode advisory).
+	return run(context.Background(), args, os.Environ(), cwd(), os.Stdin, stdout, stderr,
+		&status.NativeRunner{TeamStateProbe: claudeteam.Probe}, claudeteam.Probe)
 }
 
 // run is the injectable core. It depends only on the status.Runner interface,
@@ -42,8 +49,8 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 // drive the status path with pinned env/cwd. cobra is wired INSIDE run so the
 // package's public surface (Run) and the exit-code contract are unchanged: the
 // command tree captures env/dir/stdin/stdout/stderr/runner in its RunE closures.
-func run(ctx context.Context, args []string, env []string, dir string, stdin io.Reader, stdout io.Writer, stderr io.Writer, runner status.Runner) int {
-	root := newRootCommand(ctx, env, dir, stdin, stdout, stderr, runner)
+func run(ctx context.Context, args []string, env []string, dir string, stdin io.Reader, stdout io.Writer, stderr io.Writer, runner status.Runner, dispatchProbe claudeteam.TeamStateProbe) int {
+	root := newRootCommand(ctx, env, dir, stdin, stdout, stderr, runner, dispatchProbe)
 	root.SetArgs(args)
 	if err := root.Execute(); err != nil {
 		return exitCodeFor(err)
@@ -78,7 +85,7 @@ func exitCodeFor(err error) int {
 // package: cobra never prints its own error or usage, so the unknown-command path
 // emits the pinned message and exits 2 (the root RunE below), and the help is
 // rendered solely by printHelp.
-func newRootCommand(ctx context.Context, env []string, dir string, stdin io.Reader, stdout, stderr io.Writer, runner status.Runner) *cobra.Command {
+func newRootCommand(ctx context.Context, env []string, dir string, stdin io.Reader, stdout, stderr io.Writer, runner status.Runner, dispatchProbe claudeteam.TeamStateProbe) *cobra.Command {
 	versionFlag := false
 
 	root := &cobra.Command{
@@ -121,7 +128,7 @@ func newRootCommand(ctx context.Context, env []string, dir string, stdin io.Read
 		newStatusCommand(ctx, env, dir, stdin, stdout, stderr, runner),
 		newNewCommand(ctx, env, dir, stdin, stdout, stderr, runner),
 		newCompletionCommand(stdout, stderr),
-		newDispatchCommand(stdin, stdout, stderr),
+		newDispatchCommand(dispatchProbe, stdin, stdout, stderr),
 	)
 	return root
 }
@@ -306,14 +313,14 @@ func newCompletionCommand(stdout, stderr io.Writer) *cobra.Command {
 
 // newDispatchCommand reparents `spacedock dispatch` under cobra with flag parsing
 // disabled, forwarding its post-subcommand argv verbatim to dispatch.Run (AC-5).
-func newDispatchCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
+func newDispatchCommand(probe claudeteam.TeamStateProbe, stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:                "dispatch build | show-stage-def",
 		Short:              "Build worker dispatch artifacts",
 		GroupID:            "workflow",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if code := dispatch.Run(args, stdin, stdout, stderr); code != 0 {
+			if code := dispatch.Run(probe, args, stdin, stdout, stderr); code != 0 {
 				return exitCodeError{code}
 			}
 			return nil

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -176,7 +176,7 @@ func TestGateRemedyNamesLiveInstallCommand(t *testing.T) {
 	// while the removed `init` must fall back to root (the unknown-command path
 	// that exits 2). Resolution is deterministic and touches no host CLI.
 	var stdout, stderr bytes.Buffer
-	root := newRootCommand(context.Background(), nil, t.TempDir(), nil, &stdout, &stderr, &fakeRunner{})
+	root := newRootCommand(context.Background(), nil, t.TempDir(), nil, &stdout, &stderr, &fakeRunner{}, nil)
 	if cmd, _, err := root.Find([]string{"install"}); err != nil || cmd == root {
 		t.Fatalf("`install` did not resolve to a registered command (cmd=%v, err=%v)", cmd.Name(), err)
 	}

--- a/internal/cli/native_status_test.go
+++ b/internal/cli/native_status_test.go
@@ -26,7 +26,7 @@ func TestNativeRunnerSelectableThroughCLI(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	env := []string{"USER=pinned", "PATH=" + os.Getenv("PATH")}
-	code := run(context.Background(), []string{"status", "--workflow-dir", root}, env, root, nil, &stdout, &stderr, &status.NativeRunner{})
+	code := run(context.Background(), []string{"status", "--workflow-dir", root}, env, root, nil, &stdout, &stderr, &status.NativeRunner{}, nil)
 
 	if code != 0 {
 		t.Fatalf("native status exit=%d stderr=%q", code, stderr.String())

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -48,7 +48,7 @@ func TestStatusForwardsRequestVerbatim(t *testing.T) {
 	stdin := strings.NewReader("BODY-FROM-STDIN")
 	args := []string{"status", "--workflow-dir", "/wf", "--next"}
 
-	code := run(context.Background(), args, env, dir, stdin, &stdout, &stderr, fake)
+	code := run(context.Background(), args, env, dir, stdin, &stdout, &stderr, fake, nil)
 
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0", code)
@@ -77,7 +77,7 @@ func TestStatusReturnsRunnerExitCodeUnmodified(t *testing.T) {
 	for _, code := range []int{0, 1} {
 		fake := &fakeRunner{exitCode: code}
 		var stdout, stderr bytes.Buffer
-		got := run(context.Background(), []string{"status", "--workflow-dir", "/wf"}, nil, "", nil, &stdout, &stderr, fake)
+		got := run(context.Background(), []string{"status", "--workflow-dir", "/wf"}, nil, "", nil, &stdout, &stderr, fake, nil)
 		if got != code {
 			t.Fatalf("exit code = %d, want %d (CLI must not translate)", got, code)
 		}
@@ -90,7 +90,7 @@ func TestStatusReturnsRunnerExitCodeUnmodified(t *testing.T) {
 func TestStatusUnknownTopLevelFlagForwarded(t *testing.T) {
 	fake := &fakeRunner{exitCode: 0, stdout: "DEFAULT-TABLE\n"}
 	var stdout, stderr bytes.Buffer
-	code := run(context.Background(), []string{"status", "--workflow-dir", "/wf", "--bogus-top-level"}, nil, "", nil, &stdout, &stderr, fake)
+	code := run(context.Background(), []string{"status", "--workflow-dir", "/wf", "--bogus-top-level"}, nil, "", nil, &stdout, &stderr, fake, nil)
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
@@ -105,7 +105,7 @@ func TestStatusUnknownTopLevelFlagForwarded(t *testing.T) {
 func TestStatusRunnerErrorIsLoud(t *testing.T) {
 	fake := &fakeRunner{exitCode: -1, err: errFakeNoPython}
 	var stdout, stderr bytes.Buffer
-	code := run(context.Background(), []string{"status", "--workflow-dir", "/wf"}, nil, "", nil, &stdout, &stderr, fake)
+	code := run(context.Background(), []string{"status", "--workflow-dir", "/wf"}, nil, "", nil, &stdout, &stderr, fake, nil)
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}

--- a/internal/cli/verbs_test.go
+++ b/internal/cli/verbs_test.go
@@ -25,7 +25,7 @@ func TestNewVerbMintsInDiscoveredWorkflow(t *testing.T) {
 
 	env := []string{"USER=pinned", "PATH=" + os.Getenv("PATH")}
 	var stdout, stderr bytes.Buffer
-	code := run(context.Background(), []string{"new", "minted-task"}, env, def, strings.NewReader(newEntityBody), &stdout, &stderr, &status.NativeRunner{})
+	code := run(context.Background(), []string{"new", "minted-task"}, env, def, strings.NewReader(newEntityBody), &stdout, &stderr, &status.NativeRunner{}, nil)
 	if code != 0 {
 		t.Fatalf("new exit=%d stderr=%q", code, stderr.String())
 	}
@@ -38,7 +38,7 @@ func TestNewVerbMintsInDiscoveredWorkflow(t *testing.T) {
 
 	// --validate clean immediately after, proving a complete entity was minted.
 	var vout, verr bytes.Buffer
-	vcode := run(context.Background(), []string{"status", "--workflow-dir", def, "--validate"}, env, def, nil, &vout, &verr, &status.NativeRunner{})
+	vcode := run(context.Background(), []string{"status", "--workflow-dir", def, "--validate"}, env, def, nil, &vout, &verr, &status.NativeRunner{}, nil)
 	if vcode != 0 || strings.TrimSpace(vout.String()) != "VALID" {
 		t.Fatalf("post-new validate exit=%d out=%q err=%q", vcode, vout.String(), verr.String())
 	}
@@ -52,7 +52,7 @@ func TestNewVerbFolderForm(t *testing.T) {
 
 	env := []string{"USER=pinned", "PATH=" + os.Getenv("PATH")}
 	var stdout, stderr bytes.Buffer
-	code := run(context.Background(), []string{"new", "--folder", "foldered"}, env, def, strings.NewReader(newEntityBody), &stdout, &stderr, &status.NativeRunner{})
+	code := run(context.Background(), []string{"new", "--folder", "foldered"}, env, def, strings.NewReader(newEntityBody), &stdout, &stderr, &status.NativeRunner{}, nil)
 	if code != 0 {
 		t.Fatalf("new --folder exit=%d stderr=%q", code, stderr.String())
 	}

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -10,7 +10,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 	"github.com/spacedock-dev/spacedock/internal/status"
 )
 
@@ -59,7 +61,7 @@ func buildError(stderr io.Writer, code int, format string, a ...any) int {
 // path. Scoped to non-_mods workflows: it emits the single show-stage-def fetch
 // line and never the standing-teammate fetch line. Matches cmd_build minus the
 // _mods/standing branch (deferred to the sibling claude-runtime-segregation).
-func runBuild(workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int {
+func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int {
 	raw, err := io.ReadAll(stdin)
 	if err != nil {
 		return buildError(stderr, 1, "failed to read stdin: %s", err)
@@ -111,13 +113,17 @@ func runBuild(workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int
 	isFeedbackReflow := optBool(fields, "is_feedback_reflow")
 
 	// FO bootstrap discipline: a bare_mode dispatch with no recent TeamCreate
-	// evidence on disk gets an advisory stderr warning (exit stays 0).
-	if bareMode && !recentTeamEvidence() {
-		fmt.Fprintln(stderr,
-			"WARN: bare_mode dispatch with no recent TeamCreate evidence "+
-				"(no ~/.claude/teams/*/config.json modified in the last 30 minutes). "+
-				"If you intend teams mode, run ToolSearch select:TeamCreate and TeamCreate first. "+
-				"If bare is intentional, this warning can be ignored.")
+	// evidence on disk gets an advisory stderr warning (exit stays 0). The evidence
+	// read and the warning text both live in the Claude seam; HOME resolution stays
+	// generic here. A nil probe (a non-Claude host) emits no advisory — the warning
+	// is Claude-specific bootstrap advice, host-neutral by absence.
+	if bareMode && probe != nil {
+		// HOME resolution stays generic (plain env, no ~/.claude read); the probe
+		// owns the team-state read. An unset HOME yields "", on which the probe
+		// reports no recent evidence and the advisory fires — the pre-seam behavior.
+		if _, _, recent := probe(os.Getenv("HOME"), time.Now()); !recent {
+			claudeteam.BareModeAdvisory(stderr)
+		}
 	}
 
 	// Rule 12: entity_path must be project-root, not worktree-absolute.

--- a/internal/dispatch/build_advisory_probe_test.go
+++ b/internal/dispatch/build_advisory_probe_test.go
@@ -1,0 +1,80 @@
+// ABOUTME: AC-P2 build regression — the bare-mode advisory is gated on the probe:
+// ABOUTME: Claude (probe) + no evidence emits it; a nil probe (Codex/bare) emits none.
+package dispatch
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
+)
+
+// bareBuildFixture builds a single-root bare-mode fixture under an empty HOME (so
+// claudeteam.Probe reports no recent team evidence, the advisory-eligible state)
+// and returns the root and the bare_mode build stdin. Both probe arms run against
+// THIS one fixture so the only varying input is the probe — the dispatch envelope
+// must then be byte-identical across arms.
+func bareBuildFixture(t *testing.T) (root, stdin string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir()) // empty ~/.claude → no recent team evidence
+	root = t.TempDir()
+	writeFile(t, filepath.Join(root, "README.md"), readmeWorktree(false))
+	entityPath := filepath.Join(root, "thing.md")
+	writeFile(t, entityPath, entityFM("Thing", "backlog", ""))
+	gitInit(t, root)
+
+	stdin = mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    entityPath,
+		"workflow_dir":   root,
+		"stage":          "backlog",
+		"checklist":      []string{"- a", "- b"},
+		"bare_mode":      true,
+	}, nil)
+	return root, stdin
+}
+
+// runBareBuild runs the bare_mode build over the given fixture with the given probe.
+func runBareBuild(t *testing.T, root, stdin string, probe claudeteam.TeamStateProbe) (stdout, stderr string) {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	if code := Run(probe, []string{"build", "--workflow-dir", root}, strings.NewReader(stdin), &out, &errBuf); code != 0 {
+		t.Fatalf("bare build exit=%d stderr=%q", code, errBuf.String())
+	}
+	return out.String(), errBuf.String()
+}
+
+// advisoryMarker is a stable fragment of the Claude bare-mode advisory text. The
+// regression keys on its presence/absence rather than the full sentence so a
+// future wording tweak in claudeteam.BareModeAdvisory does not break the gate.
+const advisoryMarker = "bare_mode dispatch with no recent TeamCreate evidence"
+
+// TestBuildBareAdvisoryProbeGate is the persistent AC-P2 regression for the build
+// surface: the bare-mode advisory's PRESENCE is the seam's only observable effect.
+//   - probe supplied (Claude) + no recent evidence → advisory fires on stderr.
+//   - probe nil (Codex/bare)                        → NO advisory at all.
+//
+// The dispatch envelope on stdout is byte-identical across both arms — the seam
+// touches only the advisory's presence. The nil-probe-no-advisory arm documents
+// the host-neutrality refinement: the advisory names a Claude-only tool
+// (TeamCreate), so a non-Claude host correctly emits none. This is a deliberate,
+// scoped behavior change, NOT a parity regression: the byte-for-byte AC-P2 claim
+// is the Claude (probe-supplied) path, whose advisory behavior is unchanged from
+// the pre-seam unconditional read.
+func TestBuildBareAdvisoryProbeGate(t *testing.T) {
+	root, stdin := bareBuildFixture(t)
+	stdoutProbe, stderrProbe := runBareBuild(t, root, stdin, claudeteam.Probe)
+	stdoutNil, stderrNil := runBareBuild(t, root, stdin, nil)
+
+	if stdoutProbe != stdoutNil {
+		t.Fatalf("dispatch envelope diverged between probe and nil arms:\n--- probe ---\n%s\n--- nil ---\n%s", stdoutProbe, stdoutNil)
+	}
+	if !strings.Contains(stderrProbe, advisoryMarker) {
+		t.Fatalf("Claude probe + no evidence must emit the bare-mode advisory; stderr=%q", stderrProbe)
+	}
+	if strings.Contains(stderrNil, advisoryMarker) {
+		t.Fatalf("nil probe (Codex/bare) must emit NO bare-mode advisory; stderr=%q", stderrNil)
+	}
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -5,6 +5,8 @@ package dispatch
 import (
 	"fmt"
 	"io"
+
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 )
 
 // deferredSubcommands are the claude-team subcommands moved to the sibling
@@ -20,8 +22,9 @@ var deferredSubcommands = map[string]bool{
 // Run routes a `spacedock dispatch <subcommand> [flags]` invocation. build reads
 // stdin JSON and writes the dispatch envelope to stdout; show-stage-def writes a
 // README subsection to stdout. A deferred or unknown subcommand fails with exit
-// 2 and a usage diagnostic on stderr.
-func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+// 2 and a usage diagnostic on stderr. probe is the host-supplied team-state probe
+// gating the bare-mode advisory (nil on a non-Claude host → no advisory).
+func Run(probe claudeteam.TeamStateProbe, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		printUsage(stderr)
 		return 2
@@ -33,7 +36,7 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		if code != 0 {
 			return code
 		}
-		return runBuild(workflowDir, stdin, stdout, stderr)
+		return runBuild(probe, workflowDir, stdin, stdout, stderr)
 	case "show-stage-def":
 		workflowDir, stage, code := requireStageFlags(args[1:], stderr)
 		if code != 0 {

--- a/internal/dispatch/helpers.go
+++ b/internal/dispatch/helpers.go
@@ -8,13 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/spacedock-dev/spacedock/internal/status"
 )
-
-// teamEvidenceWindow is the lookback for the bare-mode TeamCreate-evidence probe.
-const teamEvidenceWindow = 30 * time.Minute
 
 // isJSONNull reports whether a raw JSON value is the literal null.
 func isJSONNull(v json.RawMessage) bool {
@@ -132,33 +128,6 @@ func splitRootStateCheckout(workflowDir string) string {
 		return ""
 	}
 	return filepath.Join(workflowDir, state)
-}
-
-// recentTeamEvidence reports whether any ~/.claude/teams/*/config.json was
-// modified within teamEvidenceWindow. Matches _recent_team_evidence: the
-// cheapest plausible proxy for "this session ran TeamCreate".
-func recentTeamEvidence() bool {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return false
-	}
-	teamsDir := filepath.Join(home, ".claude", "teams")
-	entries, err := os.ReadDir(teamsDir)
-	if err != nil {
-		return false
-	}
-	cutoff := time.Now().Add(-teamEvidenceWindow)
-	for _, ent := range entries {
-		cfg := filepath.Join(teamsDir, ent.Name(), "config.json")
-		info, err := os.Stat(cfg)
-		if err != nil || !info.Mode().IsRegular() {
-			continue
-		}
-		if !info.ModTime().Before(cutoff) {
-			return true
-		}
-	}
-	return false
 }
 
 // pyRelpath returns path relative to base the way os.path.relpath does for the

--- a/internal/dispatch/no_native_subcommands_test.go
+++ b/internal/dispatch/no_native_subcommands_test.go
@@ -1,0 +1,84 @@
+// ABOUTME: AC-P3 regression — this entity adds no native subcommand handlers: the
+// ABOUTME: four standing commands stay deferred and build emits no standing fetch line.
+package dispatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
+)
+
+// TestDeferredSubcommandSetUnchanged pins the deferred set to exactly the four
+// runtime-coupled standing subcommands. A native handler added here would have to
+// remove its name from this set (so Run stops routing it to the deferral
+// diagnostic), tripping this assertion — making "no new native handler" observable
+// at the routing table, complementing the behavioral TestDeferredSubcommandGuard.
+func TestDeferredSubcommandSetUnchanged(t *testing.T) {
+	var got []string
+	for name := range deferredSubcommands {
+		got = append(got, name)
+	}
+	sort.Strings(got)
+	want := []string{"context-budget", "list-standing", "show-standing", "spawn-standing"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("deferred subcommand set changed: got %v, want %v", got, want)
+	}
+}
+
+// TestBuildEmitsNoStandingFetchLine asserts the build `_mods`/standing branch is
+// still deferred to claude-runtime-segregation: even with a `_mods/` dir present,
+// the native build emits ONLY the show-stage-def fetch line — never a
+// `show-standing` / standing-teammate fetch line. Adding the native `_mods` branch
+// here would emit that line and trip this test.
+func TestBuildEmitsNoStandingFetchLine(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "README.md"), readmeWorktree(false))
+	// A _mods dir declaring a standing teammate — the input the deferred branch
+	// would consume. The native build must ignore it (the branch is not ported).
+	if err := os.MkdirAll(filepath.Join(root, "_mods"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(root, "_mods", "helper.md"),
+		"---\nstanding: true\nname: helper\n---\n## Hook: startup\nx\n## Agent Prompt\ny\n")
+	entityPath := filepath.Join(root, "thing.md")
+	writeFile(t, entityPath, entityFM("Thing", "backlog", ""))
+	gitInit(t, root)
+
+	stdin := mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    entityPath,
+		"workflow_dir":   root,
+		"stage":          "backlog",
+		"checklist":      []string{"- a", "- b"},
+		"team_name":      "fixture-team",
+		"bare_mode":      false,
+	}, nil)
+
+	var out, errBuf bytes.Buffer
+	if code := Run(claudeteam.Probe, []string{"build", "--workflow-dir", root}, strings.NewReader(stdin), &out, &errBuf); code != 0 {
+		t.Fatalf("build exit=%d stderr=%q", code, errBuf.String())
+	}
+
+	var env struct {
+		FetchCommands []string `json:"fetch_commands"`
+		Prompt        string   `json:"prompt"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("build output not JSON: %v\n%s", err, out.String())
+	}
+	if len(env.FetchCommands) != 1 || !strings.Contains(env.FetchCommands[0], "show-stage-def") {
+		t.Fatalf("expected exactly one show-stage-def fetch line; got %v", env.FetchCommands)
+	}
+	for _, fc := range env.FetchCommands {
+		if strings.Contains(fc, "standing") {
+			t.Fatalf("native build emitted a standing fetch line (the _mods branch must stay deferred): %q", fc)
+		}
+	}
+}

--- a/internal/dispatch/parity_harness_test.go
+++ b/internal/dispatch/parity_harness_test.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 )
 
 // oracleFetchPrefix and nativeFetchPrefix are the one intentional divergence:
@@ -73,7 +75,9 @@ func runOracle(t *testing.T, dir, home, stdin string, args ...string) runResult 
 // team-evidence probe is hermetic, matching the oracle's pinned HOME.
 func runNative(stdin string, args ...string) runResult {
 	var stdout, stderr bytes.Buffer
-	exit := Run(args, strings.NewReader(stdin), &stdout, &stderr)
+	// The Claude team-state probe matches the Python oracle's ~/.claude/teams read,
+	// so the bare-mode advisory parity holds byte-for-byte under the pinned HOME.
+	exit := Run(claudeteam.Probe, args, strings.NewReader(stdin), &stdout, &stderr)
 	return runResult{stdout.String(), stderr.String(), exit}
 }
 

--- a/internal/ensigncycle/cycle_test.go
+++ b/internal/ensigncycle/cycle_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 	"github.com/spacedock-dev/spacedock/internal/dispatch"
 )
 
@@ -82,7 +83,7 @@ func stageFixture(t *testing.T) cycleFixture {
 	})
 
 	var stdout, stderr strings.Builder
-	if code := dispatch.Run([]string{"build", "--workflow-dir", root},
+	if code := dispatch.Run(claudeteam.Probe, []string{"build", "--workflow-dir", root},
 		strings.NewReader(stdin), &stdout, &stderr); code != 0 {
 		t.Fatalf("dispatch build exit=%d stderr=%s", code, stderr.String())
 	}

--- a/internal/ensigncycle/feedback_test.go
+++ b/internal/ensigncycle/feedback_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 	"github.com/spacedock-dev/spacedock/internal/dispatch"
 )
 
@@ -94,7 +95,7 @@ func stageReflowFixture(t *testing.T, reflow bool, feedbackContext string) reflo
 	}
 
 	var stdout, stderr strings.Builder
-	code := dispatch.Run([]string{"build", "--workflow-dir", root},
+	code := dispatch.Run(claudeteam.Probe, []string{"build", "--workflow-dir", root},
 		strings.NewReader(mustJSON(t, fields)), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("dispatch build exit=%d stderr=%s", code, stderr.String())
@@ -180,7 +181,7 @@ func TestFeedbackReflowGoesRedOnBrokenOutput(t *testing.T) {
 		})
 
 		var stdout, stderr strings.Builder
-		code := dispatch.Run([]string{"build", "--workflow-dir", root},
+		code := dispatch.Run(claudeteam.Probe, []string{"build", "--workflow-dir", root},
 			strings.NewReader(stdin), &stdout, &stderr)
 
 		if code == 0 {

--- a/internal/hostneutrality/host_neutrality_test.go
+++ b/internal/hostneutrality/host_neutrality_test.go
@@ -1,0 +1,86 @@
+// ABOUTME: AC-3 code-side host-neutrality oracle — a go/parser scan asserting the
+// ABOUTME: generic internal/dispatch + internal/status source carries no ~/.claude read.
+package hostneutrality
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// guardedPackages are the generic packages the host-neutrality invariant polices.
+// They must carry no home-rooted Claude team/transcript read literal — those live
+// only in internal/claudeteam behind the injected probe. Paths are relative to
+// this test's package dir (go test runs with cwd at the package source dir).
+var guardedPackages = []string{"../dispatch", "../status"}
+
+// leak describes one host-coupling read found in guarded source.
+type leak struct {
+	file string
+	line int
+	kind string
+	text string
+}
+
+// TestNoClaudeHomeReadsInGenericPackages parses every non-test .go file in the
+// guarded packages and fails if any carries a ~/.claude path-join string literal
+// or an os.UserHomeDir-rooted read. These are the home-rooted team/transcript
+// reads AC-3 forbids in the generic core; after relocation behind the
+// claudeteam.TeamStateProbe seam, none remain. Re-introducing any flips this RED.
+func TestNoClaudeHomeReadsInGenericPackages(t *testing.T) {
+	var leaks []leak
+	for _, pkgDir := range guardedPackages {
+		entries, err := os.ReadDir(pkgDir)
+		if err != nil {
+			t.Fatalf("read package dir %s: %v", pkgDir, err)
+		}
+		for _, ent := range entries {
+			name := ent.Name()
+			if ent.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			path := filepath.Join(pkgDir, name)
+			leaks = append(leaks, scanFile(t, path)...)
+		}
+	}
+	if len(leaks) > 0 {
+		for _, l := range leaks {
+			t.Errorf("%s:%d: host-coupling %s in generic package: %s", l.file, l.line, l.kind, l.text)
+		}
+		t.Fatalf("found %d ~/.claude/UserHomeDir read(s) in generic source; relocate them behind claudeteam.TeamStateProbe", len(leaks))
+	}
+}
+
+// scanFile parses one source file and returns its host-coupling leaks: STRING
+// literals containing ".claude" and calls to os.UserHomeDir. Comments are not AST
+// nodes here, so prose that mentions ~/.claude (e.g. an adapter-naming comment) is
+// correctly ignored — the invariant is over executable source, not text.
+func scanFile(t *testing.T, path string) []leak {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	var found []leak
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.BasicLit:
+			if node.Kind == token.STRING && strings.Contains(node.Value, ".claude") {
+				pos := fset.Position(node.Pos())
+				found = append(found, leak{file: path, line: pos.Line, kind: "string literal", text: node.Value})
+			}
+		case *ast.SelectorExpr:
+			if pkg, ok := node.X.(*ast.Ident); ok && pkg.Name == "os" && node.Sel.Name == "UserHomeDir" {
+				pos := fset.Position(node.Pos())
+				found = append(found, leak{file: path, line: pos.Line, kind: "os.UserHomeDir call", text: "os.UserHomeDir"})
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/internal/status/boot.go
+++ b/internal/status/boot.go
@@ -11,9 +11,15 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 )
 
-const teamStateMtimeWindowSecs = 30 * 60
+// teamStateNeutralHint is the boot TEAM_STATE present:false hint on a host with
+// no team-state probe wired (Codex/bare). It carries no Claude-specific advice —
+// the Claude present:false hint (claudeteam.PresentFalseHint) is supplied by the
+// seam only when a probe is present.
+const teamStateNeutralHint = "no active team runtime detected"
 
 // orphan describes a worktree-backed entity for the ORPHANS section.
 type orphan struct {
@@ -125,43 +131,6 @@ func lookupExecutable(name, pathStr string) string {
 	return ""
 }
 
-// probeTeamState reports whether any ~/.claude/teams/*/config.json was modified
-// within the last 30 minutes. Matches probe_team_state. Uses env HOME (the
-// oracle expands ~, which resolves HOME).
-func probeTeamState(e env) (bool, string) {
-	home := e.get("HOME")
-	if home == "" {
-		home = os.Getenv("HOME")
-	}
-	teamsDir := filepath.Join(home, ".claude", "teams")
-	info, err := os.Stat(teamsDir)
-	if err != nil || !info.IsDir() {
-		return false, ""
-	}
-	cutoff := time.Now().Add(-time.Duration(teamStateMtimeWindowSecs) * time.Second)
-	entries, err := os.ReadDir(teamsDir)
-	if err != nil {
-		return false, ""
-	}
-	var newest string
-	var newestMtime time.Time
-	for _, ent := range entries {
-		cfg := filepath.Join(teamsDir, ent.Name(), "config.json")
-		st, err := os.Stat(cfg)
-		if err != nil || !st.Mode().IsRegular() {
-			continue
-		}
-		if st.ModTime().After(newestMtime) {
-			newestMtime = st.ModTime()
-			newest = ent.Name()
-		}
-	}
-	if newest != "" && !newestMtime.Before(cutoff) {
-		return true, "recent team directory: " + newest
-	}
-	return false, ""
-}
-
 // bootData holds the gathered boot-section material the text and JSON renderers
 // both consume, so the two output forms read from one source of truth.
 type bootData struct {
@@ -186,7 +155,7 @@ type bootData struct {
 // gatherBoot runs every boot probe once and returns the result. NEXT_ID is
 // minted here (timestamp-dependent for sd-b32); on a minting error it returns
 // the error after the caller has emitted the stderr diagnostic.
-func gatherBoot(entities []*entity, stages []Stage, definitionDir, entityDir, gitRoot, idStyle string, e env, stderr io.Writer) (*bootData, error) {
+func gatherBoot(probe claudeteam.TeamStateProbe, entities []*entity, stages []Stage, definitionDir, entityDir, gitRoot, idStyle string, e env, stderr io.Writer) (*bootData, error) {
 	d := &bootData{idStyle: idStyle, hooks: scanMods(entityDir)}
 
 	if idStyle == "slug" {
@@ -203,7 +172,23 @@ func gatherBoot(entities []*entity, stages []Stage, definitionDir, entityDir, gi
 	d.orphans = scanOrphans(entities, gitRoot)
 	d.prStatus, d.prResults = checkPRStates(entities, stages, e)
 	d.dispatchable = computeDispatchable(entities, stages)
-	d.teamPresent, d.teamHint = probeTeamState(e)
+	// TEAM_STATE comes from the host-supplied probe. HOME resolution stays generic
+	// here; only the ~/.claude read moves into the Claude seam. The hint for both
+	// the present and absent cases is resolved here so the renderers carry no
+	// host-specific string: with a probe wired, present:false uses the Claude seam's
+	// PresentFalseHint; a nil probe (a non-Claude host) yields a host-neutral line.
+	if probe != nil {
+		home := e.get("HOME")
+		if home == "" {
+			home = os.Getenv("HOME")
+		}
+		d.teamPresent, d.teamHint, _ = probe(home, time.Now())
+		if !d.teamPresent {
+			d.teamHint = claudeteam.PresentFalseHint
+		}
+	} else {
+		d.teamHint = teamStateNeutralHint
+	}
 
 	d.definitionDir = definitionDir
 	d.entityDir = entityDir
@@ -219,8 +204,8 @@ func gatherBoot(entities []*entity, stages []Stage, definitionDir, entityDir, gi
 }
 
 // printBoot writes all boot sections in order. Matches print_boot.
-func printBoot(w io.Writer, entities []*entity, stages []Stage, definitionDir, entityDir, gitRoot, idStyle string, e env, stderr io.Writer) error {
-	d, err := gatherBoot(entities, stages, definitionDir, entityDir, gitRoot, idStyle, e, stderr)
+func printBoot(probe claudeteam.TeamStateProbe, w io.Writer, entities []*entity, stages []Stage, definitionDir, entityDir, gitRoot, idStyle string, e env, stderr io.Writer) error {
+	d, err := gatherBoot(probe, entities, stages, definitionDir, entityDir, gitRoot, idStyle, e, stderr)
 	if err != nil {
 		return err
 	}
@@ -284,15 +269,15 @@ func printBoot(w io.Writer, entities []*entity, stages []Stage, definitionDir, e
 	fmt.Fprintln(w, "DISPATCHABLE")
 	printNextTable(w, entities, stages, nil, false)
 
-	// TEAM_STATE
+	// TEAM_STATE. The present/absent hints are both resolved in gatherBoot so this
+	// renderer carries no host-specific string.
 	fmt.Fprintln(w, "TEAM_STATE")
 	if d.teamPresent {
 		fmt.Fprintln(w, "present: true")
-		fmt.Fprintf(w, "hint: %s\n", d.teamHint)
 	} else {
 		fmt.Fprintln(w, "present: false")
-		fmt.Fprintln(w, "hint: run TeamCreate before first team-mode dispatch (claude runtime supports it)")
 	}
+	fmt.Fprintf(w, "hint: %s\n", d.teamHint)
 
 	// STATE_BACKEND
 	fmt.Fprintf(w, "STATE_BACKEND: %s (entity_dir: %s, present: %t)\n",

--- a/internal/status/boot_probe_parity_test.go
+++ b/internal/status/boot_probe_parity_test.go
@@ -1,0 +1,121 @@
+// ABOUTME: AC-P2 boot regression — the seam's observable effect is confined to
+// ABOUTME: TEAM_STATE present/hint; a nil probe yields a host-neutral present:false.
+package status
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
+)
+
+// bootWithProbe runs `status --boot` over the sdb32 fixture with the given probe
+// wired and returns stdout. The pinned env's empty HOME makes claudeteam.Probe
+// deterministic (present:false) without touching the developer's ~/.claude.
+func bootWithProbe(t *testing.T, probe claudeteam.TeamStateProbe) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("testdata", "sdb32-workflow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	runner := &NativeRunner{TeamStateProbe: probe}
+	code, err := runner.Run(context.Background(), Request{
+		Args:   []string{"--workflow-dir", root, "--boot"},
+		Dir:    root,
+		Env:    pinnedEnv(t),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	if err != nil || code != 0 {
+		t.Fatalf("boot exit=%d err=%v stderr=%q", code, err, stderr.String())
+	}
+	return stdout.String()
+}
+
+// teamStateBlock returns the TEAM_STATE section (the present + hint lines) and the
+// rest of the boot output with that section excised, so the regression can assert
+// the seam's effect is CONFINED to TEAM_STATE: everything outside it is byte-equal
+// across probe configurations, and only the present/hint lines move.
+func teamStateBlock(boot string) (block, rest string) {
+	lines := strings.Split(boot, "\n")
+	var blockLines, restLines []string
+	inBlock := false
+	for _, ln := range lines {
+		switch {
+		case ln == "TEAM_STATE":
+			inBlock = true
+			blockLines = append(blockLines, ln)
+		case inBlock && (strings.HasPrefix(ln, "present:") || strings.HasPrefix(ln, "hint:")):
+			blockLines = append(blockLines, ln)
+		default:
+			inBlock = false
+			restLines = append(restLines, ln)
+		}
+	}
+	return strings.Join(blockLines, "\n"), strings.Join(restLines, "\n")
+}
+
+// presentProbe is a stub Claude probe reporting a live team (present:true) with a
+// fixed hint, so the present:true rendering is exercised without an on-disk tree.
+func presentProbe(string, time.Time) (bool, string, bool) {
+	return true, "recent team directory: alpha", true
+}
+
+// TestBootTeamStateProbeConfinement is the persistent AC-P2 regression pinning the
+// ideation SPIKE: the injected-probe seam's observable boot effect is confined to
+// the TEAM_STATE present/hint lines. Every other boot byte is identical across a
+// present-true probe, a present-false probe (claudeteam.Probe over empty HOME),
+// and a nil probe. TEAM_STATE itself moves exactly as designed:
+//   - present-true  → present: true  + the probe's hint
+//   - present-false → present: false + claudeteam.PresentFalseHint (the Claude string)
+//   - nil probe     → present: false + the host-neutral hint, NO Claude string
+//
+// The nil-probe arm documents the host-neutrality refinement: a non-Claude host
+// emits no Claude-specific advice. The byte-identical claim is scoped to the
+// non-TEAM_STATE bytes; the Claude path's TEAM_STATE matches today's oracle output
+// (locked separately by TestNativeBootMatchesOracle).
+func TestBootTeamStateProbeConfinement(t *testing.T) {
+	bootPresent := bootWithProbe(t, presentProbe)
+	bootAbsent := bootWithProbe(t, claudeteam.Probe) // empty HOME → present:false
+	bootNil := bootWithProbe(t, nil)
+
+	// Confinement: the non-TEAM_STATE bytes are identical across all three.
+	_, restPresent := teamStateBlock(bootPresent)
+	_, restAbsent := teamStateBlock(bootAbsent)
+	_, restNil := teamStateBlock(bootNil)
+	if restPresent != restAbsent {
+		t.Fatalf("seam leaked outside TEAM_STATE (present-true vs present-false):\n--- present ---\n%s\n--- absent ---\n%s", restPresent, restAbsent)
+	}
+	if restAbsent != restNil {
+		t.Fatalf("seam leaked outside TEAM_STATE (probe vs nil):\n--- probe ---\n%s\n--- nil ---\n%s", restAbsent, restNil)
+	}
+
+	// TEAM_STATE moves exactly as designed.
+	blockPresent, _ := teamStateBlock(bootPresent)
+	wantPresent := "TEAM_STATE\npresent: true\nhint: recent team directory: alpha"
+	if blockPresent != wantPresent {
+		t.Fatalf("present-true TEAM_STATE:\n got %q\nwant %q", blockPresent, wantPresent)
+	}
+
+	blockAbsent, _ := teamStateBlock(bootAbsent)
+	wantAbsent := "TEAM_STATE\npresent: false\nhint: " + claudeteam.PresentFalseHint
+	if blockAbsent != wantAbsent {
+		t.Fatalf("present-false (Claude) TEAM_STATE:\n got %q\nwant %q", blockAbsent, wantAbsent)
+	}
+
+	blockNil, _ := teamStateBlock(bootNil)
+	wantNil := "TEAM_STATE\npresent: false\nhint: " + teamStateNeutralHint
+	if blockNil != wantNil {
+		t.Fatalf("nil-probe TEAM_STATE:\n got %q\nwant %q", blockNil, wantNil)
+	}
+
+	// The host-neutral hint must NOT carry the Claude-only advice (AC-3 intent).
+	if strings.Contains(blockNil, "claude runtime") || strings.Contains(blockNil, "TeamCreate") {
+		t.Fatalf("nil-probe TEAM_STATE leaked Claude-specific advice: %q", blockNil)
+	}
+}

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 )
 
 // runSet handles the --set mutation flow with mod-block / merge-hook /
@@ -172,7 +174,7 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 
 // runRead handles the table / --next / --boot / --validate read flows. Matches
 // the tail of main() after the mutation branches.
-func runRead(roots roots, args []string, e env, whereFilters []whereFilter,
+func runRead(probe claudeteam.TeamStateProbe, roots roots, args []string, e env, whereFilters []whereFilter,
 	includeArchive, showNext, showBoot, showNextID, showValidate bool,
 	explicitFields []string, allFieldsFlag, asJSON, quiet bool,
 	hasArchiveSlug, hasSet, hasResolve bool,
@@ -261,14 +263,14 @@ func runRead(roots roots, args []string, e env, whereFilters []whereFilter,
 	switch {
 	case showBoot:
 		if asJSON {
-			data, err := gatherBoot(entities, stages, roots.definitionDir, roots.entityDir, gitRoot, idStyle, e, stderr)
+			data, err := gatherBoot(probe, entities, stages, roots.definitionDir, roots.entityDir, gitRoot, idStyle, e, stderr)
 			if err != nil {
 				return 1
 			}
 			emitJSON(stdout, bootJSON(data))
 			return 0
 		}
-		if err := printBoot(stdout, entities, stages, roots.definitionDir, roots.entityDir, gitRoot, idStyle, e, stderr); err != nil {
+		if err := printBoot(probe, stdout, entities, stages, roots.definitionDir, roots.entityDir, gitRoot, idStyle, e, stderr); err != nil {
 			return 1
 		}
 	case showNext:

--- a/internal/status/json_commands.go
+++ b/internal/status/json_commands.go
@@ -178,12 +178,15 @@ func bootJSON(d *bootData) *jsonObj {
 
 	out.setValue("dispatchable", dispatchableJSONArr(d.dispatchable))
 
+	// present/absent hints are both resolved in gatherBoot so this renderer carries
+	// no host-specific string; present is the string-bool team_state convention.
 	team := newJSONObj()
 	if d.teamPresent {
-		team.set("present", "true").set("hint", d.teamHint)
+		team.set("present", "true")
 	} else {
-		team.set("present", "false").set("hint", "run TeamCreate before first team-mode dispatch (claude runtime supports it)")
+		team.set("present", "false")
 	}
+	team.set("hint", d.teamHint)
 	out.setValue("team_state", team)
 
 	// State backend keys, appended AFTER team_state so the FO's key-order parse of

--- a/internal/status/native_harness_test.go
+++ b/internal/status/native_harness_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 )
 
 // runNative runs the native runner with the given args/dir/env (and optional
@@ -21,7 +23,9 @@ func runNative(t *testing.T, dir string, env []string, args ...string) (string, 
 func runNativeStdin(t *testing.T, dir string, env []string, stdin io.Reader, args ...string) (string, string, int) {
 	t.Helper()
 	var stdout, stderr bytes.Buffer
-	runner := &NativeRunner{}
+	// The Claude team-state probe matches the Python oracle's ~/.claude/teams read,
+	// so boot TEAM_STATE parity holds byte-for-byte under the pinned (empty) HOME.
+	runner := &NativeRunner{TeamStateProbe: claudeteam.Probe}
 	code, err := runner.Run(context.Background(), Request{
 		Args:   args,
 		Dir:    dir,

--- a/internal/status/native_runner.go
+++ b/internal/status/native_runner.go
@@ -9,11 +9,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 )
 
 // NativeRunner is the native-Go status runner. It satisfies the same Runner
 // interface as VendorRunner; callers select it without any contract change.
-type NativeRunner struct{}
+// TeamStateProbe is the host-supplied boot TEAM_STATE probe: the Claude front
+// door wires claudeteam.Probe; a non-Claude host leaves it nil (host-neutral
+// present:false). It is the only host-coupled input the runner takes.
+type NativeRunner struct {
+	TeamStateProbe claudeteam.TeamStateProbe
+}
 
 var _ Runner = (*NativeRunner)(nil)
 
@@ -23,7 +30,7 @@ var _ Runner = (*NativeRunner)(nil)
 // runner can always run; failures are reported as exit code 1.
 func (r *NativeRunner) Run(ctx context.Context, req Request) (int, error) {
 	e := envFromSlice(req.Env)
-	code := dispatch(req.Args, req.Dir, e, req.Stdin, req.Stdout, req.Stderr)
+	code := dispatch(r.TeamStateProbe, req.Args, req.Dir, e, req.Stdin, req.Stdout, req.Stderr)
 	return code, nil
 }
 
@@ -34,8 +41,10 @@ func errExit(stderr io.Writer, msg string) int {
 	return 1
 }
 
-// dispatch is the argv-driven entry point mirroring the oracle's main().
-func dispatch(args []string, dir string, e env, stdin io.Reader, stdout, stderr io.Writer) int {
+// dispatch is the argv-driven entry point mirroring the oracle's main(). probe is
+// the host-supplied boot TEAM_STATE probe, threaded to runRead (nil on a
+// non-Claude host).
+func dispatch(probe claudeteam.TeamStateProbe, args []string, dir string, e env, stdin io.Reader, stdout, stderr io.Writer) int {
 	// --discover (incompatible with all other flags).
 	if contains(args, "--discover") {
 		return runDiscover(args, dir, stderr, stdout)
@@ -335,7 +344,7 @@ func dispatch(args []string, dir string, e env, stdin io.Reader, stdout, stderr 
 	}
 
 	// Read paths (table / next / boot / validate).
-	return runRead(roots, args, e, whereFilters, includeArchive, showNext, showBoot, showNextID, showValidate, explicitFields, allFieldsFlag, asJSON, quiet, archiveSlug != "", setResult != nil, resolveRef != "", stdout, stderr)
+	return runRead(probe, roots, args, e, whereFilters, includeArchive, showNext, showBoot, showNextID, showValidate, explicitFields, allFieldsFlag, asJSON, quiet, archiveSlug != "", setResult != nil, resolveRef != "", stdout, stderr)
 }
 
 // failOnValidationErrors prints validation errors to stderr and returns 1 when

--- a/internal/status/zz_independent_parity_test.go
+++ b/internal/status/zz_independent_parity_test.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 )
 
 // This file is an INDEPENDENT validator authored at the validation stage. It
@@ -58,7 +60,9 @@ func indRunNative(t *testing.T, dir string, env []string, stdin string, args ...
 	if stdin != "" {
 		in = strings.NewReader(stdin)
 	}
-	r := &NativeRunner{}
+	// Production wires the Claude team-state probe (the native binary is the Claude
+	// runtime's companion); reproduce it so boot TEAM_STATE matches the oracle.
+	r := &NativeRunner{TeamStateProbe: claudeteam.Probe}
 	code, err := r.Run(context.Background(), Request{
 		Args: args, Dir: dir, Env: env,
 		Stdin:  in,

--- a/skills/integration/dispatch_test.go
+++ b/skills/integration/dispatch_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 	"github.com/spacedock-dev/spacedock/internal/dispatch"
 )
 
@@ -40,7 +41,7 @@ func runBuild(t *testing.T, root, workflowDir string, input map[string]any) buil
 	// in team mode (team_name supplied), but pin it for hermeticity.
 	t.Setenv("HOME", t.TempDir())
 	var stdout, stderr bytes.Buffer
-	if exit := dispatch.Run([]string{"build", "--workflow-dir", workflowDir}, strings.NewReader(string(raw)), &stdout, &stderr); exit != 0 {
+	if exit := dispatch.Run(claudeteam.Probe, []string{"build", "--workflow-dir", workflowDir}, strings.NewReader(string(raw)), &stdout, &stderr); exit != 0 {
 		t.Fatalf("dispatch build exited %d\nstdout: %s\nstderr: %s", exit, stdout.String(), stderr.String())
 	}
 	var res buildResult


### PR DESCRIPTION
Quarantine every `~/.claude` team-state read behind a host-supplied probe so the generic dispatch/status core is host-neutral — the prerequisite seam for native runtime segregation (zs).

## What changed
- Add an `internal/claudeteam` package that owns the `~/.claude/teams` reads behind a `TeamStateProbe` func seam.
- Relocate `probeTeamState`, `recentTeamEvidence`, and the bare-mode WARN literal out of `internal/status` + `internal/dispatch`.
- Thread the probe through `gatherBoot`/`runBuild` and wire it at the single `cli.Run` construction site (codex/init/doctor pass nil → host-neutral).
- Add a `go/parser` invariant test asserting the generic packages carry no `~/.claude`/`os.UserHomeDir` team reads.

## Evidence
- `go test ./...`: 559/560 passed (sole failure the pre-existing env-gated codex-host resolver test).
- Validated twice + an independent adversarial detached-checkout audit (CLEAN): `status --boot --json` byte-identical baseline-vs-branch with full key order preserved; the live non-nil probe re-confirmed through the merged cli.go.

## Review guidance
The host-neutrality invariant is enforced by `TestNoClaudeHomeReadsInGenericPackages`; the relocated read lives only in `internal/claudeteam`.

---
[0mx](https://github.com/spacedock-dev/spacedock/blob/13c5ed75567e05a651c726bf1d01c03406337bab/host-neutrality-seam/index.md)
