### PR TITLE
ci(live-e2e): drop the run-live-e2e label gate — rely on the environment-approval gate

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -12,11 +12,10 @@
 # `environment:` (a required-reviewer approval gate, reviewer = clkao) and reads
 # ANTHROPIC_API_KEY. The live job is a matrix over two variants — sonnet (the
 # Python-land floor) on CI-E2E and claude-opus-4-8 on CI-E2E-OPUS — each its own
-# separately-approved deployment. The live job is additionally label-gated: it
-# runs only on a manual dispatch or a PR carrying the `run-live-e2e` label. So a
-# live PR run needs same-repo-or-no-secrets + the label + the per-variant
-# environment approval; each variant pauses in `waiting` until a maintainer
-# approves its environment, so the API-spending dispatch cannot start unapproved.
+# separately-approved deployment. So a live PR run needs same-repo-or-no-secrets
+# + the per-variant environment approval; each variant pauses in `waiting` until
+# a maintainer approves its environment, so the API-spending dispatch cannot
+# start unapproved.
 
 name: Runtime Live E2E
 
@@ -36,7 +35,7 @@ on:
   # pull_request (NOT pull_request_target): runs the PR-head/next version of this
   # workflow, and withholds repo secrets from FORK PRs — a fork's malicious code
   # cannot exfiltrate ANTHROPIC_API_KEY because the secret is simply absent.
-  # Same-repo PRs get the secret; the live job stays label- + environment-gated.
+  # Same-repo PRs get the secret; the live job stays per-variant environment-gated.
   pull_request:
     branches: [next]
 
@@ -69,12 +68,12 @@ jobs:
   # fail-fast is off so one model's red does not cancel the other's run.
   claude-live:
     needs: offline
-    # Live, secret-bearing job runs only on an explicit opt-in: a manual
-    # workflow_dispatch, or a PR carrying the `run-live-e2e` label. The offline
-    # gate above runs unconditionally per-PR (no secrets); this job adds the
-    # label gate ON TOP OF the per-variant environment approval, so a live PR run
-    # needs same-repo-or-no-secrets + the label + the CI-E2E* deployment approval.
-    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-live-e2e') }}
+    # Live, secret-bearing job. Every PR to `next` (and every manual
+    # workflow_dispatch) queues the live matrix; the offline gate above runs
+    # unconditionally per-PR (no secrets). Each variant then pauses in `waiting`
+    # on its CI-E2E* / CI-E2E-OPUS environment until a maintainer approves THAT
+    # deployment, so a live PR run needs same-repo-or-no-secrets + the
+    # per-variant environment approval.
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Stop the per-PR manual labeling: every PR to `next` now queues the live-runtime e2e into its environment-approval gate, instead of silently skipping unless someone remembers the `run-live-e2e` label.

## What changed
- Drop the `run-live-e2e` label clause from the `claude-live` job's `if` — every PR to `next` (and workflow_dispatch) queues the live matrix.
- Rely on the existing per-variant CI-E2E* / CI-E2E-OPUS required-reviewer environment gate for budget safety (no paid model runs pre-approval).
- Keep the secret-free `offline` job as the unconditional PR pass/fail gate; trigger stays `pull_request` (not `_target`); permissions read-only.
- Rewrite the stale label-gate prose in the workflow header/comments.

## Evidence
- yq-asserted: `claude-live` has no job-level `if`; the environment matrix (sonnet→CI-E2E, opus→CI-E2E-OPUS) is intact; `offline` is unconditional + secret-free; trigger is `pull_request` not `_target`.
- `git diff origin/next...HEAD` = one file (.github/workflows/runtime-live-e2e.yml), 11 insertions / 12 deletions; origin/main's copy untouched.

## Review guidance
`ANTHROPIC_API_KEY` stays confined to the gated `claude-live` job; budget safety now rests entirely on the environment-approval gate.

---
[q1](https://github.com/spacedock-dev/spacedock/blob/65a83cad63413dfc20da550c06e0cbcec995cf22/live-e2e-pr-trigger-ergonomics/index.md)
