### PR TITLE
refactor: architecture-review cleanups — share pyJoin, parity-tests-fail-not-skip, drop dead code

### DIFF
--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -1,5 +1,5 @@
 // ABOUTME: build assembles structured dispatch JSON from stdin + workflow README
-// ABOUTME: + entity file, matching the vendored claude-team build oracle (non-_mods).
+// ABOUTME: + entity file, matching the vendored claude-team build oracle.
 package dispatch
 
 import (
@@ -58,9 +58,9 @@ func buildError(stderr io.Writer, code int, format string, a ...any) int {
 
 // runBuild reads a dispatch request as JSON on stdin and assembles the dispatch
 // envelope on stdout plus the dispatch-file body written to a deterministic
-// path. Scoped to non-_mods workflows: it emits the single show-stage-def fetch
-// line and never the standing-teammate fetch line. Matches cmd_build minus the
-// _mods/standing branch (deferred to the sibling claude-runtime-segregation).
+// path. It always emits the show-stage-def fetch line and appends the
+// show-standing fetch line when the workflow declares at least one standing
+// teammate. Matches cmd_build.
 func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int {
 	raw, err := io.ReadAll(stdin)
 	if err != nil {

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -221,11 +221,11 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 	var worktreePath, gitRoot string
 	if entityWorktree != "" {
 		gitRoot = status.FindGitRoot(workflowDir)
-		// os.path.join (pyJoin) lets an absolute worktree value win, matching the
+		// os.path.join (status.PyJoin) lets an absolute worktree value win, matching the
 		// oracle (claude-team:329). filepath.Join would graft an absolute value
 		// under gitRoot and double the path, missing the existing worktree dir —
 		// the FO stamps absolute worktree: values on live entities.
-		worktreePath = pyJoin(gitRoot, entityWorktree)
+		worktreePath = status.PyJoin(gitRoot, entityWorktree)
 		if info, err := os.Stat(worktreePath); err != nil || !info.IsDir() {
 			return buildError(stderr, 1, "worktree path '%s' does not exist", worktreePath)
 		}
@@ -351,7 +351,7 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 	// checkout; a non-split worktree stage rewrites the path into the worktree.
 	if worktreePath != "" && !splitRoot {
 		entityRel := pyRelpath(entityPath, gitRoot)
-		worktreeEntityPath = pyJoin(worktreePath, entityRel)
+		worktreeEntityPath = status.PyJoin(worktreePath, entityRel)
 		parts = append(parts, fmt.Sprintf(
 			"Read the entity file at %s for the full spec. It contains:\n", worktreeEntityPath))
 	} else {

--- a/internal/dispatch/helpers.go
+++ b/internal/dispatch/helpers.go
@@ -140,24 +140,3 @@ func pyRelpath(path, base string) string {
 	}
 	return rel
 }
-
-// pyJoin concatenates path components the way os.path.join does: an absolute
-// later component resets the path; otherwise components join with the OS
-// separator without cleaning. Matches the status pyJoin.
-func pyJoin(parts ...string) string {
-	sep := string(filepath.Separator)
-	result := ""
-	for _, p := range parts {
-		switch {
-		case result == "":
-			result = p
-		case filepath.IsAbs(p):
-			result = p
-		case strings.HasSuffix(result, sep):
-			result += p
-		default:
-			result += sep + p
-		}
-	}
-	return result
-}

--- a/internal/status/boot.go
+++ b/internal/status/boot.go
@@ -55,9 +55,9 @@ func scanOrphans(entities []*entity, gitRoot string) []orphan {
 		}
 		// os.path.join(git_root, wt): an absolute wt discards git_root, so an
 		// absolute worktree path is probed as-is. filepath.Join would instead
-		// graft it under git_root and miss the existing dir. pyJoin matches the
+		// graft it under git_root and miss the existing dir. PyJoin matches the
 		// oracle's os.path.join absolute-component-reset semantics.
-		dirPath := pyJoin(gitRoot, wt)
+		dirPath := PyJoin(gitRoot, wt)
 		dirExists := "no"
 		if st, err := os.Stat(dirPath); err == nil && st.IsDir() {
 			dirExists = "yes"

--- a/internal/status/boot_orphan_abs_test.go
+++ b/internal/status/boot_orphan_abs_test.go
@@ -67,11 +67,9 @@ func TestBootAbsoluteWorktreeDirExists(t *testing.T) {
 		t.Fatalf("DIR_EXISTS for absolute existing worktree = %q, want \"yes\"\n%s", got, nativeOut)
 	}
 
-	// Oracle parity (skips when python3/oracle unavailable).
-	oracle := oraclePath()
-	if oracle == "" {
-		t.Skip("oracle not found; direct DIR_EXISTS assertion already proved the fix")
-	}
+	// Oracle parity. The oracle is resolved in-tree, so this comparison always
+	// runs (and hard-fails on a real divergence) on top of the direct DIR_EXISTS
+	// assertion above.
 	oracleOut, _, oracleCode := runOracle(t, root, env, args...)
 	if oracleCode != 0 {
 		t.Fatalf("oracle --boot exit=%d", oracleCode)

--- a/internal/status/discover.go
+++ b/internal/status/discover.go
@@ -164,14 +164,14 @@ func scanEntities(directory string, stderr io.Writer) []*entity {
 // worktreeMirrorPath computes the worktree-side path mirroring entityPath under
 // pipelineDir, preserving entity form: a flat {slug}.md maps to
 // {gitRoot}/{worktree}/{slug}.md and a {slug}/index.md maps to
-// {gitRoot}/{worktree}/{slug}/index.md. pyJoin matches os.path.join so an
+// {gitRoot}/{worktree}/{slug}/index.md. PyJoin matches os.path.join so an
 // absolute worktree value is honored as-is. Matches _worktree_mirror_path.
 func worktreeMirrorPath(entityPath, pipelineDir, gitRoot, worktree string) string {
 	rel, err := filepath.Rel(pipelineDir, entityPath)
 	if err != nil {
 		rel = filepath.Base(entityPath)
 	}
-	return pyJoin(gitRoot, worktree, rel)
+	return PyJoin(gitRoot, worktree, rel)
 }
 
 // loadActiveEntityFields loads an entity's frontmatter, overlaying the

--- a/internal/status/discover.go
+++ b/internal/status/discover.go
@@ -42,11 +42,6 @@ type entity struct {
 	displayID string
 }
 
-// get returns a frontmatter field value, "" when absent — matching dict.get.
-func (e *entity) get(key string) string {
-	return e.fields[key]
-}
-
 // discoverEntityFiles returns (slug, path) pairs for entities in directory,
 // sorted by slug. Flat {slug}.md and folder {slug}/index.md are both entities;
 // README.md, non-.md files, dotfiles, fence-less files, reserved dirs, and

--- a/internal/status/harness_test.go
+++ b/internal/status/harness_test.go
@@ -19,12 +19,9 @@ import (
 var update = flag.Bool("update", false, "regenerate golden files from the oracle")
 
 // oracleEnvVar names an env var that overrides the path to the live status
-// oracle script. When unset, the harness falls back to the plugin location.
+// oracle script. When unset, the harness falls back to the in-tree vendored
+// oracle, which is always present in a checkout.
 const oracleEnvVar = "SPACEDOCK_ORACLE"
-
-// defaultOraclePath is the plugin-shipped oracle the vendored copy was taken
-// from. Tests that compare against the live oracle skip when it is absent.
-const defaultOraclePath = "/Users/clkao/git/spacedock/skills/commission/bin/status"
 
 // pinnedEnv returns the locale/id/timestamp-pinned environment both the oracle
 // and the launcher must run under so env-dependent output is reproducible. The
@@ -44,18 +41,29 @@ func pinnedEnv(t *testing.T) []string {
 	}
 }
 
-// oraclePath returns the live oracle path, or "" if it cannot be found.
-func oraclePath() string {
+// oraclePath returns the oracle script the parity tests run against. A
+// SPACEDOCK_ORACLE override, when set, must point at an existing file — a
+// misconfigured override is a hard failure, not a skip. With no override the
+// in-tree vendored oracle is used; a missing vendored copy is a hard failure
+// too. The oracle is therefore always resolvable in a checkout, so the parity
+// assertions hard-fail on a real divergence instead of green-by-skip on CI or a
+// fresh clone (the test-integrity contract this enforces).
+func oraclePath(t *testing.T) string {
+	t.Helper()
 	if p := os.Getenv(oracleEnvVar); p != "" {
-		if _, err := os.Stat(p); err == nil {
-			return p
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("%s=%s does not exist: %v", oracleEnvVar, p, err)
 		}
-		return ""
+		return p
 	}
-	if _, err := os.Stat(defaultOraclePath); err == nil {
-		return defaultOraclePath
+	p, err := filepath.Abs(filepath.Join("vendor", "status"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	return ""
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("vendored oracle not found at %s: %v", p, err)
+	}
+	return p
 }
 
 // runLauncher runs the vendored-exec runner (the launcher path) with the given
@@ -77,15 +85,12 @@ func runLauncher(t *testing.T, dir string, env []string, args ...string) (string
 	return stdout.String(), stderr.String(), code
 }
 
-// runOracle runs the live oracle script directly under python3 with the given
-// args/dir/env and returns stdout, stderr, exit code. Skips the test when the
-// oracle cannot be located.
+// runOracle runs the oracle script directly under python3 with the given
+// args/dir/env and returns stdout, stderr, exit code. A missing oracle is a hard
+// failure (see oraclePath), never a skip.
 func runOracle(t *testing.T, dir string, env []string, args ...string) (string, string, int) {
 	t.Helper()
-	oracle := oraclePath()
-	if oracle == "" {
-		t.Skipf("oracle not found (set %s to the status script path)", oracleEnvVar)
-	}
+	oracle := oraclePath(t)
 	var stdout, stderr bytes.Buffer
 	cmd := exec.Command("python3", append([]string{oracle}, args...)...)
 	cmd.Dir = dir

--- a/internal/status/json_boot_test.go
+++ b/internal/status/json_boot_test.go
@@ -119,7 +119,7 @@ func TestBootJSONStructure(t *testing.T) {
 		t.Fatalf("next_id %q length=%d, want 24", boot.NextID, len(boot.NextID))
 	}
 	for _, c := range boot.NextID {
-		if !strings.ContainsRune(sdB32Alphabet, c) {
+		if !strings.ContainsRune(sdB32Chars, c) {
 			t.Fatalf("next_id %q has char %q outside SD-B32 alphabet", boot.NextID, c)
 		}
 	}

--- a/internal/status/mutate.go
+++ b/internal/status/mutate.go
@@ -209,14 +209,14 @@ func runArchive(entityDir, spellingDir, slug string, force, quiet, asJSON bool, 
 	var destPath, destSpelling string
 	if isFolder {
 		destPath = filepath.Join(archiveDir, slug)
-		destSpelling = pyJoin(spellingDir, "_archive", slug)
+		destSpelling = PyJoin(spellingDir, "_archive", slug)
 		if fileExists(destPath) {
 			fmt.Fprintf(stderr, "Error: already archived: %s/\n", slug)
 			return 1
 		}
 	} else {
 		destPath = filepath.Join(archiveDir, slug+".md")
-		destSpelling = pyJoin(spellingDir, "_archive", slug+".md")
+		destSpelling = PyJoin(spellingDir, "_archive", slug+".md")
 		if fileExists(destPath) {
 			fmt.Fprintf(stderr, "Error: already archived: %s.md\n", slug)
 			return 1
@@ -254,12 +254,12 @@ func runArchive(entityDir, spellingDir, slug string, force, quiet, asJSON bool, 
 	return 0
 }
 
-// pyJoin concatenates path components the way Python's os.path.join does: it
+// PyJoin concatenates path components the way Python's os.path.join does: it
 // joins with the OS separator without cleaning a leading "." (so
-// pyJoin(".", "_archive", "x.md") == "./_archive/x.md", unlike filepath.Join
+// PyJoin(".", "_archive", "x.md") == "./_archive/x.md", unlike filepath.Join
 // which would collapse it to "_archive/x.md"). An absolute later component
 // resets the accumulated path, matching os.path.join.
-func pyJoin(parts ...string) string {
+func PyJoin(parts ...string) string {
 	sep := string(filepath.Separator)
 	result := ""
 	for _, p := range parts {

--- a/internal/status/mutate.go
+++ b/internal/status/mutate.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -296,7 +297,7 @@ func scanMods(entityDir string) map[string][]string {
 		}
 	}
 	// glob returns sorted order.
-	sortStrings(files)
+	sort.Strings(files)
 	hooks := map[string][]string{}
 	for _, name := range files {
 		modName := strings.TrimSuffix(name, ".md")
@@ -314,7 +315,7 @@ func scanMods(entityDir string) map[string][]string {
 		}
 	}
 	for k := range hooks {
-		sortStrings(hooks[k])
+		sort.Strings(hooks[k])
 	}
 	return hooks
 }

--- a/internal/status/native_read_test.go
+++ b/internal/status/native_read_test.go
@@ -81,7 +81,7 @@ func TestNativeNextIDMatchesOracle(t *testing.T) {
 		t.Fatalf("candidate %q length=%d, want 24", candidate, len(candidate))
 	}
 	for _, c := range candidate {
-		if !strings.ContainsRune(sdB32Alphabet, c) {
+		if !strings.ContainsRune(sdB32Chars, c) {
 			t.Fatalf("candidate %q has char %q outside SD-B32 alphabet", candidate, c)
 		}
 	}

--- a/internal/status/native_runner.go
+++ b/internal/status/native_runner.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spacedock-dev/spacedock/internal/claudeteam"
@@ -492,7 +493,7 @@ func runDiscover(args []string, dir string, stderr, stdout io.Writer) int {
 		for k := range found {
 			names = append(names, k)
 		}
-		sortStrings(names)
+		sort.Strings(names)
 		return errExit(stderr, "--discover is incompatible with "+strings.Join(names, ", "))
 	}
 
@@ -507,7 +508,7 @@ func runDiscover(args []string, dir string, stderr, stdout io.Writer) int {
 		}
 	}
 	if rootPath == "" {
-		out, err := runGit(dir, "rev-parse", "--show-toplevel")
+		out, err := runGitCmd(dir, "rev-parse", "--show-toplevel")
 		if err == nil {
 			rootPath = strings.TrimSpace(out)
 		} else {
@@ -522,11 +523,6 @@ func runDiscover(args []string, dir string, stderr, stdout io.Writer) int {
 		fmt.Fprintln(stdout, p)
 	}
 	return 0
-}
-
-// runGit runs git in dir and returns stdout, or an error on non-zero exit.
-func runGit(dir string, args ...string) (string, error) {
-	return runGitCmd(dir, args...)
 }
 
 // resolveFromRootOrExit is the multi-workflow --root resolver. Matches

--- a/internal/status/native_usage_test.go
+++ b/internal/status/native_usage_test.go
@@ -4,7 +4,6 @@ package status
 
 import (
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -63,7 +62,6 @@ func TestNativeUsageErrorsExitOneNotTwo(t *testing.T) {
 			if nOut != "" || oOut != "" {
 				t.Fatalf("stdout must be empty on usage error: native=%q oracle=%q", nOut, oOut)
 			}
-			_ = strings.TrimSpace
 		})
 	}
 }

--- a/internal/status/native_validate_test.go
+++ b/internal/status/native_validate_test.go
@@ -5,7 +5,6 @@ package status
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -147,5 +146,4 @@ func TestNativeValidationGatesReads(t *testing.T) {
 	if normalize(nErr, nativeRoot) != normalize(oErr, oracleRoot) {
 		t.Fatalf("stderr: native=%q oracle=%q", normalize(nErr, nativeRoot), normalize(oErr, oracleRoot))
 	}
-	_ = strings.TrimSpace
 }

--- a/internal/status/nextid_boot_test.go
+++ b/internal/status/nextid_boot_test.go
@@ -8,9 +8,6 @@ import (
 	"testing"
 )
 
-// sdB32Alphabet is the SD-B32 alphabet the --next-id candidate is drawn from.
-const sdB32Alphabet = "0123456789abcdefghjkmnpqrstvwxyz"
-
 // AC-1: --next-id is in scope for pass-through but asserted at format + oracle-
 // equality level (not a static golden), since the candidate is SHA-derived. The
 // harness pins all id material (timestamp via env, seed/actor via flags) so the
@@ -34,7 +31,7 @@ func TestNextIDParity(t *testing.T) {
 		t.Fatalf("--next-id candidate %q length=%d, want 24", candidate, len(candidate))
 	}
 	for _, c := range candidate {
-		if !strings.ContainsRune(sdB32Alphabet, c) {
+		if !strings.ContainsRune(sdB32Chars, c) {
 			t.Fatalf("--next-id candidate %q has char %q outside SD-B32 alphabet", candidate, c)
 		}
 	}

--- a/internal/status/oracle_resolution_test.go
+++ b/internal/status/oracle_resolution_test.go
@@ -1,0 +1,29 @@
+// ABOUTME: Locks the test-integrity contract that the parity oracle resolves to
+// ABOUTME: the in-tree vendored copy, so a missing oracle FAILS rather than skips.
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOracleResolvesInTree pins the AC-2 contract: with no SPACEDOCK_ORACLE
+// override, oraclePath resolves the project-vendored oracle (internal/status/
+// vendor/status), which is always present in a checkout. This is what makes the
+// parity suite hard-fail on a real divergence instead of green-by-skip on CI or
+// a fresh clone, where a hardcoded laptop path would be absent.
+func TestOracleResolvesInTree(t *testing.T) {
+	t.Setenv(oracleEnvVar, "")
+	got := oraclePath(t)
+	want, err := filepath.Abs(filepath.Join("vendor", "status"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("oraclePath resolved %q, want the in-tree vendored oracle %q", got, want)
+	}
+	if _, err := os.Stat(got); err != nil {
+		t.Fatalf("resolved oracle %q does not exist: %v", got, err)
+	}
+}

--- a/internal/status/orderedmap.go
+++ b/internal/status/orderedmap.go
@@ -2,8 +2,6 @@
 // ABOUTME: map, matching Python dict iteration used by the field: old -> new narration.
 package status
 
-import "sort"
-
 // orderedMap is a string->string map that remembers insertion order. A key set
 // more than once keeps its first position (matching Python dict assignment).
 type orderedMap struct {
@@ -28,6 +26,3 @@ func (m *orderedMap) get(key string) (string, bool) {
 }
 
 func (m *orderedMap) keys() []string { return m.order }
-
-// sortStrings sorts in place (small helper to keep call sites terse).
-func sortStrings(s []string) { sort.Strings(s) }

--- a/internal/status/roots.go
+++ b/internal/status/roots.go
@@ -65,7 +65,7 @@ func resolveRoots(workflowDir, baseDir string) (roots, error) {
 	}
 
 	r.entityDir = filepath.Join(abs, cleaned)
-	r.entityDirSpelling = pyJoin(spellingOr(workflowDir, abs), stateValue)
+	r.entityDirSpelling = PyJoin(spellingOr(workflowDir, abs), stateValue)
 	return r, nil
 }
 

--- a/internal/status/roots.go
+++ b/internal/status/roots.go
@@ -23,11 +23,10 @@ type roots struct {
 	definitionDir string
 	// entityDir is the absolute entity root for I/O.
 	entityDir string
-	// definitionDirSpelling / entityDirSpelling are the as-passed spellings used
-	// in output so a relative --workflow-dir renders relative dests, matching the
-	// oracle's literal os.path.join(pipeline_dir, ...) output.
-	definitionDirSpelling string
-	entityDirSpelling     string
+	// entityDirSpelling is the as-passed spelling used in output so a relative
+	// --workflow-dir renders relative dests, matching the oracle's literal
+	// os.path.join(pipeline_dir, ...) output.
+	entityDirSpelling string
 }
 
 // resolveRoots returns the definition and entity roots for a workflow dir,
@@ -46,10 +45,9 @@ func resolveRoots(workflowDir, baseDir string) (roots, error) {
 	}
 
 	r := roots{
-		definitionDir:         abs,
-		entityDir:             abs,
-		definitionDirSpelling: workflowDir,
-		entityDirSpelling:     workflowDir,
+		definitionDir:     abs,
+		entityDir:         abs,
+		entityDirSpelling: workflowDir,
 	}
 
 	stateValue := strings.TrimSpace(ParseFrontmatter(filepath.Join(abs, "README.md"))["state"])

--- a/internal/status/validate.go
+++ b/internal/status/validate.go
@@ -89,8 +89,8 @@ func findEntityFormConflicts(directory, dirSpelling, scope string) []string {
 	}
 	var errs []string
 	for _, slug := range conflicts {
-		folderPath := pyJoin(dirSpelling, slug, "index.md")
-		flatPath := pyJoin(dirSpelling, slug+".md")
+		folderPath := PyJoin(dirSpelling, slug, "index.md")
+		flatPath := PyJoin(dirSpelling, slug+".md")
 		errs = append(errs, fmt.Sprintf(
 			"Error: flat/folder conflict: workflow=%s scope=%s slug=%s flat_path=%s folder_path=%s",
 			workflowField, scope, slug, flatPath, folderPath))
@@ -141,7 +141,7 @@ func validateWorkflowStageNames(definitionDir string) []string {
 func validateWorkflow(definitionDir, entityDir, idStyle string, stderr io.Writer) []string {
 	var errs []string
 	errs = append(errs, findEntityFormConflicts(entityDir, entityDir, "active")...)
-	errs = append(errs, findEntityFormConflicts(filepath.Join(entityDir, "_archive"), pyJoin(entityDir, "_archive"), "archived")...)
+	errs = append(errs, findEntityFormConflicts(filepath.Join(entityDir, "_archive"), PyJoin(entityDir, "_archive"), "archived")...)
 	errs = append(errs, validateWorkflowStageNames(definitionDir)...)
 
 	entities := activeAndArchivedEntities(entityDir, stderr)

--- a/internal/status/zz_independent_parity_test.go
+++ b/internal/status/zz_independent_parity_test.go
@@ -22,21 +22,27 @@ import (
 // the live oracle, and diffs the four observable channels after the documented
 // normalization. Failure here means a real parity gap, not a stale golden.
 
-const indOracle = "/Users/clkao/git/spacedock/skills/commission/bin/status"
-
+// indOraclePath resolves the oracle for the independent parity harness with the
+// same test-integrity contract as oraclePath: a SPACEDOCK_ORACLE override must
+// point at an existing file, and with no override the in-tree vendored oracle is
+// used. A missing oracle is a hard failure, never a skip — so the oracle-backed
+// TestInd* subtests cannot pass-by-skip on CI or a fresh clone.
 func indOraclePath(t *testing.T) string {
 	t.Helper()
 	if p := os.Getenv("SPACEDOCK_ORACLE"); p != "" {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("SPACEDOCK_ORACLE=%s does not exist: %v", p, err)
+		}
 		return p
 	}
-	if _, err := os.Stat(indOracle); err == nil {
-		return indOracle
+	p, err := filepath.Abs(filepath.Join("vendor", "status"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	// Oracle-dependent subtests skip when the oracle is absent (matching the
-	// in-tree harness). The --new / guard subtests do not touch the oracle and
-	// run unconditionally.
-	t.Skipf("oracle not found at %s (set SPACEDOCK_ORACLE)", indOracle)
-	return ""
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("vendored oracle not found at %s: %v", p, err)
+	}
+	return p
 }
 
 func indEnv(t *testing.T) []string {


### PR DESCRIPTION
Behavior-preserving cleanup from the architecture review: share the duplicated `pyJoin`, make the status parity tests fail (not skip) when the oracle is absent, and remove verified dead code.

## What changed
- Share `pyJoin` across the `internal/status` <-> `internal/dispatch` seam (one definition, was byte-duplicated).
- Make status parity tests FAIL, not silently skip, when the Python oracle is absent — so a missing oracle can't mask a divergence.
- Remove the verified dead code / test-hygiene items.
- Refresh two stale `build.go` comments that described the `_mods`/standing branch as "deferred" (it landed in #246).

## Evidence
- `go test ./...`: 587/588 passed (sole failure the pre-existing env-gated codex-host test); `-race` clean per-package; gofmt/vet clean.
- AC-2 verified both directions: oracle-present -> 0 skips/all pass; oracle-missing -> 94 fails/0 skips/exit 1.

---
[0x](https://github.com/spacedock-dev/spacedock/blob/c3e8c2d304642c09408ad222699eb24c71fb5c40/architecture-review-cleanups/index.md)
