### PR TITLE
docs(contract): ship the team's working principles + FO posture + test-first rule in the shipped instructions

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -77,14 +77,17 @@ A task moves to ideation when a pilot starts fleshing out the idea: clarify the 
   - Acceptance criteria must include how each criterion will be tested.
   - Acceptance criteria are **entity-level** - they describe properties of the finished task, not stage actions. Items that describe stage work belong in the stage report's checklist.
   - If an AC item reads as an imperative verb phrase, rewrite it as the end-state property it produces.
+  - Every task must produce a real, checkable change — code, a fixture, on-disk state, or instruction text whose effect a separate check can confirm — not just a document about itself. Each AC's "Verified by" must name something outside the task body that can fail: a test, a command's output or exit code, a file the change produces, or the resulting on-disk state. An AC whose only proof is reviewing the task's own prose ("verified by reviewing this task's decision section") can never fail, so it is not an acceptance criterion. If the task's only output is a decision with nothing shipped, it does not belong in this queue — record the decision in the roadmap instead. Cleanup and overhaul do qualify: the change is the new code plus passing tests.
+  - When the design's soundness rests on an unverified mechanism — a parser round-trip, a runtime handoff, an on-disk format, a tool actually supporting a flag — try the riskiest unknown first: run the smallest end-to-end exercise of that path before committing to the rest of the plan, and record the result in the task body. Ask "what would invalidate the rest of this work if it broke?" — that goes first; pay the small bill first. The exercise is throwaway, but what it teaches seeds the implementation's first test. If nothing is unverified — the design only composes already-proven behavior — record "no spike needed: {the proven mechanisms it relies on}" so the determination is on the record rather than silent.
   - Test plans should state what verifies the implementation, estimated cost/complexity, and whether fixture, CLI, or live workflow tests are needed.
   - Plans should describe intended behavior at the level a future worker or validator needs to reason about it. Prefer observable behavior over implementation internals unless the task is specifically about that internal representation.
-  - Choose proof at the same abstraction level as the claim: Go unit tests for parser and command behavior, golden fixtures for status output, static skill tests for instruction text, and live workflow smoke tests only when runtime behavior is the claim.
+  - Choose proof at the same abstraction level as the claim, and prefer proof that exercises the behavior and observes the outcome — output bytes, exit code, resulting on-disk state, or a test feeding many inputs and asserting uniform handling: Go unit tests for parser and command behavior, golden fixtures for status output, behavior fixtures that drive the binary for command-level claims, and live workflow smoke tests only when runtime behavior is the claim. A substring search is not proof of behavior. Searching code asserts spelling (it false-passes on a renamed-but-equivalent branch and false-fails on a rename); searching instruction prose is weaker still — the document is not the behavior, so "the contract says to run the command" never proves the agent runs it. A static check is legitimate when it parses real artifacts and tests a relationship between real values (for example, that the plugin manifest's contract range brackets the binary's contract version), or when the claim itself is about the text — a presence check over instruction files proving they carry a required clause or stay free of a banned token is proof at the claim's own level. The line is: invariant over real values, or a property of the text when the text is the claim, is legitimate; a substring search standing in for a behavioral claim is not.
+  - Prefer acceptance criteria a code gate can enforce — a guard in the binary, a test that fails on violation — over criteria the agent is merely instructed to follow. Where a behavior can be guarded by the binary or a failing test, the proof is that gate, not a sentence in a skill file. An AC whose only proof is "the instruction text says to do X" has a ceiling of wording-is-present and cannot stand on its own.
   - When captain feedback changes the target behavior, update the task body, acceptance criteria, and test plan together before re-validating.
   - For template or skill text changes: specific before/after wording, not just "change X".
 - **Good:** Clearly scoped, behavior-first, actionable, addresses a real need, considers edge cases, avoids unnecessary runtime-internal modeling, and uses tests that prove the intended behavior directly
 - **Bad:** Vague hand-waving, scope creep, solving problems that do not exist yet, no clear definition of done, acceptance criteria without a test plan, static prose tests for behavioral requirements, or tests that pass while missing the intended behavior
-- **Staff review:** When the FO assesses ideation as complex, such as native status parity, split-root behavior, or skill integration, it should request an independent review before presenting the ideation gate. The review checks design soundness, test plan sufficiency, and gaps.
+- **Staff review:** When the FO assesses ideation as complex, such as native status parity, split-root behavior, or skill integration, it should request an independent review before presenting the ideation gate. The review checks design soundness, test plan sufficiency, gaps, and that the riskiest unverified mechanism was exercised first (or that the task records an auditable "no spike needed" with the proven mechanisms it relies on). A design whose soundness rests on an unexercised, unverified mechanism is not ready for the gate.
 
 ### `implementation`
 
@@ -108,7 +111,7 @@ A task moves to validation after implementation is complete. The work here is to
   - Reject when tests pass but prove an obsolete, over-specified, or wrong target behavior.
   - A PASSED/REJECTED recommendation.
 - **Good:** Thorough testing against acceptance criteria, clear evidence of pass/fail, honest assessment, and validation that tests prove the current intended behavior
-- **Bad:** Rubber-stamping without testing, ignoring failing edge cases, validating against wrong criteria, or accepting passing tests that encode stale prose, obsolete assumptions, or the wrong abstraction level
+- **Bad:** Rubber-stamping without testing, ignoring failing edge cases, validating against wrong criteria, accepting passing tests that encode stale prose, obsolete assumptions, or the wrong abstraction level, or accepting a substring search (over code or over instruction prose) as proof of a behavioral claim — proof of behavior must run the behavior; a static test passes only as an invariant over real parsed values, not as a spelling check
 - **Spot-check principle:** Before committing to an expensive live workflow or compatibility run, do a cheap fixture or single-command spot-check to verify the infrastructure works end-to-end.
 
 ### `done`
@@ -118,7 +121,7 @@ A task reaches done when validation is complete and the captain approves the res
 - **Inputs:** The validation report with PASSED/REJECTED recommendation
 - **Outputs:** Final verdict set in frontmatter, completed timestamp recorded
 - **Good:** Clear resolution and lessons learned captured if relevant
-- **Bad:** Closing without reading the validation report or overriding a REJECTED recommendation without reason
+- **Bad:** Closing without reading the validation report, overriding a REJECTED recommendation without reason, or reaching done with PASSED on a task whose deliverable is prose with nothing outside it that can fail (a design that concludes "do not build X" ships as a roadmap decision, not a PASSED dev-queue task)
 
 ## Workflow State
 
@@ -132,6 +135,12 @@ The target launcher command is:
 
 ```bash
 spacedock status --workflow-dir docs/dev
+```
+
+To list the tasks ready for dispatch (the query the first officer runs each loop):
+
+```bash
+spacedock status --workflow-dir docs/dev --next
 ```
 
 ## Task Template
@@ -152,12 +161,28 @@ issue:
 
 Brief description of this task and what it aims to achieve.
 
+## Problem
+
+{What is broken or missing, and why it matters. Ideation fills this in.}
+
+## Proposed approach
+
+{How the task intends to solve the problem. Ideation fills this in.}
+
+## Out of scope
+
+{What this task deliberately does not cover, so the boundary is explicit.}
+
 ## Acceptance criteria
 
 Each AC names a property of the finished entity, not a stage action, and how it is verified.
 
 **AC-1 - {End-state property.}**
-Verified by: {grep / test name / file path / command a future reader can reproduce.}
+Verified by: {test name / command output or exit code / file the change produces / resulting on-disk state — something outside this task body that a future reader can reproduce and that can fail.}
+
+## Test plan
+
+{What verifies the implementation, estimated cost/complexity, and whether fixture, CLI, or live workflow tests are needed.}
 ```
 
 ## Testing Resources

--- a/skills/ensign/references/ensign-shared-core.md
+++ b/skills/ensign/references/ensign-shared-core.md
@@ -19,6 +19,15 @@ Read the assignment context provided by the first officer. It defines:
 4. Update the entity file body, not the frontmatter.
 5. Commit your work before signaling completion.
 
+## Working Practices
+
+These habits travel with the contract, so the same discipline holds no matter who runs it or on what machine.
+
+- **Write the failing test first.** For every new feature or bugfix, write a test that captures the desired behavior, run it and watch it fail for the right reason, then write only enough code to make it pass, then run it again and watch it pass. Refactor with the test green. Authoring order is your standing practice; the test you produce is what the gate later judges.
+- **Every task produces a real, checkable change.** Your deliverable is code, a fixture, on-disk state, or instruction text whose effect a separate check can confirm — not a document about itself. If you find your only output is prose with nothing outside it that can fail, stop and raise it with the first officer; it likely belongs in the roadmap, not this queue.
+- **Prove by exercising, not by re-reading.** Confirm a claim by running the behavior and observing the outcome — output, exit code, resulting on-disk state — not by re-reading your own notes or asserting that a file contains a phrase. A substring search over code or prose is not proof of behavior.
+- **No hidden machine dependencies.** Do not rely on tools, paths, environment variables, or files that happen to exist only on your machine. Anything your work needs to run or be verified must be declared and present in the repo or the task, so a teammate on a fresh setup — or a clean-room install with no personal configuration — gets the same result. If a step needs something machine-specific, surface it rather than depending on it silently.
+
 ## Worktree Ownership
 
 - For worktree-backed entities, active stage/status/report/body state belongs in the worktree copy.

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -342,8 +342,21 @@ If one entity is blocked on clarification, keep dispatching other ready entities
 
 Report workflow state once when you reach idle or a gate. Do not spam status updates while waiting.
 
+## Working Principles
+
+These habits govern how the first officer frames work and adjudicates gates, independent of any one workflow.
+
+**Prefer a code gate over a prose-only rule.** When a guarantee can be enforced by the binary or a failing test (a `status` guard, a test that fails on violation), prefer that over a guarantee the agent is only instructed to follow. A prose-only rule — a line in a skill or reference the agent is told to obey — has a ceiling of "the wording is present." Wording-present is not behavior, so a prose-only rule must not count as acceptance-criteria satisfaction on its own: if the guarantee matters, the real assurance is a code-level gate underneath, and the prose points at that gate. An acceptance criterion of the form "the contract says X" is satisfied only by "the binary or a test enforces X, and here is the run that proves it." This is why the gate's acceptance-criteria cross-check refuses a criterion whose only proof is review of the entity's own prose — such a criterion can never fail.
+
+**FO posture.** Carry this stance into every dispatch and gate:
+
+- **Name the end value before starting.** State the outcome the work is for — the change in the world the captain gets — before getting into mechanism. A task framed by its end value is one the captain can judge; a task framed by its steps is one they have to reverse-engineer.
+- **Lead with a recommendation the captain can say yes to.** When presenting a choice or a gate, open with one clear recommended direction the captain can approve in a single "yes," then supply the supporting detail underneath. Do not bury the recommendation under a menu of equally-weighted options.
+- **Do obvious reversible work without ceremony.** When the next step is obvious and reversible — a dispatch the contract already allows, a status read, a routine state transition — just do it. Reserve asking for the choices that are hard to reverse or where the decision genuinely matters. Ceremony around reversible work is friction, not diligence.
+
 ## Probe and Ideation Discipline
 
+- when a dispatched-ideation design rests on an unverified mechanism (a format round-trip, a runtime handoff, a tool actually supporting a flag), the riskiest path is exercised end-to-end first — the smallest run that would invalidate the rest of the work if it broke. The evidence from that run goes in the entity body; "no spike needed" is recorded with the proven mechanisms relied on. See the `running-research-spikes` skill. This is the integration-level analog of the acceptance-criteria rule: arrive at the gate with the riskiest claim demonstrated, not asserted.
 - when checking whether tool X supports Y, read X's schema directly via ToolSearch before greping for existing callers — usage presence is not existence evidence.
 - prefer Grep over Read for targeted entity-body inspection. Anchor a Grep to the heading or field name (a `## Stage Report`, a `### Feedback Cycles` entry, a specific frontmatter field) instead of reading the whole file. Read only when you need the full text; avoid full-file Read as a probe.
 - on Claude Code: a `Read` followed by a Bash-driven mutation of the same file (including `status --set`) triggers the file-staleness safety net, which echoes the entire current file back on the next turn as cache-write tokens. Grep does not participate in this tracking. Use Grep for targeted reads and trust `status --set` stdout for mutation narration.

--- a/skills/integration/working_principles_test.go
+++ b/skills/integration/working_principles_test.go
@@ -1,0 +1,118 @@
+// ABOUTME: AC-1 text-presence audit — the team's proven working habits ship in
+// ABOUTME: the three instruction files in plain language with zero insider jargon.
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// shippedInstructionFiles is the trio of instruction surfaces this task encodes
+// the working principles into: the workflow guide a captain reads, the FO
+// operating contract, and the worker (ensign) contract. The map value is a
+// human label used in failure messages.
+func shippedInstructionFiles(t *testing.T) map[string]string {
+	t.Helper()
+	root := skillsRoot(t)
+	repo := repoRoot(t)
+	paths := map[string]string{
+		"workflow guide (docs/dev/README.md)":        filepath.Join(repo, "docs", "dev", "README.md"),
+		"FO contract (first-officer-shared-core.md)": filepath.Join(root, "first-officer", "references", "first-officer-shared-core.md"),
+		"ensign contract (ensign-shared-core.md)":    filepath.Join(root, "ensign", "references", "ensign-shared-core.md"),
+	}
+	out := make(map[string]string, len(paths))
+	for label, p := range paths {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read shipped instruction file %s (%s): %v", label, p, err)
+		}
+		out[label] = string(b)
+	}
+	return out
+}
+
+// TestShippedInstructionsCarryNoInsiderJargon locks the plain-language guarantee
+// of AC-1: the three shipped instruction files contain zero insider-jargon
+// tokens. "oracle" is the named token — the design proposal that seeded this work
+// uses it pervasively for "external check," and that jargon must not leak into the
+// instructions a clean-room contributor reads. The check is case-insensitive so
+// "Oracle"/"ORACLE" cannot sneak through.
+func TestShippedInstructionsCarryNoInsiderJargon(t *testing.T) {
+	bannedJargon := []string{"oracle"}
+	for label, content := range shippedInstructionFiles(t) {
+		lower := strings.ToLower(content)
+		for _, token := range bannedJargon {
+			if strings.Contains(lower, token) {
+				t.Errorf("%s contains insider-jargon token %q — shipped instructions must be plain language", label, token)
+			}
+		}
+	}
+}
+
+// TestWorkflowGuideCarriesPrinciples locks the half of AC-1 that the workflow
+// guide owns: the four working principles appear in plain language in the
+// workflow-specific stage slots a captain and a worker read. These are durable
+// plain-language phrases the README prose commits to — not the proposal's jargon.
+func TestWorkflowGuideCarriesPrinciples(t *testing.T) {
+	readme := shippedInstructionFiles(t)["workflow guide (docs/dev/README.md)"]
+	markers := map[string]string{
+		"no doc-only deliverable (real checkable change)": "a real, checkable change",
+		"prove by exercising, not by re-reading":          "exercises the behavior and observes the outcome",
+		"spike the riskiest unknown first":                "riskiest",
+		"code gate preferred over prose-only rule":        "a code gate can enforce",
+	}
+	for principle, marker := range markers {
+		if !strings.Contains(readme, marker) {
+			t.Errorf("workflow guide missing the %q principle (expected plain-language marker %q)", principle, marker)
+		}
+	}
+}
+
+// TestFOContractCarriesWorkingPrinciplesAndPosture locks the FO-contract half of
+// AC-1: a `## Working Principles` section names the cross-workflow gate discipline
+// and the FO posture (name the end value, lead with a yes-able recommendation, do
+// obvious reversible work without ceremony). These live in sections disjoint from
+// the zs contract reorg.
+func TestFOContractCarriesWorkingPrinciplesAndPosture(t *testing.T) {
+	fo := shippedInstructionFiles(t)["FO contract (first-officer-shared-core.md)"]
+	if !strings.Contains(fo, "## Working Principles") {
+		t.Errorf("FO contract missing the `## Working Principles` section")
+	}
+	postureMarkers := map[string]string{
+		"name the end value before starting":          "Name the end value",
+		"lead with a yes-able recommendation":         "a recommendation the captain can say yes to",
+		"do obvious reversible work without ceremony": "reversible work without ceremony",
+	}
+	for posture, marker := range postureMarkers {
+		if !strings.Contains(fo, marker) {
+			t.Errorf("FO contract missing the %q posture (expected marker %q)", posture, marker)
+		}
+	}
+	// The spike-first discipline rides the FO's existing ideation-probe section.
+	if !strings.Contains(fo, "riskiest") {
+		t.Errorf("FO contract missing the spike-first (riskiest unverified path) discipline")
+	}
+}
+
+// TestEnsignContractCarriesTestFirstRule locks the ensign-contract half of AC-1:
+// the worker contract carries the write-the-failing-test-first rule in plain
+// language. Per the companion design study, the authoring-order rule belongs in
+// the worker's standing practice (the ensign contract), not in the gate-facing
+// workflow template.
+func TestEnsignContractCarriesTestFirstRule(t *testing.T) {
+	ensign := shippedInstructionFiles(t)["ensign contract (ensign-shared-core.md)"]
+	for _, marker := range []string{
+		"failing test",
+		"watch it fail",
+	} {
+		if !strings.Contains(ensign, marker) {
+			t.Errorf("ensign contract missing the write-the-failing-test-first rule (expected marker %q)", marker)
+		}
+	}
+	// The "no hidden machine dependencies" principle is worker-facing discipline.
+	if !strings.Contains(ensign, "hidden") {
+		t.Errorf("ensign contract missing the no-hidden-machine-dependencies principle")
+	}
+}


### PR DESCRIPTION
Ship the team's proven working habits in the tool's own shipped instructions, so a clean-room install follows the same discipline with no personal configuration.

## What changed
- Encode the working principles into the three shipped instruction files (workflow README, FO contract, ensign contract), in plain language: every task produces a real checkable change; prove by exercising; try the riskiest unknown first; no hidden machine dependencies.
- Add the FO posture (name the end value, lead with a yes-able recommendation, do obvious reversible work without ceremony) and the write-the-failing-test-first rule.
- Add the content additively in disjoint sections (zero churn to zs #246's just-merged contract reorg).

## Evidence
- A text-presence test (`working_principles_test.go`, 4/4) confirms the principles/posture/test-first are present and that the shipped files contain zero insider-jargon.
- Additive-only: no project-specific content lost (split-root model, testing table, native command surface, examples all retained).

---
[se](https://github.com/spacedock-dev/spacedock/blob/79088def2f0cea0d9ecebe60973d981c5d982bd8/ship-working-principles-in-contract/index.md)
