### PR TITLE
ci(cask): clear the macOS Gatekeeper quarantine on cask install (interim, pre-notarization)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -79,6 +79,21 @@ homebrew_casks:
       See the safehouse install docs:
         https://agent-safehouse.dev
 
+      The spacedock binary is not yet notarized, so the cask download is tagged
+      with the com.apple.quarantine attribute and macOS Gatekeeper blocks the
+      first launch. This cask clears the attribute automatically on install. If
+      Gatekeeper still blocks spacedock, clear it manually before first launch:
+        xattr -dr com.apple.quarantine "$(brew --prefix)/bin/spacedock"
+    hooks:
+      # The binary is adhoc/linker-signed only (not notarized), so the cask
+      # download carries com.apple.quarantine and Gatekeeper kills the first
+      # launch. Strip the attribute from the staged binary so the user needs no
+      # manual step. Interim until a Developer ID notarized build lands.
+      post:
+        install: |
+          system_command "/usr/bin/xattr",
+                         args: ["-dr", "com.apple.quarantine", "#{staged_path}/spacedock"]
+
 snapshot:
   # Used by `goreleaser release --snapshot --clean` (the dry-run oracle). The
   # stamp the built binary reports comes from this template when there is no tag.


### PR DESCRIPTION
The released binary is adhoc/linker-signed only (not notarized), so the Homebrew cask download gets the `com.apple.quarantine` xattr and macOS Gatekeeper blocks the first launch.

This adds, to the `homebrew_casks` entry in `.goreleaser.yaml`:

- A **caveat** explaining the Gatekeeper block, plus a manual fallback:
  `xattr -dr com.apple.quarantine "$(brew --prefix)/bin/spacedock"`
- A **postflight hook** (`hooks.post.install`) that auto-runs the xattr removal on the staged binary, so users normally need no manual step. GoReleaser v2.16 cleanly supports this — it renders into the cask's `postflight do` block.

Validated: `yq '.' .goreleaser.yaml` parses, `goreleaser check` passes, and a `--snapshot` build emits a syntactically valid cask (`ruby -c` OK) with the `postflight` block + updated caveat.

Proper notarization (needs an Apple Developer ID cert) is tracked separately; this is the interim mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)