### PR TITLE
Mod files live with the workflow definition (docs/dev/_mods/), not the state checkout

### DIFF
--- a/docs/dev/_mods/pr-merge.md
+++ b/docs/dev/_mods/pr-merge.md
@@ -1,0 +1,102 @@
+---
+name: pr-merge
+description: Open a code-branch PR to next at the merge boundary and track it to merge, state-root-aware
+version: 0.12.1
+---
+
+# PR Merge
+
+Manages the PR lifecycle for workflow entities processed in worktree stages of this **split-root** workflow. The CODE for an entity lives on its worktree branch in the main repo (`origin`, base branch `next`); the entity STATE (frontmatter, `pr:`, `mod-block:`, stage reports) lives in the separate `.spacedock-state` checkout (`origin`, branch `spacedock-state/dev`). This hook opens a PR for the code branch at the terminal merge boundary — **before** cleanup deletes the branch — records `pr:` on the entity state, blocks until the PR merges, then lets the FO terminalize and archive.
+
+The two origins stay clean by construction: the code PR carries only the code-branch range (the worktree clone has no `.spacedock-state` paths), and the `pr:`/`mod-block:` writes are `spacedock status --set` against the state checkout, committed path-scoped there. **This hook MUST NOT touch `.spacedock-state` from the code worktree** — all state writes go through `spacedock status --set --workflow-dir docs/dev`, which targets the resolved state checkout.
+
+## Hook: startup
+
+Scan all entity files (in the workflow directory only, not `_archive/`) for entities with a non-empty `pr` field and a non-terminal status. For each, extract the PR number (strip any `#`, `owner/repo#` prefix) and check: `gh pr view {number} --json state --jq '.state'`.
+
+If `MERGED`, advance the entity to its terminal stage. Because a `mod-block` is set while the PR is pending, the clear and the terminalization are two separate `--set` calls (the mechanism refuses combining `mod-block=` with terminal fields):
+1. `spacedock status --workflow-dir docs/dev --set {slug} mod-block=` (commit: `mod-block: {slug} cleared (pr-merge completed)`),
+2. `spacedock status --workflow-dir docs/dev --set {slug} completed verdict=PASSED worktree=`, then `spacedock status --workflow-dir docs/dev --archive {slug}`.
+Both `--set`s and the archive are committed path-scoped to the state checkout. Remove the worktree (`git worktree remove {path}`) and delete the **local** branch (`git branch -d {branch}`) — the remote branch was already cleaned by the PR merge. Report each auto-advanced entity to the captain.
+
+If `CLOSED` (closed without merge), report to the captain: "{entity title} has PR {pr number} which was closed without merging. How to proceed? Options: reopen the PR, create a new PR from the same branch, or clear `pr` and fall back to the local `--no-ff` merge." Wait for the captain's direction before taking action.
+
+If `OPEN`, no action needed — the PR is still in review.
+
+If `gh` is not available, warn the captain and skip PR state checks.
+
+## Hook: idle
+
+Check PR-pending entities using the same logic as the startup hook: scan entity files for non-empty `pr` and non-terminal status, run `gh pr view` for each, and advance merged PRs (two-step `mod-block=` clear then terminalize, path-scoped). This provides a periodic re-check in case the event loop's built-in PR scan missed a state change (defense in depth). Report any advanced entities to the captain.
+
+## Hook: merge
+
+Runs at the terminal merge boundary, before any local merge or cleanup, for the entity's CODE worktree branch `{branch}` (the branch named in the entity's `worktree:` field, located at `{worktree}`).
+
+**PR APPROVAL GUARDRAIL — Do NOT push or create a PR without explicit captain approval.** Opening a PR and pushing the branch are outward-facing. Before presenting the draft, construct the full PR body so the captain reviews the actual prose that will land on GitHub.
+
+Compute the audit-link inputs first: state SHA via `git -C docs/dev/.spacedock-state rev-parse HEAD` (the full SHA of the **state** checkout's HEAD — the entity's `mod-block=merge:pr-merge` commit, which the FO committed before invoking this hook, so HEAD already contains the active entity file); owner/repo via `gh repo view --json nameWithOwner --jq '.nameWithOwner'`; short entity-id slot via `spacedock status --workflow-dir docs/dev --short-id {slug}` (shortest-unique-prefix for sd-b32 workflows, matching the status table's ID column).
+
+Build the full PR body using the template below — motivation lead, `## What changed`, `## Evidence`, `---` separator, `[{short-id}](...)` audit link, and `Closes {issue}` line if the entity frontmatter `issue` is set. This is the body that will be passed to `gh pr create` verbatim; do not reconstruct it after approval. The entity body and stage reports are read from the **state checkout** (`docs/dev/.spacedock-state/{slug}/index.md`), not the worktree.
+
+Then present the draft to the captain:
+
+- **Title:** {entity title}
+- **Branch:** {branch} -> next
+- **Changes:** {N} file(s) changed across {N} commit(s) (`git -C {worktree} diff --stat origin/next...{branch}`)
+- **Files:** {list of changed files}
+- **Body:**
+
+  ```
+  {constructed body}
+  ```
+
+Wait for the captain's explicit approval before pushing. Do NOT infer approval from silence, acknowledgment of the summary, or the gate approval that preceded this step — only an explicit "push it", "go ahead", "yes", or equivalent counts.
+
+**On approval:** This is a split-root workflow — the FO rebases the code branch onto `origin/next` BEFORE invoking this hook, and the entity state lives in the separate `.spacedock-state` checkout, so this hook does NOT rebase or push any state branch. Push only the code branch:
+
+1. `git -C {worktree} push -u origin {branch}` — push the entity's code branch to the code remote (`origin` = the main repo, base branch `next`). Do NOT push `next` or any `.spacedock-state` branch from here; the FO coordinates state-remote pushes separately.
+
+If the push fails (no remote, auth error), report to the captain and fall back to the local `--no-ff` merge (see fallback below).
+
+2. Create the PR: `gh pr create --base next --head {branch} --title "{entity title}" --body "{constructed body}"` against the body already constructed above — do not rebuild it. Capture the PR number `{N}`.
+
+3. Record it on the entity STATE: `spacedock status --workflow-dir docs/dev --set {slug} pr=#{N}`. This writes `pr:` into the state-checkout entity frontmatter; the FO commits it path-scoped to `.spacedock-state` (`git -C docs/dev/.spacedock-state add -- {slug}/index.md && git -C docs/dev/.spacedock-state commit -m "pr: {slug} #{N} pending" -- {slug}/index.md`) and pushes `spacedock-state/dev` so the PR-pending state survives session resume and is visible on a 2nd host.
+
+Setting `pr:` is the **blocking** signal (FO Merge-and-Cleanup step 3a). The FO set `mod-block=merge:pr-merge` before invoking this hook; with `pr:` now set the hook has blocked, so the FO leaves `mod-block` set, reports PR-pending to the captain, and does NOT local-merge or archive. The entity stays at its current stage with `pr` set until the PR merges. The FO advances to the terminal stage and archives when it detects the merge (via the event-loop PR check, the idle hook, or the startup hook) — see those hooks for the two-step `mod-block=` clear then terminalize.
+
+### PR body template
+
+Lead with motivation + end-user value; audit metadata goes at the bottom. The goal is that a reviewer or future debugger sees the "why" first and the audit link last.
+
+**Template structure (top to bottom):**
+
+| Section | Required | Content |
+|---|---|---|
+| Motivation lead | **yes** | 1 sentence, ≤ 25 words, blending motivation and end-user value. No parentheticals. |
+| `## What changed` | **yes** | Action-verb bullets, 3–5 total, each ≤ 15 words. One change per bullet. No rationale inside the bullet — if a change needs justification, it belongs in the task body, not the PR. |
+| `## Evidence` | **yes when validation ran** | Test suites with `N/N passed` format, 1–2 bullets. Do not include per-test-class breakdowns or enumerated suite lists — one pass ratio per suite, plus at most one line confirming live-probe verification. |
+| `## Review guidance` | optional | 1 line pointing reviewer at the critical file or risky change — include only when a stage report explicitly flagged it |
+| `---` separator + `[{entity-id}](/{owner}/{repo}/blob/{state-sha}/{state-relative-path})` | **yes** | Audit link, at the bottom. `{state-sha}` is the full SHA of the state checkout's HEAD (see merge-hook step); `{state-relative-path}` is the entity file's active `.spacedock-state`-relative location (`{slug}/index.md`). An immutable state-commit SHA — NOT a branch ref — so the link still resolves after the entity archives. |
+| `Closes {issue}` | **yes when issue set** | Under the audit link, using the value exactly as it appears in frontmatter, e.g., `#48` or `owner/repo#48` |
+| `Related: {siblings}` | optional | Under Closes, only when stage reports flagged follow-ups |
+
+**Extraction rules (apply deterministically from the entity file):**
+
+| PR body section | Source in entity file | Transformation |
+|---|---|---|
+| Motivation lead | Entity body paragraph(s) between closing `---` and the first `##` heading | Condense first paragraph to 1-2 sentences. Lead with impact or action verb — not "This PR" or "This task". Blend motivation + value. |
+| What changed | Implementation stage report's DONE items | One action-verb bullet per meaningful unit. Collapse sibling bullets that describe the same thing. Do NOT include "what we deliberately did NOT change" bullets — scope boundaries belong in the task body, not the PR, unless a validation stage report flagged them as risk. |
+| Evidence | Validation stage report items that assert AC verification (typically rerun-test items) | One bullet per suite with `N/N passed` format. Include any quantitative result the stage report explicitly called out (wallclock delta, size %, perf). Fallback to implementation report's self-test items if no validation stage exists. |
+| Review guidance | Explicit "focus on X" / "risk here" notes in either stage report | 1 line. **Omit if no such note exists.** |
+| Audit link | Short entity id from `spacedock status --workflow-dir docs/dev --short-id {slug}`, active path from the entity file's `.spacedock-state`-relative location (`{slug}/index.md`), state SHA from `git -C docs/dev/.spacedock-state rev-parse HEAD` (the STATE checkout's HEAD — NOT the code worktree, NOT a branch ref) | Format as `[{short-id}](/{owner}/{repo}/blob/{state-sha}/{state-relative-path})` |
+| Closes | Entity frontmatter `issue` field (exactly as written) | Prefix `Closes ` |
+| Related | Explicit "related task" / "follow-up" mentions in stage reports | 1 line. **Omit if none.** |
+
+Target total length: **60-120 words**.
+
+### Fallback: no PR host available
+
+If `gh` is not on PATH, or `gh pr create` fails, or the branch push fails, do NOT set `pr:`. Report to the captain that no PR could be opened and fall back to the FO's default local merge (Merge-and-Cleanup step 6): a local `--no-ff` merge of the code branch `{branch}` from the worktree onto `next`, recording the local-merge landing in the entity report. Because no `pr:` was set, the hook completed **without blocking** — the FO clears the `mod-block` it set before invoking (its own standalone `spacedock status --workflow-dir docs/dev --set {slug} mod-block=`, committed path-scoped), then terminalizes and archives at the same merge boundary, just without a PR. (The mechanism-level guard refuses terminalizing while `pr` and `mod-block` are both empty and a merge hook is registered; clearing `mod-block` only after the local merge lands keeps that guard satisfied through the no-PR path.)
+
+**On captain decline (PR host present, captain says no):** Do NOT automatically fall back to local merge. Ask the captain how to proceed — options include the local `--no-ff` merge or leaving the branch unmerged. Only act on the captain's explicit choice.

--- a/internal/status/boot.go
+++ b/internal/status/boot.go
@@ -156,7 +156,7 @@ type bootData struct {
 // minted here (timestamp-dependent for sd-b32); on a minting error it returns
 // the error after the caller has emitted the stderr diagnostic.
 func gatherBoot(probe claudeteam.TeamStateProbe, entities []*entity, stages []Stage, definitionDir, entityDir, gitRoot, idStyle string, e env, stderr io.Writer) (*bootData, error) {
-	d := &bootData{idStyle: idStyle, hooks: scanMods(entityDir)}
+	d := &bootData{idStyle: idStyle, hooks: scanMods(definitionDir, entityDir)}
 
 	if idStyle == "slug" {
 		d.nextID = "n/a (id-style: slug)"

--- a/internal/status/boot.go
+++ b/internal/status/boot.go
@@ -156,7 +156,7 @@ type bootData struct {
 // minted here (timestamp-dependent for sd-b32); on a minting error it returns
 // the error after the caller has emitted the stderr diagnostic.
 func gatherBoot(probe claudeteam.TeamStateProbe, entities []*entity, stages []Stage, definitionDir, entityDir, gitRoot, idStyle string, e env, stderr io.Writer) (*bootData, error) {
-	d := &bootData{idStyle: idStyle, hooks: scanMods(definitionDir, entityDir)}
+	d := &bootData{idStyle: idStyle, hooks: scanMods(definitionDir)}
 
 	if idStyle == "slug" {
 		d.nextID = "n/a (id-style: slug)"

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -128,7 +128,7 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 	}
 
 	if !force && isTerminalUpdate() && modBlock == "" && postUpdatePR == "" && postUpdateVerdict != "rejected" {
-		mergeHooks := scanMods(roots.definitionDir, roots.entityDir)["merge"]
+		mergeHooks := scanMods(roots.definitionDir)["merge"]
 		if len(mergeHooks) > 0 {
 			return errExit(stderr, fmt.Sprintf(
 				"entity %s cannot advance to terminal — workflow has merge hook(s) [%s] that have not run "+

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -128,7 +128,7 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 	}
 
 	if !force && isTerminalUpdate() && modBlock == "" && postUpdatePR == "" && postUpdateVerdict != "rejected" {
-		mergeHooks := scanMods(roots.entityDir)["merge"]
+		mergeHooks := scanMods(roots.definitionDir, roots.entityDir)["merge"]
 		if len(mergeHooks) > 0 {
 			return errExit(stderr, fmt.Sprintf(
 				"entity %s cannot advance to terminal — workflow has merge hook(s) [%s] that have not run "+

--- a/internal/status/mutate.go
+++ b/internal/status/mutate.go
@@ -151,10 +151,12 @@ func atomicWrite(path string, data []byte) error {
 // runArchive archives an entity (flat or folder form), stamping archived: before
 // the move and printing `archived: {dest}`. Enforces the source-missing,
 // already-archived, mod-block, and merge-hook guards. Matches run_archive.
-// entityDir is the absolute entity root for I/O; spellingDir is the as-passed
-// spelling used for the printed dest (so a relative --workflow-dir renders a
-// relative `archived:` path, matching the oracle's literal os.path.join).
-func runArchive(entityDir, spellingDir, slug string, force, quiet, asJSON bool, stdout, stderr io.Writer) int {
+// entityDir is the absolute entity root for I/O; definitionDir is the README root
+// used to resolve merge-hook mods (definitionDir/_mods/, plus entityDir/_mods/
+// during a split-root mod migration); spellingDir is the as-passed spelling used
+// for the printed dest (so a relative --workflow-dir renders a relative
+// `archived:` path, matching the oracle's literal os.path.join).
+func runArchive(definitionDir, entityDir, spellingDir, slug string, force, quiet, asJSON bool, stdout, stderr io.Writer) int {
 	flatPath := filepath.Join(entityDir, slug+".md")
 	folderRoot := filepath.Join(entityDir, slug)
 	folderIndex := filepath.Join(folderRoot, "index.md")
@@ -195,7 +197,7 @@ func runArchive(entityDir, spellingDir, slug string, force, quiet, asJSON bool, 
 	// Merge-hook invariant: archival is terminal. Refuse unless the hook ran
 	// (pr set), is in flight (mod-block set, handled above), or --force.
 	if !force && modBlock == "" && pr == "" {
-		mergeHooks := scanMods(entityDir)["merge"]
+		mergeHooks := scanMods(definitionDir, entityDir)["merge"]
 		if len(mergeHooks) > 0 {
 			fmt.Fprintf(stderr,
 				"Error: entity %s cannot be archived — workflow has merge hook(s) [%s] "+
@@ -278,38 +280,57 @@ func PyJoin(parts ...string) string {
 	return result
 }
 
-// scanMods scans entityDir/_mods/*.md for `## Hook:` headings, returning
-// hookPoint -> sorted mod names. Matches scan_mods.
-func scanMods(entityDir string) map[string][]string {
-	modsDir := filepath.Join(entityDir, "_mods")
-	info, err := os.Stat(modsDir)
-	if err != nil || !info.IsDir() {
-		return map[string][]string{}
+// scanMods scans for `## Hook:` headings in `_mods/*.md`, returning hookPoint ->
+// sorted mod names. Mods are workflow definition (lifecycle hooks declared for
+// the workflow, kin to the README stages), so they live next to the README in
+// definitionDir/_mods/. The entityDir/_mods/ location is also scanned so a mod
+// registered there before migrating to the definition dir keeps its hook live
+// through the move — there is no window where the hook goes dark. A mod present
+// in both dirs (mid-migration) is counted once, with the definition-dir copy
+// taking precedence. In single-root (definitionDir == entityDir) only one dir is
+// scanned, matching scan_mods byte-for-byte.
+func scanMods(definitionDir, entityDir string) map[string][]string {
+	// Definition dir first so its copy of a same-named mod wins the dedup.
+	dirs := []string{filepath.Join(definitionDir, "_mods")}
+	if entityDir != definitionDir {
+		dirs = append(dirs, filepath.Join(entityDir, "_mods"))
 	}
-	entries, err := os.ReadDir(modsDir)
-	if err != nil {
-		return map[string][]string{}
-	}
-	var files []string
-	for _, ent := range entries {
-		if !ent.IsDir() && strings.HasSuffix(ent.Name(), ".md") {
-			files = append(files, ent.Name())
-		}
-	}
-	// glob returns sorted order.
-	sort.Strings(files)
+
+	seen := map[string]bool{}
 	hooks := map[string][]string{}
-	for _, name := range files {
-		modName := strings.TrimSuffix(name, ".md")
-		data, err := os.ReadFile(filepath.Join(modsDir, name))
+	for _, modsDir := range dirs {
+		info, err := os.Stat(modsDir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		entries, err := os.ReadDir(modsDir)
 		if err != nil {
 			continue
 		}
-		for _, line := range splitLines(string(data)) {
-			if strings.HasPrefix(line, "## Hook:") {
-				point := strings.TrimSpace(strings.TrimPrefix(line, "## Hook:"))
-				if point != "" {
-					hooks[point] = append(hooks[point], modName)
+		var files []string
+		for _, ent := range entries {
+			if !ent.IsDir() && strings.HasSuffix(ent.Name(), ".md") {
+				files = append(files, ent.Name())
+			}
+		}
+		// glob returns sorted order.
+		sort.Strings(files)
+		for _, name := range files {
+			modName := strings.TrimSuffix(name, ".md")
+			if seen[modName] {
+				continue
+			}
+			seen[modName] = true
+			data, err := os.ReadFile(filepath.Join(modsDir, name))
+			if err != nil {
+				continue
+			}
+			for _, line := range splitLines(string(data)) {
+				if strings.HasPrefix(line, "## Hook:") {
+					point := strings.TrimSpace(strings.TrimPrefix(line, "## Hook:"))
+					if point != "" {
+						hooks[point] = append(hooks[point], modName)
+					}
 				}
 			}
 		}

--- a/internal/status/mutate.go
+++ b/internal/status/mutate.go
@@ -197,7 +197,7 @@ func runArchive(definitionDir, entityDir, spellingDir, slug string, force, quiet
 	// Merge-hook invariant: archival is terminal. Refuse unless the hook ran
 	// (pr set), is in flight (mod-block set, handled above), or --force.
 	if !force && modBlock == "" && pr == "" {
-		mergeHooks := scanMods(definitionDir, entityDir)["merge"]
+		mergeHooks := scanMods(definitionDir)["merge"]
 		if len(mergeHooks) > 0 {
 			fmt.Fprintf(stderr,
 				"Error: entity %s cannot be archived — workflow has merge hook(s) [%s] "+
@@ -280,57 +280,43 @@ func PyJoin(parts ...string) string {
 	return result
 }
 
-// scanMods scans for `## Hook:` headings in `_mods/*.md`, returning hookPoint ->
-// sorted mod names. Mods are workflow definition (lifecycle hooks declared for
-// the workflow, kin to the README stages), so they live next to the README in
-// definitionDir/_mods/. The entityDir/_mods/ location is also scanned so a mod
-// registered there before migrating to the definition dir keeps its hook live
-// through the move — there is no window where the hook goes dark. A mod present
-// in both dirs (mid-migration) is counted once, with the definition-dir copy
-// taking precedence. In single-root (definitionDir == entityDir) only one dir is
-// scanned, matching scan_mods byte-for-byte.
-func scanMods(definitionDir, entityDir string) map[string][]string {
-	// Definition dir first so its copy of a same-named mod wins the dedup.
-	dirs := []string{filepath.Join(definitionDir, "_mods")}
-	if entityDir != definitionDir {
-		dirs = append(dirs, filepath.Join(entityDir, "_mods"))
+// scanMods scans definitionDir/_mods/*.md for `## Hook:` headings, returning
+// hookPoint -> sorted mod names. Mods are workflow definition (lifecycle hooks
+// declared for the workflow, kin to the README stages), so they live next to the
+// README in definitionDir/_mods/, not in the entity/state checkout. In
+// single-root (definitionDir == entityDir) this is the same dir the oracle's
+// scan_mods reads, so it matches byte-for-byte; under split-root it reads the
+// definition dir, never the state checkout.
+func scanMods(definitionDir string) map[string][]string {
+	modsDir := filepath.Join(definitionDir, "_mods")
+	info, err := os.Stat(modsDir)
+	if err != nil || !info.IsDir() {
+		return map[string][]string{}
 	}
-
-	seen := map[string]bool{}
-	hooks := map[string][]string{}
-	for _, modsDir := range dirs {
-		info, err := os.Stat(modsDir)
-		if err != nil || !info.IsDir() {
-			continue
+	entries, err := os.ReadDir(modsDir)
+	if err != nil {
+		return map[string][]string{}
+	}
+	var files []string
+	for _, ent := range entries {
+		if !ent.IsDir() && strings.HasSuffix(ent.Name(), ".md") {
+			files = append(files, ent.Name())
 		}
-		entries, err := os.ReadDir(modsDir)
+	}
+	// glob returns sorted order.
+	sort.Strings(files)
+	hooks := map[string][]string{}
+	for _, name := range files {
+		modName := strings.TrimSuffix(name, ".md")
+		data, err := os.ReadFile(filepath.Join(modsDir, name))
 		if err != nil {
 			continue
 		}
-		var files []string
-		for _, ent := range entries {
-			if !ent.IsDir() && strings.HasSuffix(ent.Name(), ".md") {
-				files = append(files, ent.Name())
-			}
-		}
-		// glob returns sorted order.
-		sort.Strings(files)
-		for _, name := range files {
-			modName := strings.TrimSuffix(name, ".md")
-			if seen[modName] {
-				continue
-			}
-			seen[modName] = true
-			data, err := os.ReadFile(filepath.Join(modsDir, name))
-			if err != nil {
-				continue
-			}
-			for _, line := range splitLines(string(data)) {
-				if strings.HasPrefix(line, "## Hook:") {
-					point := strings.TrimSpace(strings.TrimPrefix(line, "## Hook:"))
-					if point != "" {
-						hooks[point] = append(hooks[point], modName)
-					}
+		for _, line := range splitLines(string(data)) {
+			if strings.HasPrefix(line, "## Hook:") {
+				point := strings.TrimSpace(strings.TrimPrefix(line, "## Hook:"))
+				if point != "" {
+					hooks[point] = append(hooks[point], modName)
 				}
 			}
 		}

--- a/internal/status/native_runner.go
+++ b/internal/status/native_runner.go
@@ -337,7 +337,7 @@ func dispatch(probe claudeteam.TeamStateProbe, args []string, dir string, e env,
 		if rc != 0 {
 			return rc
 		}
-		return runArchive(roots.entityDir, roots.entityDirSpelling, resolved.slug, contains(args, "--force"), quiet, asJSON, stdout, stderr)
+		return runArchive(roots.definitionDir, roots.entityDir, roots.entityDirSpelling, resolved.slug, contains(args, "--force"), quiet, asJSON, stdout, stderr)
 	}
 
 	if setResult != nil {

--- a/internal/status/native_state_dir_test.go
+++ b/internal/status/native_state_dir_test.go
@@ -292,6 +292,101 @@ func TestSplitRootDiscoverySingleCount(t *testing.T) {
 	})
 }
 
+// mergeModBody is a minimal mod declaring a `merge` hook, used to arm the
+// terminal merge guard in the split-root scanMods tests.
+const mergeModBody = "---\nname: pr-merge\n---\n\n# PR Merge\n\n## Hook: merge\n\nRuns at the terminal merge boundary.\n"
+
+// writeMergeMod writes mergeModBody to <root>/_mods/pr-merge.md.
+func writeMergeMod(t *testing.T, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "_mods", "pr-merge.md"), mergeModBody)
+}
+
+// TestSplitRootDefinitionDirModArmsGuard is the AC-1(a) scan contract: under a
+// split-root workflow a merge mod placed at <definitionDir>/_mods/ registers, so
+// a terminal transition on a pr-empty / mod-block-empty entity is refused with
+// the merge-hook error. Both the terminal --set and --archive guards see it.
+// Native-only (no runOracle): split-root is an intentional native divergence.
+func TestSplitRootDefinitionDirModArmsGuard(t *testing.T) {
+	env := pinnedEnv(t)
+
+	t.Run("terminal --set refused", func(t *testing.T) {
+		def, _ := buildSplitRoot(t, splitRootReadme, map[string]string{
+			"add-login.md": "---\nstatus: implementation\n---\n",
+		})
+		writeMergeMod(t, def)
+
+		out, stderr, code := runNative(t, def, env, "--workflow-dir", def, "--set", "add-login", "status=review")
+		if code != 1 {
+			t.Fatalf("terminal --set exit=%d, want 1 (def-dir merge mod must arm guard)\nstdout=%q stderr=%q", code, out, stderr)
+		}
+		if !strings.Contains(stderr, "cannot advance to terminal") || !strings.Contains(stderr, "merge hook(s) [pr-merge]") {
+			t.Fatalf("stderr should carry the merge-hook guard text; got %q", stderr)
+		}
+		if out != "" {
+			t.Fatalf("stdout must be empty on rejection: %q", out)
+		}
+	})
+
+	t.Run("--archive refused", func(t *testing.T) {
+		def, _ := buildSplitRoot(t, splitRootReadme, map[string]string{
+			"add-login.md": "---\nstatus: implementation\n---\n",
+		})
+		writeMergeMod(t, def)
+
+		out, stderr, code := runNative(t, def, env, "--workflow-dir", def, "--archive", "add-login")
+		if code != 1 {
+			t.Fatalf("--archive exit=%d, want 1 (def-dir merge mod must arm guard)\nstdout=%q stderr=%q", code, out, stderr)
+		}
+		if !strings.Contains(stderr, "cannot be archived") || !strings.Contains(stderr, "merge hook(s) [pr-merge]") {
+			t.Fatalf("stderr should carry the archive merge-hook guard text; got %q", stderr)
+		}
+	})
+}
+
+// TestSplitRootModRegistrationNoGap is the M-1 no-gap property: the merge hook
+// stays registered whether the mod sits at <definitionDir>/_mods/ (the migrated
+// location) OR at <entityDir>/_mods/ (the state checkout, the pre-migration
+// location), so the terminal guard fires from either spot and the migration
+// opens no window where the hook goes dark. --boot lists it under MODS either
+// way. Native-only (no runOracle).
+func TestSplitRootModRegistrationNoGap(t *testing.T) {
+	env := pinnedEnv(t)
+	cases := []struct {
+		name    string
+		modRoot func(def, state string) string
+	}{
+		{"definition dir (migrated)", func(def, _ string) string { return def }},
+		{"state checkout (pre-migration)", func(_, state string) string { return state }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			def, state := buildSplitRoot(t, splitRootReadme, map[string]string{
+				"add-login.md": "---\nstatus: implementation\n---\n",
+			})
+			writeMergeMod(t, tc.modRoot(def, state))
+
+			// --boot lists the merge mod under MODS.
+			bootOut, bootErr, bootCode := runNative(t, def, env, "--workflow-dir", def, "--boot")
+			if bootCode != 0 {
+				t.Fatalf("--boot exit=%d stderr=%q", bootCode, bootErr)
+			}
+			if !strings.Contains(bootOut, "merge: pr-merge") {
+				t.Fatalf("--boot MODS should show merge: pr-merge; got\n%s", bootOut)
+			}
+
+			// The terminal guard fires.
+			out, stderr, code := runNative(t, def, env, "--workflow-dir", def, "--set", "add-login", "status=review")
+			if code != 1 {
+				t.Fatalf("terminal --set exit=%d, want 1 (hook must stay registered)\nstdout=%q stderr=%q", code, out, stderr)
+			}
+			if !strings.Contains(stderr, "merge hook(s) [pr-merge]") {
+				t.Fatalf("stderr should carry the merge-hook guard text; got %q", stderr)
+			}
+		})
+	}
+}
+
 // readBytes reads a file as a string, failing the test on error.
 func readBytes(t *testing.T, path string) string {
 	t.Helper()

--- a/internal/status/native_state_dir_test.go
+++ b/internal/status/native_state_dir_test.go
@@ -344,46 +344,72 @@ func TestSplitRootDefinitionDirModArmsGuard(t *testing.T) {
 	})
 }
 
-// TestSplitRootModRegistrationNoGap is the M-1 no-gap property: the merge hook
-// stays registered whether the mod sits at <definitionDir>/_mods/ (the migrated
-// location) OR at <entityDir>/_mods/ (the state checkout, the pre-migration
-// location), so the terminal guard fires from either spot and the migration
-// opens no window where the hook goes dark. --boot lists it under MODS either
-// way. Native-only (no runOracle).
-func TestSplitRootModRegistrationNoGap(t *testing.T) {
+// TestSplitRootStateDirModDoesNotRegister is the AC-1(b) negative: a mod placed
+// ONLY at <entityDir>/_mods/ (the state checkout) does NOT register — scanMods
+// reads the definition dir, never the state checkout — so --boot shows no MODS
+// and a terminal transition on a pr-empty / mod-block-empty entity succeeds (the
+// guard is unarmed). This is the inverse of the def-dir case and locks the clean
+// cutover. Native-only (no runOracle).
+func TestSplitRootStateDirModDoesNotRegister(t *testing.T) {
 	env := pinnedEnv(t)
-	cases := []struct {
-		name    string
-		modRoot func(def, state string) string
-	}{
-		{"definition dir (migrated)", func(def, _ string) string { return def }},
-		{"state checkout (pre-migration)", func(_, state string) string { return state }},
+	def, state := buildSplitRoot(t, splitRootReadme, map[string]string{
+		"add-login.md": "---\nstatus: implementation\n---\n",
+	})
+	writeMergeMod(t, state)
+
+	// --boot lists no MODS: the state-checkout mod is not scanned.
+	bootOut, bootErr, bootCode := runNative(t, def, env, "--workflow-dir", def, "--boot")
+	if bootCode != 0 {
+		t.Fatalf("--boot exit=%d stderr=%q", bootCode, bootErr)
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			def, state := buildSplitRoot(t, splitRootReadme, map[string]string{
-				"add-login.md": "---\nstatus: implementation\n---\n",
-			})
-			writeMergeMod(t, tc.modRoot(def, state))
+	if !strings.Contains(bootOut, "MODS: none") {
+		t.Fatalf("--boot should show MODS: none (state-dir mod must not register); got\n%s", bootOut)
+	}
 
-			// --boot lists the merge mod under MODS.
-			bootOut, bootErr, bootCode := runNative(t, def, env, "--workflow-dir", def, "--boot")
-			if bootCode != 0 {
-				t.Fatalf("--boot exit=%d stderr=%q", bootCode, bootErr)
-			}
-			if !strings.Contains(bootOut, "merge: pr-merge") {
-				t.Fatalf("--boot MODS should show merge: pr-merge; got\n%s", bootOut)
-			}
+	// The terminal transition succeeds: the guard is unarmed.
+	out, stderr, code := runNative(t, def, env, "--workflow-dir", def, "--set", "add-login", "status=review")
+	if code != 0 {
+		t.Fatalf("terminal --set exit=%d, want 0 (state-dir mod must not arm guard)\nstdout=%q stderr=%q", code, out, stderr)
+	}
+	if !strings.Contains(out, "status: implementation -> review") {
+		t.Fatalf("--set narration = %q, want the status transition to succeed", out)
+	}
+}
 
-			// The terminal guard fires.
-			out, stderr, code := runNative(t, def, env, "--workflow-dir", def, "--set", "add-login", "status=review")
-			if code != 1 {
-				t.Fatalf("terminal --set exit=%d, want 1 (hook must stay registered)\nstdout=%q stderr=%q", code, out, stderr)
-			}
-			if !strings.Contains(stderr, "merge hook(s) [pr-merge]") {
-				t.Fatalf("stderr should carry the merge-hook guard text; got %q", stderr)
-			}
-		})
+// TestSplitRootMigrationNoGap locks the no-gap property of the atomic migration:
+// because the PR delivers the scanMods def-dir read AND the docs/dev/_mods/
+// copy together, a post-migration binary always finds the mod at the definition
+// dir, so the merge hook never goes dark. During the transition the stale
+// state-checkout copy may still be present; the def-dir-only scan ignores it, so
+// the hook registers exactly once (no double-registration) and stays armed. This
+// is the no-gap closure — an atomic add plus a harmless leftover, not a runtime
+// both-dirs scan. Native-only (no runOracle).
+func TestSplitRootMigrationNoGap(t *testing.T) {
+	env := pinnedEnv(t)
+	def, state := buildSplitRoot(t, splitRootReadme, map[string]string{
+		"add-login.md": "---\nstatus: implementation\n---\n",
+	})
+	// Migrated state: the def-dir copy is the live one; the stale state-checkout
+	// copy is left in place during the transition (the FO removes it later).
+	writeMergeMod(t, def)
+	writeMergeMod(t, state)
+
+	// --boot lists the merge mod exactly once — the stale state-dir dup is ignored.
+	bootOut, bootErr, bootCode := runNative(t, def, env, "--workflow-dir", def, "--boot")
+	if bootCode != 0 {
+		t.Fatalf("--boot exit=%d stderr=%q", bootCode, bootErr)
+	}
+	if got := strings.Count(bootOut, "merge: pr-merge"); got != 1 {
+		t.Fatalf("--boot MODS should show merge: pr-merge exactly once, got %d\n%s", got, bootOut)
+	}
+
+	// The terminal guard fires: the hook stayed registered through the migration.
+	out, stderr, code := runNative(t, def, env, "--workflow-dir", def, "--set", "add-login", "status=review")
+	if code != 1 {
+		t.Fatalf("terminal --set exit=%d, want 1 (hook must stay registered through migration)\nstdout=%q stderr=%q", code, out, stderr)
+	}
+	if !strings.Contains(stderr, "merge hook(s) [pr-merge]") {
+		t.Fatalf("stderr should carry the merge-hook guard text; got %q", stderr)
 	}
 }
 


### PR DESCRIPTION
Mod lifecycle hooks now live with the workflow definition instead of the state checkout, so split-root workflows register their merge guard from the right place.

## What changed
- Resolve `_mods/` from the workflow definition dir, not the state checkout, under split-root.
- Thread `definitionDir` into all three merge-guard scan sites and `runArchive`.
- Relocate the `pr-merge` mod to `docs/dev/_mods/`.
- Carry the immutable state-SHA audit-link form into the relocated mod.
- Add split-root tests pinning mod-directory selection and no-gap migration.

## Evidence
- `go test ./internal/status/...` — 273/273 passed; oracle-parity guard tests green byte-for-byte.
- Live `--boot` + terminal `--set`/`--archive` guard smoke on the real `docs/dev` split-root workflow.

## Review guidance
Critical path: the merge-hook guard registration across `boot.go`/`handlers.go`/`mutate.go`.

---
[f2](/spacedock-dev/spacedock/blob/73551540789c905e4f76a9bf4c31b728f5859abb/mods-definition-dir-location/index.md)