### PR TITLE
status correctness: --set stage validation, inline-comment parsing, dispatch-suppression visibility

### DIFF
--- a/internal/status/comment_roundtrip_parity_test.go
+++ b/internal/status/comment_roundtrip_parity_test.go
@@ -1,0 +1,60 @@
+// ABOUTME: AC-4(ii) round-trip parity — a #-bearing --set value is written
+// ABOUTME: quoted and reads back whole, byte-identically on launcher and oracle.
+package status
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCommentValueRoundTripParity locks option C end-to-end across both
+// implementations: a --set value containing a space-then-`#` is written quoted
+// (so the reader's comment-strip does not truncate it) and reads back whole. The
+// on-disk frontmatter and the round-trip read are compared launcher-vs-oracle,
+// so the reader-strip AND the writer-quote are parity-pinned together.
+func TestCommentValueRoundTripParity(t *testing.T) {
+	env := pinnedEnv(t)
+	launcherRoot := stageFixture(t, "seq-workflow")
+	oracleRoot := stageFixture(t, "seq-workflow")
+
+	args := []string{"--set", "002-vendor-script", "source=consolidates #223, #217"}
+	lArgs := append([]string{"--workflow-dir", launcherRoot}, args...)
+	oArgs := append([]string{"--workflow-dir", oracleRoot}, args...)
+
+	lOut, lErr, lCode := runLauncher(t, launcherRoot, env, lArgs...)
+	oOut, oErr, oCode := runOracle(t, oracleRoot, env, oArgs...)
+	if lCode != 0 || oCode != 0 {
+		t.Fatalf("exit: launcher=%d (%q) oracle=%d (%q)", lCode, lErr, oCode, oErr)
+	}
+	// Narration uses the raw (unquoted) value on both sides.
+	if normalize(lOut, "") != normalize(oOut, "") {
+		t.Fatalf("narration: launcher=%q oracle=%q", lOut, oOut)
+	}
+
+	// On-disk frontmatter is byte-identical and carries the QUOTED value.
+	lFM := readFrontmatter(t, filepath.Join(launcherRoot, "002-vendor-script.md"))
+	oFM := readFrontmatter(t, filepath.Join(oracleRoot, "002-vendor-script.md"))
+	if lFM != oFM {
+		t.Fatalf("on-disk frontmatter mismatch\n--- launcher ---\n%s\n--- oracle ---\n%s", lFM, oFM)
+	}
+	if !strings.Contains(lFM, `source: "consolidates #223, #217"`) {
+		t.Fatalf("expected quoted #-bearing value on disk, got:\n%s", lFM)
+	}
+
+	// Round-trip read yields the whole value on both sides.
+	lGot := ParseFrontmatter(filepath.Join(launcherRoot, "002-vendor-script.md"))["source"]
+	if lGot != "consolidates #223, #217" {
+		t.Fatalf("launcher round-trip read = %q, want whole value", lGot)
+	}
+	// The oracle reads it back whole too (run a --fields source read and compare).
+	lRead, _, _ := runLauncher(t, launcherRoot, env, "--workflow-dir", launcherRoot, "--fields", "source")
+	oRead, _, _ := runOracle(t, oracleRoot, env, "--workflow-dir", oracleRoot, "--fields", "source")
+	if normalize(lRead, launcherRoot) != normalize(oRead, oracleRoot) {
+		t.Fatalf("--fields source read mismatch\n--- launcher ---\n%s\n--- oracle ---\n%s",
+			normalize(lRead, launcherRoot), normalize(oRead, oracleRoot))
+	}
+	if !strings.Contains(oRead, "#223") {
+		t.Fatalf("oracle did not read the #-bearing value back whole:\n%s", oRead)
+	}
+}

--- a/internal/status/enum_scope_test.go
+++ b/internal/status/enum_scope_test.go
@@ -1,0 +1,62 @@
+// ABOUTME: AC-2 (#207) enumeration-scope rule — placement, not the status value,
+// ABOUTME: decides active vs archived scope; asserted both placements, native vs oracle.
+package status
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEnumerationScopeByPlacement locks the #207 rule: enumeration scope is
+// decided by PLACEMENT, not by the `status` frontmatter value. The fixture has
+// two entities with the SAME status, one top-level (top-placed) and one under
+// _archive/ (arch-placed). The rule, asserted identically for both placements:
+//   - the default (active) read surfaces the top-level entity and NOT the
+//     archived one, even though both share status: backlog;
+//   - the --archived read surfaces the archived entity (and still the active
+//     one, since --archived appends archived to active).
+// Each read is compared native-vs-oracle so the rule is parity-pinned, not just
+// asserted on the Go side.
+func TestEnumerationScopeByPlacement(t *testing.T) {
+	env := pinnedEnv(t)
+	root := stageFixture(t, "enum-scope-workflow")
+
+	t.Run("active-scope", func(t *testing.T) {
+		nOut, nErr, nCode := runNative(t, root, env, "--workflow-dir", root)
+		oOut, oErr, oCode := runOracle(t, root, env, "--workflow-dir", root)
+		if nCode != 0 || oCode != 0 {
+			t.Fatalf("exit: native=%d (%q) oracle=%d (%q)", nCode, nErr, oCode, oErr)
+		}
+		if nOut != oOut {
+			t.Fatalf("active-read native vs oracle mismatch\n--- native ---\n%s\n--- oracle ---\n%s", nOut, oOut)
+		}
+		// The rule: top-level placement => active scope; _archive/ => not active,
+		// regardless of the shared status value.
+		if !strings.Contains(nOut, "top-placed") {
+			t.Fatalf("active read must surface the top-level entity:\n%s", nOut)
+		}
+		if strings.Contains(nOut, "arch-placed") {
+			t.Fatalf("active read must NOT surface the _archive/-placed entity:\n%s", nOut)
+		}
+	})
+
+	t.Run("archived-scope", func(t *testing.T) {
+		nOut, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--archived")
+		oOut, oErr, oCode := runOracle(t, root, env, "--workflow-dir", root, "--archived")
+		if nCode != 0 || oCode != 0 {
+			t.Fatalf("exit: native=%d (%q) oracle=%d (%q)", nCode, nErr, oCode, oErr)
+		}
+		if nOut != oOut {
+			t.Fatalf("archived-read native vs oracle mismatch\n--- native ---\n%s\n--- oracle ---\n%s", nOut, oOut)
+		}
+		// The rule: _archive/ placement => archived scope is enumerated under
+		// --archived; the active top-level entity is still present (--archived
+		// appends archived to active).
+		if !strings.Contains(nOut, "arch-placed") {
+			t.Fatalf("--archived read must surface the _archive/-placed entity:\n%s", nOut)
+		}
+		if !strings.Contains(nOut, "top-placed") {
+			t.Fatalf("--archived read must still surface the active top-level entity:\n%s", nOut)
+		}
+	})
+}

--- a/internal/status/format.go
+++ b/internal/status/format.go
@@ -149,6 +149,21 @@ type dispatchable struct {
 // computeDispatchable runs the --next dispatch rules and returns the ordered
 // dispatchable list. Matches the candidate loop in print_next_table.
 func computeDispatchable(entities []*entity, stages []Stage) []dispatchable {
+	disp, _ := dispatchAnalysis(entities, stages)
+	return disp
+}
+
+// dispatchAnalysis runs the --next candidate loop once and returns BOTH the
+// ordered dispatchable list and, for every entity, why it was NOT dispatched
+// (the #230 next-suppressed-by reason). The reason mirrors the loop's skip
+// rules exactly so the visibility surface can never diverge from --next: a
+// dispatched entity gets "" (it is not suppressed). Reasons, in the loop's
+// own precedence: terminal | gate | worktree-set | concurrency-full. An entity
+// whose status is not a known stage, or that sits at the last stage with no
+// successor, is not attributable to one of the tracked suppression reasons and
+// gets "". computeDispatchable and the surface share this one function so the
+// dispatch logic is never duplicated.
+func dispatchAnalysis(entities []*entity, stages []Stage) ([]dispatchable, map[*entity]string) {
 	stageByName := map[string]Stage{}
 	var stageNames []string
 	for _, s := range stages {
@@ -169,26 +184,36 @@ func computeDispatchable(entities []*entity, stages []Stage) []dispatchable {
 		nextCounts[k] = v
 	}
 
+	reasons := map[*entity]string{}
 	var out []dispatchable
 	for _, e := range candidates {
 		status := e.fields["status"]
 		stg, ok := stageByName[status]
 		if !ok {
+			reasons[e] = ""
 			continue
 		}
 		idx := indexOf(stageNames, status)
-		if stg.terminal || stg.gate {
+		if stg.terminal {
+			reasons[e] = "terminal"
+			continue
+		}
+		if stg.gate {
+			reasons[e] = "gate"
 			continue
 		}
 		if e.fields["worktree"] != "" {
+			reasons[e] = "worktree-set"
 			continue
 		}
 		if idx+1 >= len(stageNames) {
+			reasons[e] = ""
 			continue
 		}
 		nextName := stageNames[idx+1]
 		nextStage := stageByName[nextName]
 		if nextCounts[nextName] >= nextStage.concurrency {
+			reasons[e] = "concurrency-full"
 			continue
 		}
 		nextCounts[nextName]++
@@ -196,9 +221,46 @@ func computeDispatchable(entities []*entity, stages []Stage) []dispatchable {
 		if nextStage.Worktree {
 			nw = "yes"
 		}
+		reasons[e] = ""
 		out = append(out, dispatchable{e: e, next: nextName, nextWorktree: nw})
 	}
-	return out
+	return out, reasons
+}
+
+// suppressedByField is the computed field name the #230 visibility surface
+// exposes via --fields / --where. It is NOT a frontmatter key: it is derived
+// from the --next dispatch analysis, so it is materialized only when explicitly
+// named and is deliberately excluded from --all-fields (which documents stored
+// frontmatter keys).
+const suppressedByField = "next-suppressed-by"
+
+// materializeSuppressedBy writes the computed next-suppressed-by reason into
+// each entity's fields ONLY when the field is explicitly referenced by --fields
+// or a --where clause. Gating it keeps the value out of --all-fields and out of
+// the default field set (e.fields is otherwise untouched), so the parity-pinned
+// frontmatter-keys surfaces stay byte-identical. The reason is computed from the
+// shared dispatch analysis over the read's entity set, so the surface mirrors
+// --next exactly. Stages may be nil (no stages block) — then every entity gets
+// "" because nothing is dispatchable-or-suppressed without stage metadata.
+func materializeSuppressedBy(entities []*entity, stages []Stage, explicitFields []string, filters []whereFilter) {
+	referenced := false
+	for _, f := range explicitFields {
+		if f == suppressedByField {
+			referenced = true
+		}
+	}
+	for _, f := range filters {
+		if f.field == suppressedByField {
+			referenced = true
+		}
+	}
+	if !referenced {
+		return
+	}
+	_, reasons := dispatchAnalysis(entities, stages)
+	for _, e := range entities {
+		e.fields[suppressedByField] = reasons[e]
+	}
 }
 
 // printNextTable writes the --next table, optionally with extras. Matches

--- a/internal/status/frontmatter.go
+++ b/internal/status/frontmatter.go
@@ -121,11 +121,33 @@ func parseFrontmatterContent(data []byte) map[string]string {
 		}
 		key, val, _ := strings.Cut(line, ":")
 		key = strings.TrimSpace(key)
-		val = strings.TrimSpace(val)
-		val = stripMatchedQuotes(val)
-		fields[key] = val
+		fields[key] = parseValue(val)
 	}
 	return fields
+}
+
+// parseValue resolves a frontmatter value: it trims surrounding whitespace,
+// then either unwraps a quoted scalar (dropping any trailing inline comment
+// after the close quote) or strips an inline comment from an unquoted scalar.
+// A quoted scalar protects an interior `#` (it is literal, not a comment); an
+// unquoted scalar drops a whitespace-preceded `#…` per the YAML rule (an
+// unspaced `v1.0#163`-style token is kept). Matches the oracle's parse_value.
+func parseValue(raw string) string {
+	val := strings.TrimSpace(raw)
+	if len(val) > 0 && (val[0] == '"' || val[0] == '\'') {
+		q := val[0]
+		if j := strings.IndexByte(val[1:], q); j >= 0 {
+			closeAt := j + 1
+			rest := strings.TrimLeft(val[closeAt+1:], " \t")
+			if rest == "" || rest[0] == '#' {
+				return val[1:closeAt]
+			}
+		}
+		// Unterminated or trailing non-comment content: preserve the historical
+		// matched-surrounding-quotes behavior, no comment strip.
+		return stripMatchedQuotes(val)
+	}
+	return stripInlineComment(val)
 }
 
 // stripMatchedQuotes removes a single pair of matched surrounding quotes from a

--- a/internal/status/frontmatter_comment_test.go
+++ b/internal/status/frontmatter_comment_test.go
@@ -1,0 +1,60 @@
+// ABOUTME: AC-4(ii) generic entity-value inline-comment strip + quoted-value
+// ABOUTME: protection — reader strips unquoted comments, keeps quoted # literal.
+package status
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseFrontmatterStripsInlineComment(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want map[string]string
+	}{
+		{
+			name: "unquoted value with trailing comment stripped",
+			in:   "---\nstatus: plan  # note\n---\n",
+			want: map[string]string{"status": "plan"},
+		},
+		{
+			name: "unquoted single-token value with trailing comment",
+			in:   "---\nstatus: plan # note\n---\n",
+			want: map[string]string{"status": "plan"},
+		},
+		{
+			name: "unspaced hash kept (no preceding whitespace)",
+			in:   "---\nref: v1.0#163\n---\n",
+			want: map[string]string{"ref": "v1.0#163"},
+		},
+		{
+			name: "unquoted space-preceded hash truncates (accepted under option C)",
+			in:   "---\nsource: consolidates #223, #217\n---\n",
+			want: map[string]string{"source": "consolidates"},
+		},
+		{
+			name: "quoted value protects an interior hash",
+			in:   "---\nsource: \"consolidates #223, #217\"\n---\n",
+			want: map[string]string{"source": "consolidates #223, #217"},
+		},
+		{
+			name: "quoted value with trailing comment after close quote",
+			in:   "---\ntitle: \"hello\"  # a note\n---\n",
+			want: map[string]string{"title": "hello"},
+		},
+		{
+			name: "single-quoted value protects an interior hash",
+			in:   "---\nsource: 'see #163'\n---\n",
+			want: map[string]string{"source": "see #163"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseFrontmatterContent([]byte(tc.in))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseFrontmatterContent(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -280,6 +280,7 @@ func runRead(probe claudeteam.TeamStateProbe, roots roots, args []string, e env,
 
 	applyEffectiveIDs(allEntities, idStyle, allEntities)
 	applyEffectiveIDs(entities, idStyle, allEntities)
+	materializeSuppressedBy(entities, stages, explicitFields, whereFilters)
 	entities = applyFilters(entities, whereFilters)
 
 	switch {

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -83,6 +83,28 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 		}
 	}
 
+	// Membership guard: a --set status=X must name a stage the workflow
+	// declares. This is distinct from validateWorkflowStageNames' format regex —
+	// it checks the *value* against stages.states[].name membership. When the
+	// workflow declares no stages block we cannot validate membership, so the
+	// guard is a no-op. A non-member value exits non-zero and leaves the
+	// frontmatter unchanged.
+	if len(stages) > 0 {
+		stageNames := make([]string, len(stages))
+		stageNameSet := map[string]bool{}
+		for i, s := range stages {
+			stageNames[i] = s.Name
+			stageNameSet[s.Name] = true
+		}
+		for _, u := range set.updates {
+			if u.field == "status" && u.hasValue && !stageNameSet[u.value] {
+				return errExit(stderr, fmt.Sprintf(
+					"'%s' is not a defined stage in workflow %s — known stages: [%s]",
+					u.value, roots.definitionDir, strings.Join(stageNames, ", ")))
+			}
+		}
+	}
+
 	isTerminalUpdate := func() bool {
 		for _, u := range set.updates {
 			if u.field == "status" && u.hasValue && terminalNames[u.value] {

--- a/internal/status/json_quiet_test.go
+++ b/internal/status/json_quiet_test.go
@@ -93,11 +93,11 @@ func TestSetJSONEnvelope(t *testing.T) {
 	env := pinnedEnv(t)
 	root := stageFixture(t, "seq-workflow")
 
-	out, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--set", "002-vendor-script", "status=design", "--json")
+	out, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--set", "002-vendor-script", "status=implementation", "--json")
 	if code != 0 {
 		t.Fatalf("exit=%d stderr=%q", code, errOut)
 	}
-	want := `{"command":"set","slug":"002-vendor-script","changes":[{"field":"status","old":"ideation","new":"design"}]}` + "\n"
+	want := `{"command":"set","slug":"002-vendor-script","changes":[{"field":"status","old":"ideation","new":"implementation"}]}` + "\n"
 	if out != want {
 		t.Fatalf("--set --json stdout = %q, want %q", out, want)
 	}

--- a/internal/status/mutate.go
+++ b/internal/status/mutate.go
@@ -99,7 +99,7 @@ func updateFrontmatter(path string, updates []fieldUpdate) (*orderedMap, error) 
 			k, _, _ := strings.Cut(line, ":")
 			key := strings.TrimSpace(k)
 			if val, ok := resolved.get(key); ok {
-				lines[i] = key + ": " + val
+				lines[i] = key + ": " + quoteForWrite(val)
 				written[key] = true
 			}
 		}
@@ -111,7 +111,7 @@ func updateFrontmatter(path string, updates []fieldUpdate) (*orderedMap, error) 
 			continue
 		}
 		val, _ := resolved.get(key)
-		ins := key + ": " + val
+		ins := key + ": " + quoteForWrite(val)
 		lines = append(lines[:fmEnd], append([]string{ins}, lines[fmEnd:]...)...)
 		fmEnd++
 	}
@@ -120,6 +120,27 @@ func updateFrontmatter(path string, updates []fieldUpdate) (*orderedMap, error) 
 		return nil, err
 	}
 	return resolved, nil
+}
+
+// quoteForWrite wraps a value in quotes when it carries a space-then-`#` (` #`)
+// so the reader's inline-comment strip does not later truncate it — the writer
+// half of the option-C round-trip contract. A value already wrapped in matched
+// surrounding quotes, or one with no ` #`, is written verbatim (byte
+// preservation). The quote char is chosen to avoid clashing with a quote the
+// value already contains (the hand-rolled parser does not unescape): prefer `"`,
+// fall back to `'` when the value contains `"` but not `'`. Matches the oracle's
+// quote_for_write.
+func quoteForWrite(val string) string {
+	if !strings.Contains(val, " #") && !strings.Contains(val, "\t#") {
+		return val
+	}
+	if len(val) >= 2 && val[0] == val[len(val)-1] && (val[0] == '"' || val[0] == '\'') {
+		return val
+	}
+	if strings.Contains(val, "\"") && !strings.Contains(val, "'") {
+		return "'" + val + "'"
+	}
+	return "\"" + val + "\""
 }
 
 // atomicWrite writes data to a temp file in the same directory and renames it

--- a/internal/status/mutate.go
+++ b/internal/status/mutate.go
@@ -152,10 +152,10 @@ func atomicWrite(path string, data []byte) error {
 // the move and printing `archived: {dest}`. Enforces the source-missing,
 // already-archived, mod-block, and merge-hook guards. Matches run_archive.
 // entityDir is the absolute entity root for I/O; definitionDir is the README root
-// used to resolve merge-hook mods (definitionDir/_mods/, plus entityDir/_mods/
-// during a split-root mod migration); spellingDir is the as-passed spelling used
-// for the printed dest (so a relative --workflow-dir renders a relative
-// `archived:` path, matching the oracle's literal os.path.join).
+// used to resolve merge-hook mods (definitionDir/_mods/); spellingDir is the
+// as-passed spelling used for the printed dest (so a relative --workflow-dir
+// renders a relative `archived:` path, matching the oracle's literal
+// os.path.join).
 func runArchive(definitionDir, entityDir, spellingDir, slug string, force, quiet, asJSON bool, stdout, stderr io.Writer) int {
 	flatPath := filepath.Join(entityDir, slug+".md")
 	folderRoot := filepath.Join(entityDir, slug)

--- a/internal/status/mutate_quote_test.go
+++ b/internal/status/mutate_quote_test.go
@@ -1,0 +1,48 @@
+// ABOUTME: AC-4(ii) writer-quoting — a --set value containing a space-then-#
+// ABOUTME: is written quoted so it round-trips; values without ` #` are byte-preserved.
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestUpdateFrontmatterQuotesHashValue locks the writer half of option C: when
+// --set writes a value containing a space-then-`#` (` #`), the writer quotes it
+// so the reader (which strips an unquoted whitespace-preceded comment) reads the
+// full value back — a clean round-trip. A value WITHOUT ` #` is written
+// unquoted (byte-preservation).
+func TestUpdateFrontmatterQuotesHashValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "e.md")
+	const seed = "---\nid: e\nstatus: backlog\nsource: roadmap\n---\nbody\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a value containing a space-then-# .
+	if _, err := updateFrontmatter(path, []fieldUpdate{{field: "source", value: "consolidates #223, #217", hasValue: true}}); err != nil {
+		t.Fatalf("updateFrontmatter: %v", err)
+	}
+	b, _ := os.ReadFile(path)
+	written := string(b)
+	if !strings.Contains(written, `source: "consolidates #223, #217"`) {
+		t.Fatalf("expected the #-bearing value to be written quoted, got:\n%s", written)
+	}
+	// Round-trip: the reader yields the full value (quote-protected), not a
+	// truncated comment-stripped fragment.
+	if got := ParseFrontmatter(path)["source"]; got != "consolidates #223, #217" {
+		t.Fatalf("round-trip read = %q, want %q", got, "consolidates #223, #217")
+	}
+
+	// A value WITHOUT ` #` is written unquoted (byte-preservation).
+	if _, err := updateFrontmatter(path, []fieldUpdate{{field: "status", value: "implementation", hasValue: true}}); err != nil {
+		t.Fatalf("updateFrontmatter: %v", err)
+	}
+	b, _ = os.ReadFile(path)
+	if !strings.Contains(string(b), "status: implementation\n") {
+		t.Fatalf("expected a plain value written unquoted, got:\n%s", string(b))
+	}
+}

--- a/internal/status/next_suppressed_by_test.go
+++ b/internal/status/next_suppressed_by_test.go
@@ -1,0 +1,142 @@
+// ABOUTME: AC-1 (#230) next-suppressed-by visibility surface — the computed
+// ABOUTME: suppression reason is observable via --fields/--where, gated out of --all-fields, native vs oracle.
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fieldCell returns the value of the named extra column for slug in a status
+// table rendered with that single extra field. It locates the data row by slug
+// and returns the trailing cell text (the extra column is rendered last).
+func extraCellFor(t *testing.T, out, slug string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == slug {
+			// The extra column is the final cell; with a single --fields column
+			// it is the last whitespace-trimmed token, or empty if absent.
+			last := fields[len(fields)-1]
+			// The default columns are id slug status title score source; a
+			// non-empty extra adds one more token after source.
+			if len(fields) >= 7 {
+				return last
+			}
+			return ""
+		}
+	}
+	t.Fatalf("slug %q not found in table:\n%s", slug, out)
+	return ""
+}
+
+// TestNextSuppressedByObservable locks the #230 visibility surface: the computed
+// next-suppressed-by reason mirrors exactly why computeDispatchable skipped an
+// entity, is observable via --fields and filterable via --where, and is GATED
+// out of --all-fields (a parity-pinned frontmatter-keys surface). Native vs
+// oracle throughout.
+func TestNextSuppressedByObservable(t *testing.T) {
+	env := pinnedEnv(t)
+	root := stageFixture(t, "suppress-workflow")
+
+	t.Run("fields-shows-reason", func(t *testing.T) {
+		nOut, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--fields", "next-suppressed-by")
+		oOut, oErr, oCode := runOracle(t, root, env, "--workflow-dir", root, "--fields", "next-suppressed-by")
+		if nCode != 0 || oCode != 0 {
+			t.Fatalf("exit: native=%d (%q) oracle=%d (%q)", nCode, nErr, oCode, oErr)
+		}
+		if nOut != oOut {
+			t.Fatalf("--fields native vs oracle mismatch\n--- native ---\n%s\n--- oracle ---\n%s", nOut, oOut)
+		}
+		want := map[string]string{
+			"building": "worktree-set",
+			"waiting":  "concurrency-full",
+			"gated":    "gate",
+		}
+		for slug, reason := range want {
+			if got := extraCellFor(t, nOut, slug); got != reason {
+				t.Fatalf("next-suppressed-by for %q = %q, want %q\n%s", slug, got, reason, nOut)
+			}
+		}
+	})
+
+	t.Run("where-filters-by-reason", func(t *testing.T) {
+		nOut, _, nCode := runNative(t, root, env, "--workflow-dir", root, "--where", "next-suppressed-by = concurrency-full")
+		oOut, _, oCode := runOracle(t, root, env, "--workflow-dir", root, "--where", "next-suppressed-by = concurrency-full")
+		if nCode != 0 || oCode != 0 {
+			t.Fatalf("exit: native=%d oracle=%d", nCode, oCode)
+		}
+		if nOut != oOut {
+			t.Fatalf("--where native vs oracle mismatch\n--- native ---\n%s\n--- oracle ---\n%s", nOut, oOut)
+		}
+		if !strings.Contains(nOut, "waiting") {
+			t.Fatalf("--where concurrency-full should surface waiting:\n%s", nOut)
+		}
+		for _, other := range []string{"building", "gated"} {
+			if strings.Contains(nOut, other) {
+				t.Fatalf("--where concurrency-full must not surface %q:\n%s", other, nOut)
+			}
+		}
+	})
+
+	t.Run("all-fields-excludes-computed", func(t *testing.T) {
+		nOut, _, nCode := runNative(t, root, env, "--workflow-dir", root, "--all-fields")
+		oOut, _, oCode := runOracle(t, root, env, "--workflow-dir", root, "--all-fields")
+		if nCode != 0 || oCode != 0 {
+			t.Fatalf("exit: native=%d oracle=%d", nCode, oCode)
+		}
+		if nOut != oOut {
+			t.Fatalf("--all-fields native vs oracle mismatch\n--- native ---\n%s\n--- oracle ---\n%s", nOut, oOut)
+		}
+		if strings.Contains(strings.ToUpper(nOut), "NEXT-SUPPRESSED-BY") {
+			t.Fatalf("--all-fields must NOT surface the computed next-suppressed-by column:\n%s", nOut)
+		}
+	})
+}
+
+// TestNextSuppressedByEmptyForDispatchable locks the "" value: an entity that is
+// actually dispatchable (not suppressed) has an empty next-suppressed-by, native
+// vs oracle. Uses a fixture where the next stage has room.
+func TestNextSuppressedByEmptyForDispatchable(t *testing.T) {
+	env := pinnedEnv(t)
+	root := t.TempDir()
+	readme := `---
+entity-type: task
+id-style: slug
+stages:
+  defaults:
+    worktree: false
+    concurrency: 2
+  states:
+    - name: ideation
+      initial: true
+    - name: build
+    - name: done
+      terminal: true
+---
+
+# dispatchable fixture
+`
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte(readme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nid: ready\ntitle: ready\nstatus: ideation\nscore: \"0.5\"\nsource: probe\n---\nbody\n"
+	if err := os.WriteFile(filepath.Join(root, "ready.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInit(t, root)
+
+	nOut, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--fields", "next-suppressed-by")
+	oOut, oErr, oCode := runOracle(t, root, env, "--workflow-dir", root, "--fields", "next-suppressed-by")
+	if nCode != 0 || oCode != 0 {
+		t.Fatalf("exit: native=%d (%q) oracle=%d (%q)", nCode, nErr, oCode, oErr)
+	}
+	if nOut != oOut {
+		t.Fatalf("--fields native vs oracle mismatch\n--- native ---\n%s\n--- oracle ---\n%s", nOut, oOut)
+	}
+	if got := extraCellFor(t, nOut, "ready"); got != "" {
+		t.Fatalf("next-suppressed-by for dispatchable 'ready' = %q, want empty\n%s", got, nOut)
+	}
+}

--- a/internal/status/set_stage_membership_test.go
+++ b/internal/status/set_stage_membership_test.go
@@ -1,0 +1,88 @@
+// ABOUTME: AC-3 --set status= membership parity — a non-member stage value is
+// ABOUTME: rejected (exit 1, unchanged frontmatter), a member is accepted, launcher vs oracle.
+package status
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSetStatusNonMemberRejected locks the #189 membership check: a `--set
+// status=zzz` where zzz is not a declared stage in the workflow's
+// stages.states[].name exits non-zero with an actionable error listing the known
+// stages, and leaves the entity frontmatter UNCHANGED. Asserted launcher vs
+// oracle so the parity suite covers the new guard.
+func TestSetStatusNonMemberRejected(t *testing.T) {
+	env := pinnedEnv(t)
+	launcherRoot := stageFixture(t, "seq-workflow")
+	oracleRoot := stageFixture(t, "seq-workflow")
+
+	args := []string{"--set", "002-vendor-script", "status=zzz"}
+	lArgs := append([]string{"--workflow-dir", launcherRoot}, args...)
+	oArgs := append([]string{"--workflow-dir", oracleRoot}, args...)
+
+	lOut, lErr, lCode := runLauncher(t, launcherRoot, env, lArgs...)
+	oOut, oErr, oCode := runOracle(t, oracleRoot, env, oArgs...)
+
+	if lCode != 1 {
+		t.Fatalf("launcher exit=%d, want 1 (non-member status must reject)", lCode)
+	}
+	if lCode != oCode {
+		t.Fatalf("exit: launcher=%d oracle=%d (launcherErr=%q oracleErr=%q)", lCode, oCode, lErr, oErr)
+	}
+	// The error names the unknown value and lists the known stages.
+	for _, want := range []string{"zzz", "backlog", "ideation", "implementation", "done"} {
+		if !strings.Contains(lErr, want) {
+			t.Fatalf("launcher stderr = %q, want it to mention %q", lErr, want)
+		}
+	}
+	// The error embeds the workflow dir, which differs per run; normalize each
+	// run's own root to compare launcher vs oracle structurally.
+	if normalize(lErr, launcherRoot) != normalize(oErr, oracleRoot) {
+		t.Fatalf("stderr: launcher=%q oracle=%q",
+			normalize(lErr, launcherRoot), normalize(oErr, oracleRoot))
+	}
+	if lOut != "" || oOut != "" {
+		t.Fatalf("stdout must be empty on rejection: launcher=%q oracle=%q", lOut, oOut)
+	}
+	// Frontmatter unchanged: status still ideation, not zzz.
+	fm := readFrontmatter(t, filepath.Join(launcherRoot, "002-vendor-script.md"))
+	if !strings.Contains(fm, "status: ideation") {
+		t.Fatalf("entity status was mutated despite rejection:\n%s", fm)
+	}
+	if strings.Contains(fm, "status: zzz") {
+		t.Fatalf("entity advanced to zzz despite rejection:\n%s", fm)
+	}
+}
+
+// TestSetStatusMemberAccepted locks the complement: a `--set status=implementation`
+// (a declared stage) exits zero and mutates, launcher vs oracle, so the membership
+// guard does not reject legitimate transitions.
+func TestSetStatusMemberAccepted(t *testing.T) {
+	env := pinnedEnv(t)
+	launcherRoot := stageFixture(t, "seq-workflow")
+	oracleRoot := stageFixture(t, "seq-workflow")
+
+	args := []string{"--set", "002-vendor-script", "status=implementation"}
+	lArgs := append([]string{"--workflow-dir", launcherRoot}, args...)
+	oArgs := append([]string{"--workflow-dir", oracleRoot}, args...)
+
+	lOut, lErr, lCode := runLauncher(t, launcherRoot, env, lArgs...)
+	oOut, oErr, oCode := runOracle(t, oracleRoot, env, oArgs...)
+
+	if lCode != 0 || oCode != 0 {
+		t.Fatalf("exit: launcher=%d (%q) oracle=%d (%q)", lCode, lErr, oCode, oErr)
+	}
+	if normalize(lOut, "") != normalize(oOut, "") {
+		t.Fatalf("narration: launcher=%q oracle=%q", lOut, oOut)
+	}
+	lFM := normalize(readFrontmatter(t, filepath.Join(launcherRoot, "002-vendor-script.md")), "")
+	oFM := normalize(readFrontmatter(t, filepath.Join(oracleRoot, "002-vendor-script.md")), "")
+	if lFM != oFM {
+		t.Fatalf("frontmatter mismatch\n--- launcher ---\n%s\n--- oracle ---\n%s", lFM, oFM)
+	}
+	if !strings.Contains(lFM, "status: implementation") {
+		t.Fatalf("member status was not applied:\n%s", lFM)
+	}
+}

--- a/internal/status/stages.go
+++ b/internal/status/stages.go
@@ -69,6 +69,25 @@ func indentOf(line string) int {
 	return len(line) - len(strings.TrimLeft(line, " \t"))
 }
 
+// stripInlineComment removes a trailing ` # comment` from a value: a `#`
+// preceded by whitespace (or at the start of the value) begins a comment and is
+// dropped along with everything after it; the surviving text is right-trimmed.
+// A `#` NOT preceded by whitespace (e.g. an issue token like `#163`) is kept, so
+// values such as `consolidates #163` are preserved. The result is the same trim
+// the oracle applies, keeping the two parsers byte-aligned. Used for stage
+// numeric/bool/token fields, which never legitimately carry a literal ` #`.
+func stripInlineComment(val string) string {
+	for i := 0; i < len(val); i++ {
+		if val[i] != '#' {
+			continue
+		}
+		if i == 0 || isSpaceByte(val[i-1]) {
+			return strings.TrimRight(val[:i], " \t")
+		}
+	}
+	return val
+}
+
 // parseStagesBlock parses the stages: block from README frontmatter, returning
 // ordered stages with resolved defaults, or nil when there is no stages: block
 // or no states entries. Matches parse_stages_block.
@@ -129,7 +148,7 @@ func ParseStagesWithDefaults(path string) ([]Stage, map[string]string) {
 					}
 					if strings.Contains(dstripped, ":") {
 						k, v, _ := strings.Cut(dstripped, ":")
-						defaults[strings.TrimSpace(k)] = strings.TrimSpace(v)
+						defaults[strings.TrimSpace(k)] = stripInlineComment(strings.TrimSpace(v))
 					}
 					i++
 				}
@@ -148,12 +167,12 @@ func ParseStagesWithDefaults(path string) ([]Stage, map[string]string) {
 						break
 					}
 					if strings.HasPrefix(sstripped, "- name:") {
-						name := strings.TrimSpace(strings.TrimPrefix(sstripped, "- name:"))
+						name := stripInlineComment(strings.TrimSpace(strings.TrimPrefix(sstripped, "- name:")))
 						current = map[string]string{"name": name}
 						states = append(states, current)
 					} else if current != nil && strings.Contains(sstripped, ":") && !strings.HasPrefix(sstripped, "- ") {
 						k, v, _ := strings.Cut(sstripped, ":")
-						current[strings.TrimSpace(k)] = strings.TrimSpace(v)
+						current[strings.TrimSpace(k)] = stripInlineComment(strings.TrimSpace(v))
 					}
 					i++
 				}

--- a/internal/status/stages_comment_parity_test.go
+++ b/internal/status/stages_comment_parity_test.go
@@ -1,0 +1,73 @@
+// ABOUTME: AC-4 stage-field inline-comment strip parity — a commented stage
+// ABOUTME: concurrency drives --next identically for native and oracle (not a default fallback).
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStageInlineCommentDispatchParity locks the #163 stage-field strip end-to-end
+// through --next: a stage declaring `concurrency: 1  # cap` must cap dispatch at 1
+// (the stripped value), not 2 (the silent atoiOr default the un-stripped
+// `1  # cap` would fall back to). Asserted native-vs-oracle so the strip is
+// parity-pinned on the command path, and the dispatch count is checked to prove
+// the stripped value — not the default — drove the scheduling.
+func TestStageInlineCommentDispatchParity(t *testing.T) {
+	env := pinnedEnv(t)
+	root := t.TempDir()
+
+	readme := `---
+entity-type: task
+id-style: slug
+stages:
+  defaults:
+    worktree: false  # default
+    concurrency: 1  # cap
+  states:
+    - name: ideation
+      initial: true
+    - name: build  # the build stage
+      concurrency: 1  # only one at a time
+    - name: done
+      terminal: true
+---
+
+# Inline-comment stage fixture
+`
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte(readme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Two ideation entities are both eligible to advance into build; build's
+	// stripped concurrency is 1, so exactly one may dispatch this round.
+	for _, slug := range []string{"alpha", "beta"} {
+		body := "---\nid: " + slug + "\ntitle: " + slug + "\nstatus: ideation\nscore: \"0.5\"\nsource: probe\n---\nbody\n"
+		if err := os.WriteFile(filepath.Join(root, slug+".md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gitInit(t, root)
+
+	nOut, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--next")
+	oOut, oErr, oCode := runOracle(t, root, env, "--workflow-dir", root, "--next")
+	if nCode != 0 || oCode != 0 {
+		t.Fatalf("exit: native=%d (%q) oracle=%d (%q)", nCode, nErr, oCode, oErr)
+	}
+	if nOut != oOut {
+		t.Fatalf("--next native vs oracle mismatch\n--- native ---\n%s\n--- oracle ---\n%s", nOut, oOut)
+	}
+	// Count dispatch rows (lines naming build as NEXT). The stripped concurrency
+	// 1 caps this at one; an un-stripped value would fall back to the default 2
+	// and dispatch both, which this asserts against.
+	rows := 0
+	for _, line := range strings.Split(strings.TrimRight(nOut, "\n"), "\n") {
+		if strings.Contains(line, "build") && (strings.Contains(line, "alpha") || strings.Contains(line, "beta")) {
+			rows++
+		}
+	}
+	if rows != 1 {
+		t.Fatalf("expected exactly 1 dispatch into build (stripped concurrency=1), got %d:\n%s", rows, nOut)
+	}
+}

--- a/internal/status/stages_comment_test.go
+++ b/internal/status/stages_comment_test.go
@@ -1,0 +1,62 @@
+// ABOUTME: AC-4 stage numeric/bool inline-comment strip — concurrency/worktree
+// ABOUTME: with a trailing `# comment` parse to the value, not a silent default fallback.
+package status
+
+import "testing"
+
+// TestParseStagesStripsInlineComment locks the #163 stage-field silent-misparse
+// fix: a stage `concurrency: 5  # debate` must yield 5 (not the default 2 via the
+// atoiOr fallback) and `worktree: true  # iso` must yield true (not false). These
+// typed fields never legitimately contain `#`, so the inline-comment strip is
+// unambiguous. The defaults block is exercised too so the strip covers both the
+// per-stage and defaults paths.
+func TestParseStagesStripsInlineComment(t *testing.T) {
+	readme := `---
+stages:
+  defaults:
+    worktree: false  # default off
+    concurrency: 3  # default
+  states:
+    - name: backlog
+      initial: true  # the seed stage
+    - name: build
+      concurrency: 5  # debate
+      worktree: true  # iso
+    - name: done
+      terminal: true  # last
+---
+`
+	path := writeTemp(t, readme)
+	stages, defaults := ParseStagesWithDefaults(path)
+	if len(stages) != 3 {
+		t.Fatalf("got %d stages, want 3", len(stages))
+	}
+
+	if defaults["concurrency"] != "3" {
+		t.Fatalf("defaults concurrency = %q, want \"3\" (inline comment stripped)", defaults["concurrency"])
+	}
+	if defaults["worktree"] != "false" {
+		t.Fatalf("defaults worktree = %q, want \"false\" (inline comment stripped)", defaults["worktree"])
+	}
+
+	backlog := stages[0]
+	if !backlog.initial {
+		t.Fatalf("backlog.initial should be true (inline comment stripped), got %+v", backlog)
+	}
+	if backlog.concurrency != 3 {
+		t.Fatalf("backlog concurrency = %d, want 3 (inherits stripped default, not the built-in 2)", backlog.concurrency)
+	}
+
+	build := stages[1]
+	if build.concurrency != 5 {
+		t.Fatalf("build concurrency = %d, want 5 (inline comment stripped, not default fallback)", build.concurrency)
+	}
+	if !build.Worktree {
+		t.Fatalf("build worktree should be true (inline comment stripped), got %+v", build)
+	}
+
+	done := stages[2]
+	if !done.terminal {
+		t.Fatalf("done.terminal should be true (inline comment stripped), got %+v", done)
+	}
+}

--- a/internal/status/testdata/enum-scope-workflow/README.md
+++ b/internal/status/testdata/enum-scope-workflow/README.md
@@ -1,0 +1,24 @@
+---
+entity-type: task
+entity-label: task
+entity-label-plural: tasks
+id-style: slug
+stages:
+  defaults:
+    worktree: false
+    concurrency: 1
+  states:
+    - name: backlog
+      initial: true
+    - name: done
+      terminal: true
+---
+
+# Enumeration Scope Fixture Workflow
+
+A frozen fixture pinning the #207 enumeration-scope rule: placement, not the
+`status` frontmatter value, decides whether an entity is enumerated in the
+active scope (top-level) or the archived scope (`_archive/`). Two entities carry
+the same `status` so a scope difference can only come from placement. id-style is
+slug so the active + archived effective ids stay distinct (no duplicate-id
+validation collision across scopes).

--- a/internal/status/testdata/enum-scope-workflow/_archive/arch-placed.md
+++ b/internal/status/testdata/enum-scope-workflow/_archive/arch-placed.md
@@ -1,0 +1,12 @@
+---
+id: arch-placed
+title: Archive placed entity
+status: backlog
+score: "0.50"
+source: probe
+---
+
+# Archive placed entity
+
+Lives under _archive/. Its status is identical to the top-level sibling so the
+only thing that can place it in the archived scope is its _archive/ placement.

--- a/internal/status/testdata/enum-scope-workflow/top-placed.md
+++ b/internal/status/testdata/enum-scope-workflow/top-placed.md
@@ -1,0 +1,12 @@
+---
+id: top-placed
+title: Top-level placed entity
+status: backlog
+score: "0.50"
+source: probe
+---
+
+# Top-level placed entity
+
+Lives at the top level. Its status is identical to the archived sibling so the
+only thing that can place it in the active scope is its top-level placement.

--- a/internal/status/testdata/suppress-workflow/README.md
+++ b/internal/status/testdata/suppress-workflow/README.md
@@ -1,0 +1,28 @@
+---
+entity-type: task
+entity-label: task
+entity-label-plural: tasks
+id-style: slug
+stages:
+  defaults:
+    worktree: false
+    concurrency: 2
+  states:
+    - name: ideation
+      initial: true
+    - name: build
+      worktree: true
+      concurrency: 1
+    - name: review
+      gate: true
+    - name: done
+      terminal: true
+---
+
+# Suppression-reason Fixture Workflow
+
+A frozen fixture pinning the #230 visibility surface: each entity is suppressed
+from `--next` for a distinct, attributable reason so `next-suppressed-by` can be
+asserted to distinguish worktree-set / concurrency-full / gate (and "" for a
+dispatchable entity). build has concurrency 1 and is worktree-backed so a single
+in-flight build saturates it; review is a gate; done is terminal.

--- a/internal/status/testdata/suppress-workflow/building.md
+++ b/internal/status/testdata/suppress-workflow/building.md
@@ -1,0 +1,13 @@
+---
+id: building
+title: In-flight build
+status: build
+score: "0.90"
+source: probe
+worktree: wt/building
+---
+
+# In-flight build
+
+At the build stage with a worktree set: suppressed from --next because its
+worktree has not been torn down. Also saturates build (concurrency 1).

--- a/internal/status/testdata/suppress-workflow/gated.md
+++ b/internal/status/testdata/suppress-workflow/gated.md
@@ -1,0 +1,12 @@
+---
+id: gated
+title: Sitting at a gate
+status: review
+score: "0.70"
+source: probe
+---
+
+# Sitting at a gate
+
+At the review stage, which is a gate: --next suppresses it because advancing
+past a gate is a captain decision, not an automatic dispatch.

--- a/internal/status/testdata/suppress-workflow/waiting.md
+++ b/internal/status/testdata/suppress-workflow/waiting.md
@@ -1,0 +1,12 @@
+---
+id: waiting
+title: Ready but next stage is full
+status: ideation
+score: "0.80"
+source: probe
+---
+
+# Ready but next stage is full
+
+At ideation with no worktree: would advance to build, but build (concurrency 1)
+is saturated by the in-flight build, so --next suppresses it for concurrency.

--- a/internal/status/vendor/status
+++ b/internal/status/vendor/status
@@ -2376,6 +2376,24 @@ def main():
         stages = parse_stages_block(readme_path) if os.path.exists(readme_path) else None
         terminal_names = {s['name'] for s in (stages or []) if s.get('terminal')}
 
+        # Membership guard: a --set status=X must name a stage the workflow
+        # declares. This is distinct from validate_workflow_stage_names' format
+        # regex — it checks the *value* against stages.states[].name membership.
+        # When the workflow declares no stages block we cannot validate
+        # membership, so the guard is a no-op. A non-member value exits non-zero
+        # and leaves the frontmatter unchanged.
+        if stages:
+            stage_names = [s['name'] for s in stages]
+            stage_name_set = set(stage_names)
+            for field, value in updates:
+                if field == 'status' and value not in stage_name_set:
+                    print(
+                        f"Error: '{value}' is not a defined stage in workflow "
+                        f"{pipeline_dir} — known stages: [{', '.join(stage_names)}]",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+
         def is_terminal_update():
             """True when this --set applies any terminal field."""
             for field, value in updates:

--- a/internal/status/vendor/status
+++ b/internal/status/vendor/status
@@ -218,6 +218,24 @@ def parse_mod_metadata(filepath):
     }
 
 
+def strip_inline_comment(val):
+    """Remove a trailing ` # comment` from a value.
+
+    A `#` preceded by whitespace (or at the start of the value) begins a comment
+    and is dropped along with everything after it; the surviving text is
+    right-trimmed. A `#` NOT preceded by whitespace (e.g. an issue token like
+    `#163`) is kept, so values such as `consolidates #163` are preserved. Used
+    for stage numeric/bool/token fields, which never legitimately carry a
+    literal ` #`.
+    """
+    for i, ch in enumerate(val):
+        if ch != '#':
+            continue
+        if i == 0 or val[i - 1].isspace():
+            return val[:i].rstrip()
+    return val
+
+
 def parse_stages_block(filepath):
     """Parse the stages block from README frontmatter."""
     lines = []
@@ -272,7 +290,7 @@ def parse_stages_block(filepath):
                         break
                     if ':' in dstripped:
                         k, _, v = dstripped.partition(':')
-                        defaults[k.strip()] = v.strip()
+                        defaults[k.strip()] = strip_inline_comment(v.strip())
                     i += 1
                 continue
             elif stripped == 'states:':
@@ -289,11 +307,11 @@ def parse_stages_block(filepath):
                         break
                     if sstripped.startswith('- name:'):
                         _, _, name = sstripped.partition('- name:')
-                        current_state = {'name': name.strip()}
+                        current_state = {'name': strip_inline_comment(name.strip())}
                         states.append(current_state)
                     elif current_state is not None and ':' in sstripped and not sstripped.startswith('- '):
                         k, _, v = sstripped.partition(':')
-                        current_state[k.strip()] = v.strip()
+                        current_state[k.strip()] = strip_inline_comment(v.strip())
                     i += 1
                 continue
         i += 1
@@ -376,7 +394,7 @@ def parse_stages_with_defaults(filepath):
                         break
                     if ':' in dstripped:
                         k, _, v = dstripped.partition(':')
-                        defaults[k.strip()] = v.strip()
+                        defaults[k.strip()] = strip_inline_comment(v.strip())
                     i += 1
                 continue
             i += 1

--- a/internal/status/vendor/status
+++ b/internal/status/vendor/status
@@ -1592,6 +1592,83 @@ def update_frontmatter(filepath, updates):
     return resolved
 
 
+# The computed field name the #230 visibility surface exposes via --fields /
+# --where. It is NOT a frontmatter key: it is derived from the --next dispatch
+# analysis, so it is materialized only when explicitly named and is deliberately
+# excluded from --all-fields (which documents stored frontmatter keys).
+SUPPRESSED_BY_FIELD = 'next-suppressed-by'
+
+
+def compute_suppressed_by(entities, stages):
+    """Return {id(entity): reason} for why each entity is NOT dispatched by --next.
+
+    Mirrors the candidate loop in print_next_table exactly so the #230
+    visibility surface can never diverge from --next: a dispatched entity gets
+    '' (not suppressed). Reasons, in the loop's own precedence:
+    terminal | gate | worktree-set | concurrency-full. An entity whose status is
+    not a known stage, or that sits at the last stage with no successor, is not
+    attributable to one of the tracked suppression reasons and gets ''.
+    """
+    stage_by_name = {s['name']: s for s in (stages or [])}
+    stage_names = [s['name'] for s in (stages or [])]
+    active_counts = {}
+    for e in entities:
+        if e['worktree']:
+            st = e['status']
+            active_counts[st] = active_counts.get(st, 0) + 1
+
+    candidates = sorted(entities, key=sort_key_next)
+    next_stage_counts = dict(active_counts)
+    reasons = {}
+    for e in candidates:
+        status = e['status']
+        if status not in stage_by_name:
+            reasons[id(e)] = ''
+            continue
+        stage_idx = stage_names.index(status)
+        stage = stage_by_name[status]
+        if stage.get('terminal', False):
+            reasons[id(e)] = 'terminal'
+            continue
+        if stage.get('gate', False):
+            reasons[id(e)] = 'gate'
+            continue
+        if e['worktree']:
+            reasons[id(e)] = 'worktree-set'
+            continue
+        if stage_idx + 1 >= len(stage_names):
+            reasons[id(e)] = ''
+            continue
+        next_stage_name = stage_names[stage_idx + 1]
+        next_stage = stage_by_name[next_stage_name]
+        current_count = next_stage_counts.get(next_stage_name, 0)
+        if current_count >= next_stage['concurrency']:
+            reasons[id(e)] = 'concurrency-full'
+            continue
+        next_stage_counts[next_stage_name] = current_count + 1
+        reasons[id(e)] = ''
+    return reasons
+
+
+def materialize_suppressed_by(entities, stages, explicit_fields, where_filters):
+    """Write the computed next-suppressed-by reason into each entity ONLY when
+    the field is explicitly referenced by --fields or a --where clause.
+
+    Gating it keeps the value out of --all-fields and the default field set
+    (the entity dict is otherwise untouched), so the parity-pinned
+    frontmatter-keys surfaces stay byte-identical. The reason is computed from
+    the shared dispatch analysis over the read's entity set, so the surface
+    mirrors --next exactly.
+    """
+    referenced = SUPPRESSED_BY_FIELD in (explicit_fields or [])
+    referenced = referenced or any(f[0] == SUPPRESSED_BY_FIELD for f in (where_filters or []))
+    if not referenced:
+        return
+    reasons = compute_suppressed_by(entities, stages)
+    for e in entities:
+        e[SUPPRESSED_BY_FIELD] = reasons[id(e)]
+
+
 def apply_filters(entities, filters):
     """Filter entities based on --where conditions."""
     if not filters:
@@ -2566,6 +2643,7 @@ def main():
 
     apply_effective_ids(all_entities, id_style, all_entities)
     apply_effective_ids(entities, id_style, all_entities)
+    materialize_suppressed_by(entities, stages, explicit_fields, where_filters)
     entities = apply_filters(entities, where_filters)
 
     if show_boot:

--- a/internal/status/vendor/status
+++ b/internal/status/vendor/status
@@ -142,11 +142,8 @@ def parse_frontmatter(filepath):
                 if ':' in line:
                     key, _, val = line.partition(':')
                     key = key.strip()
-                    val = val.strip()
-                    if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
-                        val = val[1:-1]
                     if not line[0].isspace():
-                        fields[key] = val
+                        fields[key] = parse_value(val)
     return fields
 
 
@@ -223,10 +220,10 @@ def strip_inline_comment(val):
 
     A `#` preceded by whitespace (or at the start of the value) begins a comment
     and is dropped along with everything after it; the surviving text is
-    right-trimmed. A `#` NOT preceded by whitespace (e.g. an issue token like
-    `#163`) is kept, so values such as `consolidates #163` are preserved. Used
-    for stage numeric/bool/token fields, which never legitimately carry a
-    literal ` #`.
+    right-trimmed. A `#` NOT preceded by whitespace (e.g. an unspaced token like
+    `v1.0#163`) is kept. A space-preceded `#` IS a comment, so an unquoted
+    `consolidates #163` truncates to `consolidates` — to keep such a value the
+    writer quotes it (see quote_for_write).
     """
     for i, ch in enumerate(val):
         if ch != '#':
@@ -234,6 +231,49 @@ def strip_inline_comment(val):
         if i == 0 or val[i - 1].isspace():
             return val[:i].rstrip()
     return val
+
+
+def parse_value(raw):
+    """Resolve a frontmatter value: trim, then unwrap a quoted scalar (dropping
+    any trailing inline comment after the close quote) or strip an inline
+    comment from an unquoted scalar.
+
+    A quoted scalar protects an interior `#` (literal, not a comment); an
+    unquoted scalar drops a whitespace-preceded `#…` per the YAML rule. Mirrors
+    the Go parse_value.
+    """
+    val = raw.strip()
+    if val and val[0] in ('"', "'"):
+        q = val[0]
+        j = val.find(q, 1)
+        if j >= 0:
+            rest = val[j + 1:].lstrip(' \t')
+            if rest == '' or rest[0] == '#':
+                return val[1:j]
+        # Unterminated or trailing non-comment content: preserve the historical
+        # matched-surrounding-quotes behavior, no comment strip.
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+            return val[1:-1]
+        return val
+    return strip_inline_comment(val)
+
+
+def quote_for_write(val):
+    """Wrap a value in quotes when it carries a space-then-`#` (` #`) so the
+    reader's inline-comment strip does not later truncate it — the writer half
+    of the option-C round-trip. A value already wrapped in matched surrounding
+    quotes, or one with no ` #`, is written verbatim (byte preservation). The
+    quote char avoids clashing with a quote the value already holds (the parser
+    does not unescape): prefer `"`, fall back to `'` when the value contains `"`
+    but not `'`. Mirrors the Go quote_for_write.
+    """
+    if ' #' not in val and '\t#' not in val:
+        return val
+    if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+        return val
+    if '"' in val and "'" not in val:
+        return "'" + val + "'"
+    return '"' + val + '"'
 
 
 def parse_stages_block(filepath):
@@ -1577,13 +1617,13 @@ def update_frontmatter(filepath, updates):
             key, _, _ = line.partition(':')
             key_stripped = key.strip()
             if key_stripped in resolved:
-                lines[i] = f'{key_stripped}: {resolved[key_stripped]}'
+                lines[i] = f'{key_stripped}: {quote_for_write(resolved[key_stripped])}'
                 written.add(key_stripped)
 
     # Insert fields not already present in frontmatter before closing ---
     missing = [f for f in resolved if f not in written]
     for field in missing:
-        lines.insert(fm_end, f'{field}: {resolved[field]}')
+        lines.insert(fm_end, f'{field}: {quote_for_write(resolved[field])}')
         fm_end += 1
 
     with open(filepath, 'w') as f:

--- a/skills/commission/bin/status
+++ b/skills/commission/bin/status
@@ -2376,6 +2376,24 @@ def main():
         stages = parse_stages_block(readme_path) if os.path.exists(readme_path) else None
         terminal_names = {s['name'] for s in (stages or []) if s.get('terminal')}
 
+        # Membership guard: a --set status=X must name a stage the workflow
+        # declares. This is distinct from validate_workflow_stage_names' format
+        # regex — it checks the *value* against stages.states[].name membership.
+        # When the workflow declares no stages block we cannot validate
+        # membership, so the guard is a no-op. A non-member value exits non-zero
+        # and leaves the frontmatter unchanged.
+        if stages:
+            stage_names = [s['name'] for s in stages]
+            stage_name_set = set(stage_names)
+            for field, value in updates:
+                if field == 'status' and value not in stage_name_set:
+                    print(
+                        f"Error: '{value}' is not a defined stage in workflow "
+                        f"{pipeline_dir} — known stages: [{', '.join(stage_names)}]",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+
         def is_terminal_update():
             """True when this --set applies any terminal field."""
             for field, value in updates:

--- a/skills/commission/bin/status
+++ b/skills/commission/bin/status
@@ -218,6 +218,24 @@ def parse_mod_metadata(filepath):
     }
 
 
+def strip_inline_comment(val):
+    """Remove a trailing ` # comment` from a value.
+
+    A `#` preceded by whitespace (or at the start of the value) begins a comment
+    and is dropped along with everything after it; the surviving text is
+    right-trimmed. A `#` NOT preceded by whitespace (e.g. an issue token like
+    `#163`) is kept, so values such as `consolidates #163` are preserved. Used
+    for stage numeric/bool/token fields, which never legitimately carry a
+    literal ` #`.
+    """
+    for i, ch in enumerate(val):
+        if ch != '#':
+            continue
+        if i == 0 or val[i - 1].isspace():
+            return val[:i].rstrip()
+    return val
+
+
 def parse_stages_block(filepath):
     """Parse the stages block from README frontmatter."""
     lines = []
@@ -272,7 +290,7 @@ def parse_stages_block(filepath):
                         break
                     if ':' in dstripped:
                         k, _, v = dstripped.partition(':')
-                        defaults[k.strip()] = v.strip()
+                        defaults[k.strip()] = strip_inline_comment(v.strip())
                     i += 1
                 continue
             elif stripped == 'states:':
@@ -289,11 +307,11 @@ def parse_stages_block(filepath):
                         break
                     if sstripped.startswith('- name:'):
                         _, _, name = sstripped.partition('- name:')
-                        current_state = {'name': name.strip()}
+                        current_state = {'name': strip_inline_comment(name.strip())}
                         states.append(current_state)
                     elif current_state is not None and ':' in sstripped and not sstripped.startswith('- '):
                         k, _, v = sstripped.partition(':')
-                        current_state[k.strip()] = v.strip()
+                        current_state[k.strip()] = strip_inline_comment(v.strip())
                     i += 1
                 continue
         i += 1
@@ -376,7 +394,7 @@ def parse_stages_with_defaults(filepath):
                         break
                     if ':' in dstripped:
                         k, _, v = dstripped.partition(':')
-                        defaults[k.strip()] = v.strip()
+                        defaults[k.strip()] = strip_inline_comment(v.strip())
                     i += 1
                 continue
             i += 1

--- a/skills/commission/bin/status
+++ b/skills/commission/bin/status
@@ -1592,6 +1592,83 @@ def update_frontmatter(filepath, updates):
     return resolved
 
 
+# The computed field name the #230 visibility surface exposes via --fields /
+# --where. It is NOT a frontmatter key: it is derived from the --next dispatch
+# analysis, so it is materialized only when explicitly named and is deliberately
+# excluded from --all-fields (which documents stored frontmatter keys).
+SUPPRESSED_BY_FIELD = 'next-suppressed-by'
+
+
+def compute_suppressed_by(entities, stages):
+    """Return {id(entity): reason} for why each entity is NOT dispatched by --next.
+
+    Mirrors the candidate loop in print_next_table exactly so the #230
+    visibility surface can never diverge from --next: a dispatched entity gets
+    '' (not suppressed). Reasons, in the loop's own precedence:
+    terminal | gate | worktree-set | concurrency-full. An entity whose status is
+    not a known stage, or that sits at the last stage with no successor, is not
+    attributable to one of the tracked suppression reasons and gets ''.
+    """
+    stage_by_name = {s['name']: s for s in (stages or [])}
+    stage_names = [s['name'] for s in (stages or [])]
+    active_counts = {}
+    for e in entities:
+        if e['worktree']:
+            st = e['status']
+            active_counts[st] = active_counts.get(st, 0) + 1
+
+    candidates = sorted(entities, key=sort_key_next)
+    next_stage_counts = dict(active_counts)
+    reasons = {}
+    for e in candidates:
+        status = e['status']
+        if status not in stage_by_name:
+            reasons[id(e)] = ''
+            continue
+        stage_idx = stage_names.index(status)
+        stage = stage_by_name[status]
+        if stage.get('terminal', False):
+            reasons[id(e)] = 'terminal'
+            continue
+        if stage.get('gate', False):
+            reasons[id(e)] = 'gate'
+            continue
+        if e['worktree']:
+            reasons[id(e)] = 'worktree-set'
+            continue
+        if stage_idx + 1 >= len(stage_names):
+            reasons[id(e)] = ''
+            continue
+        next_stage_name = stage_names[stage_idx + 1]
+        next_stage = stage_by_name[next_stage_name]
+        current_count = next_stage_counts.get(next_stage_name, 0)
+        if current_count >= next_stage['concurrency']:
+            reasons[id(e)] = 'concurrency-full'
+            continue
+        next_stage_counts[next_stage_name] = current_count + 1
+        reasons[id(e)] = ''
+    return reasons
+
+
+def materialize_suppressed_by(entities, stages, explicit_fields, where_filters):
+    """Write the computed next-suppressed-by reason into each entity ONLY when
+    the field is explicitly referenced by --fields or a --where clause.
+
+    Gating it keeps the value out of --all-fields and the default field set
+    (the entity dict is otherwise untouched), so the parity-pinned
+    frontmatter-keys surfaces stay byte-identical. The reason is computed from
+    the shared dispatch analysis over the read's entity set, so the surface
+    mirrors --next exactly.
+    """
+    referenced = SUPPRESSED_BY_FIELD in (explicit_fields or [])
+    referenced = referenced or any(f[0] == SUPPRESSED_BY_FIELD for f in (where_filters or []))
+    if not referenced:
+        return
+    reasons = compute_suppressed_by(entities, stages)
+    for e in entities:
+        e[SUPPRESSED_BY_FIELD] = reasons[id(e)]
+
+
 def apply_filters(entities, filters):
     """Filter entities based on --where conditions."""
     if not filters:
@@ -2566,6 +2643,7 @@ def main():
 
     apply_effective_ids(all_entities, id_style, all_entities)
     apply_effective_ids(entities, id_style, all_entities)
+    materialize_suppressed_by(entities, stages, explicit_fields, where_filters)
     entities = apply_filters(entities, where_filters)
 
     if show_boot:

--- a/skills/commission/bin/status
+++ b/skills/commission/bin/status
@@ -142,11 +142,8 @@ def parse_frontmatter(filepath):
                 if ':' in line:
                     key, _, val = line.partition(':')
                     key = key.strip()
-                    val = val.strip()
-                    if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
-                        val = val[1:-1]
                     if not line[0].isspace():
-                        fields[key] = val
+                        fields[key] = parse_value(val)
     return fields
 
 
@@ -223,10 +220,10 @@ def strip_inline_comment(val):
 
     A `#` preceded by whitespace (or at the start of the value) begins a comment
     and is dropped along with everything after it; the surviving text is
-    right-trimmed. A `#` NOT preceded by whitespace (e.g. an issue token like
-    `#163`) is kept, so values such as `consolidates #163` are preserved. Used
-    for stage numeric/bool/token fields, which never legitimately carry a
-    literal ` #`.
+    right-trimmed. A `#` NOT preceded by whitespace (e.g. an unspaced token like
+    `v1.0#163`) is kept. A space-preceded `#` IS a comment, so an unquoted
+    `consolidates #163` truncates to `consolidates` — to keep such a value the
+    writer quotes it (see quote_for_write).
     """
     for i, ch in enumerate(val):
         if ch != '#':
@@ -234,6 +231,49 @@ def strip_inline_comment(val):
         if i == 0 or val[i - 1].isspace():
             return val[:i].rstrip()
     return val
+
+
+def parse_value(raw):
+    """Resolve a frontmatter value: trim, then unwrap a quoted scalar (dropping
+    any trailing inline comment after the close quote) or strip an inline
+    comment from an unquoted scalar.
+
+    A quoted scalar protects an interior `#` (literal, not a comment); an
+    unquoted scalar drops a whitespace-preceded `#…` per the YAML rule. Mirrors
+    the Go parse_value.
+    """
+    val = raw.strip()
+    if val and val[0] in ('"', "'"):
+        q = val[0]
+        j = val.find(q, 1)
+        if j >= 0:
+            rest = val[j + 1:].lstrip(' \t')
+            if rest == '' or rest[0] == '#':
+                return val[1:j]
+        # Unterminated or trailing non-comment content: preserve the historical
+        # matched-surrounding-quotes behavior, no comment strip.
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+            return val[1:-1]
+        return val
+    return strip_inline_comment(val)
+
+
+def quote_for_write(val):
+    """Wrap a value in quotes when it carries a space-then-`#` (` #`) so the
+    reader's inline-comment strip does not later truncate it — the writer half
+    of the option-C round-trip. A value already wrapped in matched surrounding
+    quotes, or one with no ` #`, is written verbatim (byte preservation). The
+    quote char avoids clashing with a quote the value already holds (the parser
+    does not unescape): prefer `"`, fall back to `'` when the value contains `"`
+    but not `'`. Mirrors the Go quote_for_write.
+    """
+    if ' #' not in val and '\t#' not in val:
+        return val
+    if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+        return val
+    if '"' in val and "'" not in val:
+        return "'" + val + "'"
+    return '"' + val + '"'
 
 
 def parse_stages_block(filepath):
@@ -1577,13 +1617,13 @@ def update_frontmatter(filepath, updates):
             key, _, _ = line.partition(':')
             key_stripped = key.strip()
             if key_stripped in resolved:
-                lines[i] = f'{key_stripped}: {resolved[key_stripped]}'
+                lines[i] = f'{key_stripped}: {quote_for_write(resolved[key_stripped])}'
                 written.add(key_stripped)
 
     # Insert fields not already present in frontmatter before closing ---
     missing = [f for f in resolved if f not in written]
     for field in missing:
-        lines.insert(fm_end, f'{field}: {resolved[field]}')
+        lines.insert(fm_end, f'{field}: {quote_for_write(resolved[field])}')
         fm_end += 1
 
     with open(filepath, 'w') as f:


### PR DESCRIPTION
Fixes three status-correctness gaps that misled FO scheduling and let bad state in silently: stage-name validation, inline-comment parsing, and dispatch-suppression visibility.

## What changed
- Reject `--set status=X` when X is not a declared workflow stage (membership check; exit 1, frontmatter unchanged).
- Strip inline `#` comments from stage fields and frontmatter values; the writer auto-quotes `#`-bearing values to round-trip.
- Add a `--fields`/`--where`-able `next-suppressed-by` reason surface (additive; `--next` output unchanged).
- Lock enumeration scope-by-placement with a characterization test and a README rule.

## Evidence
- `go test ./internal/status/...` — 295/295 passed; differential parity tamper-verified (Go ↔ Python oracle).
- Validation reproduced all four ACs on the branch binary; detached adversarial audit CONFIRMED.

## Review guidance
Parity-paired Go + Python oracle; the membership check sits before the merge-guard and rejects only non-members, so terminal stages still hit the guard.

---
[s0](/spacedock-dev/spacedock/blob/6c713bd6862a62e7f7a399e2813b3bc2e315cd71/status-enumeration-and-validation/index.md)
Closes #230, #207, #189, #163