### PR TITLE
split-root collaboration (Phase B): $inline classifier, state init, orphan-branch scaffolding, FO/ensign sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ __pycache__/
 
 # goreleaser build output (binaries, tarballs, checksums, generated cask).
 dist/
+
+# Split-root state checkouts are linked worktrees on an orphan state branch, never
+# committed to the code branch (zero code-branch churn). A fresh clone re-creates
+# the checkout with `spacedock state init`.
+**/.spacedock-state/

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -127,6 +127,7 @@ func newRootCommand(ctx context.Context, env []string, dir string, stdin io.Read
 		newDoctorCommand(ctx, env, stdout, stderr),
 		newStatusCommand(ctx, env, dir, stdin, stdout, stderr, runner),
 		newNewCommand(ctx, env, dir, stdin, stdout, stderr, runner),
+		newStateCommand(ctx, env, dir, stdout, stderr),
 		newCompletionCommand(stdout, stderr),
 		newDispatchCommand(dispatchProbe, stdin, stdout, stderr),
 	)
@@ -287,6 +288,32 @@ func newNewCommand(ctx context.Context, env []string, dir string, stdin io.Reade
 	}
 }
 
+// newStateCommand wires `spacedock state init` for split-root state-checkout
+// management. Flag parsing is disabled so the post-subcommand argv (the optional
+// --workflow-dir) reaches runStateInit verbatim. `init` is the only subcommand;
+// an unknown or missing subcommand is a usage error (exit 2).
+func newStateCommand(ctx context.Context, env []string, dir string, stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:                "state init [--workflow-dir DIR]",
+		Short:              "Initialize a cloned split-root workflow's state checkout",
+		GroupID:            "workflow",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if wantsHelp(args) {
+				return cmd.Help()
+			}
+			if len(args) == 0 || args[0] != "init" {
+				fmt.Fprintln(stderr, "spacedock state: unknown subcommand (want: init)")
+				return exitCodeError{2}
+			}
+			if code := runStateInit(ctx, args[1:], env, dir, stdout, stderr); code != 0 {
+				return exitCodeError{code}
+			}
+			return nil
+		},
+	}
+}
+
 // newCompletionCommand wires `spacedock completion bash|zsh`, emitting a static
 // completion script to stdout (exit 0). An unknown or missing shell prints the
 // named usage error and returns 2 — the CLI-layer usage-error code, matching the
@@ -434,7 +461,7 @@ _spacedock() {
   local cur prev verbs status_flags
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
-  verbs="claude codex install doctor status new completion dispatch --version --help"
+  verbs="claude codex install doctor status new state completion dispatch --version --help"
   status_flags="--workflow-dir --next --next-id --boot --validate --archived --json --quiet --new --folder --set --where --archive --resolve --short-id --discover --root"
   if [ "$COMP_CWORD" -eq 1 ]; then
     COMPREPLY=( $(compgen -W "$verbs" -- "$cur") )
@@ -442,6 +469,7 @@ _spacedock() {
   fi
   case "${COMP_WORDS[1]}" in
     status) COMPREPLY=( $(compgen -W "$status_flags" -- "$cur") ) ;;
+    state) COMPREPLY=( $(compgen -W "init --workflow-dir" -- "$cur") ) ;;
     completion) COMPREPLY=( $(compgen -W "bash zsh" -- "$cur") ) ;;
   esac
 }
@@ -453,7 +481,7 @@ const zshCompletion = `#compdef spacedock
 # spacedock zsh completion
 _spacedock() {
   local -a verbs status_flags
-  verbs=(claude codex install doctor status new completion dispatch --version --help)
+  verbs=(claude codex install doctor status new state completion dispatch --version --help)
   status_flags=(--workflow-dir --next --next-id --boot --validate --archived --json --quiet --new --folder --set --where --archive --resolve --short-id --discover --root)
   if (( CURRENT == 2 )); then
     compadd -- $verbs
@@ -461,6 +489,7 @@ _spacedock() {
   fi
   case "${words[2]}" in
     status) compadd -- $status_flags ;;
+    state) compadd -- init --workflow-dir ;;
     completion) compadd -- bash zsh ;;
   esac
 }

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -25,6 +25,7 @@ Setup
 Workflow
   status      [args]                 Show or update workflow state
   new         [--folder] SLUG        Create an entity from a stdin body (auto-discovers the workflow)
+  state       init                   Initialize a cloned split-root workflow's state checkout
   completion  bash|zsh               Print a bash or zsh completion script
   dispatch    build | show-stage-def Build worker dispatch artifacts
 

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -1,0 +1,127 @@
+// ABOUTME: `spacedock state init` — resume a cloned split-root workflow by fetching
+// ABOUTME: the orphan state branch and adding it as a linked worktree at state:.
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// runStateInit implements `spacedock state init`. It reads the workflow's
+// `state:` and `state-branch:` from the README, and for a split-root workflow
+// whose state checkout is ABSENT, fetches the orphan state branch from origin and
+// checks it out as a linked worktree at the state path. The path-exists guard
+// makes a second run a no-op (a raw 2nd `git worktree add` fatals "already
+// exists"). An inline/empty workflow has nothing to init.
+func runStateInit(ctx context.Context, args []string, env []string, dir string, stdout, stderr io.Writer) int {
+	workflowDir, code := parseStateInitArgs(args, dir, stderr)
+	if code != 0 {
+		return code
+	}
+
+	readme := filepath.Join(workflowDir, "README.md")
+	if !fileExists(readme) {
+		fmt.Fprintf(stderr, "spacedock state init: no README.md at %s\n", workflowDir)
+		return 1
+	}
+	fm := status.ParseFrontmatter(readme)
+	mode, relPath, err := status.ClassifyState(fm["state"])
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock state init: %v\n", err)
+		return 1
+	}
+	if mode == status.StateInline {
+		fmt.Fprintln(stdout, "Inline workflow — entities live beside the README; nothing to init.")
+		return 0
+	}
+
+	branch, err := status.StateBranch(workflowDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock state init: %v\n", err)
+		return 1
+	}
+	statePath := filepath.Join(workflowDir, relPath)
+
+	// Path-exists guard: a present state checkout is a no-op. Refresh it from
+	// origin so a resume sees peers' commits, then report. Never re-`worktree add`
+	// (the spike showed a 2nd add fatals "already exists").
+	if dirExists(statePath) {
+		if fetchOK, _ := runGit(statePath, "fetch", "origin", branch); fetchOK {
+			runGit(statePath, "pull", "--rebase", "origin", branch)
+		}
+		fmt.Fprintf(stdout, "State checkout already initialized at %s (branch %s).\n", statePath, branch)
+		return 0
+	}
+
+	// Fresh resume: fetch the orphan branch, then add it as a linked worktree.
+	if ok, out := runGit(workflowDir, "fetch", "origin", branch); !ok {
+		fmt.Fprintf(stderr, "spacedock state init: git fetch origin %s failed:\n%s\n"+
+			"Manual fallback: git fetch origin %s && git worktree add %s %s\n",
+			branch, out, branch, statePath, branch)
+		return 1
+	}
+	if ok, out := runGit(workflowDir, "worktree", "add", statePath, branch); !ok {
+		fmt.Fprintf(stderr, "spacedock state init: git worktree add %s %s failed:\n%s\n",
+			statePath, branch, out)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Initialized state checkout at %s (branch %s).\n", statePath, branch)
+	return 0
+}
+
+// parseStateInitArgs reads `--workflow-dir DIR`, resolving a relative path
+// against dir. With no flag it discovers the enclosing workflow from dir.
+func parseStateInitArgs(args []string, dir string, stderr io.Writer) (workflowDir string, code int) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--workflow-dir":
+			if i+1 >= len(args) {
+				fmt.Fprintln(stderr, "spacedock state init: --workflow-dir requires a path")
+				return "", 2
+			}
+			workflowDir = args[i+1]
+			i++
+		default:
+			fmt.Fprintf(stderr, "spacedock state init: unknown argument %q\n", args[i])
+			return "", 2
+		}
+	}
+	if workflowDir == "" {
+		discovered, ok := status.DiscoverWorkflowDir(dir)
+		if !ok {
+			fmt.Fprintln(stderr, "spacedock state init: no workflow here — pass --workflow-dir or run inside a workflow")
+			return "", 1
+		}
+		workflowDir = discovered
+	} else if !filepath.IsAbs(workflowDir) {
+		workflowDir = filepath.Join(dir, workflowDir)
+	}
+	return workflowDir, 0
+}
+
+// runGit runs a git command in dir, returning success and combined output. On
+// failure it does NOT print — the caller decides whether the failure is fatal (a
+// fresh fetch) or tolerable (a refresh pull on an already-initialized checkout).
+func runGit(dir string, gitArgs ...string) (bool, string) {
+	cmd := exec.Command("git", append([]string{"-C", dir}, gitArgs...)...)
+	out, err := cmd.CombinedOutput()
+	return err == nil, string(out)
+}
+
+// fileExists reports whether path is an existing regular file.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+// dirExists reports whether path is an existing directory.
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/cli/state_init_test.go
+++ b/internal/cli/state_init_test.go
@@ -1,0 +1,284 @@
+// ABOUTME: B.2/B.3 real-git e2e — commission orphan-branch scaffolding (Spike a)
+// ABOUTME: + `spacedock state init` fresh-clone resume (Spike b), no mocks.
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// splitWorkflowReadme is a commissioned split-root README declaring the state
+// checkout path. The state-branch defaults to spacedock-state/<basename> (B.2).
+const splitWorkflowReadme = `---
+commissioned-by: spacedock@1
+id-style: slug
+state: .spacedock-state
+stages:
+  states:
+    - name: ideation
+      initial: true
+    - name: done
+      terminal: true
+---
+
+# Split Workflow
+`
+
+// git runs a git command in dir, failing the test on a non-zero exit.
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+// gitOK runs a git command and reports whether it succeeded, returning combined
+// output for the caller to inspect. Used for the path-exists-guard assertion
+// where a 2nd `git worktree add` is expected to FATAL.
+func gitOK(t *testing.T, dir string, args ...string) (string, bool) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err == nil
+}
+
+// commissionSplitWorkflow replicates the spiked Spike (a) commission mechanics
+// inside hostClone: write README + gitignore the state path on the code branch,
+// commit code, then birth the orphan state branch in a temp detached worktree
+// (clear the inherited tree, seed an entity), check it out as a linked worktree
+// at the gitignored path, and push the orphan branch to origin. Returns the
+// workflow dir and the seeded entity slug.
+func commissionSplitWorkflow(t *testing.T, hostClone string) (workflowDir, stateBranch, seedSlug string) {
+	t.Helper()
+	workflowRel := filepath.Join("docs", "dev")
+	workflowDir = filepath.Join(hostClone, workflowRel)
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(workflowDir, ".spacedock-state")
+	seedSlug = "first-task"
+	stateBranch = "spacedock-state/dev"
+
+	// Code-branch files: README + a tracked .gitignore for the state path (M-1
+	// step 2 made durable — collaborators/fresh clones must ignore it).
+	if err := os.WriteFile(filepath.Join(workflowDir, "README.md"), []byte(splitWorkflowReadme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hostClone, ".gitignore"), []byte("docs/dev/.spacedock-state/\n.worktrees/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, hostClone, "add", "docs/dev/README.md", ".gitignore")
+	git(t, hostClone, "commit", "-q", "-m", "commission split workflow")
+
+	// Birth the orphan state branch in a temp detached worktree, clearing the
+	// inherited index/tree (the spike-surfaced mechanic), seeding one entity.
+	tmpWT := filepath.Join(t.TempDir(), "orphan-birth")
+	git(t, hostClone, "worktree", "add", "--detach", tmpWT)
+	git(t, tmpWT, "checkout", "--orphan", stateBranch)
+	git(t, tmpWT, "rm", "-rf", "--cached", ".")
+	// Remove the inherited working-tree files so the orphan tree starts empty.
+	entries, err := os.ReadDir(tmpWT)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() == ".git" {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(tmpWT, e.Name())); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(tmpWT, seedSlug+".md"),
+		[]byte("---\nstatus: ideation\n---\n# First Task\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, tmpWT, "add", "-A")
+	git(t, tmpWT, "commit", "-q", "-m", "seed state")
+	git(t, tmpWT, "push", "origin", stateBranch)
+	git(t, hostClone, "worktree", "remove", "--force", tmpWT)
+
+	// Check the orphan branch out at the gitignored state path as a linked worktree.
+	git(t, hostClone, "worktree", "add", statePath, stateBranch)
+	return workflowDir, stateBranch, seedSlug
+}
+
+// TestCommissionOrphanBranchScaffolding pins B.3/AC-3 + the M-4 spike-replication
+// asserts for Spike (a): the orphan branch exists on origin, the state path is a
+// linked worktree, the orphan's tree carries NO code-branch files (clear-inherited
+// mechanic), the code branch porcelain is empty (R1), and status renders.
+func TestCommissionOrphanBranchScaffolding(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+
+	hostClone := filepath.Join(t.TempDir(), "host")
+	git(t, t.TempDir(), "clone", "-q", bare, hostClone)
+	git(t, hostClone, "config", "user.email", "t@t")
+	git(t, hostClone, "config", "user.name", "t")
+
+	workflowDir, stateBranch, seedSlug := commissionSplitWorkflow(t, hostClone)
+	statePath := filepath.Join(workflowDir, ".spacedock-state")
+
+	// Orphan branch exists on origin.
+	if out := git(t, bare, "branch", "--list", stateBranch); !strings.Contains(out, stateBranch) {
+		t.Fatalf("orphan branch %q not on origin; branches=%q", stateBranch, out)
+	}
+	// State path is a linked worktree of the host clone.
+	if out := git(t, hostClone, "worktree", "list"); !strings.Contains(out, statePath) {
+		t.Fatalf("state path is not a linked worktree; worktree list=%q", out)
+	}
+	// Clear-inherited mechanic: the orphan's tree has NO code-branch files (no
+	// README.md, no .gitignore) — only the seeded entity.
+	orphanFiles := git(t, statePath, "ls-tree", "--name-only", stateBranch)
+	if strings.Contains(orphanFiles, "README.md") || strings.Contains(orphanFiles, ".gitignore") || strings.Contains(orphanFiles, "docs") {
+		t.Fatalf("orphan tree carries inherited code-branch files: %q", orphanFiles)
+	}
+	if !strings.Contains(orphanFiles, seedSlug+".md") {
+		t.Fatalf("orphan tree missing the seeded entity %q; tree=%q", seedSlug+".md", orphanFiles)
+	}
+	// R1: the code branch working tree is clean (state path is gitignored).
+	if out := git(t, hostClone, "status", "--porcelain"); strings.TrimSpace(out) != "" {
+		t.Fatalf("code branch porcelain not empty (R1 violated): %q", out)
+	}
+	// status renders the seeded entity from the state checkout.
+	assertStatusRenders(t, workflowDir, seedSlug)
+}
+
+// TestStateInitResumesFreshClone pins B.2/AC-4 + the M-4 spike-replication asserts
+// for Spike (b): a fresh clone of origin has the state path absent
+// (entity_dir_present:false); `state init` fetches the orphan branch and adds the
+// linked worktree so status renders; a 2nd `state init` is a no-op (path-exists
+// guard), NOT a fatal (the spike showed a raw 2nd `worktree add` fatals).
+func TestStateInitResumesFreshClone(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+
+	hostClone := filepath.Join(t.TempDir(), "host")
+	git(t, t.TempDir(), "clone", "-q", bare, hostClone)
+	git(t, hostClone, "config", "user.email", "t@t")
+	git(t, hostClone, "config", "user.name", "t")
+	commissionSplitWorkflow(t, hostClone)
+	// Push the code branch (the orphan branch was already pushed in commission).
+	git(t, hostClone, "push", "-q", "origin", "HEAD")
+
+	// Fresh clone: code branch only, state path absent.
+	fresh := filepath.Join(t.TempDir(), "fresh")
+	git(t, t.TempDir(), "clone", "-q", bare, fresh)
+	git(t, fresh, "config", "user.email", "t@t")
+	git(t, fresh, "config", "user.name", "t")
+	freshWorkflow := filepath.Join(fresh, "docs", "dev")
+	freshState := filepath.Join(freshWorkflow, ".spacedock-state")
+
+	if _, err := os.Stat(freshState); !os.IsNotExist(err) {
+		t.Fatalf("fresh clone should NOT have the state path yet (err=%v)", err)
+	}
+
+	// Pre-init boot shows entity_dir_present:false.
+	bootOut := runStatusBoot(t, freshWorkflow)
+	if !strings.Contains(bootOut, "STATE_BACKEND: split-root") {
+		t.Fatalf("pre-init boot should show split-root; got\n%s", bootOut)
+	}
+	if !strings.Contains(bootOut, "present: false") {
+		t.Fatalf("pre-init boot should show present: false; got\n%s", bootOut)
+	}
+
+	// state init: fetch + worktree add.
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "init", "--workflow-dir", freshWorkflow},
+		os.Environ(), fresh, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("state init exit=%d stdout=%q stderr=%q", code, out.String(), errBuf.String())
+	}
+	if _, err := os.Stat(freshState); err != nil {
+		t.Fatalf("state init did not create the state worktree: %v", err)
+	}
+	assertStatusRenders(t, freshWorkflow, "first-task")
+
+	// 2nd state init is an idempotent no-op (path-exists guard) — NOT a fatal.
+	var out2, errBuf2 strings.Builder
+	code2 := run(context.Background(), []string{"state", "init", "--workflow-dir", freshWorkflow},
+		os.Environ(), fresh, nil, &out2, &errBuf2, &status.NativeRunner{}, nil)
+	if code2 != 0 {
+		t.Fatalf("2nd state init must be a no-op (exit 0), got exit=%d stderr=%q", code2, errBuf2.String())
+	}
+	if strings.Contains(errBuf2.String(), "already exists") {
+		t.Fatalf("2nd state init leaked git's 'already exists' fatal: %q", errBuf2.String())
+	}
+	// State still renders after the no-op re-run.
+	assertStatusRenders(t, freshWorkflow, "first-task")
+}
+
+// TestStateInitInlineNoOp pins the inline/empty no-op: a non-split workflow has
+// nothing to init; `state init` exits 0 with a one-liner and creates no worktree.
+func TestStateInitInlineNoOp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	wf := filepath.Join(root, "wf")
+	if err := os.MkdirAll(wf, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wf, "README.md"),
+		[]byte("---\ncommissioned-by: spacedock@1\nid-style: slug\nstate: $inline\nstages:\n  states:\n    - name: ideation\n      initial: true\n    - name: done\n      terminal: true\n---\n\n# Inline WF\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, root, "init", "-q")
+	git(t, root, "add", "-A")
+	git(t, root, "commit", "-q", "-m", "init")
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "init", "--workflow-dir", wf},
+		os.Environ(), root, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("inline state init exit=%d stderr=%q", code, errBuf.String())
+	}
+	if out.Len() == 0 {
+		t.Fatalf("inline state init should print a one-liner; stdout empty")
+	}
+}
+
+// assertStatusRenders runs `spacedock status` against workflowDir and asserts the
+// seeded entity slug appears in the rendered table.
+func assertStatusRenders(t *testing.T, workflowDir, slug string) {
+	t.Helper()
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"status", "--workflow-dir", workflowDir},
+		os.Environ(), workflowDir, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("status exit=%d stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), slug) {
+		t.Fatalf("status did not render entity %q; got\n%s", slug, out.String())
+	}
+}
+
+// runStatusBoot runs `spacedock status --boot` against workflowDir and returns
+// stdout.
+func runStatusBoot(t *testing.T, workflowDir string) string {
+	t.Helper()
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"status", "--workflow-dir", workflowDir, "--boot"},
+		os.Environ(), workflowDir, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("status --boot exit=%d stderr=%q", code, errBuf.String())
+	}
+	return out.String()
+}

--- a/internal/cli/state_sync_test.go
+++ b/internal/cli/state_sync_test.go
@@ -1,0 +1,184 @@
+// ABOUTME: B.6 real-git 2-writer sync e2e — push / non-ff rejection / pull-rebase /
+// ABOUTME: re-push (Spike c) plus the M-3 same-entity rebase-conflict halt path.
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// cloneOnStateBranch makes a working clone of the bare origin and checks out the
+// shared state branch, configured with a committer identity. Returns the clone
+// path. This models a host's state checkout participating in the shared orphan
+// state branch (the e2e exercises the state branch directly, the unit the sync
+// contract governs).
+func cloneOnStateBranch(t *testing.T, bare, name, stateBranch string) string {
+	t.Helper()
+	clone := filepath.Join(t.TempDir(), name)
+	git(t, t.TempDir(), "clone", "-q", "-b", stateBranch, bare, clone)
+	git(t, clone, "config", "user.email", name+"@t")
+	git(t, clone, "config", "user.name", name)
+	return clone
+}
+
+// commitEntity writes/overwrites an entity file in the clone and commits it
+// path-scoped (the concurrency-safe commit rule), returning nothing. fail the
+// test on git error.
+func commitEntity(t *testing.T, clone, slug, body, msg string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(clone, slug+".md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, clone, "add", slug+".md")
+	git(t, clone, "commit", "-q", "-m", msg, "--", slug+".md")
+}
+
+// seedStateBranch births a state branch on the bare origin with one entity, the
+// minimal fixture the 2-writer sync e2e shares. Returns the state branch name.
+func seedStateBranch(t *testing.T, bare string) string {
+	t.Helper()
+	stateBranch := "spacedock-state/dev"
+	seed := filepath.Join(t.TempDir(), "seed")
+	git(t, t.TempDir(), "clone", "-q", bare, seed)
+	git(t, seed, "config", "user.email", "seed@t")
+	git(t, seed, "config", "user.name", "seed")
+	git(t, seed, "checkout", "--orphan", stateBranch)
+	// A fresh bare clone has no commits, so the orphan index is already empty;
+	// rm --cached is tolerated as a no-op (and clears any inherited tree when the
+	// origin did carry a code branch).
+	gitOK(t, seed, "rm", "-rf", "--cached", ".")
+	entries, _ := os.ReadDir(seed)
+	for _, e := range entries {
+		if e.Name() != ".git" {
+			os.RemoveAll(filepath.Join(seed, e.Name()))
+		}
+	}
+	if err := os.WriteFile(filepath.Join(seed, "alpha.md"),
+		[]byte("---\nstatus: ideation\n---\n# Alpha\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, seed, "add", "-A")
+	git(t, seed, "commit", "-q", "-m", "seed alpha")
+	git(t, seed, "push", "origin", stateBranch)
+	return stateBranch
+}
+
+// TestTwoWriterSyncHappyPath replicates Spike (c): host A commits+pushes a
+// path-scoped entity; host B's push is REJECTED (non-fast-forward); B
+// `pull --rebase` replays B's distinct-file commit atop A's with ZERO conflict →
+// both entities present + linear history; B re-pushes; A `pull --rebase` sees B's.
+func TestTwoWriterSyncHappyPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+	stateBranch := seedStateBranch(t, bare)
+
+	hostA := cloneOnStateBranch(t, bare, "hostA", stateBranch)
+	hostB := cloneOnStateBranch(t, bare, "hostB", stateBranch)
+
+	// A commits a distinct entity and pushes first.
+	commitEntity(t, hostA, "beta", "---\nstatus: ideation\n---\n# Beta (A)\n", "A: add beta")
+	git(t, hostA, "push", "origin", stateBranch)
+
+	// B commits a DIFFERENT distinct entity; its push is rejected (non-ff).
+	commitEntity(t, hostB, "gamma", "---\nstatus: ideation\n---\n# Gamma (B)\n", "B: add gamma")
+	if out, ok := gitOK(t, hostB, "push", "origin", stateBranch); ok {
+		t.Fatalf("B's push should be REJECTED (non-fast-forward); it succeeded:\n%s", out)
+	}
+
+	// B pull --rebase: distinct files → zero conflict, B's commit replays atop A's.
+	if out, ok := gitOK(t, hostB, "pull", "--rebase", "origin", stateBranch); !ok {
+		t.Fatalf("B pull --rebase should replay cleanly (distinct files); it failed:\n%s", out)
+	}
+	// Both entities present in B's tree.
+	for _, slug := range []string{"alpha", "beta", "gamma"} {
+		if _, err := os.Stat(filepath.Join(hostB, slug+".md")); err != nil {
+			t.Fatalf("B tree missing %s after pull --rebase: %v", slug, err)
+		}
+	}
+	// Linear history: no merge commit (all commits have a single parent).
+	if out := git(t, hostB, "log", "--merges", "--oneline"); strings.TrimSpace(out) != "" {
+		t.Fatalf("history is not linear after pull --rebase; merge commits:\n%s", out)
+	}
+	// B re-pushes successfully.
+	git(t, hostB, "push", "origin", stateBranch)
+	// A pull --rebase sees B's gamma.
+	git(t, hostA, "pull", "--rebase", "origin", stateBranch)
+	if _, err := os.Stat(filepath.Join(hostA, "gamma.md")); err != nil {
+		t.Fatalf("A tree missing gamma after pull --rebase: %v", err)
+	}
+}
+
+// TestTwoWriterSameEntityConflictHalts pins the M-3 contract behavior: when two
+// writers edit the SAME entity's frontmatter concurrently, B's `pull --rebase`
+// CONFLICTS; the writer aborts the rebase (clean checkout, no merge in progress)
+// and does NOT force-push — the halt. The e2e asserts the conflict is real, the
+// abort restores a clean tree, and a plain re-push stays rejected (B did not
+// force-push to clobber A).
+func TestTwoWriterSameEntityConflictHalts(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+	stateBranch := seedStateBranch(t, bare)
+
+	hostA := cloneOnStateBranch(t, bare, "hostA", stateBranch)
+	hostB := cloneOnStateBranch(t, bare, "hostB", stateBranch)
+
+	// Both edit the SAME entity (alpha) frontmatter concurrently.
+	commitEntity(t, hostA, "alpha", "---\nstatus: implementation\n---\n# Alpha (A)\n", "A: alpha -> implementation")
+	git(t, hostA, "push", "origin", stateBranch)
+	commitEntity(t, hostB, "alpha", "---\nstatus: review\n---\n# Alpha (B)\n", "B: alpha -> review")
+
+	// B's push is rejected (non-ff).
+	if _, ok := gitOK(t, hostB, "push", "origin", stateBranch); ok {
+		t.Fatalf("B's push should be rejected (non-fast-forward)")
+	}
+	// B pull --rebase CONFLICTS (same file, divergent frontmatter).
+	out, ok := gitOK(t, hostB, "pull", "--rebase", "origin", stateBranch)
+	if ok {
+		t.Fatalf("same-entity pull --rebase should CONFLICT; it succeeded:\n%s", out)
+	}
+	if !strings.Contains(out, "CONFLICT") && !strings.Contains(out, "conflict") {
+		t.Fatalf("pull --rebase output should report a conflict; got:\n%s", out)
+	}
+	// A rebase is in progress (the conflict state the contract halts on).
+	if _, err := os.Stat(filepath.Join(hostB, ".git", "rebase-merge")); err != nil {
+		if _, err2 := os.Stat(filepath.Join(hostB, ".git", "rebase-apply")); err2 != nil {
+			t.Fatalf("expected a rebase in progress after the conflict; none found")
+		}
+	}
+
+	// The M-3 halt: abort the rebase (do NOT auto-resolve, do NOT force-push).
+	git(t, hostB, "rebase", "--abort")
+	// The abort leaves a clean checkout.
+	if out := git(t, hostB, "status", "--porcelain"); strings.TrimSpace(out) != "" {
+		t.Fatalf("rebase --abort should leave a clean checkout; porcelain:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(hostB, ".git", "rebase-merge")); err == nil {
+		t.Fatalf("rebase still in progress after --abort")
+	}
+	// B did NOT force-push, so a plain push stays rejected — A's edit survives on
+	// origin (the contract: no silent clobber of a peer's frontmatter edit).
+	if _, ok := gitOK(t, hostB, "push", "origin", stateBranch); ok {
+		t.Fatalf("a plain (non-force) push after abort must stay rejected; A's edit would be clobbered otherwise")
+	}
+	// A's edit is what's on origin (verify via a fresh read of the bare ref).
+	originAlpha := showOriginFile(t, bare, stateBranch, "alpha.md")
+	if !strings.Contains(originAlpha, "status: implementation") {
+		t.Fatalf("origin alpha should carry A's edit (status: implementation); got:\n%s", originAlpha)
+	}
+}
+
+// showOriginFile reads a file's contents at the tip of branch in the bare repo.
+func showOriginFile(t *testing.T, bare, branch, file string) string {
+	t.Helper()
+	cmd := exec.Command("git", "-C", bare, "show", branch+":"+file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git show %s:%s in %s: %v\n%s", branch, file, bare, err, out)
+	}
+	return string(out)
+}

--- a/internal/dispatch/helpers.go
+++ b/internal/dispatch/helpers.go
@@ -123,11 +123,11 @@ func isFile(path string) bool {
 func splitRootStateCheckout(workflowDir string) string {
 	readmePath := filepath.Join(workflowDir, "README.md")
 	fm := status.ParseFrontmatter(readmePath)
-	state := strings.TrimSpace(fm["state"])
-	if state == "" {
+	mode, relPath, err := status.ClassifyState(fm["state"])
+	if err != nil || mode != status.StateSplitRoot {
 		return ""
 	}
-	return filepath.Join(workflowDir, state)
+	return filepath.Join(workflowDir, relPath)
 }
 
 // pyRelpath returns path relative to base the way os.path.relpath does for the

--- a/internal/dispatch/inline_sentinel_checkout_test.go
+++ b/internal/dispatch/inline_sentinel_checkout_test.go
@@ -1,0 +1,41 @@
+// ABOUTME: M-2 site-level negative — splitRootStateCheckout returns "" for the
+// ABOUTME: $inline sentinel, never a literal `…/$inline` checkout path.
+package dispatch
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSplitRootStateCheckoutInlineSentinel pins the M-2 negative at the
+// splitRootStateCheckout site: a `state: $inline` README yields "" (inline, no
+// state checkout), identical to an absent state: field — never a literal
+// `…/$inline` path.
+func TestSplitRootStateCheckoutInlineSentinel(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state string
+	}{
+		{"explicit inline sentinel", "$inline"},
+		{"absent state", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wf := t.TempDir()
+			fm := "---\ncommissioned-by: spacedock@1\nid-style: slug\n"
+			if tc.state != "" {
+				fm += "state: " + tc.state + "\n"
+			}
+			fm += "---\n\n# WF\n"
+			writeFile(t, filepath.Join(wf, "README.md"), fm)
+
+			got := splitRootStateCheckout(wf)
+			if got != "" {
+				t.Fatalf("splitRootStateCheckout = %q, want \"\" (inline has no state checkout)", got)
+			}
+			if strings.Contains(got, "$inline") {
+				t.Fatalf("splitRootStateCheckout joined the literal sentinel: %q", got)
+			}
+		})
+	}
+}

--- a/internal/hostneutrality/split_root_sync_contract_test.go
+++ b/internal/hostneutrality/split_root_sync_contract_test.go
@@ -1,0 +1,98 @@
+// ABOUTME: B5/B6 contract skill-text tests — assert the FO halt-gate + push/pull
+// ABOUTME: sync + rebase-conflict halt prose is present at the FO and ensign homes.
+package hostneutrality
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// foCorePath is the FO shared-core contract.
+var foCorePath = filepath.Join("..", "..", "skills", "first-officer", "references",
+	"first-officer-shared-core.md")
+
+// ensignCorePath is the ensign shared-core contract.
+var ensignCorePath = filepath.Join("..", "..", "skills", "ensign", "references",
+	"ensign-shared-core.md")
+
+// commissionSkillPath is the commission SKILL.md.
+var commissionSkillPath = filepath.Join("..", "..", "skills", "commission", "SKILL.md")
+
+// readSkill reads a skill file, failing the test on error.
+func readSkill(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// assertAll fails with a per-token diagnostic for each token missing from text.
+func assertAll(t *testing.T, name, text string, tokens []string) {
+	t.Helper()
+	for _, tok := range tokens {
+		if !strings.Contains(text, tok) {
+			t.Errorf("%s missing required contract token: %q", name, tok)
+		}
+	}
+}
+
+// TestFOHaltGateProse pins B5: the FO core carries the boot halt-gate keyed on
+// the Phase-A boot fields (split-root && entity_dir_present false → halt dispatch,
+// point at `spacedock state init`).
+func TestFOHaltGateProse(t *testing.T) {
+	text := readSkill(t, foCorePath)
+	assertAll(t, "FO core (B5 halt-gate)", text, []string{
+		"state_backend",
+		"entity_dir_present",
+		"split-root",
+		"spacedock state init",
+		"HALT",
+	})
+}
+
+// TestFOSyncProse pins the FO half of B6: pull --rebase on boot, push after a
+// state commit, and the M-3 rebase-conflict halt (abort + surface + no
+// force-push, no auto-resolve).
+func TestFOSyncProse(t *testing.T) {
+	text := readSkill(t, foCorePath)
+	assertAll(t, "FO core (B6 sync)", text, []string{
+		"pull --rebase",
+		"push origin",
+		"rebase --abort",
+		"--force",
+		"auto-resolve",
+		"must NOT",
+	})
+}
+
+// TestEnsignSyncProse pins the ensign half of B6: push after committing, pull
+// --rebase on a push rejection, and the M-3 rebase-conflict halt (abort +
+// surface + no force-push, no auto-resolve), alongside the path-scoped rule.
+func TestEnsignSyncProse(t *testing.T) {
+	text := readSkill(t, ensignCorePath)
+	assertAll(t, "ensign core (B6 sync)", text, []string{
+		"push origin",
+		"pull --rebase",
+		"rebase --abort",
+		"--force",
+		"auto-resolve",
+	})
+}
+
+// TestCommissionJourneyProse pins B3: the commission SKILL.md carries the
+// journey-1 orphan-branch mechanics (clear inherited tree, linked worktree,
+// state init pointer) and the journey-2 $inline prose.
+func TestCommissionJourneyProse(t *testing.T) {
+	text := readSkill(t, commissionSkillPath)
+	assertAll(t, "commission SKILL.md (journeys)", text, []string{
+		"checkout --orphan",
+		"clear",
+		"linked worktree",
+		"spacedock state init",
+		"$inline",
+	})
+}

--- a/internal/status/classify_state_test.go
+++ b/internal/status/classify_state_test.go
@@ -1,0 +1,71 @@
+// ABOUTME: B.1 classifier proof — ClassifyState maps $inline/empty to inline and
+// ABOUTME: a relative path to split-root, the single shared state: interpreter.
+package status
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestClassifyState covers the three modes and the absolute/escape rejection the
+// classifier owns for all three read sites. $inline and empty both classify as
+// inline with no path to join; a relative path classifies as split-root with the
+// cleaned path; an absolute or `..`-escaping value is rejected.
+func TestClassifyState(t *testing.T) {
+	cases := []struct {
+		name     string
+		value    string
+		wantMode StateMode
+		wantPath string
+		wantErr  bool
+	}{
+		{"empty", "", StateInline, "", false},
+		{"whitespace", "   ", StateInline, "", false},
+		{"explicit inline sentinel", "$inline", StateInline, "", false},
+		{"inline sentinel with surrounding space", "  $inline  ", StateInline, "", false},
+		{"relative path", ".spacedock-state", StateSplitRoot, ".spacedock-state", false},
+		{"nested relative path", "state/dev", StateSplitRoot, filepath.Join("state", "dev"), false},
+		{"dot-prefixed relative", "./.spacedock-state", StateSplitRoot, ".spacedock-state", false},
+		{"absolute rejected", "/abs/state", StateInline, "", true},
+		{"dotdot escape rejected", "../escape", StateInline, "", true},
+		{"dotdot bare rejected", "..", StateInline, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, relPath, err := ClassifyState(tc.value)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ClassifyState(%q) = (%v,%q,nil), want error", tc.value, mode, relPath)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ClassifyState(%q) returned error: %v", tc.value, err)
+			}
+			if mode != tc.wantMode {
+				t.Fatalf("ClassifyState(%q) mode = %v, want %v", tc.value, mode, tc.wantMode)
+			}
+			if relPath != tc.wantPath {
+				t.Fatalf("ClassifyState(%q) relPath = %q, want %q", tc.value, relPath, tc.wantPath)
+			}
+		})
+	}
+}
+
+// TestClassifyStateInlineNeverJoinsLiteral is the M-2 negative: the $inline
+// sentinel must never become a path to join. A split-root mode is the only mode
+// that yields a non-empty relPath; inline (from $inline or empty) yields "".
+func TestClassifyStateInlineNeverJoinsLiteral(t *testing.T) {
+	for _, v := range []string{"", "$inline", "  $inline  "} {
+		mode, relPath, err := ClassifyState(v)
+		if err != nil {
+			t.Fatalf("ClassifyState(%q) error: %v", v, err)
+		}
+		if mode != StateInline {
+			t.Fatalf("ClassifyState(%q) mode = %v, want inline", v, mode)
+		}
+		if relPath != "" {
+			t.Fatalf("ClassifyState(%q) relPath = %q, want empty (never a literal $inline join)", v, relPath)
+		}
+	}
+}

--- a/internal/status/discover_walkup.go
+++ b/internal/status/discover_walkup.go
@@ -49,13 +49,9 @@ func stateCheckoutParent(pointedDir string) (string, bool) {
 	for {
 		readme := filepath.Join(d, "README.md")
 		if isRegularFile(readme) {
-			stateValue := strings.TrimSpace(ParseFrontmatter(readme)["state"])
-			if stateValue != "" && !filepath.IsAbs(stateValue) {
-				cleaned := filepath.Clean(stateValue)
-				if cleaned != ".." && !strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
-					if realpathOf(filepath.Join(d, cleaned)) == target {
-						return d, true
-					}
+			if mode, relPath, err := ClassifyState(ParseFrontmatter(readme)["state"]); err == nil && mode == StateSplitRoot {
+				if realpathOf(filepath.Join(d, relPath)) == target {
+					return d, true
 				}
 			}
 		}

--- a/internal/status/discover_walkup.go
+++ b/internal/status/discover_walkup.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 )
 
-// discoverWorkflowDir walks up from startDir to the nearest ancestor whose
+// DiscoverWorkflowDir walks up from startDir to the nearest ancestor whose
 // README.md frontmatter declares a `commissioned-by: spacedock@` field, the
 // same predicate discoverWorkflows uses to recognize a workflow. The first
 // match on the way up wins — when workflows are nested, this resolves to the
 // innermost enclosing workflow. Returns (dir, true) on a match, ("", false) at
 // the filesystem root with no match.
-func discoverWorkflowDir(startDir string) (string, bool) {
+func DiscoverWorkflowDir(startDir string) (string, bool) {
 	d, err := filepath.Abs(startDir)
 	if err != nil {
 		d = startDir

--- a/internal/status/discover_walkup_test.go
+++ b/internal/status/discover_walkup_test.go
@@ -18,12 +18,12 @@ func TestDiscoverWorkflowDirWalksUp(t *testing.T) {
 	if err := os.MkdirAll(deep, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	got, ok := discoverWorkflowDir(deep)
+	got, ok := DiscoverWorkflowDir(deep)
 	if !ok {
-		t.Fatalf("discoverWorkflowDir(%q) = ok false, want true", deep)
+		t.Fatalf("DiscoverWorkflowDir(%q) = ok false, want true", deep)
 	}
 	if realpathOf(got) != realpathOf(def) {
-		t.Fatalf("discoverWorkflowDir(%q) = %q, want %q", deep, got, def)
+		t.Fatalf("DiscoverWorkflowDir(%q) = %q, want %q", deep, got, def)
 	}
 }
 
@@ -35,8 +35,8 @@ func TestDiscoverWorkflowDirMiss(t *testing.T) {
 	if err := os.MkdirAll(deep, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := discoverWorkflowDir(deep); ok {
-		t.Fatalf("discoverWorkflowDir(%q) = ok true, want false (no commissioned README)", deep)
+	if _, ok := DiscoverWorkflowDir(deep); ok {
+		t.Fatalf("DiscoverWorkflowDir(%q) = ok true, want false (no commissioned README)", deep)
 	}
 }
 
@@ -52,12 +52,12 @@ func TestDiscoverWorkflowDirInnermostWins(t *testing.T) {
 	if err := os.MkdirAll(deep, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	got, ok := discoverWorkflowDir(deep)
+	got, ok := DiscoverWorkflowDir(deep)
 	if !ok {
-		t.Fatalf("discoverWorkflowDir(%q) = ok false, want true", deep)
+		t.Fatalf("DiscoverWorkflowDir(%q) = ok false, want true", deep)
 	}
 	if realpathOf(got) != realpathOf(inner) {
-		t.Fatalf("discoverWorkflowDir(%q) = %q, want innermost %q (first match wins)", deep, got, inner)
+		t.Fatalf("DiscoverWorkflowDir(%q) = %q, want innermost %q (first match wins)", deep, got, inner)
 	}
 }
 

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -411,11 +411,8 @@ func discoverWorkflows(root string) []string {
 					resultSet[resolved] = true
 					results = append(results, resolved)
 				}
-				if stateValue := strings.TrimSpace(fields["state"]); stateValue != "" {
-					if cleaned := filepath.Clean(stateValue); !filepath.IsAbs(stateValue) &&
-						cleaned != ".." && !strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
-						prunedStateDirs[realpathOf(filepath.Join(dir, cleaned))] = true
-					}
+				if mode, relPath, err := ClassifyState(fields["state"]); err == nil && mode == StateSplitRoot {
+					prunedStateDirs[realpathOf(filepath.Join(dir, relPath))] = true
 				}
 			}
 		}

--- a/internal/status/inline_sentinel_sites_test.go
+++ b/internal/status/inline_sentinel_sites_test.go
@@ -1,0 +1,79 @@
+// ABOUTME: M-2 site-level negative — the $inline sentinel is never joined as a
+// ABOUTME: literal path at resolveRoots or the discoverWorkflows prune.
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// inlineSentinelReadme is a commissioned slug-style workflow declaring the
+// explicit-inline sentinel, with an entity beside the README (inline layout).
+const inlineSentinelReadme = `---
+commissioned-by: spacedock@1
+id-style: slug
+state: $inline
+stages:
+  states:
+    - name: ideation
+      initial: true
+    - name: done
+      terminal: true
+---
+
+# Inline Sentinel Workflow
+`
+
+// TestResolveRootsInlineSentinelNoLiteralJoin pins the M-2 negative at the
+// resolveRoots site: a `state: $inline` workflow resolves entityDir ==
+// definitionDir (no `/$inline` suffix), exactly like an absent state: field.
+func TestResolveRootsInlineSentinelNoLiteralJoin(t *testing.T) {
+	def := t.TempDir()
+	writeFile(t, filepath.Join(def, "README.md"), inlineSentinelReadme)
+
+	r, err := resolveRoots(def, "")
+	if err != nil {
+		t.Fatalf("resolveRoots returned error: %v", err)
+	}
+	if r.entityDir != def {
+		t.Fatalf("entityDir = %q, want %q (inline sentinel must not join /$inline)", r.entityDir, def)
+	}
+	if strings.Contains(r.entityDir, inlineSentinel) || strings.Contains(r.entityDirSpelling, inlineSentinel) {
+		t.Fatalf("entityDir/spelling references the literal sentinel: dir=%q spelling=%q", r.entityDir, r.entityDirSpelling)
+	}
+}
+
+// TestDiscoverWorkflowsInlineSentinelPrunesNothing pins the M-2 negative at the
+// discoverWorkflows prune site: a `state: $inline` workflow is discovered once,
+// and the prune scan creates/references no `…/$inline` path on disk.
+func TestDiscoverWorkflowsInlineSentinelPrunesNothing(t *testing.T) {
+	def := t.TempDir()
+	writeFile(t, filepath.Join(def, "README.md"), inlineSentinelReadme)
+	writeFile(t, filepath.Join(def, "thing.md"), "---\nstatus: ideation\n---\n# Thing\n")
+
+	got := discoverWorkflows(def)
+	if len(got) != 1 || realpathOf(got[0]) != realpathOf(def) {
+		t.Fatalf("discovery = %v, want exactly [%s]", got, def)
+	}
+	if _, err := os.Stat(filepath.Join(def, inlineSentinel)); !os.IsNotExist(err) {
+		t.Fatalf("a literal %q path exists under the definition dir (stat err=%v)", inlineSentinel, err)
+	}
+}
+
+// TestStateCheckoutParentInlineSentinelNeverMatches pins the M-2 negative at the
+// stateCheckoutParent site: a `state: $inline` README never claims any pointed
+// dir as its state checkout (the sentinel is not a path).
+func TestStateCheckoutParentInlineSentinelNeverMatches(t *testing.T) {
+	def := t.TempDir()
+	writeFile(t, filepath.Join(def, "README.md"), inlineSentinelReadme)
+	// A child dir under the def that a buggy literal join could resolve to.
+	child := filepath.Join(def, inlineSentinel)
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := stateCheckoutParent(child); ok {
+		t.Fatalf("stateCheckoutParent matched the literal %q dir; the sentinel must not be treated as a path", inlineSentinel)
+	}
+}

--- a/internal/status/native_runner.go
+++ b/internal/status/native_runner.go
@@ -74,7 +74,7 @@ func dispatch(probe claudeteam.TeamStateProbe, args []string, dir string, e env,
 		pipelineDir = e.get("PIPELINE_DIR")
 	}
 	if pipelineDir == "" && rootPath == "" {
-		if discovered, ok := discoverWorkflowDir(dir); ok {
+		if discovered, ok := DiscoverWorkflowDir(dir); ok {
 			pipelineDir = discovered
 		} else {
 			return errExit(stderr, "no Spacedock workflow here — pass --workflow-dir or run inside a workflow")

--- a/internal/status/roots.go
+++ b/internal/status/roots.go
@@ -50,20 +50,17 @@ func resolveRoots(workflowDir, baseDir string) (roots, error) {
 		entityDirSpelling: workflowDir,
 	}
 
-	stateValue := strings.TrimSpace(ParseFrontmatter(filepath.Join(abs, "README.md"))["state"])
-	if stateValue == "" {
+	stateValue := ParseFrontmatter(filepath.Join(abs, "README.md"))["state"]
+	mode, relPath, err := ClassifyState(stateValue)
+	if err != nil {
+		return roots{}, err
+	}
+	if mode == StateInline {
 		return r, nil
 	}
-	if filepath.IsAbs(stateValue) {
-		return roots{}, fmt.Errorf("state: must be a path relative to the workflow README directory, not absolute: %s", stateValue)
-	}
-	cleaned := filepath.Clean(stateValue)
-	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
-		return roots{}, fmt.Errorf("state: must not escape the workflow README directory: %s", stateValue)
-	}
 
-	r.entityDir = filepath.Join(abs, cleaned)
-	r.entityDirSpelling = PyJoin(spellingOr(workflowDir, abs), stateValue)
+	r.entityDir = filepath.Join(abs, relPath)
+	r.entityDirSpelling = PyJoin(spellingOr(workflowDir, abs), relPath)
 	return r, nil
 }
 

--- a/internal/status/state.go
+++ b/internal/status/state.go
@@ -1,0 +1,73 @@
+// ABOUTME: The single shared `state:` interpreter — classifyState maps the README
+// ABOUTME: state: field to a backend mode, and stateBranch derives the state branch.
+package status
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// inlineSentinel is the explicit-inline token for the README `state:` field. The
+// `$` sigil reads as "not a path" at a glance and cannot collide with a v0 child
+// checkout name (the validator rejects absolute and `..`-escaping values, and a
+// real checkout name never leads with `$`). An empty `state:` means the same
+// thing — inline — as the backward-compatible default.
+const inlineSentinel = "$inline"
+
+// StateMode names how a workflow's mutable entity state is laid out, derived from
+// the README `state:` field.
+type StateMode int
+
+const (
+	// StateInline keeps entities beside the README on the same branch (single-root).
+	// Both an empty `state:` and the explicit $inline sentinel resolve here.
+	StateInline StateMode = iota
+	// StateSplitRoot keeps entities in a separate state checkout at the `state:`
+	// relative path (split-root).
+	StateSplitRoot
+)
+
+// ClassifyState is the SINGLE interpreter of the README `state:` field, consumed
+// by every site that reads it (resolveRoots, splitRootStateCheckout, the
+// discoverWorkflows prune, stateCheckoutParent). It runs after TrimSpace:
+//
+//   - empty / whitespace → inline, no path to join (backward-compatible default).
+//   - the $inline sentinel → inline, no path to join (explicit inline).
+//   - any other value → split-root, after rejecting an absolute or `..`-escaping
+//     path. The returned relPath is filepath.Clean'd, ready to join under the
+//     definition dir.
+//
+// Centralizing the absolute/`..` rejection here means the inline sentinel is never
+// treated as an ordinary relative path and joined into a literal `…/$inline` dir
+// at any read site.
+func ClassifyState(stateValue string) (StateMode, string, error) {
+	value := strings.TrimSpace(stateValue)
+	if value == "" || value == inlineSentinel {
+		return StateInline, "", nil
+	}
+	if filepath.IsAbs(value) {
+		return StateInline, "", fmt.Errorf("state: must be a path relative to the workflow README directory, not absolute: %s", value)
+	}
+	cleaned := filepath.Clean(value)
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return StateInline, "", fmt.Errorf("state: must not escape the workflow README directory: %s", value)
+	}
+	return StateSplitRoot, cleaned, nil
+}
+
+// StateBranch returns the orphan state branch for a split-root workflow. By
+// default it derives from the workflow dir's basename
+// (spacedock-state/<basename>), reproducing the shipped spacedock-state/dev for
+// docs/dev. An explicit README `state-branch:` field always wins verbatim.
+func StateBranch(workflowDir string) (string, error) {
+	fm := ParseFrontmatter(filepath.Join(workflowDir, "README.md"))
+	if override := strings.TrimSpace(fm["state-branch"]); override != "" {
+		return override, nil
+	}
+	base := filepath.Base(filepath.Clean(workflowDir))
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		return "", fmt.Errorf("cannot derive state-branch from workflow dir: %s", workflowDir)
+	}
+	return "spacedock-state/" + base, nil
+}

--- a/internal/status/state_branch_test.go
+++ b/internal/status/state_branch_test.go
@@ -1,0 +1,39 @@
+// ABOUTME: B.2 proof — StateBranch derives spacedock-state/<workflow-dir-basename>
+// ABOUTME: by default and honors an explicit README state-branch: override.
+package status
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestStateBranchDefaultFromBasename derives the state branch from the workflow
+// dir's basename, reproducing the shipped spacedock-state/dev for docs/dev.
+func TestStateBranchDefaultFromBasename(t *testing.T) {
+	def := t.TempDir()
+	wf := filepath.Join(def, "docs", "dev")
+	writeFile(t, filepath.Join(wf, "README.md"), "---\nstate: .spacedock-state\n---\n")
+
+	got, err := StateBranch(wf)
+	if err != nil {
+		t.Fatalf("StateBranch error: %v", err)
+	}
+	if got != "spacedock-state/dev" {
+		t.Fatalf("StateBranch = %q, want spacedock-state/dev", got)
+	}
+}
+
+// TestStateBranchOverride honors an explicit README state-branch: verbatim.
+func TestStateBranchOverride(t *testing.T) {
+	wf := t.TempDir()
+	writeFile(t, filepath.Join(wf, "README.md"),
+		"---\nstate: .spacedock-state\nstate-branch: custom/state-line\n---\n")
+
+	got, err := StateBranch(wf)
+	if err != nil {
+		t.Fatalf("StateBranch error: %v", err)
+	}
+	if got != "custom/state-line" {
+		t.Fatalf("StateBranch = %q, want custom/state-line (override wins)", got)
+	}
+}

--- a/skills/commission/SKILL.md
+++ b/skills/commission/SKILL.md
@@ -277,9 +277,41 @@ Do NOT include a Scoring Rubric section by default. Scoring uses a simple 0.0–
 **State backend (`state:` field).** Decide where the workflow's mutable entity state lives:
 
 - **Split-root** (`state: .spacedock-state` in the README frontmatter): use when the workflow is embedded in a code repo whose PRs you care about. The README (the living spec) stays on your code branch; the mutable entity state lives in a separate `.spacedock-state` checkout, so routine stage transitions never churn the code branch and never collide with a feature PR.
-- **Single-root** (omit `state:`): use for a standalone workflow that is not embedded in a code repo you ship from — the entities live beside the README in the same directory.
+- **Inline** (`state: $inline`, or omit `state:`): use for a standalone workflow that is not embedded in a code repo you ship from — the entities live beside the README in the same directory. Write `state: $inline` explicitly for a new inline workflow so the backend choice is self-documenting; an absent `state:` means the same thing (backward-compatible default).
 
-If you choose split-root, also set up the `.spacedock-state` checkout (and, for collaboration/resume, declare its remote).
+#### Journey 1 — Scaffold a split-root workflow (orphan-branch state, same repo)
+
+State lives on an **orphan branch in the same repo** (no second repo, no second remote): state commits land on the orphan branch and the code branch never sees them (zero churn). The state checkout is a **linked worktree** of the main repo at the gitignored `state:` path. To scaffold it, run this sequence after writing the README (substitute `{state_path}` = the `state:` value, e.g. `.spacedock-state`; `{state_branch}` = `spacedock-state/{workflow-dir-basename}`, e.g. `spacedock-state/dev` for `docs/dev`):
+
+1. Add the state path to the code branch's tracked `.gitignore` so state commits never churn the code branch:
+
+   ```bash
+   grep -qxF '{dir}/{state_path}/' {project_root}/.gitignore 2>/dev/null || echo '{dir}/{state_path}/' >> {project_root}/.gitignore
+   ```
+
+2. Birth the orphan branch in a **temporary detached worktree**, clearing the inherited tree before seeding (a `--orphan` checkout inherits the source branch's tree — you MUST clear it, or the state branch is polluted with code-branch files):
+
+   ```bash
+   git worktree add --detach /tmp/orphan-birth
+   git -C /tmp/orphan-birth checkout --orphan {state_branch}
+   git -C /tmp/orphan-birth rm -rf --cached .
+   # remove the inherited working-tree files (keep .git), then seed the first entity
+   git -C /tmp/orphan-birth commit -q -m "seed state"
+   git -C /tmp/orphan-birth push origin {state_branch}   # if origin exists
+   git worktree remove --force /tmp/orphan-birth
+   ```
+
+3. Check the orphan branch out at the gitignored state path as a linked worktree:
+
+   ```bash
+   git worktree add {dir}/{state_path} {state_branch}
+   ```
+
+The result: `spacedock status` renders the seeded entity from the state checkout, and the code branch `git status --porcelain` is empty (R1 — zero churn). On a fresh clone of this repo the state worktree is absent (orphan branch not checked out); the operator runs `spacedock state init` to fetch the orphan branch and re-add the linked worktree.
+
+#### Journey 2 — Scaffold an inline workflow
+
+Write `state: $inline` in the README frontmatter (or omit `state:`). Entities live beside the README on the same branch — no orphan branch, no worktree, no `.gitignore` entry.
 
 Use this template structure, filling in all `{variables}` from the design phase:
 

--- a/skills/ensign/references/ensign-shared-core.md
+++ b/skills/ensign/references/ensign-shared-core.md
@@ -47,6 +47,20 @@ When the workflow is split-root — the workflow README declares a `state:` chec
 - **Preferred — tool-managed atomic state commits.** When the status tool owns the state `add`+`commit` under a lock, route your entity commit through it.
 - **Fallback — path-scoped commit.** Otherwise stage and commit ONLY your own entity path: `git -C {state_checkout} add {entity_path} && git -C {state_checkout} commit -m "…" -- {entity_path}`. Never a bare `git add -A` or bare `git commit` in the shared state checkout. Retry on `index.lock` contention after a short wait (~2s).
 
+**Multi-writer sync (push / pull --rebase).** The state checkout is an orphan state branch shared via the main repo's `origin`; peers (the FO and sibling ensigns, possibly on other hosts) write concurrently. After your path-scoped state commit:
+
+- **Push the state branch** so peers see your entity/report: `git -C {state_checkout} push origin {state_branch}` (`{state_branch}` is the workflow's state branch, e.g. `spacedock-state/dev`).
+- **On a push rejection (non-fast-forward) → `pull --rebase` then re-push.** A peer pushed first: `git -C {state_checkout} pull --rebase origin {state_branch}` replays your single path-scoped commit atop the peer's. Because you committed exactly ONE entity file, concurrent writers touch disjoint paths → the rebase replays with no conflict. Then re-push.
+
+**Rebase-conflict halt.** If that `git -C {state_checkout} pull --rebase origin {state_branch}` CONFLICTS — the only realistic cause is two writers editing the SAME entity's frontmatter concurrently, the path-scoped rule's known boundary — you MUST:
+
+1. **HALT** the operation in progress (your commit/push).
+2. **Abort the rebase** (`git -C {state_checkout} rebase --abort`) to leave the checkout clean.
+3. **Surface** the conflict to the first officer with the conflicting entity path(s) and the peer commit, and **stop**. This is manual intervention.
+4. Do NOT `--force` / `--force-with-lease` push, and do NOT auto-resolve (no `-X ours/theirs`, no discarding either side) — either silently loses a peer's frontmatter edit.
+
+This matches the escalate-rather-than-guess discipline in the Rules below. A full lock model is out of scope; the halt IS the boundary behavior for the rare same-entity collision.
+
 ## Rules
 
 - Do NOT modify YAML frontmatter in entity files.

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -20,6 +20,9 @@ This file captures the shared first-officer semantics. Keep it aligned with `age
    - **ORPHANS** — entities with worktree fields, cross-referenced against filesystem and git state. Report anomalies; do not auto-redispatch.
    - **PR_STATE** — PR-pending entities with current merge state. Advance merged PRs.
    - **DISPATCHABLE** — entities ready for dispatch (same as `--next`).
+   - **STATE_BACKEND** — `split-root` or `single-root`, the resolved entity dir, and whether that dir is present. The split-root halt-gate below keys off this.
+6. **Split-root state halt-gate.** If the boot `STATE_BACKEND` line shows `state_backend == split-root` AND `entity_dir_present == false`, the state checkout is NOT initialized — the orphan state branch exists on origin but is not checked out at the `state:` path (a fresh clone, or a removed worktree). The boot table would render EMPTY (no entities) and `--validate` would say VALID — a silent failure. Do NOT dispatch against this phantom-empty workflow. HALT dispatch, report "state not initialized," and run (or prompt the captain to run) `spacedock state init` (which fetches the orphan branch and adds the linked worktree; the manual fallback is `git fetch origin <state-branch> && git worktree add <state-path> <state-branch>`). After init, re-read `--boot` and proceed only once `entity_dir_present == true`.
+7. **Split-root pull-on-boot.** For a split-root workflow, before the first dispatch, integrate peers' state with `git -C <state-path> pull --rebase origin <state-branch>` (the state branch is shared via `origin`; one pull at boot, NOT per-read). If that `pull --rebase` CONFLICTS, follow the rebase-conflict halt in **State Management** below: HALT, `git rebase --abort`, surface the conflict, and stop — do not dispatch against an unmerged state tree.
 
 ## Status Viewer
 
@@ -235,7 +238,7 @@ When an entity reaches its terminal stage:
 
 ### Ship-Local Ceremony
 
-When the merge boundary has no PR host — the README declares `merge: local`, or the pr-merge fallback applies (no `gh`, push failed, captain chose local) — the FO runs ONE fixed ceremony per entity instead of re-deriving the steps. The README's top-level `merge:` key (read at boot, default `pr`) selects whether this ceremony or the PR path applies. The happy path uses NO `--force`:
+When the merge boundary has no PR host — the README declares `merge: local`, or the pr-merge fallback applies (no `gh`, push failed, captain chose local) — the FO runs ONE fixed ceremony per entity instead of re-deriving the steps. The README's top-level `merge:` key (read on-demand by the status viewer at each terminal-transition guard, default `pr`) selects whether this ceremony or the PR path applies. The happy path uses NO `--force`:
 
 1. Set the merge mod-block before invoking the hook: `spacedock status --workflow-dir {workflow_dir} --set {slug} mod-block=merge:{mod_name}` (commit path-scoped).
 2. Invoke the merge hook, which performs the local `--no-ff` merge of `{branch}` onto `next`.
@@ -294,6 +297,21 @@ When the workflow is split-root — the workflow README declares a `state:` chec
 
 - **Preferred — tool-managed atomic state commits.** When the status tool owns the `add`+`commit` of an entity's state under a lock, route entity commits through it so concurrent writers serialize and never cross-attribute.
 - **Fallback — path-scoped commits per writer.** Until the tool owns commits, stage and commit ONLY the writer's own entity path: `git -C {state_checkout} add {entity_path} && git -C {state_checkout} commit -m "…" -- {entity_path}`. Never a bare `git add -A` or bare `git commit` in the shared state checkout. Retry on `index.lock` contention after a short wait (~2s).
+
+**Multi-writer sync (push / pull --rebase).** The state branch is shared via the main repo's `origin`; concurrent writers (the FO and ensigns, across hosts or same-host parallel stages) must converge without clobbering. Three minimal sync points extend the path-scoped-commit rule — NOT a pull before every dispatch:
+
+- **After a state commit → push.** Whoever commits an entity/report to the state checkout pushes the state branch so peers see it: `git -C {state_checkout} push origin {state_branch}`.
+- **On push rejection (non-fast-forward) → `pull --rebase` then re-push.** A peer pushed first; `git -C {state_checkout} pull --rebase origin {state_branch}` replays the local path-scoped commit atop the peer's. Because each writer commits exactly ONE entity file, concurrent writers touch disjoint paths → the rebase replays with no conflict. Then re-push.
+- **At FO boot (before first dispatch) → `pull --rebase`.** Integrate peers' state once at boot (the Startup pull-on-boot step), not per-read.
+
+**Rebase-conflict halt (B6).** When a `git -C {state_checkout} pull --rebase origin {state_branch}` (at boot, or after a push rejection) CONFLICTS — the only realistic cause is two writers editing the SAME entity's frontmatter concurrently, the path-scoped rule's known boundary — the FO MUST:
+
+1. **HALT** the operation in progress (dispatch). Do not proceed against an unmerged state tree.
+2. **Abort the rebase** (`git -C {state_checkout} rebase --abort`) to leave the checkout in a clean, known state.
+3. **Surface** the conflict to the captain with the conflicting entity path(s) and the peer commit, and **stop**. This is manual intervention.
+4. The FO must NOT `--force` / `--force-with-lease` push, and must NOT auto-resolve (no `-X ours/theirs`, no discarding either side) — either choice silently loses a peer's frontmatter edit.
+
+This matches the escalate-rather-than-guess discipline. A full lock model is out of scope; the halt IS the boundary behavior for the rare same-entity collision.
 
 ## FO Write Scope
 


### PR DESCRIPTION
Split-root workflows become multi-host collaborative: a fresh clone resumes its state with one command, and concurrent writers sync safely.

## What changed
- Add a shared `ClassifyState` interpreter for the README `state:` key (`$inline` sentinel; a path → split-root) routed through every resolution site.
- Derive a per-workflow `state-branch` (`spacedock-state/<slug>`, overridable).
- Add `spacedock state init` to materialize a cloned workflow's state worktree (fetch + worktree-add, idempotent).
- Scaffold commission's orphan-branch state worktree for new split workflows.
- Add FO/ensign sync contracts: a boot halt-gate on uninitialized state, push/pull-rebase, and a rebase-conflict halt that never force-pushes or auto-resolves.

## Evidence
- `go test ./...` 667 passed (sole failure is the env-only codex case); real-git e2es for commission scaffolding, `state init` resume, and 2-writer sync.
- Validation reproduced all six ACs with three independent tamper-confirms; a detached adversarial audit confirmed no `$inline` literal-join and no peer-edit loss.

## Review guidance
Native-only (the Python oracle is byte-identical and unchanged); the `$inline` sentinel is the exact bare token; the rebase-conflict path halts rather than force-pushing.

---
[sc](/spacedock-dev/spacedock/blob/a47d8861e37d11a854bf637960eb50030776d05a/split-root-collaboration-remote-resume/index.md)