### PR TITLE
spacedock codex can't detect an installed codex plugin — codex plugin list parse drift

### DIFF
--- a/internal/cli/codex_resolve_test.go
+++ b/internal/cli/codex_resolve_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestCodexResolveManifestAgainstInstalledHost drives the production codex
-// resolver against the real `codex` CLI. codex 0.132.0 rejects `--json` (exit 2),
+// resolver against the real `codex` CLI. codex 0.136.0 rejects `--json` (exit 2),
 // so the resolver must use the supported `codex plugin list` text output. When
 // spacedock@spacedock is installed, ResolveManifest must return a non-empty path
 // to an existing .codex-plugin/plugin.json; when it is NOT installed, it must

--- a/internal/cli/codex_resolve_test.go
+++ b/internal/cli/codex_resolve_test.go
@@ -26,7 +26,7 @@ func TestCodexResolveManifestAgainstInstalledHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("codex plugin list failed (exit/output): %v\n%s", err, listOut)
 	}
-	installed := strings.Contains(string(listOut), "spacedock@spacedock (installed")
+	installed := codexEntryInstalled(string(listOut), "spacedock@spacedock")
 
 	path, err := execHost{}.ResolveManifest("codex")
 	if err != nil {

--- a/internal/cli/codex_resolver_unit_test.go
+++ b/internal/cli/codex_resolver_unit_test.go
@@ -90,9 +90,13 @@ func TestLatestVersionDirNoSubdirs(t *testing.T) {
 	}
 }
 
-// TestCodexEntryInstalled exercises the `codex plugin list` text parse: an
-// installed entry carries `<id> (installed`; a not-installed entry, or a
-// listing without the id, does not match.
+// TestCodexEntryInstalled exercises the `codex plugin list` text parse on the
+// tolerated legacy paren form. Current codex renders the comma/table form
+// `<id>  installed, enabled  <ver>  <path>` (covered by
+// TestCodexEntryInstalledRealFormats); the paren form `<id> (installed[, enabled])`
+// is the older rendering the predicate still accepts. An installed entry's
+// status field reads `installed` after stripping surrounding `()`; a
+// not-installed entry, or a listing without the id, does not match.
 func TestCodexEntryInstalled(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/cli/codex_resolver_unit_test.go
+++ b/internal/cli/codex_resolver_unit_test.go
@@ -114,6 +114,96 @@ func TestCodexEntryInstalled(t *testing.T) {
 	}
 }
 
+// TestCodexEntryInstalledRealFormats pins the parse to the formats codex
+// actually emits. The current comma/table form (`<id>  installed, enabled  <ver>
+// <path>`) renders the status as `installed,` with NO parens, inside a
+// column-aligned table with a header row and a marketplace PATH cell that
+// contains the bare marketplace word `spacedock`. The predicate must field-match
+// the id exactly and read the next field as the status, so it accepts the comma
+// form and the legacy paren form, rejects `not installed`, a foreign id, and the
+// PATH line, and never matches the bare substring `installed` inside
+// `not installed`.
+func TestCodexEntryInstalledRealFormats(t *testing.T) {
+	// Live-captured block from `codex plugin list` (codex-cli 0.136.0): a
+	// column-aligned table with a header row, the spacedock data row (comma
+	// status), a not-installed row, and the marketplace PATH cell containing
+	// the bare word `spacedock`.
+	commaTable := "" +
+		"PLUGIN               STATUS              VERSION  PATH\n" +
+		"browser@openai-bundled  installed, enabled  26.519.22136  /Users/clkao/.codex/.tmp/bundled-marketplaces/openai-bundled/plugins/browser\n" +
+		"chrome@openai-bundled  not installed  /Users/clkao/.codex/.tmp/bundled-marketplaces/openai-bundled/plugins/chrome\n" +
+		"\n" +
+		"PLUGIN               STATUS              VERSION  PATH\n" +
+		"spacedock@spacedock  installed, enabled  0.12.1   /Users/clkao/.codex/.tmp/marketplaces/spacedock/plugins/spacedock\n"
+
+	cases := []struct {
+		name    string
+		listing string
+		want    bool
+	}{
+		// The real comma/table form codex emits today — this is the case the
+		// paren-literal predicate misses, shipping the no-plugin-found drift.
+		{"real-comma-table", commaTable, true},
+		// The marketplace PATH cell contains the bare word `spacedock` but the
+		// id `spacedock@spacedock` is not a field on this line — no false match.
+		{"marketplace-path-line", "  not a row but a path /Users/clkao/.codex/.tmp/marketplaces/spacedock/plugins/spacedock", false},
+		// `not installed` must reject: the status field after the id is `not`,
+		// and the bare substring `installed` inside `not installed` must NOT match.
+		{"not-installed-comma", "spacedock@spacedock  not installed  0.12.1  /some/path", false},
+		// Legacy paren forms stay accepted (codex-revert tolerance).
+		{"legacy-paren-installed", "  spacedock@spacedock (installed)", true},
+		{"legacy-paren-enabled", "  spacedock@spacedock (installed, enabled)", true},
+		// A foreign id that is not spacedock@spacedock must not match even when installed.
+		{"foreign-id-installed", "other@market  installed, enabled  1.0.0  /some/path", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := codexEntryInstalled(tc.listing, "spacedock@spacedock"); got != tc.want {
+				t.Fatalf("codexEntryInstalled(%q) = %v, want %v", tc.listing, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCodexCacheManifestResolvesCachedPluginJSON drives the cache-resolution
+// tail of resolveCodexManifest — the half the predicate test does not cover.
+// With a temp CODEX_HOME holding the real install layout
+// (plugins/cache/spacedock/spacedock/<ver>/.codex-plugin/plugin.json), the
+// resolver must return that exact plugin.json path. This is what proves the
+// predicate fix alone is insufficient: the front door only launches if this
+// cache tail lands on a real manifest.
+func TestCodexCacheManifestResolvesCachedPluginJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	manifest := filepath.Join(home, "plugins", "cache", "spacedock", "spacedock", "0.12.1", ".codex-plugin", "plugin.json")
+	if err := os.MkdirAll(filepath.Dir(manifest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifest, []byte(`{"name":"spacedock"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := codexCacheManifest()
+	if err != nil {
+		t.Fatalf("codexCacheManifest errored: %v", err)
+	}
+	if got != manifest {
+		t.Fatalf("codexCacheManifest = %q, want %q", got, manifest)
+	}
+}
+
+// TestCodexCacheManifestAbsentCache: with no cached install under CODEX_HOME,
+// the cache tail degrades to "" (no error) — the no-cached-manifest state.
+func TestCodexCacheManifestAbsentCache(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	got, err := codexCacheManifest()
+	if err != nil {
+		t.Fatalf("codexCacheManifest errored on absent cache: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("codexCacheManifest = %q, want empty for an absent cache", got)
+	}
+}
+
 // TestCodexHomeFromEnv: CODEX_HOME takes precedence over ~/.codex.
 func TestCodexHomeFromEnv(t *testing.T) {
 	t.Setenv("CODEX_HOME", "/tmp/custom-codex")

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -77,6 +77,15 @@ func (execHost) resolveCodexManifest() (string, error) {
 	if !codexEntryInstalled(string(out), "spacedock@spacedock") {
 		return "", nil
 	}
+	return codexCacheManifest()
+}
+
+// codexCacheManifest resolves the cached spacedock@spacedock manifest under the
+// Codex plugin cache: <CODEX_HOME>/plugins/cache/spacedock/spacedock/<version>/
+// .codex-plugin/plugin.json. It picks the semver-greatest version dir and
+// returns that manifest path, or "" (no error) when no cached manifest exists
+// yet (absent cache root, no version dir, or the manifest file is missing).
+func codexCacheManifest() (string, error) {
 	cacheRoot := filepath.Join(codexHome(), "plugins", "cache", "spacedock", "spacedock")
 	versionDir, err := latestVersionDir(cacheRoot)
 	if err != nil || versionDir == "" {
@@ -90,13 +99,26 @@ func (execHost) resolveCodexManifest() (string, error) {
 }
 
 // codexEntryInstalled reports whether the `codex plugin list` text output marks
-// the given plugin id as installed. The listing renders one indented line per
-// plugin as `<id> (installed[, enabled]) | (not installed)`; an installed entry
-// carries the literal `<id> (installed`.
+// the given plugin id as installed. The listing renders a column-aligned table
+// (PLUGIN STATUS VERSION PATH header) with one space-padded row per plugin as
+// `<id>  <status>  <ver>  <path>`, where an installed row's status is
+// `installed,` (or `installed`) and a not-installed row's is `not installed`.
+// (Older codex rendered the status in parens — `<id> (installed[, enabled])` —
+// which this still tolerates.) The match is field-based: the id must be a
+// whitespace-delimited field, and the next field, stripped of surrounding `()`
+// and a trailing `,`, must equal `installed` exactly. Field equality (not a
+// substring scan) rejects a marketplace PATH cell that contains the bare
+// marketplace word; reading the next field rejects `not installed`.
 func codexEntryInstalled(listing, id string) bool {
 	for _, line := range strings.Split(listing, "\n") {
-		if strings.Contains(line, id+" (installed") {
-			return true
+		fields := strings.Fields(line)
+		for i, f := range fields {
+			if f != id {
+				continue
+			}
+			if i+1 < len(fields) && strings.Trim(fields[i+1], "(),") == "installed" {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -29,7 +29,7 @@ type pluginListEntry struct {
 // ResolveManifest returns the installed spacedock@spacedock plugin manifest path
 // for host, or "" (no error) when no plugin is installed. The two hosts resolve
 // differently: Claude reports an installPath in `claude plugin list --json`;
-// Codex 0.132.0 has no --json (it rejects the flag, exit 2) and its text listing
+// Codex 0.136.0 has no --json (it rejects the flag, exit 2) and its text listing
 // carries no install path, so the Codex path confirms the install via the text
 // listing and resolves the manifest under the deterministic Codex plugin cache.
 func (e execHost) ResolveManifest(host string) (string, error) {
@@ -63,7 +63,7 @@ func (execHost) resolveClaudeManifest(host string) (string, error) {
 }
 
 // resolveCodexManifest confirms spacedock@spacedock is installed via the text
-// `codex plugin list` (no --json — 0.132.0 rejects it) and resolves the manifest
+// `codex plugin list` (no --json — 0.136.0 rejects it) and resolves the manifest
 // under the Codex plugin cache. Codex installs land at
 // <CODEX_HOME>/plugins/cache/<marketplace>/<plugin>/<version>/.codex-plugin/plugin.json;
 // the listing carries no install path, so the cache layout is the resolver.


### PR DESCRIPTION
Restores `spacedock codex` plugin detection: the install check parsed a list format codex no longer emits, so the launcher wrongly reported no installed plugin.

## What changed
- Replace paren-literal codex install detection with field-based matching on the real comma/table format.
- Add captured-real-format unit tests (comma/table, not-installed, legacy paren, foreign-id, marketplace PATH line).
- Extract `codexCacheManifest` so the post-detection cache resolution is fixture-testable.
- Refresh codex resolver doc-comments to the real list format and codex version.

## Evidence
- `go test ./...` green; `internal/cli` 131/131 passed; `go vet` clean.
- Live-probe: against installed codex 0.136.0, `spacedock codex` / `doctor --host codex` went from "no installed codex plugin found" to a real contract verdict.

## Review guidance
Critical path: `codexEntryInstalled` field-parse in `internal/cli/host_exec.go` — verified against live codex 0.136.0 table output.

---
[5p](/spacedock-dev/spacedock/blob/86039824a2bdf1ca26232ae26b0d8f31c943b0cb/codex-plugin-list-parse-drift/index.md)
