### PR TITLE
spacedock claude --plugin-dir before -- (captain dev workflow) + restore the live-e2e net

### DIFF
--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -283,6 +283,7 @@ type frontDoorFlags struct {
 	enable    *[]string
 	addDirs   *[]string
 	addDirsRO *[]string
+	pluginDir *[]string
 }
 
 func bindFrontDoorFlags(fs *pflag.FlagSet) frontDoorFlags {
@@ -297,6 +298,8 @@ func bindFrontDoorFlags(fs *pflag.FlagSet) frontDoorFlags {
 			"Grant safehouse read-write access to a directory; repeatable"),
 		addDirsRO: fs.StringArray("safehouse-add-dirs-ro", nil,
 			"Grant safehouse read-only access to a directory; repeatable"),
+		pluginDir: fs.StringArray("plugin-dir", nil,
+			"Load a local plugin checkout (relaxes the contract gate); repeatable"),
 	}
 }
 
@@ -347,6 +350,20 @@ func parseFrontDoorArgs(args []string) (fd frontDoorArgs, err error) {
 	if len(taskTokens) > 0 {
 		fd.task = strings.Join(taskTokens, " ")
 		fd.hasTask = true
+	}
+
+	// --plugin-dir is the one host flag spacedock parses before `--`: pflag knows
+	// its arity (one value, repeatable), so the dirs are captured correctly in
+	// space/equals/repeated forms. Re-inject each as a `--plugin-dir <dir>` pair at
+	// the FRONT of passthrough so it forwards to the host and hasPluginDir sees it,
+	// ahead of any after-`--` tokens. This keeps the spacedock prompt the always-last
+	// assembled token and hasPluginDir the single gate-relax reader (D4).
+	if dirs := *flags.pluginDir; len(dirs) > 0 {
+		front := make([]string, 0, len(dirs)*2+len(fd.passthrough))
+		for _, d := range dirs {
+			front = append(front, "--plugin-dir", d)
+		}
+		fd.passthrough = append(front, fd.passthrough...)
 	}
 	return fd, nil
 }

--- a/internal/cli/frontdoor_parse_test.go
+++ b/internal/cli/frontdoor_parse_test.go
@@ -2,7 +2,10 @@
 // ABOUTME: task before --, host flags after --, and the safehouse/skip knobs anywhere.
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestParseFrontDoorArgs pins the Option-2 front-door grammar (AC-3 + AC-6). The
 // task is the joined non-flag positionals BEFORE `--`; host value-taking flags
@@ -155,5 +158,21 @@ func TestStrayHostFlagBeforeDashErrors(t *testing.T) {
 				t.Fatalf("parseFrontDoorArgs(%v) err = nil, want a parse error for the stray host flag", tc.args)
 			}
 		})
+	}
+}
+
+// TestBareValuelessPluginDirErrors pins the load-bearing loud-error property that
+// chose StringArray over ParseErrorsWhitelist.UnknownFlags: a bare before-`--`
+// `--plugin-dir` with no following value is a LOUD parse error naming the flag
+// (pflag knows its arity), NOT a silent drop. Under UnknownFlags the missing value
+// would vanish without a trace — the worst outcome the spike rejected. The returned
+// error means runClaude/runCodex return 1 before reaching Launch (no launch).
+func TestBareValuelessPluginDirErrors(t *testing.T) {
+	_, err := parseFrontDoorArgs([]string{"--plugin-dir"})
+	if err == nil {
+		t.Fatalf("parseFrontDoorArgs([--plugin-dir]) err = nil, want a loud arity error (not a silent drop)")
+	}
+	if !strings.Contains(err.Error(), "--plugin-dir") {
+		t.Fatalf("error %q does not name --plugin-dir; the loud-error property must be specific", err.Error())
 	}
 }

--- a/internal/cli/frontdoor_parse_test.go
+++ b/internal/cli/frontdoor_parse_test.go
@@ -74,6 +74,41 @@ func TestParseFrontDoorArgs(t *testing.T) {
 			task:           "task text",
 			hasTask:        true,
 		},
+		{
+			name:        "plugin-dir-before-dash-space-form",
+			args:        []string{"--plugin-dir", "/p"},
+			passthrough: []string{"--plugin-dir", "/p"},
+		},
+		{
+			name:        "plugin-dir-before-dash-equals-form",
+			args:        []string{"--plugin-dir=/p"},
+			passthrough: []string{"--plugin-dir", "/p"},
+		},
+		{
+			name:        "plugin-dir-before-dash-repeated",
+			args:        []string{"--plugin-dir", "/a", "--plugin-dir=/b"},
+			passthrough: []string{"--plugin-dir", "/a", "--plugin-dir", "/b"},
+		},
+		{
+			name:        "plugin-dir-before-dash-then-task",
+			args:        []string{"--plugin-dir", "/p", "review the PRs"},
+			passthrough: []string{"--plugin-dir", "/p"},
+			task:        "review the PRs",
+			hasTask:     true,
+		},
+		{
+			name:        "plugin-dir-before-dash-with-skip-and-task",
+			args:        []string{"--plugin-dir", "/p", "--skip-contract-check", "do it"},
+			passthrough: []string{"--plugin-dir", "/p"},
+			skipCheck:   true,
+			task:        "do it",
+			hasTask:     true,
+		},
+		{
+			name:        "plugin-dir-before-and-after-dash-both-forward",
+			args:        []string{"--plugin-dir", "/before", "--", "--plugin-dir", "/after"},
+			passthrough: []string{"--plugin-dir", "/before", "--plugin-dir", "/after"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -95,6 +130,29 @@ func TestParseFrontDoorArgs(t *testing.T) {
 			}
 			if fd.skipCheck != tc.skipCheck {
 				t.Errorf("skipCheck = %v, want %v", fd.skipCheck, tc.skipCheck)
+			}
+		})
+	}
+}
+
+// TestStrayHostFlagBeforeDashErrors pins the spike WINNER's loud-failure boundary:
+// only --plugin-dir is promoted as a spacedock-parsed flag before `--`; every other
+// host flag left before `--` is an UNKNOWN flag and produces a parse error (not a
+// silent mis-split, the rejected generic-pre-pass failure mode). This is exactly why
+// the live test must move its non-plugin-dir host flags after `--`.
+func TestStrayHostFlagBeforeDashErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "shorthand-p-before-dash", args: []string{"-p", "Drive."}},
+		{name: "model-before-dash", args: []string{"--model", "sonnet"}},
+		{name: "plugin-dir-then-stray-host-flag", args: []string{"--plugin-dir", "/p", "--model", "sonnet"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseFrontDoorArgs(tc.args); err == nil {
+				t.Fatalf("parseFrontDoorArgs(%v) err = nil, want a parse error for the stray host flag", tc.args)
 			}
 		})
 	}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -54,8 +54,9 @@ Usage:
 Start `+hostTitle(host)+` as your Spacedock first officer. The optional task is the
 launch prompt; everything after -- forwards verbatim to `+host+`.
 
-A --plugin-dir launch (after --) loads a local plugin checkout and relaxes the
-contract gate, so it does not require a prior "spacedock install".
+A --plugin-dir launch loads a local plugin checkout and relaxes the contract gate,
+so it does not require a prior "spacedock install". --plugin-dir is accepted both
+before -- (as a spacedock-parsed flag, repeatable) and after -- (forwarded verbatim).
 
 Flags:
 `)
@@ -68,6 +69,7 @@ Forwarding:
 Examples:
   spacedock `+host+`
   spacedock `+host+` "review the open PRs"
+  spacedock `+host+` --plugin-dir ./checkout
   spacedock `+host+` --safehouse-add-dirs ~/scratch -- --plugin-dir ./checkout
 `)
 	})

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -29,6 +29,10 @@ func TestFrontDoorHelpCarriesDetail(t *testing.T) {
 				"--plugin-dir",
 				"forward verbatim",
 				"Examples:",
+				// the --plugin-dir example line and the before-`--` prose (D1):
+				// --plugin-dir is a real spacedock-parsed flag accepted before `--`.
+				"spacedock " + host + " --plugin-dir ./checkout",
+				"before --",
 			} {
 				if !strings.Contains(out, want) {
 					t.Errorf("%s --help missing %q:\n%s", host, want, out)

--- a/internal/cli/launch_parity_test.go
+++ b/internal/cli/launch_parity_test.go
@@ -284,6 +284,42 @@ func TestPluginDirRelaxesGate(t *testing.T) {
 			t.Fatalf("exit = %d, want 0 (--plugin-dir relaxes the gate); stderr=%q", code, stderr.String())
 		}
 	})
+	t.Run("claude-before-dash-forwards-and-relaxes", func(t *testing.T) {
+		fake := &fakeHost{manifest: tooOldBinaryManifest(t)} // gate would FAIL
+		var stdout, stderr bytes.Buffer
+		code := runClaude(context.Background(), []string{"--plugin-dir", "/a", "--plugin-dir=/b"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("exit = %d, want 0 (before-`--` --plugin-dir relaxes the gate); stderr=%q", code, stderr.String())
+		}
+		want := []string{"claude", "--agent", "spacedock:first-officer", "--plugin-dir", "/a", "--plugin-dir", "/b", wantBootstrapPrompt}
+		if !equalArgv(fake.launchedArg, want) {
+			t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
+		}
+	})
+	t.Run("codex-before-dash-forwards-and-relaxes", func(t *testing.T) {
+		fake := &fakeHost{manifest: tooOldBinaryManifest(t)} // gate would FAIL
+		var stdout, stderr bytes.Buffer
+		code := runCodex(context.Background(), []string{"--plugin-dir", "/a"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("exit = %d, want 0 (before-`--` --plugin-dir relaxes the gate); stderr=%q", code, stderr.String())
+		}
+		want := []string{"codex", "--plugin-dir", "/a", wantCodexBootstrapPrompt}
+		if !equalArgv(fake.launchedArg, want) {
+			t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
+		}
+	})
+	t.Run("claude-before-dash-plugin-dir-with-task", func(t *testing.T) {
+		fake := &fakeHost{manifest: tooOldBinaryManifest(t)} // gate would FAIL
+		var stdout, stderr bytes.Buffer
+		code := runClaude(context.Background(), []string{"--plugin-dir", "/a", "review the PRs"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("exit = %d, want 0 (captain no-`--` form relaxes the gate); stderr=%q", code, stderr.String())
+		}
+		want := []string{"claude", "--agent", "spacedock:first-officer", "--plugin-dir", "/a", wantBootstrapPrompt + " review the PRs"}
+		if !equalArgv(fake.launchedArg, want) {
+			t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
+		}
+	})
 	t.Run("no-plugin-dir-still-fails-fast", func(t *testing.T) {
 		fake := &fakeHost{manifest: tooOldBinaryManifest(t)}
 		var stdout, stderr bytes.Buffer

--- a/internal/ensigncycle/live_test.go
+++ b/internal/ensigncycle/live_test.go
@@ -82,21 +82,26 @@ func TestLiveEnsignCycle(t *testing.T) {
 	defer cancel()
 
 	// The real front door: `spacedock claude --plugin-dir <repo> --skip-contract-check
-	// -p <bootstrap> ... -- <task>`. --plugin-dir loads the local v1 plugin checkout
-	// (and relaxes the contract gate); --skip-contract-check is belt-and-braces.
-	// stream-json + bypassPermissions + the model pin mirror the headless launch
-	// the Python net uses. The task is fenced after `--` so it rides as the
-	// launch-prompt override. CLAUDECODE is dropped by isolatedClaudeEnv so the
-	// binary takes the real front-door path rather than a nested-session shortcut.
+	// -- -p <bootstrap> ... <task>`. --plugin-dir and --skip-contract-check are
+	// spacedock-owned flags BEFORE `--`: --plugin-dir loads the local v1 plugin
+	// checkout (and relaxes the contract gate, the keystone this entity fixes);
+	// --skip-contract-check is belt-and-braces. Every host flag (-p, --permission-mode,
+	// --output-format, --verbose, --model) rides AFTER `--` and forwards verbatim to
+	// claude, ahead of the fenced task — only --plugin-dir is promoted before `--`
+	// (the spike WINNER: every other host flag stays after `--`). stream-json +
+	// bypassPermissions + the model pin mirror the headless launch the Python net
+	// uses. CLAUDECODE is dropped by isolatedClaudeEnv so the binary takes the real
+	// front-door path rather than a nested-session shortcut.
 	cmd := exec.CommandContext(ctx, binary, "claude",
 		"--plugin-dir", repoRoot,
 		"--skip-contract-check",
+		"--",
 		"-p", "Drive the workflow.",
 		"--permission-mode", "bypassPermissions",
 		"--output-format", "stream-json",
 		"--verbose",
 		"--model", model,
-		"--", task,
+		task,
 	)
 	cmd.Dir = root
 	cmd.Env = childEnv


### PR DESCRIPTION
Restore the captain's `spacedock claude --plugin-dir` dev workflow (the launcher's primary form) and the live-runtime e2e net, both broken by the cobra flag-convention change.

## What changed
- Accept `--plugin-dir` before `--` as a repeatable flag, forwarding it to the host and relaxing the contract gate.
- Restore TestLiveEnsignCycle by moving the other host flags after `--`.
- Add the help row + example, and a loud-error guard for a valueless `--plugin-dir`.

## Evidence
- `go test ./...` green (680 tests, 12 pkgs); `internal/cli` 134/134; `go vet` clean.
- Independent adversarial audit refuted nothing; this PR's CI-E2E is the binding live-net proof.

## Review guidance
`parseFrontDoorArgs` re-injects captured `--plugin-dir` at the front of passthrough; the spacedock prompt stays the last host-argv token (the Option-2 invariant).

---
[jg](/spacedock-dev/spacedock/blob/459a5de9e23c95f84b9a127fea5a62a0c1006e28/front-door-plugin-dir/index.md)
