### PR TITLE
Live-e2e per-stage timeouts — port the FOStreamWatcher pattern, ban the monolithic long timeout

### DIFF
--- a/internal/ensigncycle/live_budget_test.go
+++ b/internal/ensigncycle/live_budget_test.go
@@ -1,0 +1,142 @@
+// ABOUTME: AC-1 static guard: parses the live path's source AST and asserts no
+// ABOUTME: timeout literal/const exceeds 60s and no monolithic deadline ctx remains in live_test.go.
+package ensigncycle
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// AC-1 bans any individual timeout > 60s AND the monolithic deadline ctx. This
+// guard PARSES the source AST and evaluates the real duration each `N *
+// time.Unit` literal denotes — a relationship over real values, NOT a substring
+// grep for the spelling "60". A literal written `120 * time.Second` would be
+// caught (its real value is 120s); a literal written `1 * time.Minute` passes
+// (60s). It also asserts `live_test.go` carries no `liveTimeout` identifier and
+// no `context.WithTimeout` call — the monolithic deadline ctx this entity
+// removes. The guard runs under DEFAULT build tags and reads live_test.go as
+// source (the parser reads it regardless of its //go:build live tag), so it
+// covers the live path from the offline suite with no model spend.
+
+// liveBudgetSources are the source files on the live path whose timeout literals
+// must all be ≤60s: the streamWatcher (the per-step budget discipline) and the
+// live test that wires it.
+var liveBudgetSources = []string{"streamwatch.go", "live_test.go"}
+
+func TestNoTimeoutLiteralExceeds60s(t *testing.T) {
+	for _, file := range liveBudgetSources {
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			be, ok := n.(*ast.BinaryExpr)
+			if !ok || be.Op != token.MUL {
+				return true
+			}
+			d, isDuration := durationOfMul(be)
+			if !isDuration {
+				return true
+			}
+			if d > 60*time.Second {
+				t.Errorf("%s: timeout literal %q evaluates to %s, exceeding the 60s cap (AC-1)",
+					file, exprText(fset, be), d)
+			}
+			return true
+		})
+	}
+}
+
+func TestLiveTestHasNoMonolithicDeadlineCtx(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "live_test.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse live_test.go: %v", err)
+	}
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.Ident:
+			if node.Name == "liveTimeout" {
+				t.Errorf("live_test.go still references the banned monolithic `liveTimeout` const (AC-1)")
+			}
+		case *ast.SelectorExpr:
+			// context.WithTimeout — the banned monolithic deadline ctx.
+			if pkg, ok := node.X.(*ast.Ident); ok && pkg.Name == "context" && node.Sel.Name == "WithTimeout" {
+				t.Errorf("live_test.go still calls context.WithTimeout — the monolithic deadline ctx is banned (AC-1)")
+			}
+		}
+		return true
+	})
+}
+
+// durationOfMul evaluates a `N * time.Unit` (or `time.Unit * N`) binary
+// expression to its real time.Duration. Returns isDuration=false when the
+// expression is not an int-times-time.Unit shape, so non-duration multiplications
+// (and the package's int arithmetic) are skipped rather than mis-flagged.
+func durationOfMul(be *ast.BinaryExpr) (time.Duration, bool) {
+	if n, unit, ok := intAndUnit(be.X, be.Y); ok {
+		return time.Duration(n) * unit, true
+	}
+	if n, unit, ok := intAndUnit(be.Y, be.X); ok {
+		return time.Duration(n) * unit, true
+	}
+	return 0, false
+}
+
+// intAndUnit reports whether `a` is an integer literal and `b` is a time.Unit
+// selector, returning the parsed int and the unit's duration.
+func intAndUnit(a, b ast.Expr) (int64, time.Duration, bool) {
+	lit, ok := a.(*ast.BasicLit)
+	if !ok || lit.Kind != token.INT {
+		return 0, 0, false
+	}
+	n, err := strconv.ParseInt(lit.Value, 0, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	unit, ok := timeUnitDuration(b)
+	if !ok {
+		return 0, 0, false
+	}
+	return n, unit, true
+}
+
+// timeUnitDuration maps a `time.Nanosecond|Microsecond|Millisecond|Second|
+// Minute|Hour` selector to its time.Duration value.
+func timeUnitDuration(e ast.Expr) (time.Duration, bool) {
+	sel, ok := e.(*ast.SelectorExpr)
+	if !ok {
+		return 0, false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "time" {
+		return 0, false
+	}
+	switch sel.Sel.Name {
+	case "Nanosecond":
+		return time.Nanosecond, true
+	case "Microsecond":
+		return time.Microsecond, true
+	case "Millisecond":
+		return time.Millisecond, true
+	case "Second":
+		return time.Second, true
+	case "Minute":
+		return time.Minute, true
+	case "Hour":
+		return time.Hour, true
+	}
+	return 0, false
+}
+
+// exprText renders a binary expression back to source for the failure message.
+func exprText(fset *token.FileSet, be *ast.BinaryExpr) string {
+	start := fset.Position(be.Pos())
+	end := fset.Position(be.End())
+	return start.String() + "-" + strconv.Itoa(end.Column)
+}

--- a/internal/ensigncycle/live_test.go
+++ b/internal/ensigncycle/live_test.go
@@ -5,13 +5,13 @@
 package ensigncycle
 
 import (
-	"context"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
-	"time"
 )
 
 // This is the live analog of TestEnsignCycleMechanicalOutputs (cycle_test.go).
@@ -33,12 +33,6 @@ import (
 // (the secret-free offline job). It compiles and runs ONLY under
 // `go test -tags live`, the gated job's invocation that spends the live
 // credential behind the CI-E2E approval gate.
-
-// liveTimeout caps the single live dispatch->cycle run. A sonnet/opus run driving
-// the flat entity to the terminal stage is well inside this (the FO live runs
-// landed at ~350s); the cap turns a hung model run into a red FAIL with output
-// rather than a silent CI hang.
-const liveTimeout = 12 * time.Minute
 
 // TestLiveEnsignCycle stages the skeleton's flat-entity backlog fixture, shells
 // the real `spacedock claude` front door headless to drive the entity to done
@@ -78,9 +72,6 @@ func TestLiveEnsignCycle(t *testing.T) {
 		"entity make-it-work.md all the way to the done stage by dispatching an " +
 		"ensign for it. Do not stop until the entity reaches the terminal stage."
 
-	ctx, cancel := context.WithTimeout(context.Background(), liveTimeout)
-	defer cancel()
-
 	// The real front door: `spacedock claude --plugin-dir <repo> --skip-contract-check
 	// -- -p <bootstrap> ... <task>`. --plugin-dir and --skip-contract-check are
 	// spacedock-owned flags BEFORE `--`: --plugin-dir loads the local v1 plugin
@@ -92,7 +83,14 @@ func TestLiveEnsignCycle(t *testing.T) {
 	// bypassPermissions + the model pin mirror the headless launch the Python net
 	// uses. CLAUDECODE is dropped by isolatedClaudeEnv so the binary takes the real
 	// front-door path rather than a nested-session shortcut.
-	cmd := exec.CommandContext(ctx, binary, "claude",
+	//
+	// The subprocess runs under a plain context.Background() with NO deadline ctx
+	// (AC-1 bans the monolithic timeout); the streamWatcher's per-step quiet
+	// budgets ARE the timeout discipline. Both stdout and stderr feed one io.Pipe
+	// so the watcher reads claude's stream-json line-by-line as it arrives (a hang
+	// leaves a partial transcript — AC-2) rather than CombinedOutput()'s zero-byte
+	// block-until-exit.
+	cmd := exec.Command(binary, "claude",
 		"--plugin-dir", repoRoot,
 		"--skip-contract-check",
 		"--",
@@ -106,13 +104,39 @@ func TestLiveEnsignCycle(t *testing.T) {
 	cmd.Dir = root
 	cmd.Env = childEnv
 
-	out, err := cmd.CombinedOutput()
-	t.Logf("spacedock claude exit: %v\n--- transcript (tail) ---\n%s", err, tail(string(out), 8000))
-	if ctx.Err() == context.DeadlineExceeded {
-		t.Fatalf("live cycle timed out after %s", liveTimeout)
+	pr, pw := io.Pipe()
+	cmd.Stdout = pw
+	cmd.Stderr = pw
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spacedock claude failed to start: %v", err)
 	}
+
+	// Run cmd.Wait() in the background; closing the pipe write-end when it
+	// returns lets the watcher's line scanner reach EOF and drain the final
+	// lines. cmdPoller.poll() reads the recorded exit non-blockingly so the
+	// watcher's expect/expectDispatchClose loops can check for early exit, and
+	// expectExit waits on it. The poller's kill() forcibly stops a hung claude.
+	poller := newCmdPoller(cmd, pw)
+	watcher := newStreamWatcher(newPipeLineSource(pr), poller, func(line string) { t.Log(line) })
+
+	// The proven upstream watch sequence: TeamCreate (teams mode engaged) → the
+	// single ensign dispatch closes (backlog→done is ONE dispatch that writes
+	// `## Stage Report: done`) → the FO subprocess exits. terminalize + archive
+	// are NOT watched as stream events — they are the post-exit filesystem state
+	// the end-state assertions below verify. Each step is bounded by its own
+	// no-progress quiet budget; a stalled step fails FAST and LOCALIZED.
+	if _, err := watcher.expect(isTeamCreate, quietBudgetDefault, "TeamCreate"); err != nil {
+		t.Fatalf("live cycle failed at TeamCreate: %v", err)
+	}
+	if err := watcher.expectDispatchClose(quietBudgetDefault, "dispatch close"); err != nil {
+		t.Fatalf("live cycle failed at the ensign dispatch close: %v", err)
+	}
+	exitCode, err := watcher.expectExit(exitBudgetDefault)
 	if err != nil {
-		t.Fatalf("spacedock claude failed: %v", err)
+		t.Fatalf("live cycle failed waiting for FO exit: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("spacedock claude exited non-zero: code=%d", exitCode)
 	}
 
 	// Locate the entity at the REAL completed-cycle end-state. A full FO-to-done
@@ -211,4 +235,58 @@ func repoRoot(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return root
+}
+
+// isTeamCreate matches the FO's TeamCreate assistant tool_use — the first
+// progress beat of the teams-mode live cycle (the team is engaged).
+func isTeamCreate(e streamEntry) bool {
+	b := e.toolUseBlock()
+	return b != nil && b.Name == "TeamCreate"
+}
+
+// cmdPoller is the live procPoller: it Waits the exec.Cmd in the background,
+// records the exit code, and reports it non-blockingly via poll() so the
+// watcher's expect loops can detect an early crash and expectExit can wait for a
+// clean exit. Closing the pipe write-end on exit unblocks the line scanner so
+// the watcher drains the final stream-json lines. kill() forcibly stops a hung
+// claude on a quiet-budget timeout.
+type cmdPoller struct {
+	cmd *exec.Cmd
+
+	mu     sync.Mutex
+	exited bool
+	code   int
+}
+
+// newCmdPoller starts the background Wait. pw is the pipe write-end shared by
+// cmd.Stdout/Stderr; it is closed when Wait returns so the reader reaches EOF.
+func newCmdPoller(cmd *exec.Cmd, pw io.Closer) *cmdPoller {
+	p := &cmdPoller{cmd: cmd}
+	go func() {
+		err := cmd.Wait()
+		code := 0
+		if exit, ok := err.(*exec.ExitError); ok {
+			code = exit.ExitCode()
+		} else if err != nil {
+			code = -1
+		}
+		pw.Close()
+		p.mu.Lock()
+		p.exited = true
+		p.code = code
+		p.mu.Unlock()
+	}()
+	return p
+}
+
+func (p *cmdPoller) poll() (int, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.code, p.exited
+}
+
+func (p *cmdPoller) kill() {
+	if p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+	}
 }

--- a/internal/ensigncycle/live_test.go
+++ b/internal/ensigncycle/live_test.go
@@ -119,12 +119,28 @@ func TestLiveEnsignCycle(t *testing.T) {
 	poller := newCmdPoller(cmd, pw)
 	watcher := newStreamWatcher(newPipeLineSource(pr), poller, func(line string) { t.Log(line) })
 
+	// Kill the subprocess on ANY exit path. Only expectExit kills on its own
+	// timeout; an EARLY t.Fatalf (a TeamCreate-stall or dispatch-close-stall
+	// below) would otherwise orphan a token-spending `claude`. kill() is a no-op
+	// once the process has exited, so this is harmless on the clean path.
+	defer poller.kill()
+
 	// The proven upstream watch sequence: TeamCreate (teams mode engaged) → the
 	// single ensign dispatch closes (backlog→done is ONE dispatch that writes
 	// `## Stage Report: done`) → the FO subprocess exits. terminalize + archive
 	// are NOT watched as stream events — they are the post-exit filesystem state
 	// the end-state assertions below verify. Each step is bounded by its own
 	// no-progress quiet budget; a stalled step fails FAST and LOCALIZED.
+	//
+	// KNOWN GAP (conscious, by design — NOT a missing timeout): the quiet budget
+	// resets on ANY drained line, so it catches a SILENT hang (no new stream
+	// activity → tripped in ≤60s, localized) but NOT a "stuck-but-emitting"
+	// (chatty) hang — an FO that keeps emitting unrelated stream lines without
+	// ever reaching the next watched step. That case is deliberately left to
+	// Go's BUILT-IN default test timeout rather than an explicit long `-timeout`:
+	// the captain banned long individual timeouts, and a chatty hang is far rarer
+	// than a silent one (which the quiet budget does catch). Documenting it here
+	// keeps the trade-off explicit instead of silently absent.
 	if _, err := watcher.expect(isTeamCreate, quietBudgetDefault, "TeamCreate"); err != nil {
 		t.Fatalf("live cycle failed at TeamCreate: %v", err)
 	}

--- a/internal/ensigncycle/streamwatch.go
+++ b/internal/ensigncycle/streamwatch.go
@@ -1,0 +1,513 @@
+// ABOUTME: Streaming per-step watcher over the FO's stream-json: bounds each live
+// ABOUTME: stage by a no-progress quiet budget, replacing the monolithic timeout (Go port of FOStreamWatcher).
+package ensigncycle
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// streamWatcher consumes the FO's stream-json JSONL as it arrives and bounds
+// each stage-progress step by its own no-progress (quiet) budget. It is the Go
+// port of the upstream Python FOStreamWatcher (scripts/test_lib.py), specialised
+// to the v1 live cycle. expect / expectDispatchClose / expectExit each poll for
+// new lines, tee them to the test log immediately so a hang leaves a partial
+// transcript, and trip a labelled stepTimeout / stepFailure that names the
+// stalled step.
+//
+// The one intentional delta from upstream expect(): the per-step budget is a
+// NO-PROGRESS bound, not an overall cap. The deadline resets to now+budget on
+// every drained line, so a live stage that legitimately runs for minutes never
+// trips as long as the stream keeps moving; only genuine silence past the budget
+// trips. This reconciles the captain's "no individual timeout > 60s" directive
+// with stages that legitimately take minutes.
+//
+// It compiles under DEFAULT build tags (no //go:build live) so the offline unit
+// test exercises it against synthetic logs with no model spend; the //go:build
+// live live_test.go wires it to the real subprocess pipe.
+
+const (
+	// quietBudgetDefault is the per-step no-progress bound for expect and
+	// expectDispatchClose — the deadline resets on any drained line, so this
+	// caps stream SILENCE, not total stage wallclock.
+	quietBudgetDefault = 60 * time.Second
+	// exitBudgetDefault is how long expectExit waits for the FO to exit after
+	// the last watched step matched, before killing it.
+	exitBudgetDefault = 60 * time.Second
+	// pollIntervalDefault matches upstream POLL_INTERVAL_S = 0.2.
+	pollIntervalDefault = 200 * time.Millisecond
+	// transcriptTailLines bounds the tail carried in failure messages.
+	transcriptTailLines = 20
+)
+
+// lineSource yields newly-completed stream-json lines since the previous drain.
+// Partial trailing lines are held internally until their newline arrives — the
+// port of upstream _drain_entries's buffer. drain never blocks.
+type lineSource interface {
+	drain() []string
+}
+
+// procPoller reports whether the FO subprocess has exited (and its code), and
+// kills it on timeout. The port of the Python proc.poll() / proc.kill() surface;
+// the offline unit test injects a fake (the port of _FakeProc), the live test
+// wraps the real exec.Cmd.
+type procPoller interface {
+	poll() (code int, exited bool)
+	kill()
+}
+
+// stepTimeout: no progress within the quiet budget (or no exit within the exit
+// budget). Carries the step label and a transcript tail.
+type stepTimeout struct {
+	label string
+	msg   string
+}
+
+func (e *stepTimeout) Error() string { return e.msg }
+
+// stepFailure: the FO subprocess exited BEFORE the expected step matched. Carries
+// the step label, the non-zero exit code, and a transcript tail.
+type stepFailure struct {
+	label    string
+	exitCode int
+	msg      string
+}
+
+func (e *stepFailure) Error() string { return e.msg }
+
+// openDispatch tracks an in-flight ensign dispatch from its Agent tool_use to
+// its matching close anchor.
+type openDispatch struct {
+	dispatchID string
+	ensignName string
+}
+
+type streamWatcher struct {
+	src  lineSource
+	proc procPoller
+	tee  func(string)
+
+	quietBudget  time.Duration
+	exitBudget   time.Duration
+	pollInterval time.Duration
+
+	transcript     []string
+	openDispatches map[string]*openDispatch
+	closedCount    int
+}
+
+// newStreamWatcher builds a watcher over the given line source and proc poller.
+// tee receives every drained line immediately (the live test passes t.Log so a
+// hang leaves a partial, step-naming transcript). Budgets default to the ≤60s
+// constants; the offline unit test shrinks them for speed.
+func newStreamWatcher(src lineSource, proc procPoller, tee func(string)) *streamWatcher {
+	return &streamWatcher{
+		src:            src,
+		proc:           proc,
+		tee:            tee,
+		quietBudget:    quietBudgetDefault,
+		exitBudget:     exitBudgetDefault,
+		pollInterval:   pollIntervalDefault,
+		openDispatches: map[string]*openDispatch{},
+	}
+}
+
+// drainEntries reads the newly-available lines, tees them, records them in the
+// bounded transcript, updates dispatch open/close tracking, and returns the
+// parsed entries. Returns the count of lines drained so callers can reset the
+// no-progress deadline on any activity.
+func (w *streamWatcher) drainEntries() (entries []streamEntry, drained int) {
+	lines := w.src.drain()
+	for _, line := range lines {
+		drained++
+		w.tee(line)
+		w.transcript = append(w.transcript, line)
+		var e streamEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			continue
+		}
+		entries = append(entries, e)
+	}
+	w.updateDispatches(entries)
+	return entries, drained
+}
+
+// transcriptTail returns the last transcriptTailLines streamed lines joined by
+// newlines — the self-diagnosing tail carried in every failure message.
+func (w *streamWatcher) transcriptTail() string {
+	start := len(w.transcript) - transcriptTailLines
+	if start < 0 {
+		start = 0
+	}
+	return strings.Join(w.transcript[start:], "\n")
+}
+
+// expect returns the first drained entry where predicate is true, bounding the
+// wait by a NO-PROGRESS quiet budget: the deadline resets to now+budget on every
+// drained line. Trips stepTimeout on silence past the budget; stepFailure if the
+// proc exits before a match (after a final drain).
+func (w *streamWatcher) expect(predicate func(streamEntry) bool, budget time.Duration, label string) (streamEntry, error) {
+	deadline := time.Now().Add(budget)
+	for {
+		entries, drained := w.drainEntries()
+		if drained > 0 {
+			deadline = time.Now().Add(budget)
+		}
+		for _, e := range entries {
+			if safePredicate(predicate, e) {
+				return e, nil
+			}
+		}
+
+		if _, exited := w.proc.poll(); exited {
+			// Final drain so a line that landed alongside exit still wins.
+			entries, _ := w.drainEntries()
+			for _, e := range entries {
+				if safePredicate(predicate, e) {
+					return e, nil
+				}
+			}
+			code, _ := w.proc.poll()
+			return streamEntry{}, &stepFailure{
+				label:    label,
+				exitCode: code,
+				msg: fmt.Sprintf("FO subprocess exited (code=%d) before step %q matched.\nTranscript tail:\n%s",
+					code, label, w.transcriptTail()),
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return streamEntry{}, &stepTimeout{
+				label: label,
+				msg: fmt.Sprintf("step %q made no progress within %s (no-progress quiet budget).\nTranscript tail:\n%s",
+					label, budget, w.transcriptTail()),
+			}
+		}
+		time.Sleep(w.pollInterval)
+	}
+}
+
+// expectDispatchClose blocks until the next ensign dispatch closes (any of the
+// three mode anchors registered it), bounding the wait by the same no-progress
+// quiet budget as expect. The flat-entity live cycle dispatches exactly one
+// ensign, so the live test calls this once.
+func (w *streamWatcher) expectDispatchClose(budget time.Duration, label string) error {
+	baseline := w.closedCount
+	deadline := time.Now().Add(budget)
+	for {
+		_, drained := w.drainEntries()
+		if drained > 0 {
+			deadline = time.Now().Add(budget)
+		}
+		if w.closedCount > baseline {
+			return nil
+		}
+
+		if _, exited := w.proc.poll(); exited {
+			w.drainEntries()
+			if w.closedCount > baseline {
+				return nil
+			}
+			code, _ := w.proc.poll()
+			return &stepFailure{
+				label:    label,
+				exitCode: code,
+				msg: fmt.Sprintf("FO subprocess exited (code=%d) before step %q closed.\nTranscript tail:\n%s",
+					code, label, w.transcriptTail()),
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return &stepTimeout{
+				label: label,
+				msg: fmt.Sprintf("step %q did not close within %s (no-progress quiet budget). Open dispatches: %v.\nTranscript tail:\n%s",
+					label, budget, w.openDispatchNames(), w.transcriptTail()),
+			}
+		}
+		time.Sleep(w.pollInterval)
+	}
+}
+
+// expectExit waits up to budget for the FO subprocess to exit AFTER the last
+// watched step matched, draining any final lines. On timeout it kills the
+// subprocess and trips stepTimeout("expect_exit") so a hung claude does not
+// outlive the test.
+func (w *streamWatcher) expectExit(budget time.Duration) (int, error) {
+	deadline := time.Now().Add(budget)
+	for {
+		w.drainEntries()
+		if code, exited := w.proc.poll(); exited {
+			w.drainEntries()
+			return code, nil
+		}
+		if time.Now().After(deadline) {
+			w.proc.kill()
+			return 0, &stepTimeout{
+				label: "expect_exit",
+				msg: fmt.Sprintf("FO subprocess did not exit within %s.\nTranscript tail:\n%s",
+					budget, w.transcriptTail()),
+			}
+		}
+		time.Sleep(w.pollInterval)
+	}
+}
+
+// openDispatchNames lists the descriptions of dispatches still open, for the
+// timeout message.
+func (w *streamWatcher) openDispatchNames() []string {
+	names := make([]string, 0, len(w.openDispatches))
+	for _, d := range w.openDispatches {
+		names = append(names, d.ensignName)
+	}
+	return names
+}
+
+// updateDispatches registers open dispatches from Agent(subagent_type=
+// "spacedock:ensign") tool_use entries and closes them on any of the three mode
+// anchors — the port of upstream _update_dispatch_budgets's open/close logic
+// (the soft/hard budget + cooperative-shutdown machinery is out of scope here;
+// the per-step quiet budget is the only timeout discipline).
+func (w *streamWatcher) updateDispatches(entries []streamEntry) {
+	for _, e := range entries {
+		// Open: Agent(subagent_type="spacedock:ensign") assistant tool_use.
+		if b := e.toolUseBlock(); b != nil && b.Name == "Agent" && b.Input.SubagentType == "spacedock:ensign" {
+			id := b.ID
+			if id == "" {
+				id = fmt.Sprintf("anon-%d", len(w.openDispatches))
+			}
+			name := b.Input.Description
+			if name == "" {
+				name = "unnamed-ensign"
+			}
+			w.openDispatches[id] = &openDispatch{dispatchID: id, ensignName: name}
+			continue
+		}
+
+		// Teams-mode-with-TTY close: system task_notification status=completed.
+		if e.Type == "system" && e.Subtype == "task_notification" && e.Status == "completed" {
+			if _, ok := w.openDispatches[e.ToolUseID]; ok {
+				w.closeDispatch(e.ToolUseID)
+			}
+			continue
+		}
+
+		// User tool_result close anchors: bare-mode Done payload (keyed by the
+		// Agent tool_use_id) or the headless inbox-poll Done: Bash result.
+		if e.Type == "user" {
+			for _, rb := range e.resultBlocks() {
+				text := rb.flatText()
+				// Bare-mode: the Agent tool_use_id's tool_result carrying a real
+				// Done payload (NOT just a "Spawned successfully" spawn-ack).
+				if _, ok := w.openDispatches[rb.ToolUseID]; ok && looksLikeBareDone(text) {
+					w.closeDispatch(rb.ToolUseID)
+					continue
+				}
+				// Headless inbox-poll: a Bash result whose body carries
+				// `from: spacedock-ensign-…-{stage}` + `text: Done:`. Closes the
+				// open dispatch whose description shares the stage substring.
+				if sender := parseInboxDoneSender(text); sender != "" {
+					if id := w.findOpenDispatchForSender(sender); id != "" {
+						w.closeDispatch(id)
+					}
+				}
+			}
+		}
+	}
+}
+
+func (w *streamWatcher) closeDispatch(id string) {
+	if _, ok := w.openDispatches[id]; ok {
+		delete(w.openDispatches, id)
+		w.closedCount++
+	}
+}
+
+// findOpenDispatchForSender returns the open dispatch whose ensignName shares a
+// stage substring with the inbox sender (e.g. sender
+// "spacedock-ensign-make-it-work-done" matches a dispatch described
+// "…: done"). The port of upstream _find_open_dispatch_for_sender.
+func (w *streamWatcher) findOpenDispatchForSender(sender string) string {
+	s := strings.ToLower(sender)
+	stages := []string{"implementation", "validation", "analysis", "design", "backlog", "ideation", "done", "work"}
+	for id, d := range w.openDispatches {
+		name := strings.ToLower(d.ensignName)
+		for _, stage := range stages {
+			if strings.Contains(s, stage) && strings.Contains(name, stage) {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+// safePredicate runs the caller's predicate, treating a panic as no-match (the
+// port of upstream's try/except around predicate(entry)).
+func safePredicate(predicate func(streamEntry) bool, e streamEntry) (matched bool) {
+	defer func() { _ = recover() }()
+	return predicate(e)
+}
+
+// looksLikeBareDone reports whether an Agent tool_result text is a bare-mode
+// completion payload rather than a teams-mode spawn ack. The port of upstream
+// _looks_like_bare_done: a teams-mode Agent() tool_result is just a
+// "Spawned successfully" ack; a bare-mode one is the worker's Done payload.
+func looksLikeBareDone(text string) bool {
+	return !strings.Contains(text, "Spawned successfully")
+}
+
+// parseInboxDoneSender returns the `from:` sender when text is an inbox-poll
+// Done: entry (carries both `from:` and a `text: Done:` line). The port of
+// upstream _parse_inbox_done_sender — the combined signature so plain agent
+// names or unrelated Bash output don't accidentally close a dispatch.
+func parseInboxDoneSender(text string) string {
+	if !strings.Contains(text, "Done:") || !strings.Contains(text, "from:") {
+		return ""
+	}
+	var sender string
+	sawDone := false
+	for _, line := range strings.Split(text, "\n") {
+		s := strings.TrimSpace(line)
+		if strings.HasPrefix(s, "from:") {
+			sender = strings.TrimSpace(strings.TrimPrefix(s, "from:"))
+		} else if strings.HasPrefix(s, "text:") && strings.Contains(s, "Done:") {
+			sawDone = true
+			break
+		}
+	}
+	if sender != "" && sawDone {
+		return sender
+	}
+	return ""
+}
+
+// --- parsed stream-json entry shapes -------------------------------------
+
+// streamEntry is the parsed shape of one stream-json JSONL line — only the
+// fields the watcher reads. claude's stream-json is standard Claude Code output
+// (spacedock claude syscall.Exec-forwards --output-format stream-json verbatim),
+// so these shapes match what the upstream Python watcher parses.
+type streamEntry struct {
+	Type      string         `json:"type"`
+	Subtype   string         `json:"subtype"`
+	Status    string         `json:"status"`
+	ToolUseID string         `json:"tool_use_id"`
+	Message   *streamMessage `json:"message"`
+}
+
+type streamMessage struct {
+	Model   string        `json:"model"`
+	Content []streamBlock `json:"content"`
+}
+
+type streamBlock struct {
+	Type       string          `json:"type"`
+	ID         string          `json:"id"`
+	Name       string          `json:"name"`
+	Input      streamToolInput `json:"input"`
+	ToolUseID  string          `json:"tool_use_id"`
+	RawContent json.RawMessage `json:"content"`
+}
+
+type streamToolInput struct {
+	SubagentType string `json:"subagent_type"`
+	Description  string `json:"description"`
+}
+
+// toolUseBlock returns the first tool_use block of an assistant entry, or nil —
+// the port of upstream _tool_use_block.
+func (e streamEntry) toolUseBlock() *streamBlock {
+	if e.Type != "assistant" || e.Message == nil {
+		return nil
+	}
+	for i := range e.Message.Content {
+		if e.Message.Content[i].Type == "tool_use" {
+			return &e.Message.Content[i]
+		}
+	}
+	return nil
+}
+
+// resultBlocks returns the tool_result blocks of a user entry.
+func (e streamEntry) resultBlocks() []*streamBlock {
+	if e.Type != "user" || e.Message == nil {
+		return nil
+	}
+	var out []*streamBlock
+	for i := range e.Message.Content {
+		if e.Message.Content[i].Type == "tool_result" {
+			out = append(out, &e.Message.Content[i])
+		}
+	}
+	return out
+}
+
+// flatText flattens a tool_result content payload (a string OR a list of text
+// blocks) into one string — the port of upstream _tool_result_text.
+func (b *streamBlock) flatText() string {
+	if len(b.RawContent) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(b.RawContent, &s) == nil {
+		return s
+	}
+	var blocks []struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(b.RawContent, &blocks) == nil {
+		parts := make([]string, 0, len(blocks))
+		for _, blk := range blocks {
+			if blk.Text != "" {
+				parts = append(parts, blk.Text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+	return ""
+}
+
+// --- live pipe adapters (used only by the //go:build live live test) -----
+
+// pipeLineSource is the live lineSource: a background goroutine reads the
+// subprocess's StdoutPipe via a bufio.Scanner and pushes complete lines onto a
+// channel; drain returns the lines buffered since the last poll. The Go port of
+// upstream _drain_entries's read-and-hold-partial-lines logic — bufio.Scanner
+// holds partial trailing lines until their newline arrives, so a half-written
+// JSONL line is never parsed early.
+type pipeLineSource struct {
+	lines chan string
+}
+
+// newPipeLineSource starts reading r in the background and returns a lineSource
+// over it. Closing r (subprocess exit) ends the goroutine.
+func newPipeLineSource(r io.Reader) *pipeLineSource {
+	p := &pipeLineSource{lines: make(chan string, 1024)}
+	go func() {
+		defer close(p.lines)
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+		for scanner.Scan() {
+			p.lines <- scanner.Text()
+		}
+	}()
+	return p
+}
+
+func (p *pipeLineSource) drain() []string {
+	var out []string
+	for {
+		select {
+		case line, ok := <-p.lines:
+			if !ok {
+				return out
+			}
+			out = append(out, line)
+		default:
+			return out
+		}
+	}
+}

--- a/internal/ensigncycle/streamwatch_unit_test.go
+++ b/internal/ensigncycle/streamwatch_unit_test.go
@@ -366,6 +366,39 @@ func TestExpectExitWaitsThenKills(t *testing.T) {
 	})
 }
 
+// TestEarlyStepTripCanKillProc guards the live test's `defer poller.kill()`
+// contract at the unit level: an early-step stall (TeamCreate / dispatch-close)
+// trips a stepTimeout WITHOUT the watcher itself killing the proc (only
+// expectExit kills internally) — so the still-running child must remain killable
+// by the caller's deferred kill(). Before the fix, an early t.Fatalf orphaned a
+// token-spending claude; this proves the kill() the live defer calls is
+// effective on a proc that is still alive after an early trip. The live defer
+// itself runs only under //go:build live, so this is the offline proof of the
+// building block.
+func TestEarlyStepTripCanKillProc(t *testing.T) {
+	src := &fakeLineSource{}
+	proc := &fakeProc{} // never exits — models a hung child
+	w := newTestWatcher(src, proc)
+
+	// An early step goes silent → stepTimeout. The watcher does NOT kill on this
+	// path (that is the caller's deferred responsibility).
+	_, err := w.expect(isToolUse("TeamCreate"), w.quietBudget, "TeamCreate")
+	var st *stepTimeout
+	if !errors.As(err, &st) {
+		t.Fatalf("want *stepTimeout on an early-step stall, got %T: %v", err, err)
+	}
+	if proc.wasKilled() {
+		t.Fatal("expect must NOT kill on its own trip — killing is the caller's deferred job")
+	}
+
+	// The deferred kill() the live test runs on this exit path must still stop
+	// the hung child.
+	proc.kill()
+	if !proc.wasKilled() {
+		t.Error("the child must be killable after an early-step trip (the defer poller.kill() contract)")
+	}
+}
+
 // --- synthetic stream-json line builders ---------------------------------
 //
 // These emit the standard Claude Code stream-json shapes the watcher parses.

--- a/internal/ensigncycle/streamwatch_unit_test.go
+++ b/internal/ensigncycle/streamwatch_unit_test.go
@@ -1,0 +1,426 @@
+// ABOUTME: Offline unit test for the live cycle's streamWatcher: synthetic JSONL
+// ABOUTME: + a fake exit-poller exercise the no-progress quiet trip, reset-on-activity, and early-exit failure (no live model).
+package ensigncycle
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// These run under the DEFAULT build tags (no //go:build live) so `go test ./...`
+// covers them; they spend NO model. They mirror the upstream Python
+// test_fo_stream_watcher.py split: a synthetic JSONL line source + a fake
+// exit-poller (the Go port of _FakeProc) drive the watcher's expect loop. The
+// load-bearing semantic these prove is the one place the Go port intentionally
+// differs from upstream expect(): the per-step budget is a NO-PROGRESS quiet
+// bound — the deadline resets to now+budget on every drained line — not a
+// total-stage cap.
+
+// fakeLineSource hands out synthetic stream-json lines on demand, the offline
+// stand-in for the StdoutPipe line drainer. push() appends lines a later drain()
+// will return; each drain() returns only the lines pushed since the previous
+// drain (the "new complete lines since last poll" contract the real drainer also
+// honors). holdPartial models a half-written trailing line the drainer holds
+// until its newline arrives.
+type fakeLineSource struct {
+	mu      sync.Mutex
+	pending []string
+}
+
+func (s *fakeLineSource) push(lines ...string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pending = append(s.pending, lines...)
+}
+
+func (s *fakeLineSource) drain() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.pending
+	s.pending = nil
+	return out
+}
+
+// fakeProc is the Go port of the Python _FakeProc: poll() reports the exit code
+// once setExited has flipped it, and reports not-exited before then. Guarded by
+// a mutex because the watcher polls it from a goroutine while the test flips it.
+type fakeProc struct {
+	mu     sync.Mutex
+	code   int
+	exited bool
+	killed bool
+}
+
+func (p *fakeProc) poll() (int, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.code, p.exited
+}
+
+func (p *fakeProc) setExited(code int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.code = code
+	p.exited = true
+}
+
+func (p *fakeProc) kill() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.killed = true
+}
+
+func (p *fakeProc) wasKilled() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.killed
+}
+
+// A tiny predicate over the parsed entry: matches an assistant tool_use for the
+// named tool. The real watcher uses the same parsed-entry shape against the live
+// stream-json.
+func isToolUse(name string) func(streamEntry) bool {
+	return func(e streamEntry) bool {
+		b := e.toolUseBlock()
+		return b != nil && b.Name == name
+	}
+}
+
+// newTestWatcher builds a watcher with a SHRUNK quiet/exit budget and a fast
+// poll interval so the offline tests run in well under a second; the production
+// budgets are 60s.
+func newTestWatcher(src *fakeLineSource, proc *fakeProc) *streamWatcher {
+	w := newStreamWatcher(src, proc, func(string) {})
+	w.quietBudget = 150 * time.Millisecond
+	w.exitBudget = 150 * time.Millisecond
+	w.pollInterval = 5 * time.Millisecond
+	return w
+}
+
+// TestExpectReturnsMatchedEntry: expect returns the matched entry on success.
+func TestExpectReturnsMatchedEntry(t *testing.T) {
+	src := &fakeLineSource{}
+	proc := &fakeProc{}
+	w := newTestWatcher(src, proc)
+
+	src.push(toolUseLine("Bash", `"command":"echo one"`))
+	src.push(toolUseLine("TeamCreate", `"team_name":"t"`))
+
+	entry, err := w.expect(isToolUse("TeamCreate"), w.quietBudget, "TeamCreate")
+	if err != nil {
+		t.Fatalf("expect returned error: %v", err)
+	}
+	if b := entry.toolUseBlock(); b == nil || b.Name != "TeamCreate" {
+		t.Fatalf("expect returned the wrong entry: %+v", entry)
+	}
+}
+
+// TestExpectQuietTimeoutCarriesLabel: a stream that goes silent before the
+// predicate matches trips StepTimeout carrying the step label. This is the
+// localized no-progress trip — not a total-stage cap.
+func TestExpectQuietTimeoutCarriesLabel(t *testing.T) {
+	src := &fakeLineSource{}
+	proc := &fakeProc{}
+	w := newTestWatcher(src, proc)
+
+	src.push(toolUseLine("TeamCreate", `"team_name":"t"`))
+
+	start := time.Now()
+	_, err := w.expect(isToolUse("Agent"), w.quietBudget, "dispatch close")
+	elapsed := time.Since(start)
+
+	var st *stepTimeout
+	if !errors.As(err, &st) {
+		t.Fatalf("want *stepTimeout, got %T: %v", err, err)
+	}
+	if st.label != "dispatch close" {
+		t.Errorf("stepTimeout.label = %q, want %q", st.label, "dispatch close")
+	}
+	if !strings.Contains(st.Error(), "dispatch close") {
+		t.Errorf("error message must name the step: %q", st.Error())
+	}
+	// Tripped on the quiet budget, NOT a total-stage cap: it returns within
+	// ~1x the (shrunk) quiet budget once the stream goes silent.
+	if elapsed > 3*w.quietBudget {
+		t.Errorf("quiet trip took %s, far beyond ~1x the %s budget — not localized", elapsed, w.quietBudget)
+	}
+}
+
+// TestExpectResetsDeadlineOnActivity: a noisy-but-unmatched stream that keeps
+// emitting lines PAST the quiet budget does NOT trip — the deadline resets on
+// every drained line — and expect returns once the predicate finally matches.
+// This is the single intentional delta from upstream's overall budget.
+func TestExpectResetsDeadlineOnActivity(t *testing.T) {
+	src := &fakeLineSource{}
+	proc := &fakeProc{}
+	w := newTestWatcher(src, proc)
+
+	// Drive unrelated lines for well past the quiet budget, one per poll, so the
+	// total elapsed exceeds quietBudget several times over. A total-stage cap
+	// would trip; the no-progress bound must not, because each drained line
+	// resets the deadline.
+	matched := make(chan error, 1)
+	go func() {
+		_, err := w.expect(isToolUse("Agent"), w.quietBudget, "agent dispatch")
+		matched <- err
+	}()
+
+	noiseEnd := time.Now().Add(4 * w.quietBudget)
+	for time.Now().Before(noiseEnd) {
+		src.push(toolUseLine("Bash", `"command":"heartbeat"`))
+		time.Sleep(w.pollInterval)
+	}
+	// Now emit the matching line; expect must return cleanly despite total
+	// elapsed already exceeding the quiet budget many times.
+	src.push(toolUseLine("Agent", `"subagent_type":"spacedock:ensign"`))
+
+	select {
+	case err := <-matched:
+		if err != nil {
+			t.Fatalf("noisy-but-progressing stream must NOT trip the quiet budget; got %v", err)
+		}
+	case <-time.After(2 * w.quietBudget):
+		t.Fatalf("expect did not return after the matching line arrived")
+	}
+}
+
+// TestExpectStepFailureOnEarlyExit: the subprocess exits before the predicate
+// matches → StepFailure carrying the non-zero exit code + the label.
+func TestExpectStepFailureOnEarlyExit(t *testing.T) {
+	src := &fakeLineSource{}
+	proc := &fakeProc{}
+	w := newTestWatcher(src, proc)
+
+	src.push(toolUseLine("Bash", `"command":"noise"`))
+
+	go func() {
+		time.Sleep(2 * w.pollInterval)
+		proc.setExited(1)
+	}()
+
+	_, err := w.expect(isToolUse("Agent"), 5*time.Second, "agent dispatch")
+	var sf *stepFailure
+	if !errors.As(err, &sf) {
+		t.Fatalf("want *stepFailure, got %T: %v", err, err)
+	}
+	if sf.exitCode != 1 {
+		t.Errorf("stepFailure.exitCode = %d, want 1", sf.exitCode)
+	}
+	if sf.label != "agent dispatch" {
+		t.Errorf("stepFailure.label = %q, want %q", sf.label, "agent dispatch")
+	}
+	if !strings.Contains(sf.Error(), "code=1") {
+		t.Errorf("error must carry the exit code: %q", sf.Error())
+	}
+}
+
+// TestExpectFinalDrainBeforePoll: when the matching line is already drained
+// and the proc has exited, expect must drain-then-check so the match wins over
+// the exit (the ordering the Python port guarantees).
+func TestExpectFinalDrainBeforePoll(t *testing.T) {
+	src := &fakeLineSource{}
+	proc := &fakeProc{}
+	w := newTestWatcher(src, proc)
+
+	src.push(toolUseLine("Agent", `"subagent_type":"spacedock:ensign"`))
+	proc.setExited(0)
+
+	entry, err := w.expect(isToolUse("Agent"), w.quietBudget, "agent dispatch")
+	if err != nil {
+		t.Fatalf("expect must match the final-flushed line before reporting exit; got %v", err)
+	}
+	if b := entry.toolUseBlock(); b == nil || b.Name != "Agent" {
+		t.Fatalf("wrong entry returned: %+v", entry)
+	}
+}
+
+// TestExpectFailureCarriesTranscriptTail: a hang leaves a step-naming tail that
+// includes the lines streamed so far (AC-2's diagnosability proof, offline).
+func TestExpectFailureCarriesTranscriptTail(t *testing.T) {
+	src := &fakeLineSource{}
+	proc := &fakeProc{}
+	w := newTestWatcher(src, proc)
+
+	// Advance through TeamCreate, then go silent before the dispatch-close.
+	src.push(toolUseLine("TeamCreate", `"team_name":"t"`))
+	if _, err := w.expect(isToolUse("TeamCreate"), w.quietBudget, "TeamCreate"); err != nil {
+		t.Fatalf("TeamCreate should have matched: %v", err)
+	}
+
+	_, err := w.expect(isToolUse("Agent"), w.quietBudget, "dispatch close")
+	var st *stepTimeout
+	if !errors.As(err, &st) {
+		t.Fatalf("want *stepTimeout, got %T: %v", err, err)
+	}
+	msg := st.Error()
+	if !strings.Contains(msg, "dispatch close") {
+		t.Errorf("tail-bearing error must name the stalled step: %q", msg)
+	}
+	if !strings.Contains(msg, "TeamCreate") {
+		t.Errorf("transcript tail must include the last reached step (TeamCreate): %q", msg)
+	}
+}
+
+// TestExpectDispatchCloseOnThreeAnchors: a dispatch opens on an
+// Agent(subagent_type="spacedock:ensign") tool_use and closes on each of the
+// three mode anchors the port carries — bare-mode Agent tool_result, teams-mode
+// task_notification status=completed, and the headless inbox-poll Done: Bash
+// tool_result. Each anchor, on its own, must close the open dispatch.
+func TestExpectDispatchCloseOnThreeAnchors(t *testing.T) {
+	cases := []struct {
+		name      string
+		openTUID  string
+		closeLine string
+	}{
+		{
+			name:      "bare_mode_agent_tool_result",
+			openTUID:  "toolu_bare",
+			closeLine: bareDoneToolResultLine("toolu_bare"),
+		},
+		{
+			name:      "teams_task_notification_completed",
+			openTUID:  "toolu_teams",
+			closeLine: taskNotificationCompletedLine("toolu_teams"),
+		},
+		{
+			name:      "headless_inbox_poll_done",
+			openTUID:  "toolu_headless",
+			closeLine: inboxPollDoneLine("spacedock-ensign-make-it-work-done"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &fakeLineSource{}
+			proc := &fakeProc{}
+			w := newTestWatcher(src, proc)
+
+			src.push(agentDispatchLine(tc.openTUID, "Create a greeting file: done"))
+			src.push(tc.closeLine)
+
+			if err := w.expectDispatchClose(w.quietBudget, "dispatch close"); err != nil {
+				t.Fatalf("dispatch close on the %s anchor did not register: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestExpectDispatchCloseSpawnAckDoesNotClose: a teams-mode Agent tool_result
+// that is just the "Spawned successfully" ack must NOT close the dispatch — only
+// a real Done payload (or the other anchors) does. Guards the bare-vs-teams
+// discriminator the port carries.
+func TestExpectDispatchCloseSpawnAckDoesNotClose(t *testing.T) {
+	src := &fakeLineSource{}
+	proc := &fakeProc{}
+	w := newTestWatcher(src, proc)
+
+	src.push(agentDispatchLine("toolu_x", "Create a greeting file: done"))
+	src.push(spawnAckToolResultLine("toolu_x"))
+
+	err := w.expectDispatchClose(w.quietBudget, "dispatch close")
+	var st *stepTimeout
+	if !errors.As(err, &st) {
+		t.Fatalf("a spawn-ack must NOT close the dispatch; want *stepTimeout, got %T: %v", err, err)
+	}
+}
+
+// TestExpectExitWaitsThenKills: expectExit returns the exit code once the proc
+// exits; on a hung proc it trips StepTimeout and kills it.
+func TestExpectExitWaitsThenKills(t *testing.T) {
+	t.Run("exits_cleanly", func(t *testing.T) {
+		src := &fakeLineSource{}
+		proc := &fakeProc{}
+		w := newTestWatcher(src, proc)
+		go func() {
+			time.Sleep(2 * w.pollInterval)
+			proc.setExited(0)
+		}()
+		code, err := w.expectExit(w.exitBudget)
+		if err != nil {
+			t.Fatalf("expectExit on a clean exit returned error: %v", err)
+		}
+		if code != 0 {
+			t.Errorf("exit code = %d, want 0", code)
+		}
+	})
+
+	t.Run("hung_proc_trips_and_is_killed", func(t *testing.T) {
+		src := &fakeLineSource{}
+		proc := &fakeProc{} // never exits
+		w := newTestWatcher(src, proc)
+
+		_, err := w.expectExit(w.exitBudget)
+		var st *stepTimeout
+		if !errors.As(err, &st) {
+			t.Fatalf("want *stepTimeout on a hung exit, got %T: %v", err, err)
+		}
+		if st.label != "expect_exit" {
+			t.Errorf("stepTimeout.label = %q, want expect_exit", st.label)
+		}
+		if !proc.wasKilled() {
+			t.Error("expectExit must kill a hung subprocess on timeout")
+		}
+	})
+}
+
+// --- synthetic stream-json line builders ---------------------------------
+//
+// These emit the standard Claude Code stream-json shapes the watcher parses.
+// `spacedock claude` syscall.Exec-replaces itself with `claude`, forwarding
+// --output-format stream-json verbatim, so the live pipe carries exactly these
+// shapes (Spike in the entity body). Each builder returns one JSONL line.
+
+// toolUseLine builds an assistant tool_use entry. extraInputJSON is raw JSON
+// key/value fragments (e.g. `"command":"echo one"`) spliced into the input
+// object — enough for the predicate to discriminate on the tool name + a field.
+func toolUseLine(toolName, extraInputJSON string) string {
+	return `{"type":"assistant","message":{"model":"claude-sonnet-4-6","content":[` +
+		`{"type":"tool_use","id":"toolu_anon","name":` + strconv.Quote(toolName) +
+		`,"input":{` + extraInputJSON + `}}]}}`
+}
+
+// agentDispatchLine opens a dispatch: an assistant Agent tool_use with
+// subagent_type=spacedock:ensign and a description, keyed by tool_use_id.
+func agentDispatchLine(toolUseID, description string) string {
+	return `{"type":"assistant","message":{"model":"claude-sonnet-4-6","content":[` +
+		`{"type":"tool_use","id":` + strconv.Quote(toolUseID) + `,"name":"Agent","input":{` +
+		`"subagent_type":"spacedock:ensign","description":` + strconv.Quote(description) + `}}]}}`
+}
+
+// bareDoneToolResultLine is the bare-mode close anchor: the user tool_result for
+// the Agent tool_use_id carrying the teammate's Done payload directly (a list of
+// text blocks, NOT a "Spawned successfully" spawn-ack).
+func bareDoneToolResultLine(toolUseID string) string {
+	return `{"type":"user","message":{"content":[` +
+		`{"type":"tool_result","tool_use_id":` + strconv.Quote(toolUseID) +
+		`,"content":[{"type":"text","text":"Done: completed done. Report written."}]}]}}`
+}
+
+// spawnAckToolResultLine is the teams-mode Agent tool_result that is JUST the
+// spawn ack — it must NOT close the dispatch.
+func spawnAckToolResultLine(toolUseID string) string {
+	return `{"type":"user","message":{"content":[` +
+		`{"type":"tool_result","tool_use_id":` + strconv.Quote(toolUseID) +
+		`,"content":[{"type":"text","text":"Spawned successfully. agent_id: a123-xyz"}]}]}}`
+}
+
+// taskNotificationCompletedLine is the teams-mode-with-TTY close anchor: a
+// system task_notification with status=completed keyed by the Agent tool_use_id.
+func taskNotificationCompletedLine(toolUseID string) string {
+	return `{"type":"system","subtype":"task_notification","status":"completed","tool_use_id":` +
+		strconv.Quote(toolUseID) + `}`
+}
+
+// inboxPollDoneLine is the headless `claude -p` close anchor: a Bash tool_result
+// whose body carries `from: spacedock-ensign-…-{stage}` and `text: Done:`,
+// surfaced by the FO's inbox-poll script. Closes any open dispatch whose
+// description shares the stage substring.
+func inboxPollDoneLine(sender string) string {
+	body := "team: t\nfrom: " + sender + "\ntimestamp: now\nsummary: s\ntext: Done: completed done."
+	return `{"type":"user","message":{"content":[` +
+		`{"type":"tool_result","tool_use_id":"toolu_bash","content":[{"type":"text","text":` +
+		strconv.Quote(body) + `}]}]}}`
+}


### PR DESCRIPTION
Make the live-runtime e2e net fail fast and diagnosably: per-stage no-progress timeouts replace the 12-minute monolithic black-box that hid hangs.

## What changed
- Replace the live test's monolithic 12m timeout + `CombinedOutput()` with a streaming per-stage watcher (a Go port of upstream `FOStreamWatcher`).
- Bound each step (TeamCreate → dispatch-close → exit) by a ≤60s no-progress quiet budget that resets on stream activity; kill the subprocess on any trip.
- Stream the FO transcript to the test log so a hang names the stalled step.
- Add a static guard asserting no live-path timeout exceeds 60s.

## Evidence
- `go test ./internal/ensigncycle/` + `-race` green (15 watcher/budget tests); `go vet -tags live` clean.
- Live reliability binds at this PR's CI-E2E (sonnet + opus); local runs can't auth.

## Review guidance
Intentional delta from upstream: the per-stage budget is a NO-PROGRESS (quiet) bound, not a total-stage cap — it resets on any drained stream line.

---
[37](/spacedock-dev/spacedock/blob/e266666c2fad52943d8601928375fb04b63d02fc/live-e2e-per-stage-timeouts/index.md)
