### PR TITLE
0.19.x code-quality cleanups — loud unknown-command/stray-flag errors, init→install rename, replace-first version stamp, StandingTeammate dedup, prose-contrast, bump-calendar doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ step-by-step journey with the observable output at each step.
 ```bash
 brew tap spacedock-dev/homebrew-tap
 brew install spacedock
-spacedock init --host claude
+spacedock install --host claude
 ```
 
 The no-tap one-liner `brew install spacedock-dev/homebrew-tap/spacedock` is
@@ -45,10 +45,10 @@ go build -o spacedock ./cmd/spacedock
 plugin is out of date (predates this binary's contract), reinstall it:
 
 ```bash
-spacedock init --host claude
+spacedock install --host claude
 ```
 
-`spacedock init` reinstalls from `spacedock-dev/spacedock@next`, replacing a
+`spacedock install` reinstalls from `spacedock-dev/spacedock@next`, replacing a
 stale already-installed plugin (it uninstalls before installing, since a plain
 `plugin install` no-ops when the plugin is already present).
 

--- a/docs/install-journey.md
+++ b/docs/install-journey.md
@@ -58,7 +58,7 @@ when you want sandboxed runs.
 3. **Install the host plugin.**
 
    ```bash
-   spacedock init --host claude
+   spacedock install --host claude
    ```
 
    Adds the `spacedock-dev/spacedock` marketplace plugin for Claude Code, then

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -32,11 +32,15 @@ before publishing.
    git worktree add .worktrees/release-X.Y.Z -b release/X.Y.Z origin/next
    ```
 
-3. Bump the two plugin manifests with the release tool, then commit:
+3. Bump the version stamps with the release tool, then commit. `stamp-version`
+   writes the release `X.Y.Z` into the plugin manifests; `bump-calendar` advances
+   the marketplace entry's separate `0.0.YYYYMMDDNN` calendar key (the
+   `claude plugin update` re-pull key) — they stamp different files, so both run:
 
    ```bash
    go run ./cmd/spacedock-release stamp-version X.Y.Z .claude-plugin/plugin.json .codex-plugin/plugin.json
-   git commit -m "release: bump version to spacedock@X.Y.Z" -- .claude-plugin/plugin.json .codex-plugin/plugin.json
+   go run ./cmd/spacedock-release bump-calendar .claude-plugin/marketplace.json
+   git commit -m "release: bump version to spacedock@X.Y.Z" -- .claude-plugin/plugin.json .codex-plugin/plugin.json .claude-plugin/marketplace.json
    ```
 
 4. Write a changelog. Summarize the commits since the last tag into plain text:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -50,7 +50,7 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 // package's public surface (Run) and the exit-code contract are unchanged: the
 // command tree captures env/dir/stdin/stdout/stderr/runner in its RunE closures.
 func run(ctx context.Context, args []string, env []string, dir string, stdin io.Reader, stdout io.Writer, stderr io.Writer, runner status.Runner, dispatchProbe claudeteam.TeamStateProbe) int {
-	root := newRootCommand(ctx, env, dir, stdin, stdout, stderr, runner, dispatchProbe)
+	root := newRootCommand(ctx, args, env, dir, stdin, stdout, stderr, runner, dispatchProbe)
 	root.SetArgs(args)
 	if err := root.Execute(); err != nil {
 		return exitCodeFor(err)
@@ -85,7 +85,7 @@ func exitCodeFor(err error) int {
 // package: cobra never prints its own error or usage, so the unknown-command path
 // emits the pinned message and exits 2 (the root RunE below), and the help is
 // rendered solely by printHelp.
-func newRootCommand(ctx context.Context, env []string, dir string, stdin io.Reader, stdout, stderr io.Writer, runner status.Runner, dispatchProbe claudeteam.TeamStateProbe) *cobra.Command {
+func newRootCommand(ctx context.Context, rawArgs []string, env []string, dir string, stdin io.Reader, stdout, stderr io.Writer, runner status.Runner, dispatchProbe claudeteam.TeamStateProbe) *cobra.Command {
 	versionFlag := false
 
 	root := &cobra.Command{
@@ -107,10 +107,18 @@ func newRootCommand(ctx context.Context, env []string, dir string, stdin io.Read
 				return nil
 			}
 			// No subcommand and no recognized flag: an unknown command token
-			// (e.g. `spacedock bogus`) exits 2 with the pinned message; bare
-			// `spacedock` renders the grouped help.
+			// (e.g. `spacedock bogus`) exits 2 with the pinned message.
 			if len(args) > 0 {
 				return unknownCommand(args[0], stderr)
+			}
+			// A leading unknown flag (e.g. `spacedock --bogus`, or the space-form
+			// `spacedock --foo install` where `--foo` consumed `install` as its
+			// value) reaches RunE with empty args because the UnknownFlags whitelist
+			// strips it during parse. Left to the bare-help path it would exit 0 — a
+			// silent usage error. Detect it from the raw argv and route to the
+			// usage/exit-2 path; a bare `spacedock` (no leading flag) still helps + 0.
+			if leadingUnknownFlag(rawArgs) {
+				return unknownFlag(rawArgs[0], stderr)
 			}
 			printHelp(stdout)
 			return nil
@@ -384,6 +392,26 @@ func unknownCommand(name string, stderr io.Writer) error {
 	fmt.Fprintf(stderr, "unknown command: %s\n", name)
 	printHelp(stderr)
 	return exitCodeError{2}
+}
+
+// unknownFlag writes the pinned unknown-flag diagnostic plus the grouped help to
+// stderr and returns the exit-2 carrier. It mirrors unknownCommand for a leading
+// flag that resolves to no subcommand, so a stray `spacedock --bogus` is a loud
+// usage error rather than a silent exit 0.
+func unknownFlag(name string, stderr io.Writer) error {
+	fmt.Fprintf(stderr, "unknown flag: %s\n", name)
+	printHelp(stderr)
+	return exitCodeError{2}
+}
+
+// leadingUnknownFlag reports whether the raw argv begins with a `-`-prefixed token
+// that is not a recognized root flag. `--version` and `-h`/`--help` are handled
+// before this is consulted (version returns early; help is intercepted by the
+// help func), so any leading flag reaching the bare-help path is unknown — the
+// UnknownFlags whitelist stripped it during parse, leaving empty positional args.
+// A bare invocation (no args, or a leading non-flag token) is not a leading flag.
+func leadingUnknownFlag(rawArgs []string) bool {
+	return len(rawArgs) > 0 && strings.HasPrefix(rawArgs[0], "-")
 }
 
 // runStatus forwards the post-"status" argv verbatim to the runner and returns

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -89,11 +89,18 @@ func newRootCommand(ctx context.Context, env []string, dir string, stdin io.Read
 	versionFlag := false
 
 	root := &cobra.Command{
-		Use:               "spacedock",
-		SilenceErrors:     true,
-		SilenceUsage:      true,
-		Args:              cobra.ArbitraryArgs,
-		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+		Use:           "spacedock",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Args:          cobra.ArbitraryArgs,
+		// An unknown subcommand carrying a trailing flag (e.g. the removed
+		// `spacedock init --host claude`) must reach RunE so args[0] drives the
+		// unknown-command diagnostic. Without this, the root flagset errors on the
+		// unrecognized flag during parse and, under SilenceErrors/SilenceUsage,
+		// exits 2 with no output — a silent exit. Whitelisting unknown flags lets
+		// parsing fall through to RunE so the command token is reported.
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		CompletionOptions:  cobra.CompletionOptions{DisableDefaultCmd: true},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if versionFlag {
 				printVersion(stdout)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -136,3 +136,33 @@ func TestUnknownCommand(t *testing.T) {
 		t.Fatalf("stderr missing unknown-command message: %q", stderr.String())
 	}
 }
+
+// TestUnknownCommandWithFlag pins AC-6: an unknown subcommand carrying a trailing
+// flag must STILL print `unknown command: <name>` + the grouped help to stderr and
+// exit 2 — never a silent exit 2. The removed `spacedock init --host claude` is the
+// captain's live case: with flag parsing enabled the root flagset errored on the
+// unknown --host before RunE ran, silencing all output. The bogus-with-flag case is
+// the generalized form.
+func TestUnknownCommandWithFlag(t *testing.T) {
+	for _, args := range [][]string{
+		{"init", "--host", "claude"},
+		{"bogus", "--someflag"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := Run(args, &stdout, &stderr)
+
+			if code != 2 {
+				t.Fatalf("Run(%v) = %d, want 2", args, code)
+			}
+			out := stderr.String()
+			if !strings.Contains(out, "unknown command: "+args[0]) {
+				t.Fatalf("Run(%v) stderr missing %q: %q", args, "unknown command: "+args[0], out)
+			}
+			// The grouped help block follows the diagnostic — the tagline pins it.
+			if !strings.Contains(out, tagline) {
+				t.Fatalf("Run(%v) stderr missing the usage block (tagline): %q", args, out)
+			}
+		})
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -137,6 +137,50 @@ func TestUnknownCommand(t *testing.T) {
 	}
 }
 
+// TestLeadingUnknownFlagIsUsageError pins AC-6's leading-flag half: a stray
+// leading unknown flag that resolves to no valid subcommand (before any command
+// token) must print the usage block to stderr and exit NON-ZERO — never the
+// silent exit-0+help the UnknownFlags whitelist would otherwise yield. The
+// space-form `--foo install` (where `--foo` would consume `install` as its value)
+// must NOT silently swallow the valid command token either. Distinct from the
+// bare invocation, which still prints help + exit 0 (TestLeadingFlagBareStillHelp).
+func TestLeadingUnknownFlagIsUsageError(t *testing.T) {
+	for _, args := range [][]string{
+		{"--bogus"},
+		{"--boot"},
+		{"--foo", "install"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := Run(args, &stdout, &stderr)
+
+			if code == 0 {
+				t.Fatalf("Run(%v) exited 0 on a leading unknown flag; want non-zero usage error (stdout=%q)", args, stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tagline) {
+				t.Fatalf("Run(%v) stderr missing the usage block (tagline): %q", args, stderr.String())
+			}
+		})
+	}
+}
+
+// TestLeadingFlagBareStillHelp guards the regression boundary: bare `spacedock`
+// (no args) still renders help to stdout and exits 0 — the leading-unknown-flag
+// fix must not turn the legitimate bare invocation into a usage error.
+func TestLeadingFlagBareStillHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("bare spacedock exited %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), tagline) {
+		t.Fatalf("bare spacedock stdout missing help: %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("bare spacedock stderr = %q, want empty", stderr.String())
+	}
+}
+
 // TestUnknownCommandWithFlag pins AC-6: an unknown subcommand carrying a trailing
 // flag must STILL print `unknown command: <name>` + the grouped help to stderr and
 // exit 2 — never a silent exit 2. The removed `spacedock init --host claude` is the

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -176,7 +176,7 @@ func TestGateRemedyNamesLiveInstallCommand(t *testing.T) {
 	// while the removed `init` must fall back to root (the unknown-command path
 	// that exits 2). Resolution is deterministic and touches no host CLI.
 	var stdout, stderr bytes.Buffer
-	root := newRootCommand(context.Background(), nil, t.TempDir(), nil, &stdout, &stderr, &fakeRunner{}, nil)
+	root := newRootCommand(context.Background(), nil, nil, t.TempDir(), nil, &stdout, &stderr, &fakeRunner{}, nil)
 	if cmd, _, err := root.Find([]string{"install"}); err != nil || cmd == root {
 		t.Fatalf("`install` did not resolve to a registered command (cmd=%v, err=%v)", cmd.Name(), err)
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,4 +1,4 @@
-// ABOUTME: spacedock init/doctor command paths — install the per-host plugin via
+// ABOUTME: spacedock install/doctor command paths — install the per-host plugin via
 // ABOUTME: the host plugin mechanism (claude) or emit the documented add prose (codex).
 package cli
 
@@ -30,7 +30,7 @@ func runInit(ctx context.Context, args []string, ops hostOps, stdout, stderr io.
 		if !check {
 			out, err := ops.Install(host, marketplaceSource, devBranch)
 			if err != nil {
-				fmt.Fprintf(stderr, "spacedock init: host install failed: %v\n", err)
+				fmt.Fprintf(stderr, "spacedock install: host install failed: %v\n", err)
 				return 1
 			}
 			if out != "" {
@@ -47,7 +47,7 @@ func runInit(ctx context.Context, args []string, ops hostOps, stdout, stderr io.
 		}
 		return runDoctor(ctx, []string{"--host", "codex"}, ops, stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "spacedock init: unknown host %q (want claude or codex)\n", host)
+		fmt.Fprintf(stderr, "spacedock install: unknown host %q (want claude or codex)\n", host)
 		return 2
 	}
 }
@@ -99,7 +99,7 @@ func parseInitArgs(args []string, stderr io.Writer) (host string, check bool, co
 		switch args[i] {
 		case "--host":
 			if i+1 >= len(args) {
-				fmt.Fprintln(stderr, "spacedock init: --host requires a value (claude or codex)")
+				fmt.Fprintln(stderr, "spacedock install: --host requires a value (claude or codex)")
 				return "", false, 2
 			}
 			host = args[i+1]
@@ -107,7 +107,7 @@ func parseInitArgs(args []string, stderr io.Writer) (host string, check bool, co
 		case "--check":
 			check = true
 		default:
-			fmt.Fprintf(stderr, "spacedock init: unknown argument %q\n", args[i])
+			fmt.Fprintf(stderr, "spacedock install: unknown argument %q\n", args[i])
 			return "", false, 2
 		}
 	}

--- a/internal/cli/init_devbranch_test.go
+++ b/internal/cli/init_devbranch_test.go
@@ -1,4 +1,4 @@
-// ABOUTME: AC-3a — `spacedock init --host claude` targets @next when devBranch is
+// ABOUTME: AC-3a — `spacedock install --host claude` targets @next when devBranch is
 // ABOUTME: pinned to next, and the composed marketplace-add argv carries @next.
 package cli
 
@@ -11,7 +11,7 @@ import (
 
 // TestInitTargetsNextWhenDevBranchPinned locks AC-3a: with devBranch pinned to
 // `next` (the released binary's default, until `next` is the default branch),
-// `spacedock init --host claude` drives the install seam with branch=next, so the
+// `spacedock install --host claude` drives the install seam with branch=next, so the
 // issued `marketplace add` resolves `spacedock-dev/spacedock@next`. The package
 // var is saved/restored so the assertion does not leak into sibling tests.
 func TestInitTargetsNextWhenDevBranchPinned(t *testing.T) {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// TestInitClaudeIssuesHostPluginCommands: `spacedock init --host claude` drives
+// TestInitClaudeIssuesHostPluginCommands: `spacedock install --host claude` drives
 // the install seam (host plugin marketplace add + install) rather than a
 // filesystem copy of skill files.
 func TestInitClaudeIssuesHostPluginCommands(t *testing.T) {
@@ -101,7 +101,7 @@ func TestInitCheckRunsDoctorWithoutInstalling(t *testing.T) {
 	}
 }
 
-// TestInitCodexEmitsAddCommandProse: `spacedock init --host codex` emits the
+// TestInitCodexEmitsAddCommandProse: `spacedock install --host codex` emits the
 // documented `codex plugin marketplace add` + `codex plugin add` pair as prose
 // (install verb is `add`, not `install`) and does NOT shell the claude install
 // seam.

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -40,7 +40,7 @@ const (
 	// PluginPredatesContract means the manifest has no requires-contract field at
 	// all: the installed plugin predates the contract mechanism. Kin to
 	// too-old-plugin, but with no range to name; remedy reinstalls via
-	// `spacedock init` and omits the `plugin update` fallback (which no-ops on a
+	// `spacedock install` and omits the `plugin update` fallback (which no-ops on a
 	// stale install).
 	PluginPredatesContract
 )
@@ -186,7 +186,7 @@ func tooOldPluginRemedy(c int, rangeStr, host string) string {
 
 // pluginPredatesContractRemedy is the pinned remedy for an installed plugin that
 // predates the contract mechanism (no requires-contract field). It names the
-// `spacedock init` one-liner — never raw `<host> plugin` commands — and omits the
+// `spacedock install` one-liner — never raw `<host> plugin` commands — and omits the
 // `plugin update` fallback, which no-ops on a stale already-installed plugin. The
 // host is parameterized; the optional pre-release branch suffixes the reinstall
 // source so a dev install reflects the branch (the default release path omits it).
@@ -197,7 +197,7 @@ func pluginPredatesContractRemedy(host, branch string) string {
 	}
 	return fmt.Sprintf(
 		"plugin-predates-contract: your installed Spacedock plugin is out of date "+
-			"(predates this binary's contract). Upgrade it: spacedock init --host %s "+
+			"(predates this binary's contract). Upgrade it: spacedock install --host %s "+
 			"(reinstalls from %s).",
 		host, source)
 }

--- a/internal/contract/contract_test.go
+++ b/internal/contract/contract_test.go
@@ -78,7 +78,7 @@ func TestCompare(t *testing.T) {
 		{"too-old-plugin-at-hi", 2, ">=1,<2", TooOldPlugin, "too-old-plugin"},
 		{"too-old-plugin-above-hi", 5, ">=1,<2", TooOldPlugin, "too-old-plugin"},
 		{"malformed", 1, ">=1", MalformedRange, "malformed contract range"},
-		{"predates-contract-empty", 1, "", PluginPredatesContract, "spacedock init --host claude"},
+		{"predates-contract-empty", 1, "", PluginPredatesContract, "spacedock install --host claude"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -122,7 +122,7 @@ func TestCompareMessageShape(t *testing.T) {
 }
 
 // TestPluginPredatesContractRemedy locks the new verdict for an absent/empty
-// requires-contract: it names the `spacedock init --host <host>` one-liner,
+// requires-contract: it names the `spacedock install --host <host>` one-liner,
 // reflects the dev branch (@next) when set, and OMITS the `plugin update`
 // fallback that reusing too-old-plugin would drag in (that fallback no-ops on a
 // stale install). A whitespace-only value routes here too; a non-empty
@@ -133,8 +133,8 @@ func TestPluginPredatesContractRemedy(t *testing.T) {
 		if res.Verdict != PluginPredatesContract {
 			t.Fatalf("Compare(1,%q) verdict = %v, want plugin-predates-contract", raw, res.Verdict)
 		}
-		if !strings.Contains(res.Message, "spacedock init --host claude") {
-			t.Errorf("predates-contract remedy missing init one-liner: %q", res.Message)
+		if !strings.Contains(res.Message, "spacedock install --host claude") {
+			t.Errorf("predates-contract remedy missing install one-liner: %q", res.Message)
 		}
 		if !strings.Contains(res.Message, "@next") {
 			t.Errorf("predates-contract remedy missing @next branch: %q", res.Message)
@@ -149,8 +149,8 @@ func TestPluginPredatesContractRemedy(t *testing.T) {
 	if strings.Contains(plain.Message, "@next") {
 		t.Errorf("predates-contract remedy with no branch should omit @next: %q", plain.Message)
 	}
-	if !strings.Contains(plain.Message, "spacedock init --host claude") {
-		t.Errorf("predates-contract remedy with no branch missing init one-liner: %q", plain.Message)
+	if !strings.Contains(plain.Message, "spacedock install --host claude") {
+		t.Errorf("predates-contract remedy with no branch missing install one-liner: %q", plain.Message)
 	}
 
 	// A non-empty unparseable value is still a packaging bug, not predates-contract.

--- a/internal/contract/doctor.go
+++ b/internal/contract/doctor.go
@@ -18,7 +18,7 @@ var errNoManifest = errors.New("manifest not found")
 // requires-contract string. A missing file yields errNoManifest; an absent
 // requires-contract field yields an empty string (which Compare classifies as
 // plugin-predates-contract — the installed plugin predates the contract
-// mechanism — and routes to the actionable `spacedock init` upgrade remedy).
+// mechanism — and routes to the actionable `spacedock install` upgrade remedy).
 func readRequiresContract(manifestPath string) (string, error) {
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -240,6 +240,16 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 	stateCheckout := splitRootStateCheckout(workflowDir)
 	splitRoot := stateCheckout != ""
 
+	// stateBranch is the orphan state branch peers push/pull on a split-root
+	// workflow (spacedock-state/<workflow-basename>, or a README state-branch:
+	// override). The state-commit guidance names it in the push reminder; an
+	// underivable branch (should not happen for a split-root dir) falls back to a
+	// branch-neutral reminder inside stateCommitGuidance.
+	var stateBranch string
+	if splitRoot {
+		stateBranch, _ = status.StateBranch(workflowDir)
+	}
+
 	// Rule 5: Feedback context required for feedback reflow.
 	if isFeedbackReflow && feedbackContext == "" {
 		return buildError(stderr, 1,
@@ -334,7 +344,7 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 					"code to main.\n"+
 					"%s",
 				worktreePath, worktreePath, branch,
-				stateCommitGuidance(stateCheckout, entityPath)))
+				stateCommitGuidance(stateCheckout, entityPath, stateBranch)))
 		} else {
 			parts = append(parts, fmt.Sprintf(
 				"Your working directory is %s\n"+
@@ -344,7 +354,7 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 				worktreePath, worktreePath, branch))
 		}
 	} else if splitRoot {
-		parts = append(parts, stateCommitGuidance(stateCheckout, entityPath))
+		parts = append(parts, stateCommitGuidance(stateCheckout, entityPath, stateBranch))
 	}
 
 	// 4. Entity-read instruction. Under split root the entity lives in the state
@@ -455,8 +465,27 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 // substitutes the resolved absolute state checkout and entity paths into the
 // path-scoped commit command — never literal {state_checkout}/{entity_path}
 // brace tokens — and carries the concurrency-safe "never a bare git add -A"
-// rule that governs every split-root stage.
-func stateCommitGuidance(stateCheckout, entityPath string) string {
+// rule that governs every split-root stage. After the commit it reminds the
+// worker to push the orphan state branch peers share and `pull --rebase` on a
+// rejection; stateBranch is named verbatim when resolved, else a branch-neutral
+// reminder stands in.
+func stateCommitGuidance(stateCheckout, entityPath, stateBranch string) string {
+	pushReminder := "Then push the state branch so peers see your entity/report: " +
+		"`git -C " + stateCheckout + " push origin "
+	if stateBranch != "" {
+		pushReminder += stateBranch + "`"
+	} else {
+		pushReminder += "<state-branch>`"
+	}
+	pushReminder += "; on a non-fast-forward rejection, " +
+		"`git -C " + stateCheckout + " pull --rebase origin "
+	if stateBranch != "" {
+		pushReminder += stateBranch + "`"
+	} else {
+		pushReminder += "<state-branch>`"
+	}
+	pushReminder += " then re-push.\n"
+
 	return fmt.Sprintf(
 		"This workflow is split-root: the entity body and your stage report "+
 			"live in the shared state checkout, not alongside the code. Write and "+
@@ -466,8 +495,8 @@ func stateCommitGuidance(stateCheckout, entityPath string) string {
 			"git -C %s commit -m \"...\" -- %s` — "+
 			"never a bare `git add -A` or bare `git commit` in the state "+
 			"checkout (a bare commit cross-attributes a concurrent writer's "+
-			"staged entity). Retry on index.lock contention after a short wait.\n",
-		stateCheckout, entityPath, stateCheckout, entityPath)
+			"staged entity). Retry on index.lock contention after a short wait. %s",
+		stateCheckout, entityPath, stateCheckout, entityPath, pushReminder)
 }
 
 // emitBuildJSON writes out as two-space-indented JSON with a trailing newline,

--- a/internal/dispatch/build_statecommit_test.go
+++ b/internal/dispatch/build_statecommit_test.go
@@ -139,6 +139,10 @@ func TestSingleRootNoStateCommitGuidance(t *testing.T) {
 				t.Errorf("%s: single-root body leaks a `git -C` state-commit command\n--- body ---\n%s",
 					tc.name, body)
 			}
+			if strings.Contains(body, "pull --rebase") {
+				t.Errorf("%s: single-root body leaks a state-branch push/`pull --rebase` reminder\n--- body ---\n%s",
+					tc.name, body)
+			}
 		})
 	}
 }
@@ -210,6 +214,29 @@ func TestStateCommitGuidanceResolvesPaths(t *testing.T) {
 			if !strings.Contains(body, wantCommit) {
 				t.Errorf("%s: body missing resolved commit command %q\n--- body ---\n%s",
 					tc.name, wantCommit, body)
+			}
+
+			// CONCURRENCY-SAFETY PHRASE: the split-root guidance must keep the
+			// "never a bare `git add -A`" warning that guards the shared state index.
+			const concurrencyPhrase = "never a bare `git add -A`"
+			if !strings.Contains(body, concurrencyPhrase) {
+				t.Errorf("%s: body missing concurrency-safety phrase %q\n--- body ---\n%s",
+					tc.name, concurrencyPhrase, body)
+			}
+
+			// PUSH REMINDER: split-root commits land on a shared orphan state branch
+			// peers also write, so the guidance must remind the worker to push that
+			// branch and `pull --rebase` on a rejection. The resolved branch name
+			// (spacedock-state/<workflow-basename>) is named verbatim.
+			stateBranch := "spacedock-state/" + filepath.Base(workflowDir)
+			wantPush := "git -C " + stateCheckout + " push origin " + stateBranch
+			if !strings.Contains(body, wantPush) {
+				t.Errorf("%s: body missing resolved push reminder %q\n--- body ---\n%s",
+					tc.name, wantPush, body)
+			}
+			if !strings.Contains(body, "pull --rebase") {
+				t.Errorf("%s: body missing `pull --rebase` on-rejection reminder\n--- body ---\n%s",
+					tc.name, body)
 			}
 
 			// NEGATIVE (the encoded failure): no literal brace tokens survive.

--- a/internal/dispatch/mods.go
+++ b/internal/dispatch/mods.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 	"github.com/spacedock-dev/spacedock/internal/status"
 )
 
@@ -85,24 +86,13 @@ func (e *modHeadingError) Error() string {
 		"Everything after '## Agent Prompt' is treated as the prompt body."
 }
 
-// StandingTeammate is one declared standing teammate: the spawn name (from the
-// mod's ## Hook: startup section, falling back to frontmatter name), the
-// frontmatter description, and the routing-usage body (extracted from the mod's
-// ## Routing Usage section, "" when absent). The body is carried as data so the
-// Claude-specific render lives in internal/claudeteam without re-reading the mod.
-type StandingTeammate struct {
-	Name             string
-	Description      string
-	RoutingUsageBody string
-}
-
 // EnumerateDeclaredStandingTeammates returns the declared standing teammates for
 // a workflow: every {workflow_dir}/_mods/*.md with standing: true in frontmatter,
 // in sorted path order. The name comes from ## Hook: startup (authoritative,
 // matching spawn-standing) falling back to frontmatter name; a mod with no
 // resolvable name is skipped. Returns an empty slice for bare mode (empty
 // teamName), no _mods dir, or no standing mods. Mirrors the Python helper.
-func EnumerateDeclaredStandingTeammates(workflowDir, teamName string) []StandingTeammate {
+func EnumerateDeclaredStandingTeammates(workflowDir, teamName string) []claudeteam.StandingTeammate {
 	if teamName == "" {
 		return nil
 	}
@@ -111,7 +101,7 @@ func EnumerateDeclaredStandingTeammates(workflowDir, teamName string) []Standing
 		return nil
 	}
 
-	var declared []StandingTeammate
+	var declared []claudeteam.StandingTeammate
 	for _, modPath := range sortedModPaths(modsDir) {
 		meta, err := ParseModMetadata(modPath)
 		if err != nil {
@@ -129,7 +119,7 @@ func EnumerateDeclaredStandingTeammates(workflowDir, teamName string) []Standing
 			continue
 		}
 		body, _ := ParseRoutingUsageBody(modPath)
-		declared = append(declared, StandingTeammate{
+		declared = append(declared, claudeteam.StandingTeammate{
 			Name:             name,
 			Description:      meta.Frontmatter["description"],
 			RoutingUsageBody: body,

--- a/internal/dispatch/parity_harness_test.go
+++ b/internal/dispatch/parity_harness_test.go
@@ -93,15 +93,17 @@ func rewriteOracleFetch(s string) string {
 	return s
 }
 
-// stateCommitGuidanceLine matches the split-root state-commit guidance sentence
-// (a single line ending in "after a short wait.\n"). The native emitter and the
-// Python oracle diverge here intentionally — the same documented divergence as
-// the fetch line: the oracle ships the gated literal-brace block (and emits
-// nothing at all for non-worktree split-root stages), while the native emitter
-// substitutes resolved absolute paths on both branches. The body-parity compare
-// strips this block from BOTH sides so the unchanged bytes still byte-match; the
-// diverged content is covered by build_statecommit_test.go instead.
-var stateCommitGuidanceLine = regexp.MustCompile(`This workflow is split-root: [^\n]*? after a short wait\.\n`)
+// stateCommitGuidanceLine matches the split-root state-commit guidance, a single
+// line from "This workflow is split-root:" to its terminating newline. The native
+// emitter and the Python oracle diverge here intentionally — the same documented
+// divergence as the fetch line: the oracle ships the gated literal-brace block
+// ending in "after a short wait." (and emits nothing at all for non-worktree
+// split-root stages), while the native emitter substitutes resolved absolute paths
+// on both branches and appends the push-the-state-branch reminder ending in "then
+// re-push.". Matching the whole line to its newline covers both endings. The
+// body-parity compare strips this block from BOTH sides so the unchanged bytes
+// still byte-match; the diverged content is covered by build_statecommit_test.go.
+var stateCommitGuidanceLine = regexp.MustCompile(`This workflow is split-root: [^\n]*\n`)
 
 // stripStateCommitGuidance removes the diverged state-commit guidance line and
 // collapses the blank-line artifact left where it was removed, so a body with

--- a/internal/dispatch/standing.go
+++ b/internal/dispatch/standing.go
@@ -65,7 +65,7 @@ func runShowStanding(workflowDir string, stdout, stderr io.Writer) int {
 	// A truthy sentinel team name: the filesystem scan is team-agnostic, and the
 	// bare-mode short-circuit lives in build upstream of this call.
 	teammates := EnumerateDeclaredStandingTeammates(workflowDir, "_show_standing_")
-	rendered := claudeteam.RenderStandingTeammatesSection(toClaudeTeammates(teammates))
+	rendered := claudeteam.RenderStandingTeammatesSection(teammates)
 	if rendered != "" {
 		fmt.Fprintln(stdout, rendered)
 	}
@@ -179,18 +179,4 @@ type spawnSpec struct {
 // including its ensure_ascii escaping of a non-ASCII Agent Prompt.
 func emitSpawnJSON(stdout io.Writer, spec spawnSpec) int {
 	return claudeteam.EmitPythonJSON(stdout, spec)
-}
-
-// toClaudeTeammates maps the runtime-neutral StandingTeammate to the Claude
-// render's input type (same fields), so the render package needs no dispatch import.
-func toClaudeTeammates(in []StandingTeammate) []claudeteam.StandingTeammate {
-	out := make([]claudeteam.StandingTeammate, len(in))
-	for i, tm := range in {
-		out[i] = claudeteam.StandingTeammate{
-			Name:             tm.Name,
-			Description:      tm.Description,
-			RoutingUsageBody: tm.RoutingUsageBody,
-		}
-	}
-	return out
 }

--- a/internal/hostneutrality/prose_neutrality_test.go
+++ b/internal/hostneutrality/prose_neutrality_test.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -35,10 +36,19 @@ var claudeHelperTokens = []string{
 	"lookup_model",
 }
 
-// hostQualifierMarkers mark a span as explicitly host-qualified: it names a
-// non-Claude runtime alternative (the `X on Codex, Y on Claude` shape) so the
-// Claude token is a qualified realization, not an unqualified generic step.
-var hostQualifierMarkers = []string{"Codex", "codex"}
+// A span counts as host-qualified only when it names BOTH runtimes by their
+// capitalized product names — the `X on Codex, Y on Claude` contrast shape, where
+// the Claude token is a qualified realization presented alongside the Codex
+// alternative, not an unqualified generic step. Requiring the contrast (both
+// names), rather than a lone "Codex"/"codex" anywhere, keeps a span that merely
+// mentions a host in passing (e.g. a bare `codex exec`) from falsely qualifying an
+// unqualified Claude-only helper. The names are matched capitalized so the
+// lowercase `claude-` inside a helper token (claude-team) does not self-satisfy
+// the Claude half of the contrast.
+const (
+	codexMarker  = "Codex"
+	claudeMarker = "Claude"
+)
 
 // TestSharedCoreHasNoUnqualifiedClaudeHelpers parses the generic core's markdown
 // structure into spans (numbered/bulleted list items and paragraphs) and fails if
@@ -60,7 +70,7 @@ func TestSharedCoreHasNoUnqualifiedClaudeHelpers(t *testing.T) {
 			violations = append(violations,
 				strings.TrimSpace(
 					sp.text[:min(len(sp.text), 120)])+
-					" [unqualified token: "+tok+", first line "+itoa(sp.startLine)+"]")
+					" [unqualified token: "+tok+", first line "+strconv.Itoa(sp.startLine)+"]")
 		}
 	}
 	if len(violations) > 0 {
@@ -86,6 +96,48 @@ func TestClaudeAdapterOwnsRelocatedCommands(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("Claude adapter %s does not name the relocated command %q", claudeRuntimePath, want)
 		}
+	}
+}
+
+// TestSpanHostQualifiedRequiresContrast pins AC-4: a span counts as host-qualified
+// only when it presents the Codex/Claude CONTRAST — naming both a Codex token and a
+// Claude token — not when it merely mentions "codex" in passing. The bare-word
+// markers wrongly qualified any span containing "Codex"/"codex"; the de-brittled
+// oracle qualifies only the contrast. Each case names a Claude helper token so the
+// qualification decision is what gates a violation.
+func TestSpanHostQualifiedRequiresContrast(t *testing.T) {
+	cases := []struct {
+		name      string
+		text      string
+		qualified bool
+	}{
+		{
+			name:      "real-contrast",
+			text:      "The concrete routing call is the runtime adapter's (`send_input` on Codex, `SendMessage` on Claude teams).",
+			qualified: true,
+		},
+		{
+			name:      "declares-contrast",
+			text:      "The probe command is the adapter's (Codex declares none; Claude supplies one — see the context-budget section).",
+			qualified: true,
+		},
+		{
+			name:      "bare-codex-mention-no-claude",
+			text:      "Run the context-budget probe before reuse (the codex exec flow does the same).",
+			qualified: false,
+		},
+		{
+			name:      "no-host-tokens",
+			text:      "Before evaluating reuse conditions, consult the context-budget probe.",
+			qualified: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := spanHostQualified(c.text); got != c.qualified {
+				t.Errorf("spanHostQualified(%q) = %v, want %v", c.text, got, c.qualified)
+			}
+		})
 	}
 }
 
@@ -195,42 +247,11 @@ func isListItemStart(line string) bool {
 }
 
 // spanHostQualified reports whether a span is explicitly host-qualified — it names
-// a non-Claude runtime alternative, the `X on Codex, Y on Claude` shape. Such a
-// span may reference a Claude helper because it is presenting the Claude
-// realization alongside the alternative, not stating an unqualified generic step.
+// BOTH runtimes, the `X on Codex, Y on Claude` contrast shape. Such a span may
+// reference a Claude helper because it is presenting the Claude realization
+// alongside the Codex alternative, not stating an unqualified generic step. A span
+// that names only one runtime (a passing mention) is not the contrast and does not
+// qualify.
 func spanHostQualified(text string) bool {
-	for _, m := range hostQualifierMarkers {
-		if strings.Contains(text, m) {
-			return true
-		}
-	}
-	return false
-}
-
-// min returns the smaller of a and b.
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// itoa is a tiny int-to-string for diagnostics (avoids importing strconv twice).
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var b []byte
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	for n > 0 {
-		b = append([]byte{byte('0' + n%10)}, b...)
-		n /= 10
-	}
-	if neg {
-		b = append([]byte{'-'}, b...)
-	}
-	return string(b)
+	return strings.Contains(text, codexMarker) && strings.Contains(text, claudeMarker)
 }

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -10,11 +10,28 @@ import (
 	"time"
 )
 
-// topLevelVersionRe matches the first `"version": "..."` member of a JSON object.
-// In a plugin.json the top-level version is the first such member; in a
-// marketplace.json the version lives only on the nested plugin entry, so a blob
-// with no top-level `version` key is left untouched by StampVersion.
-var topLevelVersionRe = regexp.MustCompile(`("version"\s*:\s*")[^"]*(")`)
+// versionRe matches a `"version": "..."` member of a JSON object. Both stamp
+// steps rewrite only the FIRST match in the blob (see replaceFirstVersion): in a
+// plugin.json that first match is the top-level version; in a marketplace.json,
+// which carries no top-level version, it is the nested plugin entry's calendar
+// key. A second `version` key elsewhere in the blob is left untouched.
+var versionRe = regexp.MustCompile(`("version"\s*:\s*")[^"]*(")`)
+
+// replaceFirstVersion rewrites only the FIRST `"version": "..."` member of blob
+// to value, preserving the `"version": "` prefix and closing `"` and leaving any
+// later `version` key untouched. Returns blob unchanged when there is no match.
+func replaceFirstVersion(blob []byte, value string) []byte {
+	loc := versionRe.FindSubmatchIndex(blob)
+	if loc == nil {
+		return blob
+	}
+	// loc indices: [matchStart, matchEnd, g1Start, g1End, g2Start, g2End].
+	out := make([]byte, 0, len(blob)+len(value))
+	out = append(out, blob[:loc[3]]...) // up to and including the prefix group
+	out = append(out, value...)
+	out = append(out, blob[loc[4]:]...) // from the closing-quote group onward
+	return out
+}
 
 // StampVersion rewrites the top-level `version` field of a plugin manifest
 // (plugin.json / .codex-plugin/plugin.json) to version, preserving the rest of
@@ -31,14 +48,8 @@ func StampVersion(manifest []byte, version string) ([]byte, error) {
 		// No top-level version (marketplace.json shape): nothing to stamp.
 		return manifest, nil
 	}
-	out := topLevelVersionRe.ReplaceAll(manifest, []byte("${1}"+version+"${2}"))
-	return out, nil
+	return replaceFirstVersion(manifest, version), nil
 }
-
-// entryVersionRe matches the `"version": "..."` member of the nested plugin
-// entry in a marketplace.json. A marketplace.json carries no top-level version,
-// so the first match is the entry's calendar key.
-var entryVersionRe = regexp.MustCompile(`("version"\s*:\s*")[^"]*(")`)
 
 // BumpCalendarVersion advances the marketplace plugin entry's calendar version
 // to `0.0.YYYYMMDDNN` for the date in now. NN is a per-day sequence: when the
@@ -70,6 +81,5 @@ func BumpCalendarVersion(marketplace []byte, now time.Time) ([]byte, error) {
 	}
 	next := fmt.Sprintf("%s%02d", prefix, seq)
 
-	out := entryVersionRe.ReplaceAll(marketplace, []byte("${1}"+next+"${2}"))
-	return out, nil
+	return replaceFirstVersion(marketplace, next), nil
 }

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -72,6 +72,42 @@ func TestStampVersionLeavesMarketplaceCalendarUntouched(t *testing.T) {
 	}
 }
 
+// TestStampVersionRewritesOnlyFirstVersionKey locks the replace-first contract:
+// a manifest carrying a second nested `version` key (beyond the top-level one)
+// must have ONLY its top-level version rewritten — the nested key is left
+// exactly as-is. A blanket ReplaceAll over every `"version":` match would clobber
+// the nested key too; the targeted first-match replace must not.
+func TestStampVersionRewritesOnlyFirstVersionKey(t *testing.T) {
+	src := `{
+  "name": "spacedock",
+  "version": "0.1.0-dev",
+  "skills": "./skills/",
+  "metadata": {
+    "version": "schema-7"
+  }
+}
+`
+	out, err := StampVersion([]byte(src), "0.19.0")
+	if err != nil {
+		t.Fatalf("StampVersion: %v", err)
+	}
+	var m struct {
+		Version  string `json:"version"`
+		Metadata struct {
+			Version string `json:"version"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("stamped manifest does not parse: %v\n%s", err, out)
+	}
+	if m.Version != "0.19.0" {
+		t.Errorf("top-level version = %q, want 0.19.0", m.Version)
+	}
+	if m.Metadata.Version != "schema-7" {
+		t.Errorf("nested metadata.version was clobbered: %q, want schema-7 (replace-first must leave it untouched)", m.Metadata.Version)
+	}
+}
+
 // TestBumpCalendarVersionStrictlyIncreases locks AC-2d: invoking the bump
 // function twice over the SAME marketplace.json produces a strictly increasing
 // entry version (the `plugin update` re-pull key actually moves), not two
@@ -112,6 +148,36 @@ func TestBumpCalendarVersionStrictlyIncreases(t *testing.T) {
 	}
 	if !strings.HasPrefix(v2, "0.0.20260601") {
 		t.Errorf("second bump = %q, want 0.0.20260601NN prefix", v2)
+	}
+}
+
+// TestBumpCalendarVersionRewritesOnlyFirstVersionKey locks the replace-first
+// contract for the calendar bump: a marketplace.json whose plugin entry carries a
+// trailing second `version` key (e.g. a nested source/metadata block) must have
+// ONLY the entry's first `version` advanced — the trailing key stays intact. A
+// blanket ReplaceAll would over-rewrite it.
+func TestBumpCalendarVersionRewritesOnlyFirstVersionKey(t *testing.T) {
+	src := `{
+  "name": "spacedock",
+  "plugins": [
+    {
+      "name": "spacedock",
+      "version": "0.0.2026053101",
+      "schema": { "version": "marketplace-2" }
+    }
+  ]
+}
+`
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	out, err := BumpCalendarVersion([]byte(src), now)
+	if err != nil {
+		t.Fatalf("bump: %v", err)
+	}
+	if v := entryVersion(t, out); v != "0.0.2026060101" {
+		t.Errorf("entry calendar version = %q, want 0.0.2026060101", v)
+	}
+	if !strings.Contains(string(out), `"version": "marketplace-2"`) {
+		t.Errorf("nested schema.version was clobbered; replace-first must leave it untouched:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
Six low-risk 0.19.x cleanups: unknown commands and stray flags now fail loudly, the stale `spacedock init` is gone, and version stamping is multi-key-safe.

## What changed
- Make unknown subcommands and stray leading flags print usage and exit non-zero (no more silent exit 2 or exit-0 typos).
- Finish the `init`→`install` rename across code, docs, and the version-mismatch remedy.
- Stamp only the first `version` key (replace-first), preventing a multi-key clobber.
- Collapse the duplicate `StandingTeammate` struct + mapper into one; add a state-branch push reminder.
- Qualify prose-neutrality spans on the Codex/Claude contrast; document the `bump-calendar` release step.

## Evidence
- `go test ./...` 720+ passed; gofmt/vet clean.
- AC-6 leading-flag fix mutation-verified; the detached audit's two test-strength findings (M1/M2) closed.

## Review guidance
- Riskiest change: the root `FParseErrWhitelist` in `internal/cli/cli.go` — verify stray leading flags exit non-zero while valid subcommands are unaffected.

---
[1x](/spacedock-dev/spacedock/blob/a60f6260d52b70a9aa986b3431dd4db5a2d1b12d/code-cleanups-0193/index.md)
