### PR TITLE
Local LLM-summarized release notes — author + review locally, CI feeds goreleaser --release-notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,27 @@ jobs:
         with:
           go-version: "1.22"
 
+      # The release notes are authored LOCALLY (via `spacedock-release notes`)
+      # and carried in the annotated tag's message body, so CI never runs
+      # `claude` — it only reads the tag. `%(contents:body)` strips the tag
+      # subject and yields just the notes body. Guard against an empty body
+      # (a lightweight tag, or one cut outside the notes flow) so we fail loudly
+      # rather than publish an empty Release; this step MUST precede goreleaser,
+      # which consumes the file via --release-notes.
+      - name: Extract release notes from the tag body
+        run: |
+          set -euo pipefail
+          git tag -l --format='%(contents:body)' "$GITHUB_REF_NAME" > release-notes.txt
+          if [ ! -s release-notes.txt ]; then
+            echo "::error::tag $GITHUB_REF_NAME has an empty annotated-tag body; cut it via 'spacedock-release notes <version>'" >&2
+            exit 1
+          fi
+
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
-          args: release --clean
+          args: release --clean --release-notes release-notes.txt
         env:
           # GITHUB_TOKEN creates the release on this repo. HOMEBREW_TAP_TOKEN is a
           # PAT with write access to spacedock-dev/homebrew-tap so the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,10 @@ jobs:
         run: |
           set -euo pipefail
           git tag -l --format='%(contents:body)' "$GITHUB_REF_NAME" > release-notes.txt
-          if [ ! -s release-notes.txt ]; then
+          # %(contents:body) always appends a trailing newline, so the file is
+          # never zero-byte; gate on stripped content so a whitespace/newline-only
+          # body (lightweight tag, subject-only tag, empty second -m) fails loudly.
+          if [ -z "$(tr -d '[:space:]' < release-notes.txt)" ]; then
             echo "::error::tag $GITHUB_REF_NAME has an empty annotated-tag body; cut it via 'spacedock-release notes <version>'" >&2
             exit 1
           fi

--- a/cmd/spacedock-release/main.go
+++ b/cmd/spacedock-release/main.go
@@ -3,8 +3,11 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/spacedock-dev/spacedock/internal/release"
@@ -19,7 +22,10 @@ import (
 //
 // stamp-version rewrites each manifest's top-level `version` to the release
 // version (AC-4). bump-calendar advances the marketplace plugin entry's calendar
-// key to today's `0.0.YYYYMMDDNN` (AC-2d). Both rewrite in place.
+// key to today's `0.0.YYYYMMDDNN` (AC-2d). Both rewrite in place. notes
+// summarizes the commit log since the last tag into clean release notes and, on
+// confirmation, cuts the annotated tag whose body carries them (CI extracts that
+// body and feeds goreleaser via --release-notes).
 func main() {
 	if len(os.Args) < 2 {
 		usage()
@@ -30,6 +36,8 @@ func main() {
 		os.Exit(stampVersion(os.Args[2:]))
 	case "bump-calendar":
 		os.Exit(bumpCalendar(os.Args[2:]))
+	case "notes":
+		os.Exit(notes(os.Args[2:]))
 	default:
 		fmt.Fprintf(os.Stderr, "spacedock-release: unknown command %q\n", os.Args[1])
 		usage()
@@ -87,11 +95,155 @@ func bumpCalendar(args []string) int {
 	return 0
 }
 
+// notes summarizes the commits since the last tag into clean release notes and,
+// on the captain's confirmation, cuts an annotated tag whose body IS those
+// notes. The tag is created locally only — pushing it (which fires the release
+// build) stays a deliberate manual step the captain runs after review.
+func notes(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "spacedock-release notes: need exactly one <release-version> (e.g. 0.19.2)")
+		return 2
+	}
+	version := strings.TrimPrefix(args[0], "v")
+	tag := "v" + version
+
+	io := release.NotesIO{
+		RawLog: commitLogSinceLastTag,
+		Claude: runClaude,
+	}
+	proposed, err := release.GenerateNotes(version, io)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "generate notes: %v\n", err)
+		return 1
+	}
+
+	fmt.Println("==========================================")
+	fmt.Printf("PROPOSED RELEASE NOTES FOR %s\n", tag)
+	fmt.Println("==========================================")
+	fmt.Println(proposed)
+	fmt.Println("==========================================")
+
+	tagIO := release.TagIO{
+		Confirm: confirmNotes,
+		CutTag: func(body string) error {
+			return cutAnnotatedTag(tag, body)
+		},
+	}
+	if err := release.ConfirmAndTag(proposed, tagIO); err != nil {
+		fmt.Fprintf(os.Stderr, "cut tag: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// commitLogSinceLastTag returns the `git log --oneline` range from the most
+// recent tag to HEAD (or all of HEAD when no tag exists yet).
+func commitLogSinceLastTag() (string, error) {
+	prev, err := exec.Command("git", "describe", "--tags", "--abbrev=0").Output()
+	rangeSpec := "HEAD"
+	if err == nil {
+		if p := strings.TrimSpace(string(prev)); p != "" {
+			rangeSpec = p + "..HEAD"
+		}
+	}
+	out, err := exec.Command("git", "log", rangeSpec, "--oneline", "--no-decorate").Output()
+	if err != nil {
+		return "", fmt.Errorf("git log %s: %w", rangeSpec, err)
+	}
+	return strings.TrimRight(string(out), "\n"), nil
+}
+
+// runClaude pipes the filtered log through `claude -p <prompt> --model opus
+// --effort low`. A non-nil error (claude absent or failing) tells GenerateNotes
+// to fall back to the filtered raw log.
+func runClaude(prompt, input string) (string, error) {
+	if _, err := exec.LookPath("claude"); err != nil {
+		return "", err
+	}
+	cmd := exec.Command("claude", "-p", prompt, "--model", "opus", "--effort", "low")
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(out), "\n"), nil
+}
+
+// confirmNotes lets the captain review the proposed notes and choose to cut the
+// tag (y), edit the notes in $EDITOR before tagging (e), or decline (anything
+// else → no tag). The edited body is what gets tagged.
+func confirmNotes(proposed string) (string, bool) {
+	fmt.Print("Cut the annotated tag with these notes? [y/e=edit/N] ")
+	r := bufio.NewReader(os.Stdin)
+	line, _ := r.ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return proposed, true
+	case "e", "edit":
+		edited, err := editInEditor(proposed)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "edit failed (%v); no tag cut\n", err)
+			return proposed, false
+		}
+		return edited, true
+	default:
+		fmt.Fprintln(os.Stderr, "declined; no tag cut")
+		return proposed, false
+	}
+}
+
+// editInEditor opens the proposed notes in $EDITOR (falling back to vi) and
+// returns the captain's edited text.
+func editInEditor(proposed string) (string, error) {
+	f, err := os.CreateTemp("", "spacedock-release-notes-*.txt")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(proposed); err != nil {
+		f.Close()
+		return "", err
+	}
+	f.Close()
+
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vi"
+	}
+	cmd := exec.Command(editor, f.Name())
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	edited, err := os.ReadFile(f.Name())
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(edited), "\n"), nil
+}
+
+// cutAnnotatedTag creates the annotated tag locally with body as the WHOLE tag
+// message (no subject line), so `git tag -l --format='%(contents:body)'` in CI
+// round-trips exactly these notes into goreleaser's --release-notes. The tag is
+// not pushed — that stays a manual step.
+func cutAnnotatedTag(tag, body string) error {
+	if strings.TrimSpace(body) == "" {
+		return fmt.Errorf("refusing to cut %s with empty notes body", tag)
+	}
+	if err := exec.Command("git", "tag", "-a", tag, "-m", body).Run(); err != nil {
+		return err
+	}
+	fmt.Printf("created annotated tag %s (local only)\n", tag)
+	fmt.Printf("push to trigger the release build: git push origin %s\n", tag)
+	return nil
+}
+
 func usage() {
 	fmt.Fprint(os.Stderr, `spacedock-release is the release-pipeline version tool.
 
 Usage:
   spacedock-release stamp-version <release-version> <plugin.json> [<plugin.json> ...]
   spacedock-release bump-calendar <marketplace.json>
+  spacedock-release notes <release-version>
 `)
 }

--- a/cmd/spacedock-release/main.go
+++ b/cmd/spacedock-release/main.go
@@ -126,7 +126,7 @@ func notes(args []string) int {
 	tagIO := release.TagIO{
 		Confirm: confirmNotes,
 		CutTag: func(body string) error {
-			return cutAnnotatedTag(tag, body)
+			return cutAnnotatedTag(tag, version, body)
 		},
 	}
 	if err := release.ConfirmAndTag(proposed, tagIO); err != nil {
@@ -222,15 +222,16 @@ func editInEditor(proposed string) (string, error) {
 	return strings.TrimRight(string(edited), "\n"), nil
 }
 
-// cutAnnotatedTag creates the annotated tag locally with body as the WHOLE tag
-// message (no subject line), so `git tag -l --format='%(contents:body)'` in CI
-// round-trips exactly these notes into goreleaser's --release-notes. The tag is
-// not pushed — that stays a manual step.
-func cutAnnotatedTag(tag, body string) error {
+// cutAnnotatedTag creates the annotated tag locally with the notes in the tag
+// message BODY (under a `Release <version>` subject), so `git tag -l
+// --format='%(contents:body)'` in CI round-trips exactly these notes into
+// goreleaser's --release-notes. The tag is not pushed — that stays a manual
+// step.
+func cutAnnotatedTag(tag, version, body string) error {
 	if strings.TrimSpace(body) == "" {
 		return fmt.Errorf("refusing to cut %s with empty notes body", tag)
 	}
-	if err := exec.Command("git", "tag", "-a", tag, "-m", body).Run(); err != nil {
+	if err := exec.Command("git", release.AnnotatedTagArgs(tag, version, body)...).Run(); err != nil {
 		return err
 	}
 	fmt.Printf("created annotated tag %s (local only)\n", tag)

--- a/internal/release/notes.go
+++ b/internal/release/notes.go
@@ -118,6 +118,18 @@ type TagIO struct {
 	CutTag  func(body string) error
 }
 
+// AnnotatedTagArgs returns the `git tag` arguments that cut an annotated tag
+// carrying body in the tag MESSAGE BODY (not the subject). The two `-m` flags
+// give git a `Release <version>` subject and the notes as the following
+// paragraph, so `git tag -l --format='%(contents:body)'` extracts exactly body.
+// A single `-m body` would fold the notes into the subject, leaving the body
+// empty — which CI's empty-body guard would (correctly) reject. This is the
+// single source of truth for the tag-cut shape, shared by the CLI and the
+// AC-3 round-trip test.
+func AnnotatedTagArgs(tag, version, body string) []string {
+	return []string{"tag", "-a", tag, "-m", "Release " + version, "-m", body}
+}
+
 // ConfirmAndTag presents the proposed notes for review and cuts the annotated
 // tag only on explicit confirmation, using the captain's edited body. A decline
 // leaves no tag.

--- a/internal/release/notes.go
+++ b/internal/release/notes.go
@@ -1,0 +1,130 @@
+// ABOUTME: Release-notes core — filter the commit log of workflow-state noise,
+// ABOUTME: build the LLM changelog prompt, and gate tag-cutting on confirmation.
+package release
+
+import (
+	"fmt"
+	"strings"
+)
+
+// workflowNoisePrefixes are the commit-subject prefixes the release changelog
+// must drop: the FO/ensign workflow-state commits (`dispatch:`/`advance:`/
+// `merge:`/`archive:`) and the two CI version commits this repo's pipeline
+// writes (`release: stamp …`, `next: bump …`). They are matched against the
+// commit SUBJECT — the text after the `<sha> ` prefix of a `git log --oneline`
+// line — so a real commit whose conventional scope merely mentions a noise word
+// (e.g. `fix(dispatch): …`) is kept.
+var workflowNoisePrefixes = []string{
+	"dispatch:",
+	"advance:",
+	"merge:",
+	"archive:",
+	"release: stamp",
+	"next: bump",
+}
+
+// FilterCommitLog drops the workflow-state commits the changelog prompt is told
+// to ignore, so the `claude` input (and the no-claude fallback output) is
+// already clean. The input is a `git log --oneline` block (`<sha> <subject>`
+// per line); lines whose subject starts with a workflow-noise prefix are
+// removed and the remaining lines are returned in order.
+func FilterCommitLog(rawLog string) string {
+	var kept []string
+	for _, line := range strings.Split(rawLog, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if isWorkflowNoise(commitSubject(line)) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}
+
+// commitSubject returns the subject of a `git log --oneline` line — the text
+// after the leading short-sha and its space. A line with no space is returned
+// unchanged.
+func commitSubject(oneline string) string {
+	if i := strings.IndexByte(oneline, ' '); i >= 0 {
+		return oneline[i+1:]
+	}
+	return oneline
+}
+
+func isWorkflowNoise(subject string) bool {
+	for _, p := range workflowNoisePrefixes {
+		if strings.HasPrefix(subject, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// BuildChangelogPrompt returns the captain-confirmed changelog prompt for the
+// given release version, with the ignore-list adapted to this repo's
+// workflow-state noise. The prompt is reused verbatim from the proven
+// scripts/release.sh flow; the parenthetical ignore-list names this repo's
+// noise prefixes so the LLM is told to drop them even if FilterCommitLog misses
+// a class.
+func BuildChangelogPrompt(version string) string {
+	return fmt.Sprintf("Summarize these git commits into a release changelog for spacedock v%s. "+
+		"Plain text only — no markdown headers, no bold/italic. "+
+		"Start with one sentence describing the major theme of this release. "+
+		"Then list individual changes as '- ' bullet lines. "+
+		"For each bullet, lead with the user value (what upgrading gives you), then briefly describe what changed at a high level. "+
+		"Ignore workflow-state commits (dispatch/advance/merge/archive entity commits, the "+
+		"`release: stamp` and `next: bump` CI commits, and entity-file changes under docs/dev/.spacedock-state/). "+
+		"Group related commits into single entries.", version)
+}
+
+// NotesIO injects the side-effecting dependencies of GenerateNotes so the
+// generation core stays unit-testable: RawLog yields the `git log` range, and
+// Claude runs the summarizer over (prompt, filtered-log) input — returning an
+// error when `claude` is unavailable, which triggers the filtered-raw-log
+// fallback.
+type NotesIO struct {
+	RawLog func() (string, error)
+	Claude func(prompt, input string) (string, error)
+}
+
+// GenerateNotes produces the release notes for version: it resolves the commit
+// log, filters the workflow-state noise, and feeds the filtered log to `claude`
+// with the captain-confirmed prompt. When `claude` is unavailable (the Claude
+// hook returns an error), it falls back to the filtered raw log so the flow
+// still emits usable notes rather than failing.
+func GenerateNotes(version string, io NotesIO) (string, error) {
+	raw, err := io.RawLog()
+	if err != nil {
+		return "", fmt.Errorf("resolve commit log: %w", err)
+	}
+	filtered := FilterCommitLog(raw)
+	if io.Claude == nil {
+		return filtered, nil
+	}
+	notes, err := io.Claude(BuildChangelogPrompt(version), filtered)
+	if err != nil {
+		return filtered, nil
+	}
+	return notes, nil
+}
+
+// TagIO injects the confirm-then-tag boundary so the gate stays unit-testable:
+// Confirm presents the proposed notes and returns the (possibly captain-edited)
+// final body plus whether to proceed; CutTag creates the annotated tag with
+// that body.
+type TagIO struct {
+	Confirm func(proposed string) (body string, ok bool)
+	CutTag  func(body string) error
+}
+
+// ConfirmAndTag presents the proposed notes for review and cuts the annotated
+// tag only on explicit confirmation, using the captain's edited body. A decline
+// leaves no tag.
+func ConfirmAndTag(proposed string, io TagIO) error {
+	body, ok := io.Confirm(proposed)
+	if !ok {
+		return nil
+	}
+	return io.CutTag(body)
+}

--- a/internal/release/notes_extract_test.go
+++ b/internal/release/notes_extract_test.go
@@ -3,7 +3,10 @@
 package release
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -48,4 +51,90 @@ func TestAnnotatedTagBodyRoundTrips(t *testing.T) {
 	if strings.Contains(got, "Release 9.9.9") {
 		t.Errorf("contents:body leaked the tag subject:\n%s", got)
 	}
+}
+
+// guardConditionRe pulls the empty-body guard condition out of release.yml's
+// "Extract release notes from the tag body" step, e.g. the `[ -z "..." ]` test
+// inside `if <cond>; then`. The test runs the REAL guard string from the
+// workflow, so a regression (e.g. back to the dead `[ ! -s release-notes.txt ]`
+// form) breaks this test instead of silently shipping a blank-body Release.
+var guardConditionRe = regexp.MustCompile(`(?m)^\s*if (\[.*\]); then\s*$`)
+
+// TestReleaseYAMLGuardRejectsEmptyBody locks the release.yml empty-body guard:
+// `git tag -l --format='%(contents:body)'` always appends a trailing newline, so
+// the file is never zero-byte and a `[ ! -s ]` guard is dead code. For each tag
+// shape the guard's comment claims to catch — lightweight, subject-only, and an
+// empty second `-m` — the extracted body is whitespace-only and the guard MUST
+// fail (exit non-zero); a real body MUST pass. The guard string is read from the
+// workflow itself, not duplicated, so the test exercises what CI actually runs.
+func TestReleaseYAMLGuardRejectsEmptyBody(t *testing.T) {
+	guard := extractWorkflowGuard(t)
+
+	dir := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		return string(out)
+	}
+	git("init", "-q")
+	git("config", "user.email", "test@example.com")
+	git("config", "user.name", "test")
+	git("commit", "-q", "--allow-empty", "-m", "seed")
+
+	// Lightweight, subject-only annotated, and empty-second-`-m` annotated tags
+	// each yield a newline-only %(contents:body); a real body must survive.
+	git("tag", "light")
+	git("tag", "-a", "subjonly", "-m", "Release 1.0.0")
+	git("tag", "-a", "emptybody", "-m", "Release 1.0.0", "-m", "")
+	git(AnnotatedTagArgs("realbody", "1.0.0", "- a real user-facing change")...)
+
+	cases := []struct {
+		tag        string
+		wantReject bool
+	}{
+		{"light", true},
+		{"subjonly", true},
+		{"emptybody", true},
+		{"realbody", false},
+	}
+	for _, c := range cases {
+		notesPath := filepath.Join(dir, "release-notes.txt")
+		// Mirror CI exactly: extract %(contents:body) to release-notes.txt, then
+		// evaluate the guard condition against that file.
+		body := git("tag", "-l", "--format=%(contents:body)", c.tag)
+		if err := os.WriteFile(notesPath, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", notesPath, err)
+		}
+		cmd := exec.Command("sh", "-c", "if "+guard+"; then exit 1; fi")
+		cmd.Dir = dir
+		err := cmd.Run()
+		fired := err != nil // guard's `if <cond>; then exit 1` ran exit 1
+		if fired != c.wantReject {
+			t.Errorf("tag %q: guard fired=%v, want reject=%v (body=%q)", c.tag, fired, c.wantReject, body)
+		}
+	}
+}
+
+// extractWorkflowGuard reads the `if [ ... ]; then` guard condition from the
+// Extract-release-notes step of .github/workflows/release.yml, so the test runs
+// the same expression CI does rather than a hand-copied duplicate.
+func extractWorkflowGuard(t *testing.T) string {
+	t.Helper()
+	// The release package sits at internal/release; the workflow is at the repo
+	// root under .github/workflows.
+	path := filepath.Join("..", "..", ".github", "workflows", "release.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	m := guardConditionRe.FindSubmatch(data)
+	if m == nil {
+		t.Fatalf("no `if [ ... ]; then` guard found in %s", path)
+	}
+	return string(m[1])
 }

--- a/internal/release/notes_extract_test.go
+++ b/internal/release/notes_extract_test.go
@@ -1,0 +1,46 @@
+// ABOUTME: AC-3 extraction proof — an annotated tag's body round-trips through
+// ABOUTME: `git tag -l --format='%(contents:body)'`, the form CI feeds goreleaser.
+package release
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestAnnotatedTagBodyRoundTrips locks the AC-3 extraction half in a throwaway
+// `git init` repo: an annotated tag whose message body carries the release
+// notes is extracted byte-for-byte by `git tag -l --format='%(contents:body)'`
+// — and that form strips any subject line, which is why release.yml uses it.
+// This is the seam CI relies on to feed goreleaser --release-notes.
+func TestAnnotatedTagBodyRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		return string(out)
+	}
+
+	git("init", "-q")
+	git("config", "user.email", "test@example.com")
+	git("config", "user.name", "test")
+	git("commit", "-q", "--allow-empty", "-m", "seed")
+
+	body := "A clean release.\n- feat: the user value\n- fix: the other thing"
+	// A subject line precedes a blank line and then the body, so we prove the
+	// `:body` form drops the subject.
+	git("tag", "-a", "v9.9.9", "-m", "Release 9.9.9\n\n"+body)
+
+	got := strings.TrimRight(git("tag", "-l", "--format=%(contents:body)", "v9.9.9"), "\n")
+	if got != body {
+		t.Errorf("contents:body round-trip mismatch:\n got: %q\nwant: %q", got, body)
+	}
+	if strings.Contains(got, "Release 9.9.9") {
+		t.Errorf("contents:body leaked the tag subject:\n%s", got)
+	}
+}

--- a/internal/release/notes_extract_test.go
+++ b/internal/release/notes_extract_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: AC-3 extraction proof — an annotated tag's body round-trips through
-// ABOUTME: `git tag -l --format='%(contents:body)'`, the form CI feeds goreleaser.
+// ABOUTME: AC-3 extraction proof — the tag cut by AnnotatedTagArgs round-trips
+// ABOUTME: through `git tag -l --format='%(contents:body)'`, the form CI feeds goreleaser.
 package release
 
 import (
@@ -8,11 +8,13 @@ import (
 	"testing"
 )
 
-// TestAnnotatedTagBodyRoundTrips locks the AC-3 extraction half in a throwaway
-// `git init` repo: an annotated tag whose message body carries the release
-// notes is extracted byte-for-byte by `git tag -l --format='%(contents:body)'`
-// — and that form strips any subject line, which is why release.yml uses it.
-// This is the seam CI relies on to feed goreleaser --release-notes.
+// TestAnnotatedTagBodyRoundTrips locks AC-3's seam in a throwaway `git init`
+// repo, exercising the REAL tag-cutting path: a tag cut via AnnotatedTagArgs
+// (the single source of truth the CLI's cutAnnotatedTag also uses) must have its
+// notes land in the tag BODY, so `git tag -l --format='%(contents:body)'`
+// returns exactly those notes and is NON-EMPTY. This is the exact extraction
+// release.yml feeds goreleaser via --release-notes; a single `-m` would fold the
+// notes into the subject and leave the body empty (the seam bug this guards).
 func TestAnnotatedTagBodyRoundTrips(t *testing.T) {
 	dir := t.TempDir()
 	git := func(args ...string) string {
@@ -32,13 +34,16 @@ func TestAnnotatedTagBodyRoundTrips(t *testing.T) {
 	git("commit", "-q", "--allow-empty", "-m", "seed")
 
 	body := "A clean release.\n- feat: the user value\n- fix: the other thing"
-	// A subject line precedes a blank line and then the body, so we prove the
-	// `:body` form drops the subject.
-	git("tag", "-a", "v9.9.9", "-m", "Release 9.9.9\n\n"+body)
+	// Cut the tag through the SAME arg builder the CLI uses — no hand-built
+	// "subject\n\nbody" string the production code never emits.
+	git(AnnotatedTagArgs("v9.9.9", "9.9.9", body)...)
 
 	got := strings.TrimRight(git("tag", "-l", "--format=%(contents:body)", "v9.9.9"), "\n")
 	if got != body {
 		t.Errorf("contents:body round-trip mismatch:\n got: %q\nwant: %q", got, body)
+	}
+	if strings.TrimSpace(got) == "" {
+		t.Errorf("contents:body is empty — notes folded into the subject (the seam bug)")
 	}
 	if strings.Contains(got, "Release 9.9.9") {
 		t.Errorf("contents:body leaked the tag subject:\n%s", got)

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -4,6 +4,7 @@ package release
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -198,6 +199,154 @@ func TestBumpCalendarVersionNewDayResetsSequence(t *testing.T) {
 	}
 	if !(v > "0.0.2026053199") {
 		t.Errorf("new-day bump %q did not exceed prior-day max 0.0.2026053199", v)
+	}
+}
+
+// TestFilterCommitLogDropsWorkflowNoise locks AC-1: FilterCommitLog removes the
+// workflow-state commit classes the changelog prompt is told to ignore
+// (`dispatch:`/`advance:`/`merge:`/`archive:` subjects plus the CI commits
+// `release: stamp …` and `next: bump …`) while preserving real user-facing
+// commits, so both the `claude` input and the no-claude fallback output are
+// already clean. The input is the `git log --oneline` shape (`<sha> <subject>`).
+func TestFilterCommitLogDropsWorkflowNoise(t *testing.T) {
+	raw := strings.Join([]string{
+		"a28bb9d feat(ci): wire approval-gated live-runtime e2e job",
+		"ff98605 dispatch: release-notes-local-summary entering implementation",
+		"41e76a7 fix(dispatch): bind resolved state checkout",
+		"fcee0ed release: stamp plugin manifests to 0.19.1",
+		"23aa4d7 next: bump marketplace calendar version",
+		"e00d3f3 advance: cli-cobra-redesign entering validation",
+		"22a42ec merge: release-pipeline (jf) — goreleaser homebrew_casks",
+		"6eeaad1 archive: release-notes-local-summary",
+		"080ec3e feat(plugin): vendor repo plugin manifest",
+	}, "\n")
+
+	got := FilterCommitLog(raw)
+
+	// Real commits survive — including ones whose subject merely mentions a
+	// noise word inside a scope (`fix(dispatch): …`) rather than as the prefix.
+	keep := []string{
+		"feat(ci): wire approval-gated live-runtime e2e job",
+		"fix(dispatch): bind resolved state checkout",
+		"feat(plugin): vendor repo plugin manifest",
+	}
+	for _, want := range keep {
+		if !strings.Contains(got, want) {
+			t.Errorf("FilterCommitLog dropped a real commit %q:\n%s", want, got)
+		}
+	}
+
+	// Each workflow-noise class is gone.
+	drop := []string{
+		"dispatch: release-notes-local-summary",
+		"release: stamp plugin manifests",
+		"next: bump marketplace calendar",
+		"advance: cli-cobra-redesign",
+		"merge: release-pipeline",
+		"archive: release-notes-local-summary",
+	}
+	for _, bad := range drop {
+		if strings.Contains(got, bad) {
+			t.Errorf("FilterCommitLog kept workflow-noise commit %q:\n%s", bad, got)
+		}
+	}
+}
+
+// TestBuildChangelogPromptShape locks AC-1's prompt half: the prompt names the
+// release version, demands plain text (no markdown), and its ignore-list names
+// this repo's workflow-noise classes so the LLM is told to drop them.
+func TestBuildChangelogPromptShape(t *testing.T) {
+	p := BuildChangelogPrompt("0.19.2")
+	if !strings.Contains(p, "0.19.2") {
+		t.Errorf("prompt does not name the version:\n%s", p)
+	}
+	if !strings.Contains(p, "Plain text only") {
+		t.Errorf("prompt does not demand plain text:\n%s", p)
+	}
+	for _, noise := range []string{"dispatch", "advance", "merge", "archive"} {
+		if !strings.Contains(p, noise) {
+			t.Errorf("prompt ignore-list omits the %q noise class:\n%s", noise, p)
+		}
+	}
+}
+
+// TestGenerateNotesFallsBackWithoutClaude locks AC-1's fallback: when the claude
+// runner returns an error (binary absent), GenerateNotes still produces notes —
+// the filtered raw log — rather than failing.
+func TestGenerateNotesFallsBackWithoutClaude(t *testing.T) {
+	raw := "a28bb9d feat(ci): real change\nff98605 dispatch: noise"
+	io := NotesIO{
+		RawLog: func() (string, error) { return raw, nil },
+		Claude: func(prompt, input string) (string, error) { return "", errors.New("claude: not found") },
+	}
+	notes, err := GenerateNotes("0.19.2", io)
+	if err != nil {
+		t.Fatalf("GenerateNotes: %v", err)
+	}
+	if !strings.Contains(notes, "feat(ci): real change") {
+		t.Errorf("fallback notes lost the real commit:\n%s", notes)
+	}
+	if strings.Contains(notes, "dispatch: noise") {
+		t.Errorf("fallback notes kept workflow noise:\n%s", notes)
+	}
+}
+
+// TestGenerateNotesUsesClaudeOnFilteredLog locks AC-1: when claude is available,
+// it is fed the FILTERED log (not the raw one) and its output is the notes.
+func TestGenerateNotesUsesClaudeOnFilteredLog(t *testing.T) {
+	raw := "a28bb9d feat(ci): real change\nff98605 dispatch: noise"
+	var sawInput string
+	io := NotesIO{
+		RawLog: func() (string, error) { return raw, nil },
+		Claude: func(prompt, input string) (string, error) {
+			sawInput = input
+			return "A summary release.\n- feat: real change", nil
+		},
+	}
+	notes, err := GenerateNotes("0.19.2", io)
+	if err != nil {
+		t.Fatalf("GenerateNotes: %v", err)
+	}
+	if strings.Contains(sawInput, "dispatch: noise") {
+		t.Errorf("claude was fed unfiltered noise:\n%s", sawInput)
+	}
+	if !strings.Contains(sawInput, "feat(ci): real change") {
+		t.Errorf("claude was not fed the real commit:\n%s", sawInput)
+	}
+	if notes != "A summary release.\n- feat: real change" {
+		t.Errorf("notes != claude output: %q", notes)
+	}
+}
+
+// TestConfirmAndTagDeclineCutsNoTag locks AC-2's negative half: when the captain
+// declines, the tag hook is never invoked.
+func TestConfirmAndTagDeclineCutsNoTag(t *testing.T) {
+	tagged := false
+	io := TagIO{
+		Confirm: func(proposed string) (string, bool) { return proposed, false },
+		CutTag:  func(body string) error { tagged = true; return nil },
+	}
+	if err := ConfirmAndTag("notes body", io); err != nil {
+		t.Fatalf("ConfirmAndTag: %v", err)
+	}
+	if tagged {
+		t.Errorf("tag was cut despite the captain declining")
+	}
+}
+
+// TestConfirmAndTagConfirmCutsEditedBody locks AC-2's positive half: on confirm,
+// the tag hook is called with the captain's EDITED body, not the proposed one.
+func TestConfirmAndTagConfirmCutsEditedBody(t *testing.T) {
+	var gotBody string
+	io := TagIO{
+		Confirm: func(proposed string) (string, bool) { return "captain-edited body", true },
+		CutTag:  func(body string) error { gotBody = body; return nil },
+	}
+	if err := ConfirmAndTag("proposed body", io); err != nil {
+		t.Fatalf("ConfirmAndTag: %v", err)
+	}
+	if gotBody != "captain-edited body" {
+		t.Errorf("tag cut with body %q, want the captain-edited body", gotBody)
 	}
 }
 


### PR DESCRIPTION
GitHub Release notes become clean, LLM-summarized notes authored and reviewed locally before tagging — instead of goreleaser's raw, workflow-noise commit dump.

## What changed
- Add a `spacedock-release notes` subcommand: filter workflow-state commits, summarize via `claude` (raw-log fallback if absent), author the result into the annotated tag body after captain review.
- Wire `release.yml` to extract the tag body (`%(contents:body)`) and feed goreleaser `--release-notes`, skipping its default changelog.
- Guard an empty/whitespace tag body by stripped content (not file size) so a blank-notes Release fails loudly.

## Evidence
- `go test ./...` green; `internal/release` 11/11.
- Tag-body→`--release-notes` round-trip proven live on the real binary; the empty-body guard now fires on a newline-only body (a dead `[ ! -s ]` guard the detached audit caught, now fixed + tested).

## Review guidance
- `release.yml` is release-critical: confirm the extract step precedes goreleaser and the stripped-content guard rejects a whitespace-only body.

---
[7h](/spacedock-dev/spacedock/blob/2dc77330a93882b7d760a6aa1aa1c648883a5d6c/release-notes-local-summary/index.md)
