### PR TITLE
Persist + upload the live-e2e transcript as a CI artifact (diagnose failures past log truncation)

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -145,7 +145,8 @@ jobs:
         env:
           SPACEDOCK_LIVE_MODEL: ${{ matrix.model }}
         run: |
-          go test -tags live -run TestLiveEnsignCycle ./internal/ensigncycle/ -v
+          set -o pipefail
+          go test -tags live -run TestLiveEnsignCycle ./internal/ensigncycle/ -v 2>&1 | tee live-e2e-transcript.txt
 
       - name: Upload live artifacts
         if: always()
@@ -154,4 +155,5 @@ jobs:
           name: runtime-live-e2e-claude-live-${{ matrix.model }}
           path: |
             ./spacedock
+            ./live-e2e-transcript.txt
           if-no-files-found: warn


### PR DESCRIPTION
A failed live-e2e run now uploads its full streamed transcript as a CI artifact, so failures are diagnosable past gh's job-log truncation.

## What changed
- Add `set -o pipefail` + `2>&1 | tee live-e2e-transcript.txt` to the live ensign-cycle step.
- Add the transcript to the existing `if: always()` artifact upload, so a failed/killed run still keeps it.

## Evidence
- Offline-proven: `set -o pipefail` preserves the run's non-zero exit (a failing cycle stays RED); without it `tee` would mask the failure to exit 0. `tee` streams, so a killed run leaves a partial transcript.
- Detached audit confirmed exit-preservation, the write/upload path match, and well-formed YAML — no failure-masking.

## Review guidance
- CI exit contract: `set -o pipefail` is load-bearing (GitHub Actions' default bash has pipefail off).

---
[3g](/spacedock-dev/spacedock/blob/e9a0f1314bb81c852ed665550c81e05526590820/live-e2e-transcript-artifact/index.md)
