### PR TITLE
Archive the live-e2e session JSONL as a CI artifact (diagnose the headless FO-drive flake)

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -145,7 +145,8 @@ jobs:
         env:
           SPACEDOCK_LIVE_MODEL: ${{ matrix.model }}
         run: |
-          go test -tags live -run TestLiveEnsignCycle ./internal/ensigncycle/ -v
+          set -o pipefail
+          go test -tags live -run TestLiveEnsignCycle ./internal/ensigncycle/ -v 2>&1 | tee live-e2e-transcript.txt
 
       - name: Upload live artifacts
         if: always()
@@ -154,4 +155,5 @@ jobs:
           name: runtime-live-e2e-claude-live-${{ matrix.model }}
           path: |
             ./spacedock
+            ./live-e2e-transcript.txt
           if-no-files-found: warn

--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -89,6 +89,12 @@ jobs:
       DISABLE_AUTOUPDATER: "1"
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"
+      # Archivable per-job config dir under $RUNNER_TEMP: the child claude writes
+      # its session jsonl to projects/<slug>/<session>.jsonl HERE (the test honors
+      # this via isolatedClaudeEnv), so the Upload step below grabs the structured
+      # transcript even on a failed/killed run. The /${{ matrix.model }} segment
+      # keeps the two matrix legs from sharing a config dir.
+      CLAUDE_CONFIG_DIR: ${{ runner.temp }}/spacedock-claude-config/${{ matrix.model }}
     steps:
       - name: Check required secret
         run: |
@@ -156,4 +162,5 @@ jobs:
           path: |
             ./spacedock
             ./live-e2e-transcript.txt
+            ${{ runner.temp }}/spacedock-claude-config/${{ matrix.model }}/projects
           if-no-files-found: warn

--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -89,12 +89,6 @@ jobs:
       DISABLE_AUTOUPDATER: "1"
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"
-      # Archivable per-job config dir under $RUNNER_TEMP: the child claude writes
-      # its session jsonl to projects/<slug>/<session>.jsonl HERE (the test honors
-      # this via isolatedClaudeEnv), so the Upload step below grabs the structured
-      # transcript even on a failed/killed run. The /${{ matrix.model }} segment
-      # keeps the two matrix legs from sharing a config dir.
-      CLAUDE_CONFIG_DIR: ${{ runner.temp }}/spacedock-claude-config/${{ matrix.model }}
     steps:
       - name: Check required secret
         run: |
@@ -146,6 +140,18 @@ jobs:
           echo "- \`go version\`: \`$(go version)\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Model: \`${{ matrix.model }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Effort: \`${{ inputs.effort }}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      # Archivable per-job config dir under $RUNNER_TEMP, exported to later steps
+      # via $GITHUB_ENV. $RUNNER_TEMP is the runtime shell variable (the `runner`
+      # CONTEXT is NOT available in a job-level `env:` — the runner is unassigned
+      # until the job starts, so referencing it there is a parse-time startup
+      # failure). The child claude writes its session jsonl to
+      # projects/<slug>/<session>.jsonl HERE (the test honors this via
+      # isolatedClaudeEnv), so the Upload step below grabs the structured
+      # transcript even on a failed/killed run. The /${{ matrix.model }} segment
+      # keeps the two matrix legs from sharing a config dir.
+      - name: Set archivable CLAUDE_CONFIG_DIR
+        run: echo "CLAUDE_CONFIG_DIR=$RUNNER_TEMP/spacedock-claude-config/${{ matrix.model }}" >> "$GITHUB_ENV"
 
       - name: Run live ensign cycle
         env:

--- a/internal/ensigncycle/liveenv_decision_test.go
+++ b/internal/ensigncycle/liveenv_decision_test.go
@@ -97,6 +97,83 @@ func TestDecideClaudeEnv(t *testing.T) {
 	})
 }
 
+// TestResolveClaudeConfigDir covers the CLAUDE_CONFIG_DIR resolution the child
+// env carries: the parent's value passes through when set (the CI path — the
+// archivable $RUNNER_TEMP dir the upload step grabs), else a deterministic path
+// under the isolated HOME (the local path — a fresh, inspectable config dir).
+func TestResolveClaudeConfigDir(t *testing.T) {
+	// CI path: the job env sets CLAUDE_CONFIG_DIR to the archivable per-job dir;
+	// the child must keep it verbatim so claude writes projects/<slug>/*.jsonl
+	// there (not under the reaped isolated HOME) for the upload step to capture.
+	t.Run("parent_value_passes_through", func(t *testing.T) {
+		isolatedHome := t.TempDir()
+		parent := "/runner/_temp/spacedock-claude-config/sonnet"
+
+		got := resolveClaudeConfigDir(parent, isolatedHome)
+
+		if got != parent {
+			t.Errorf("resolveClaudeConfigDir = %q, want the parent value %q", got, parent)
+		}
+	})
+
+	// Local path: no CLAUDE_CONFIG_DIR in the parent env (an operator run with no
+	// CI env) -> a deterministic dir under the isolated HOME so local runs still
+	// land the jsonl somewhere inspectable.
+	t.Run("unset_parent_defaults_under_isolated_home", func(t *testing.T) {
+		isolatedHome := t.TempDir()
+
+		got := resolveClaudeConfigDir("", isolatedHome)
+
+		want := filepath.Join(isolatedHome, ".claude")
+		if got != want {
+			t.Errorf("resolveClaudeConfigDir = %q, want the isolated-home default %q", got, want)
+		}
+	})
+}
+
+// TestIsolatedClaudeEnvHonorsParentConfigDir asserts the concrete child env keeps
+// the parent's CLAUDE_CONFIG_DIR (the CI archivable path) rather than dropping or
+// overriding it — the contract the upload step depends on.
+func TestIsolatedClaudeEnvHonorsParentConfigDir(t *testing.T) {
+	fakeHome := t.TempDir() // no benchmark-token -> API-key path
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ci-api-key")
+	t.Setenv("CLAUDECODE", "1")
+	parentConfig := "/runner/_temp/spacedock-claude-config/sonnet"
+	t.Setenv("CLAUDE_CONFIG_DIR", parentConfig)
+
+	env := isolatedClaudeEnv(t, fakeHome)
+
+	cfg, ok := envValue(env, "CLAUDE_CONFIG_DIR")
+	if !ok || cfg != parentConfig {
+		t.Errorf("CLAUDE_CONFIG_DIR = %q (present=%v), want the parent CI path %q", cfg, ok, parentConfig)
+	}
+}
+
+// TestIsolatedClaudeEnvDefaultsConfigDirUnderHome asserts that when the parent
+// has no CLAUDE_CONFIG_DIR (local operator run), the child env gets a
+// deterministic config dir under the fresh isolated HOME.
+func TestIsolatedClaudeEnvDefaultsConfigDirUnderHome(t *testing.T) {
+	fakeHome := t.TempDir() // no benchmark-token -> API-key path
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ci-api-key")
+	t.Setenv("CLAUDECODE", "1")
+	os.Unsetenv("CLAUDE_CONFIG_DIR")
+
+	env := isolatedClaudeEnv(t, fakeHome)
+
+	home, ok := envValue(env, "HOME")
+	if !ok {
+		t.Fatal("HOME must be set to the fresh isolated dir")
+	}
+	cfg, ok := envValue(env, "CLAUDE_CONFIG_DIR")
+	if !ok {
+		t.Fatal("CLAUDE_CONFIG_DIR must default to a dir under the isolated HOME")
+	}
+	want := filepath.Join(home, ".claude")
+	if cfg != want {
+		t.Errorf("CLAUDE_CONFIG_DIR = %q, want the isolated-home default %q", cfg, want)
+	}
+}
+
 // TestIsolatedClaudeEnvOAuthPath asserts the concrete child env the OAuth path
 // produces: CLAUDE_CODE_OAUTH_TOKEN set, ANTHROPIC_API_KEY ABSENT (dropped),
 // CLAUDECODE dropped, and HOME pointing at a fresh dir that is NOT the real one.

--- a/internal/ensigncycle/liveenv_test.go
+++ b/internal/ensigncycle/liveenv_test.go
@@ -87,6 +87,20 @@ func cleanEnviron(drop ...string) []string {
 	return env
 }
 
+// resolveClaudeConfigDir picks the child claude's CLAUDE_CONFIG_DIR. When the
+// parent env sets it (the CI path: the live job points it at an archivable
+// $RUNNER_TEMP dir so the upload step grabs projects/<slug>/*.jsonl after a
+// failed/killed run), pass that value through verbatim. When it is unset (a
+// local operator run with no CI env), default to a deterministic dir under the
+// isolated HOME so local runs still land the session jsonl somewhere inspectable
+// and outside the live $HOME/.claude.
+func resolveClaudeConfigDir(parentValue, isolatedHome string) string {
+	if parentValue != "" {
+		return parentValue
+	}
+	return filepath.Join(isolatedHome, ".claude")
+}
+
 // isolatedClaudeEnv resolves the child environment for the live `spacedock
 // claude` launch: a fresh empty HOME (so parallel invocations never collide in
 // ~/.claude) plus the authoritative credential per decideClaudeEnv. When no
@@ -94,7 +108,9 @@ func cleanEnviron(drop ...string) []string {
 // path (c). realHome is the home directory to probe for the benchmark-token;
 // pass os.Getenv("HOME") for the live path. CLAUDECODE is always dropped so the
 // child binary takes the real front-door path rather than a nested-session
-// shortcut.
+// shortcut. CLAUDE_CONFIG_DIR is resolved by resolveClaudeConfigDir so claude
+// writes its session jsonl at the archivable CI path (or the isolated-HOME
+// default locally) rather than under the reaped HOME's .claude.
 func isolatedClaudeEnv(t *testing.T, realHome string) []string {
 	t.Helper()
 	decision := decideClaudeEnv(realHome, os.Getenv("ANTHROPIC_API_KEY"))
@@ -104,16 +120,17 @@ func isolatedClaudeEnv(t *testing.T, realHome string) []string {
 	}
 
 	cleanHome := t.TempDir()
+	configDir := resolveClaudeConfigDir(os.Getenv("CLAUDE_CONFIG_DIR"), cleanHome)
 	switch decision.mode {
 	case authOAuthToken:
 		// Operator-local: drop the API key so the OAuth token is authoritative.
-		env := cleanEnviron("CLAUDECODE", "HOME", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")
-		env = append(env, "HOME="+cleanHome, "CLAUDE_CODE_OAUTH_TOKEN="+decision.oauthToken)
+		env := cleanEnviron("CLAUDECODE", "HOME", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR")
+		env = append(env, "HOME="+cleanHome, "CLAUDE_CODE_OAUTH_TOKEN="+decision.oauthToken, "CLAUDE_CONFIG_DIR="+configDir)
 		return env
 	case authAPIKey:
 		// CI: pass ANTHROPIC_API_KEY through against the fresh HOME.
-		env := cleanEnviron("CLAUDECODE", "HOME")
-		env = append(env, "HOME="+cleanHome)
+		env := cleanEnviron("CLAUDECODE", "HOME", "CLAUDE_CONFIG_DIR")
+		env = append(env, "HOME="+cleanHome, "CLAUDE_CONFIG_DIR="+configDir)
 		return env
 	default:
 		t.Fatalf("unreachable auth mode %d", decision.mode)


### PR DESCRIPTION
A failed/killed live-e2e run now archives the agent session JSONL (the FO + ensign transcripts) as a CI artifact, so the headless-FO-drive flake (`hd`) becomes diagnosable past gh's log truncation.

## What changed
- Set a per-job `CLAUDE_CONFIG_DIR` under `$RUNNER_TEMP` and upload its `projects/` subtree (the session jsonl) via the existing `if: always()` step.
- Thread `CLAUDE_CONFIG_DIR` through the live-test env helper so the child `claude` writes its jsonl at the archivable path (not the reaped `t.TempDir()` HOME).
- Keep the `set -o pipefail` + stdout `tee` as a secondary signal.

## Evidence
- Offline behavioral: env-helper unit tests green (passthrough on CI, deterministic-under-HOME locally); scope is the workflow file + `_test.go` only; `pipefail` keeps a failing build RED.
- Detached audit confirmed correct-by-construction: `CLAUDE_CONFIG_DIR` reaches `claude` via `syscall.Exec(os.Environ())` verbatim, the export path == the upload path, exit not masked. AC-1/AC-2 (a non-empty session jsonl present in a real failed-run artifact) are runtime-observable and confirm on the next live-e2e failure.

## Review guidance
- The jsonl-archival is runtime-observable; verified correct-by-construction offline, end-to-end confirmed on the next failed run.

---
[3g](/spacedock-dev/spacedock/blob/d898fc023bb387fa5e69a4ee5d22c92533e1ebba/live-e2e-transcript-artifact/index.md)
