### PR TITLE
Prune/demote the tautological prose-pin integration tests (pin behavior + structure, not wording)

### DIFF
--- a/skills/integration/ship_local_ceremony_test.go
+++ b/skills/integration/ship_local_ceremony_test.go
@@ -1,10 +1,8 @@
-// ABOUTME: AC-5 ship-local ceremony prose check + #217 false-claim removal —
-// ABOUTME: the FO shared core names the ceremony and the pr-merge mod prose is honest.
+// ABOUTME: Structural lint over the FO shared core's ship-local ceremony block —
+// ABOUTME: the named subsection exists and references the merge-policy branch and sentinel.
 package integration
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -35,11 +33,15 @@ func subsectionAfter(text, heading string) string {
 	return strings.Join(lines[start:end], "\n")
 }
 
-// TestShipLocalCeremonyBlockExists locks AC-5: the FO shared core carries a
-// single named ship-local ceremony block that references the merge-policy branch
-// and documents no affirmative `--force` use in its happy-path steps. The check
-// scopes to the ceremony subsection so the worktree-removal `--force` audit
-// escape (a different subsection) is irrelevant.
+// TestShipLocalCeremonyBlockExists is a structural lint: the FO shared core
+// carries a single named ship-local ceremony block that references the
+// merge-policy branch and the local-merge sentinel. It scopes to the ceremony
+// subsection — a real on-disk anchor whose absence (or a missing policy/sentinel
+// reference) breaks the documented ship-local flow. The no-`--force` behavioral
+// property of the terminal/local-merge transition is enforced by the real
+// status codepath in internal/status (merge_policy_guard_test.go:
+// TestMergeLocalNoSentinelTerminalSetSucceeds and siblings), so this lint does
+// not grep the ceremony prose for force-related wording.
 func TestShipLocalCeremonyBlockExists(t *testing.T) {
 	fo := vendoredSkillFiles(t)["first-officer/references/first-officer-shared-core.md"]
 	region := subsectionAfter(fo, "### Ship-Local Ceremony")
@@ -51,43 +53,5 @@ func TestShipLocalCeremonyBlockExists(t *testing.T) {
 	}
 	if !strings.Contains(region, "local-merge:") {
 		t.Error("ship-local ceremony must name the local-merge sentinel")
-	}
-	// The ceremony must state the no-force guarantee, and must contain no
-	// affirmative instruction to use --force — every --force token in this block
-	// is a negation ("NO --force", "without --force", "never part of...").
-	if !strings.Contains(region, "NO `--force`") && !strings.Contains(region, "no `--force`") {
-		t.Error("ship-local ceremony must state the no-force guarantee for the happy path")
-	}
-	for _, affirmative := range []string{"use --force", "pass --force", "use `--force`", "pass `--force`", "with --force", "--force to bypass"} {
-		if strings.Contains(region, affirmative) {
-			t.Errorf("ship-local ceremony happy path instructs an affirmative --force use: %q", affirmative)
-		}
-	}
-}
-
-// TestPRMergeFallbackProseIsHonest locks the #217 fix: the relocated pr-merge mod
-// fallback no longer claims clearing mod-block "keeps that guard satisfied" (the
-// guard checks post-update state, not merge order), and the corrected prose names
-// both honest no-force paths — the merge: local policy and the post-merge sentinel.
-func TestPRMergeFallbackProseIsHonest(t *testing.T) {
-	root := skillsRoot(t)
-	// The mod was relocated to the workflow definition dir (docs/dev/_mods/),
-	// resolved relative to the repo root (the skills/ parent's parent).
-	repoRoot := filepath.Dir(root)
-	p := filepath.Join(repoRoot, "docs", "dev", "_mods", "pr-merge.md")
-	b, err := os.ReadFile(p)
-	if err != nil {
-		t.Fatalf("read pr-merge mod: %v", err)
-	}
-	mod := string(b)
-
-	if strings.Contains(mod, "keeps that guard satisfied") {
-		t.Error("pr-merge fallback still carries the false 'keeps that guard satisfied' claim (#217)")
-	}
-	if !strings.Contains(mod, "pr=local-merge:") {
-		t.Error("pr-merge fallback must document the post-merge local-merge sentinel")
-	}
-	if !strings.Contains(mod, "merge: local") {
-		t.Error("pr-merge fallback must document the merge: local policy exemption")
 	}
 }

--- a/skills/integration/skill_text_test.go
+++ b/skills/integration/skill_text_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -106,27 +107,93 @@ func TestNoPRMergeOrModBehaviorIntroduced(t *testing.T) {
 	}
 }
 
-// TestCommissionStateBackendDecisionRule locks AC-2: the commission SKILL.md
-// carries the split-root-vs-single-root state-backend decision rule, so a newly
-// commissioned workflow no longer defaults to single-root with no guidance. The
-// three load-bearing fragments are the split-root frontmatter spelling, the
-// split-root trigger phrase, and the single-root "omit" guidance.
-func TestCommissionStateBackendDecisionRule(t *testing.T) {
+// commissionStateBackendDecisionRows extracts the two state-backend decision rows
+// from the commission SKILL.md decision table: each `- **{Label}** (...)` bullet
+// directly under the `**State backend (...)**` decision lead-in, returned keyed by
+// its bold branch label. It bounds each row to its own bullet line so an
+// assertion can check what that row alone binds, not a free-floating substring
+// anywhere in the file.
+func commissionStateBackendDecisionRows(t *testing.T) map[string]string {
+	t.Helper()
 	p := filepath.Join(skillsRoot(t), "commission", "SKILL.md")
 	b, err := os.ReadFile(p)
 	if err != nil {
 		t.Fatalf("read commission SKILL.md: %v", err)
 	}
-	skill := string(b)
-
-	for _, frag := range []string{
-		"state: .spacedock-state",
-		"embedded in a code repo whose PRs you care about",
-		"omit `state:`",
-	} {
-		if !strings.Contains(skill, frag) {
-			t.Errorf("commission SKILL.md missing state-backend decision-rule fragment %q", frag)
+	lines := strings.Split(string(b), "\n")
+	// Find the decision lead-in, then collect the contiguous `- **Label**` bullets
+	// that immediately follow (the decision-table rows), stopping at the first
+	// non-bullet line.
+	start := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "**State backend") {
+			start = i + 1
+			break
 		}
+	}
+	if start == -1 {
+		return nil
+	}
+	rows := map[string]string{}
+	labelRow := regexp.MustCompile(`^- \*\*([^*]+)\*\*`)
+	for i := start; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		m := labelRow.FindStringSubmatch(line)
+		if m == nil {
+			if len(rows) > 0 {
+				break // past the contiguous decision-table block
+			}
+			continue
+		}
+		rows[m[1]] = line
+	}
+	return rows
+}
+
+// TestCommissionStateBackendDecisionRule asserts the structural shape of the
+// commission SKILL.md state-backend decision table: two distinct labeled branches
+// under one decision lead-in, each row binding its own frontmatter outcome — the
+// split-root row binds `state: .spacedock-state`, the inline row binds the omit/
+// $inline outcome and NOT the split-root path. A scaffolding agent reads exactly
+// this table to choose a backend, so the load-bearing property is that both
+// branches exist as separate rows and neither collapses into the other.
+//
+// This DEMOTES the prior grep-over-prose check (it asserted three free-floating
+// substrings exist anywhere in the file, which a meaning-inverting paraphrase —
+// e.g. swapping which condition selects split-root — would keep green). REPLACE
+// with a behavioral driver was not feasible: the commission flow is
+// instruction-driven (the agent follows SKILL.md's "Write the README with ..."
+// steps); there is no Go scaffolder function that takes a standalone-vs-code-repo
+// input and emits frontmatter, so nothing behavioral is invocable from a test.
+// The honest fallback per the task is this structural decision-table assertion,
+// which pins the two-row shape and each row's bound outcome rather than prose
+// wording, and FAILS if a branch is dropped, merged, or rebound to the wrong path.
+func TestCommissionStateBackendDecisionRule(t *testing.T) {
+	rows := commissionStateBackendDecisionRows(t)
+	splitRoot, hasSplit := rows["Split-root"]
+	inline, hasInline := rows["Inline"]
+	if !hasSplit {
+		t.Fatal("commission SKILL.md state-backend table missing the `- **Split-root**` row")
+	}
+	if !hasInline {
+		t.Fatal("commission SKILL.md state-backend table missing the `- **Inline**` row")
+	}
+	// The split-root row must bind the orphan-state path; the inline row must NOT
+	// claim it (that is the binding that flips if the two branches are swapped or
+	// collapsed).
+	if !strings.Contains(splitRoot, "state: .spacedock-state") {
+		t.Errorf("split-root decision row does not bind `state: .spacedock-state`: %q", splitRoot)
+	}
+	if strings.Contains(inline, "state: .spacedock-state") {
+		t.Errorf("inline decision row wrongly binds the split-root path `state: .spacedock-state`: %q", inline)
+	}
+	// The inline row must bind its own outcome (the $inline value, or the omit
+	// guidance) so the two rows carry distinct frontmatter choices.
+	if !strings.Contains(inline, "$inline") && !strings.Contains(inline, "omit") {
+		t.Errorf("inline decision row binds no inline outcome ($inline or omit): %q", inline)
 	}
 }
 

--- a/skills/integration/working_principles_test.go
+++ b/skills/integration/working_principles_test.go
@@ -51,68 +51,16 @@ func TestShippedInstructionsCarryNoInsiderJargon(t *testing.T) {
 	}
 }
 
-// TestWorkflowGuideCarriesPrinciples locks the half of AC-1 that the workflow
-// guide owns: the four working principles appear in plain language in the
-// workflow-specific stage slots a captain and a worker read. These are durable
-// plain-language phrases the README prose commits to — not the proposal's jargon.
-func TestWorkflowGuideCarriesPrinciples(t *testing.T) {
-	readme := shippedInstructionFiles(t)["workflow guide (docs/dev/README.md)"]
-	markers := map[string]string{
-		"no doc-only deliverable (real checkable change)": "a real, checkable change",
-		"prove by exercising, not by re-reading":          "exercises the behavior and observes the outcome",
-		"spike the riskiest unknown first":                "riskiest",
-		"code gate preferred over prose-only rule":        "a code gate can enforce",
-	}
-	for principle, marker := range markers {
-		if !strings.Contains(readme, marker) {
-			t.Errorf("workflow guide missing the %q principle (expected plain-language marker %q)", principle, marker)
-		}
-	}
-}
-
-// TestFOContractCarriesWorkingPrinciplesAndPosture locks the FO-contract half of
-// AC-1: a `## Working Principles` section names the cross-workflow gate discipline
-// and the FO posture (name the end value, lead with a yes-able recommendation, do
-// obvious reversible work without ceremony). These live in sections disjoint from
-// the zs contract reorg.
-func TestFOContractCarriesWorkingPrinciplesAndPosture(t *testing.T) {
+// TestFOContractCarriesWorkingPrinciplesSection is a structural lint: it asserts
+// the `## Working Principles` section heading exists in the FO contract. The
+// heading is a structural anchor — a real on-disk section that other instruction
+// text and refits reference by name — so deleting it is a non-paraphrasable
+// mutation the lint catches. It deliberately does NOT grep the section's prose:
+// wording is doc review, not a Go assertion, and a paraphrase that keeps the
+// heading is not something this lint should pass or fail on.
+func TestFOContractCarriesWorkingPrinciplesSection(t *testing.T) {
 	fo := shippedInstructionFiles(t)["FO contract (first-officer-shared-core.md)"]
 	if !strings.Contains(fo, "## Working Principles") {
-		t.Errorf("FO contract missing the `## Working Principles` section")
-	}
-	postureMarkers := map[string]string{
-		"name the end value before starting":          "Name the end value",
-		"lead with a yes-able recommendation":         "a recommendation the captain can say yes to",
-		"do obvious reversible work without ceremony": "reversible work without ceremony",
-	}
-	for posture, marker := range postureMarkers {
-		if !strings.Contains(fo, marker) {
-			t.Errorf("FO contract missing the %q posture (expected marker %q)", posture, marker)
-		}
-	}
-	// The spike-first discipline rides the FO's existing ideation-probe section.
-	if !strings.Contains(fo, "riskiest") {
-		t.Errorf("FO contract missing the spike-first (riskiest unverified path) discipline")
-	}
-}
-
-// TestEnsignContractCarriesTestFirstRule locks the ensign-contract half of AC-1:
-// the worker contract carries the write-the-failing-test-first rule in plain
-// language. Per the companion design study, the authoring-order rule belongs in
-// the worker's standing practice (the ensign contract), not in the gate-facing
-// workflow template.
-func TestEnsignContractCarriesTestFirstRule(t *testing.T) {
-	ensign := shippedInstructionFiles(t)["ensign contract (ensign-shared-core.md)"]
-	for _, marker := range []string{
-		"failing test",
-		"watch it fail",
-	} {
-		if !strings.Contains(ensign, marker) {
-			t.Errorf("ensign contract missing the write-the-failing-test-first rule (expected marker %q)", marker)
-		}
-	}
-	// The "no hidden machine dependencies" principle is worker-facing discipline.
-	if !strings.Contains(ensign, "hidden") {
-		t.Errorf("ensign contract missing the no-hidden-machine-dependencies principle")
+		t.Errorf("FO contract missing the `## Working Principles` section heading")
 	}
 }


### PR DESCRIPTION
Remove the banned grep-over-prose antipattern from the integration suite: a classification workflow proved 6 of 26 funcs were tautological prose-pins (they stayed green when the asserted prose was inverted). Prune/demote/replace them so the suite pins behavior and structure, not wording.

## What changed
- PRUNE 3 pure prose-pins (`TestWorkflowGuideCarriesPrinciples`, `TestEnsignContractCarriesTestFirstRule`, `TestPRMergeFallbackProseIsHonest`) + the no-`--force` half of `TestShipLocalCeremonyBlockExists` — that property is owned behaviorally by `internal/status/merge_policy_guard_test.go`.
- DEMOTE `TestFOContractCarriesWorkingPrinciplesAndPosture` → a `## Working Principles` heading-presence structural lint.
- DEMOTE `TestCommissionStateBackendDecisionRule` → a per-row decision-table assertion (REPLACE was infeasible — commission is LLM-instruction-driven, no invocable Go scaffolder; recorded).

## Evidence
- Each disposition mutation-proven: the structural/decision mutation FAILS while a meaning-inverting paraphrase that keeps the anchor stays green (no longer prose-pinned). The 20 legitimate funcs (10 lint-invariants + 8 behavioral) are untouched.
- Audit confirmed no lost coverage: flipping the fixture `merge: local`→`pr` fails the merge-policy guard; swapping the commission decision bindings fails the decision-table test. `go test ./...` 732 passed; gofmt/vet clean.

## Review guidance
- Touches `skills/integration/*_test.go` only. The DEMOTE'd lints intentionally pin the structural anchor, not the prose meaning (meaning is doc review).

---
[rx](/spacedock-dev/spacedock/blob/6a3d529261a017808b3d1c5ff81400c333240692/prune-tautological-prose-tests/index.md)
