### PR TITLE
Ship a Codex runtime and install-readiness contract — codex ensign/first-officer adapters + Codex-shaped dispatch + wait/observe semantics

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -39,13 +39,23 @@ func runInit(ctx context.Context, args []string, ops hostOps, stdout, stderr io.
 		}
 		return runDoctor(ctx, []string{"--host", "claude"}, ops, stdout, stderr)
 	case "codex":
-		// Codex install is documented prose: the host install verb is `add`
-		// (NOT `install`), and the marketplace add accepts the branch via --ref.
-		printCodexInstallProse(stdout)
-		if !check {
-			return 0
+		resolved, err := ops.ResolveManifest("codex")
+		if err != nil {
+			fmt.Fprintf(stderr, "spacedock init: could not resolve the installed codex plugin: %v\n", err)
+			return 1
 		}
-		return runDoctor(ctx, []string{"--host", "codex"}, ops, stdout, stderr)
+		if resolved != "" || check {
+			code := contract.RunDoctor(resolved, "codex", devBranch, stdout, stderr)
+			if code != 0 || resolved != "" || check {
+				return code
+			}
+		}
+
+		// Codex install is documented prose when no installed plugin resolves: the
+		// host install verb is `add` (NOT `install`), and the marketplace add
+		// accepts the branch via --ref.
+		printCodexInstallProse(stdout)
+		return 0
 	default:
 		fmt.Fprintf(stderr, "spacedock install: unknown host %q (want claude or codex)\n", host)
 		return 2

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -101,30 +101,67 @@ func TestInitCheckRunsDoctorWithoutInstalling(t *testing.T) {
 	}
 }
 
-// TestInitCodexEmitsAddCommandProse: `spacedock install --host codex` emits the
-// documented `codex plugin marketplace add` + `codex plugin add` pair as prose
-// (install verb is `add`, not `install`) and does NOT shell the claude install
-// seam.
-func TestInitCodexEmitsAddCommandProse(t *testing.T) {
-	fake := &fakeHost{}
-	var stdout, stderr bytes.Buffer
+func TestInitCodexInstallReadiness(t *testing.T) {
+	t.Run("compatible-installed", func(t *testing.T) {
+		fake := &fakeHost{manifest: compatibleManifest(t)}
+		var stdout, stderr bytes.Buffer
 
-	code := runInit(context.Background(), []string{"--host", "codex"}, fake, &stdout, &stderr)
+		code := runInit(context.Background(), []string{"--host", "codex"}, fake, &stdout, &stderr)
 
-	if code != 0 {
-		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
-	}
-	out := stdout.String()
-	for _, want := range []string{
-		"codex plugin marketplace add",
-		"codex plugin add spacedock@spacedock",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("codex init prose missing %q:\n%s", want, out)
+		if code != 0 {
+			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
-	}
-	// Codex install verb is `add`, never `install`.
-	if strings.Contains(out, "codex plugin install") {
-		t.Errorf("codex init prose must not use 'codex plugin install' (verb is add):\n%s", out)
-	}
+		out := stdout.String()
+		if !strings.Contains(out, "OK: binary contract") {
+			t.Fatalf("codex init should report compatible installed plugin first; stdout = %q", out)
+		}
+		for _, banned := range []string{"codex plugin marketplace add", "codex plugin add spacedock@spacedock"} {
+			if strings.Contains(out, banned) {
+				t.Errorf("compatible codex init must not print manual add command %q:\n%s", banned, out)
+			}
+		}
+	})
+
+	t.Run("not-installed", func(t *testing.T) {
+		fake := &fakeHost{}
+		var stdout, stderr bytes.Buffer
+
+		code := runInit(context.Background(), []string{"--host", "codex"}, fake, &stdout, &stderr)
+
+		if code != 0 {
+			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+		}
+		out := stdout.String()
+		for _, want := range []string{
+			"codex plugin marketplace add",
+			"codex plugin add spacedock@spacedock",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("codex init prose missing %q:\n%s", want, out)
+			}
+		}
+		if strings.Contains(out, "codex plugin install") {
+			t.Errorf("codex init prose must not use 'codex plugin install' (verb is add):\n%s", out)
+		}
+	})
+
+	t.Run("incompatible-installed", func(t *testing.T) {
+		fake := &fakeHost{manifest: tooOldBinaryManifest(t)}
+		var stdout, stderr bytes.Buffer
+
+		code := runInit(context.Background(), []string{"--host", "codex"}, fake, &stdout, &stderr)
+
+		if code == 0 {
+			t.Fatalf("exit = 0, want non-zero for incompatible installed plugin")
+		}
+		errOut := stderr.String()
+		if !strings.Contains(errOut, "too-old-binary") {
+			t.Fatalf("codex init should surface doctor mismatch; stderr = %q", errOut)
+		}
+		for _, banned := range []string{"codex plugin marketplace add", "codex plugin add spacedock@spacedock"} {
+			if strings.Contains(stdout.String(), banned) || strings.Contains(errOut, banned) {
+				t.Errorf("incompatible codex init must not imply absent plugin via %q\nstdout=%s\nstderr=%s", banned, stdout.String(), errOut)
+			}
+		}
+	})
 }

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -109,6 +109,13 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 	teamName := optString(fields, "team_name")
 	feedbackContext := optString(fields, "feedback_context")
 	scopeNotes := optString(fields, "scope_notes")
+	host := optString(fields, "host")
+	if host == "" {
+		host = "claude"
+	}
+	if host != "claude" && host != "codex" {
+		return buildError(stderr, 1, "unsupported host %q (want claude or codex)", host)
+	}
 	bareMode := optBool(fields, "bare_mode")
 	isFeedbackReflow := optBool(fields, "is_feedback_reflow")
 
@@ -302,18 +309,7 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 	var parts []string
 
 	// 0. Operating-contract first-action directive.
-	parts = append(parts,
-		"## First action\n"+
-			"\n"+
-			"Before anything else, invoke your operating contract:\n"+
-			"\n"+
-			"    Skill(skill=\"spacedock:ensign\")\n"+
-			"\n"+
-			"This loads the shared ensign discipline (stage-report format, BashOutput "+
-			"polling, worktree ownership, completion signal protocol). The call is safe "+
-			"to call more than once; if the agent-definition preload ever starts "+
-			"working, calling it again is a no-op (the skill content is re-loaded but "+
-			"has no behavioral effect). Do not paraphrase; call the tool.\n")
+	parts = append(parts, firstActionBlock(host))
 
 	// 1. Header.
 	parts = append(parts, fmt.Sprintf("You are working on: %s\n\nStage: %s\n", entityTitle, stage))
@@ -409,18 +405,7 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 		if worktreePath != "" && !splitRoot {
 			entityFileRef = worktreeEntityPath
 		}
-		parts = append(parts, fmt.Sprintf(
-			"\n\n### Completion Signal\n\n"+
-				"When you finish (after all commits and stage report writes are done), "+
-				"your last action MUST be:\n\n"+
-				"    SendMessage(to=\"team-lead\", message=\"Done: %s completed "+
-				"%s. Report written to %s.\")\n\n"+
-				"**If you are the first officer forwarding this prompt to Agent():** copy "+
-				"the entire block above into `Agent(prompt=...)` character-for-character. "+
-				"Do NOT paraphrase `SendMessage(to=\"team-lead\", ...)` as \"SendMessage with "+
-				"to='team-lead'\" or any other English rewrite — the parenthesis-equals "+
-				"syntax is the literal call the ensign must emit, not a description of one.",
-			entityTitle, stage, entityFileRef))
+		parts = append(parts, completionSignalBlock(host, entityTitle, stage, entityFileRef))
 	}
 
 	dispatchBody := strings.Join(parts, "\n")
@@ -437,9 +422,7 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 		return 1
 	}
 
-	prompt := fmt.Sprintf(
-		"Skill(skill=\"spacedock:ensign\"); then Read %s and treat its content as your assignment.",
-		dispatchFilePath)
+	prompt := dispatchPointerPrompt(host, dispatchFilePath)
 
 	out := buildOutput{
 		SchemaVersion: schemaVersion,
@@ -458,6 +441,64 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 	}
 
 	return emitBuildJSON(stdout, out)
+}
+
+func firstActionBlock(host string) string {
+	if host == "codex" {
+		return "## First action\n" +
+			"\n" +
+			"Read this dispatch file directly and treat its content as your operating contract and assignment.\n" +
+			"\n" +
+			"This file contains the shared ensign discipline entry points (stage-report format, polling, " +
+			"worktree ownership, and completion signal protocol) plus the stage-specific assignment. " +
+			"Do not try to invoke a Claude skill wrapper; Codex dispatch uses this file " +
+			"pointer as the contract surface.\n"
+	}
+	return "## First action\n" +
+		"\n" +
+		"Before anything else, invoke your operating contract:\n" +
+		"\n" +
+		"    Skill(skill=\"spacedock:ensign\")\n" +
+		"\n" +
+		"This loads the shared ensign discipline (stage-report format, BashOutput " +
+		"polling, worktree ownership, completion signal protocol). The call is safe " +
+		"to call more than once; if the agent-definition preload ever starts " +
+		"working, calling it again is a no-op (the skill content is re-loaded but " +
+		"has no behavioral effect). Do not paraphrase; call the tool.\n"
+}
+
+func completionSignalBlock(host, entityTitle, stage, entityFileRef string) string {
+	if host == "codex" {
+		return fmt.Sprintf(
+			"\n\n### Completion Signal\n\n"+
+				"When you finish (after all commits and stage report writes are done), send one concise final "+
+				"message in this Codex worker thread:\n\n"+
+				"    Done: %s completed %s. Report written to %s.\n\n"+
+				"The first officer observes completion through the Codex final-status notification in the FO mailbox. "+
+				"Do not emit a Claude `SendMessage` call; the Codex mailbox notification is the completion signal.",
+			entityTitle, stage, entityFileRef)
+	}
+	return fmt.Sprintf(
+		"\n\n### Completion Signal\n\n"+
+			"When you finish (after all commits and stage report writes are done), "+
+			"your last action MUST be:\n\n"+
+			"    SendMessage(to=\"team-lead\", message=\"Done: %s completed "+
+			"%s. Report written to %s.\")\n\n"+
+			"**If you are the first officer forwarding this prompt to Agent():** copy "+
+			"the entire block above into `Agent(prompt=...)` character-for-character. "+
+			"Do NOT paraphrase `SendMessage(to=\"team-lead\", ...)` as \"SendMessage with "+
+			"to='team-lead'\" or any other English rewrite — the parenthesis-equals "+
+			"syntax is the literal call the ensign must emit, not a description of one.",
+		entityTitle, stage, entityFileRef)
+}
+
+func dispatchPointerPrompt(host, dispatchFilePath string) string {
+	if host == "codex" {
+		return fmt.Sprintf("Read %s and treat its content as your assignment.", dispatchFilePath)
+	}
+	return fmt.Sprintf(
+		"Skill(skill=\"spacedock:ensign\"); then Read %s and treat its content as your assignment.",
+		dispatchFilePath)
 }
 
 // stateCommitGuidance is the split-root state-commit instruction, shared by the

--- a/internal/dispatch/build_codex_host_test.go
+++ b/internal/dispatch/build_codex_host_test.go
@@ -1,0 +1,67 @@
+// ABOUTME: Codex dispatch-build host shape — the outer prompt and dispatch-file
+// ABOUTME: body use Codex mailbox semantics instead of Claude Skill()/SendMessage.
+package dispatch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildCodexHostPromptShape(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "README.md"), readmeWorktree(false))
+	worktreeRel := ".worktrees/spacedock-ensign-thing"
+	if err := os.MkdirAll(filepath.Join(root, worktreeRel), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entityPath := filepath.Join(root, "thing.md")
+	writeFile(t, entityPath, entityFM("Thing", "implementation", worktreeRel))
+	gitInit(t, root)
+
+	stdin := mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    entityPath,
+		"workflow_dir":   root,
+		"stage":          "implementation",
+		"checklist":      []string{"- a", "- b"},
+		"team_name":      "fixture-team",
+		"bare_mode":      false,
+		"host":           "codex",
+	}, nil)
+
+	native := runNative(stdin, "build", "--workflow-dir", root)
+	if native.exit != 0 {
+		t.Fatalf("build exit=%d stderr=%q", native.exit, native.stderr)
+	}
+	var out struct {
+		Prompt string `json:"prompt"`
+	}
+	if err := json.Unmarshal([]byte(native.stdout), &out); err != nil {
+		t.Fatalf("stdout is not build JSON: %v\n%s", err, native.stdout)
+	}
+	if strings.Contains(out.Prompt, "Skill(skill=") {
+		t.Fatalf("codex prompt must not depend on Skill(...): %q", out.Prompt)
+	}
+	if !strings.Contains(out.Prompt, "Read ") || !strings.Contains(out.Prompt, "treat its content as your assignment") {
+		t.Fatalf("codex prompt should be the read-dispatch-file form: %q", out.Prompt)
+	}
+
+	body := readDispatchBody(t, dispatchFilePathFromStdout(t, native.stdout))
+	for _, banned := range []string{"Skill(skill=\"spacedock:ensign\")", "SendMessage(to=\"team-lead\""} {
+		if strings.Contains(body, banned) {
+			t.Fatalf("codex dispatch body must omit %q:\n%s", banned, body)
+		}
+	}
+	for _, want := range []string{
+		"Read this dispatch file directly",
+		"Codex final-status notification",
+		"FO mailbox",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("codex dispatch body missing %q:\n%s", want, body)
+		}
+	}
+}

--- a/internal/hostneutrality/codex_runtime_contract_test.go
+++ b/internal/hostneutrality/codex_runtime_contract_test.go
@@ -1,0 +1,69 @@
+// ABOUTME: Codex runtime adapter contract tests — the skill surface loads
+// ABOUTME: dedicated Codex FO/ensign adapters with mailbox wait semantics.
+package hostneutrality
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCodexRuntimeAdaptersAreLoadable(t *testing.T) {
+	root := filepath.Join("..", "..")
+	cases := []struct {
+		name      string
+		skillPath string
+		adapter   string
+	}{
+		{
+			name:      "first-officer",
+			skillPath: filepath.Join(root, "skills", "first-officer", "SKILL.md"),
+			adapter:   filepath.Join(root, "skills", "first-officer", "references", "codex-first-officer-runtime.md"),
+		},
+		{
+			name:      "ensign",
+			skillPath: filepath.Join(root, "skills", "ensign", "SKILL.md"),
+			adapter:   filepath.Join(root, "skills", "ensign", "references", "codex-ensign-runtime.md"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			skill := readText(t, tc.skillPath)
+			adapterBase := filepath.Base(tc.adapter)
+			if !strings.Contains(skill, "CODEX_THREAD_ID") || !strings.Contains(skill, adapterBase) {
+				t.Fatalf("%s SKILL.md must branch on CODEX_THREAD_ID and load %s:\n%s", tc.name, adapterBase, skill)
+			}
+
+			body := readText(t, tc.adapter)
+			for _, want := range []string{"## Awaiting Completion", "## Dispatch", "send_input", "## Completion Signal", "Codex declares none"} {
+				if !strings.Contains(body, want) {
+					t.Fatalf("%s adapter missing %q:\n%s", tc.name, want, body)
+				}
+			}
+		})
+	}
+}
+
+func TestCodexAwaitingCompletionPinsMailboxSemantics(t *testing.T) {
+	body := readText(t, filepath.Join("..", "..", "skills", "first-officer", "references", "codex-first-officer-runtime.md"))
+	for _, want := range []string{
+		"async final-status notification in the FO mailbox",
+		"wait_agent timeout return is normal",
+		"do not poll, re-dispatch, or close the worker",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("Codex FO adapter must pin waiting clause %q:\n%s", want, body)
+		}
+	}
+}
+
+func readText(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/skills/ensign/SKILL.md
+++ b/skills/ensign/SKILL.md
@@ -11,5 +11,6 @@ description: Execute workflow stage work as a dispatched worker.
 
 Load the runtime adapter for your platform:
 - Claude Code (`CLAUDECODE` env var is set): read `references/claude-ensign-runtime.md`
+- Codex (`CODEX_THREAD_ID` env var is set): read `references/codex-ensign-runtime.md`
 
 Then read your assignment and begin work.

--- a/skills/ensign/references/codex-ensign-runtime.md
+++ b/skills/ensign/references/codex-ensign-runtime.md
@@ -1,0 +1,69 @@
+# Codex Ensign Runtime
+
+This file defines how the shared ensign core executes on Codex.
+
+## Agent Surface
+
+The ensign is dispatched by the first officer through Codex multi-agent
+dispatch. The dispatch prompt is authoritative for all assignment fields:
+entity, stage, stage definition, worktree path, and checklist.
+
+Codex dispatch build prompts are file pointers. Read the named dispatch file
+directly and treat its content as the assignment; do not try to invoke a Claude
+`Skill(skill=...)` wrapper.
+
+Codex declares none for the context-budget probe. The first officer owns any
+reuse decision; the ensign should follow the assignment it receives.
+
+## Dispatch
+
+Initial dispatch comes from `spacedock dispatch build` with `host: "codex"`.
+The generated dispatch file carries the stage definition fetch commands,
+worktree rules, split-root state commit guidance, checklist, and completion
+signal wording. Do not reconstruct those fields manually.
+
+## Awaiting Completion
+
+The first officer observes completion through the async final-status
+notification in the FO mailbox. After you send the completion signal, stop and
+let Codex deliver that notification; do not send follow-up status chatter unless
+the first officer routes more work through `send_input`.
+
+## Clarification
+
+If requirements are unclear or ambiguous, ask for clarification in the Codex
+worker thread. Describe what you understand and what is ambiguous so the first
+officer can route an answer through `send_input`.
+
+## Captain Communication
+
+When dispatched for a stage that involves direct interaction with the captain,
+communicate with the captain via direct Codex conversation text. Keep operational
+completion signals concise so the first officer's mailbox notification remains
+easy to interpret.
+
+## Completion Signal
+
+When your work is done, send one minimal final message in the Codex worker
+thread:
+
+```text
+Done: {entity title} completed {stage}. Report written to {entity_file_path}.
+```
+
+The entity file is the artifact. Do not include the checklist or summary in the
+message. Plain text only. Never send JSON and never emit a Claude
+`SendMessage(to="team-lead", ...)` call on Codex.
+
+## Feedback Interaction
+
+When dispatched for a feedback stage, the first officer may route follow-up
+through `send_input`. Apply the feedback, update the stage report if needed, and
+send the same completion signal when finished.
+
+## Shutdown Response Protocol
+
+If the first officer sends an explicit shutdown request through `send_input`,
+acknowledge it in plain text and stop unless you have load-bearing in-flight
+work that would be lost. In that case, briefly name what must be preserved before
+shutdown.

--- a/skills/first-officer/SKILL.md
+++ b/skills/first-officer/SKILL.md
@@ -21,5 +21,6 @@ If this skill is invoked directly in a non-interactive run and the prompt names 
 
 Load the runtime adapter for your platform:
 - Claude Code (`CLAUDECODE` env var is set): read `references/claude-first-officer-runtime.md`
+- Codex (`CODEX_THREAD_ID` env var is set): read `references/codex-first-officer-runtime.md`
 
 Then begin the Startup procedure from the shared core.

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -1,0 +1,54 @@
+# Codex First Officer Runtime
+
+This file defines how the shared first-officer core executes on Codex.
+
+## Team Creation
+
+Codex does not expose Claude Code's `TeamCreate` registry. Do not create or
+delete teams, and do not inspect Claude team directories. Codex workers are
+spawned and observed through the multi-agent mailbox surface.
+
+Codex declares none for the context-budget probe. When the shared core asks for a
+reuse budget signal, treat the probe as unavailable and prefer a fresh dispatch
+unless the current task explicitly depends on the previous worker's context.
+
+## Dispatch
+
+Use `spawn_agent` for initial worker dispatch. Assemble the dispatch input with
+`spacedock dispatch build` and pass `host: "codex"` in the JSON envelope. Forward
+the emitted prompt exactly as returned; for Codex it is a read-dispatch-file
+prompt and must not be rewritten into `Skill(skill=...)`.
+
+Codex has no team registry, so there is no `team_name` lifecycle to create,
+recover, or tear down. Use Codex task names and mailbox notifications as the
+worker handle. Do not use Claude `SendMessage` completion syntax in Codex
+dispatch prompts.
+
+## Reuse And Feedback Routing
+
+Route feedback or continuation to an existing Codex worker with `send_input`.
+Set `interrupt=true` only when the worker must immediately change direction.
+Reuse is appropriate when the next task depends heavily on the worker's retained
+context; otherwise dispatch a fresh worker from entity state.
+
+## Awaiting Completion
+
+The Codex completion signal is the async final-status notification in the FO mailbox. `wait_agent` is only an optional accelerator when a critical-path step is blocked on the worker result.
+
+A wait_agent timeout return is normal. It means no final-status mailbox update
+arrived before the deadline; it is not a failure, a zombie signal, or a teardown
+trigger.
+
+Between dispatch and the async final-status notification, do not poll, re-dispatch, or close the worker. End the turn and let Codex deliver the mailbox notification. Close workers only after completion has been observed or when the captain explicitly requests shutdown.
+
+## Completion Signal
+
+An ensign completes by sending a concise final message in its Codex worker
+thread. The FO observes that message through the Codex final-status notification
+in the FO mailbox and then resumes the shared event loop.
+
+## Captain Interaction
+
+The captain is the user of the Codex session. Communicate gate results,
+clarifications, and status directly in the conversation. Do not invent a
+team-lead mailbox on Codex.


### PR DESCRIPTION
Codex users now get truthful install readiness and explicit Spacedock runtime guidance before dispatching workers.

## What changed

- Report compatible Codex plugin installs before manual add guidance.
- Add Codex FO and ensign runtime adapters.
- Load Codex adapters via `CODEX_THREAD_ID` skill branches.
- Emit Codex dispatch prompts without `Skill(...)` or Claude `SendMessage`.

## Evidence

- 3/3 post-rebase Go gates passed: focused packages, `go test ./...`, `go test ./... -race`.

---
[r0](/spacedock-dev/spacedock/blob/d3b655a27d0f2cbc0ec1d9efc558b6cdf8091949/codex-runtime-adapter/index.md)