### PR TITLE
Make the live-e2e FO drive headless — spacedock on the FO PATH + discoverable fixture (root-caused via 3g's jsonl)

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -124,6 +124,7 @@ jobs:
         run: |
           go build -o ./spacedock ./cmd/spacedock
           echo "SPACEDOCK_BIN=$(pwd)/spacedock" >> "$GITHUB_ENV"
+          echo "$(pwd)" >> "$GITHUB_PATH"
 
       - name: Configure git identity
         run: |

--- a/internal/ensigncycle/cycle_test.go
+++ b/internal/ensigncycle/cycle_test.go
@@ -232,6 +232,7 @@ func TestEnsignCycleGoesRedOnBrokenOutput(t *testing.T) {
 // stage, so the cycle exercises the flat-entity / no-worktree path.
 func readmeNonWorktree() string {
 	return "---\n" +
+		"commissioned-by: spacedock@1\n" +
 		"entity-type: task\n" +
 		"id-style: slug\n" +
 		"stages:\n" +

--- a/internal/ensigncycle/live_test.go
+++ b/internal/ensigncycle/live_test.go
@@ -57,6 +57,13 @@ func TestLiveEnsignCycle(t *testing.T) {
 	// directly with a fake home so it never touches the real ~/.claude.
 	childEnv := isolatedClaudeEnv(t, os.Getenv("HOME"))
 
+	// Put the built binary's directory first on the FO subprocess's PATH. The FO
+	// contract's first step is `spacedock --version` and the FO knows `spacedock`
+	// only by PATH name (not SPACEDOCK_BIN, which is the test's own resolution
+	// hook); without this the runner PATH has no `spacedock` and the FO aborts at
+	// the binary gate before ever reaching TeamCreate (CI run 26839572693).
+	childEnv = withBinaryOnPath(childEnv, binary)
+
 	// Stage the SAME flat-entity backlog fixture the skeleton builds: a
 	// git-init'd root with a non-worktree workflow README and a flat entity in
 	// the initial (backlog) stage. The real FO drives it to the TERMINAL stage,

--- a/internal/ensigncycle/liveenv_path_test.go
+++ b/internal/ensigncycle/liveenv_path_test.go
@@ -1,0 +1,77 @@
+// ABOUTME: Offline unit test for the child-env PATH-prepend helper that puts the
+// ABOUTME: built spacedock binary's dir first so the FO resolves `spacedock` by name.
+package ensigncycle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWithBinaryOnPath covers the seam that fixed the live-e2e binary-not-on-PATH
+// defect (CI run 26839572693): the FO subprocess inherits PATH verbatim from the
+// child env, and the built binary's directory was never on it, so the FO's first
+// contract step `spacedock --version` hit `command not found`. withBinaryOnPath
+// prepends filepath.Dir(binary) as the FIRST PATH element so an exec.LookPath-style
+// resolution finds the just-built binary ahead of any other `spacedock`. No model.
+func TestWithBinaryOnPath(t *testing.T) {
+	// A binary under a temp dir whose directory is NOT already on the child PATH:
+	// this reproduces the CI defect (the runner PATH had the claude dir but never
+	// the built-spacedock dir).
+	binDir := t.TempDir()
+	binary := filepath.Join(binDir, "spacedock")
+
+	// A child env with a PATH that does NOT contain binDir, plus a couple of
+	// unrelated keys we expect the helper to preserve untouched.
+	otherDirs := strings.Join([]string{"/usr/local/bin", "/usr/bin", "/bin"}, string(os.PathListSeparator))
+	childEnv := []string{
+		"HOME=/some/isolated/home",
+		"PATH=" + otherDirs,
+		"ANTHROPIC_API_KEY=sk-ci-api-key",
+	}
+
+	got := withBinaryOnPath(childEnv, binary)
+
+	pathVal, ok := envValue(got, "PATH")
+	if !ok {
+		t.Fatal("PATH must be present in the augmented child env")
+	}
+	dirs := strings.Split(pathVal, string(os.PathListSeparator))
+	if dirs[0] != binDir {
+		t.Errorf("PATH[0] = %q, want the binary's dir %q first so `spacedock` resolves by name", dirs[0], binDir)
+	}
+	// The original PATH entries must be preserved after the prepended dir, so any
+	// other tool (claude) the FO shells still resolves.
+	if !strings.Contains(pathVal, otherDirs) {
+		t.Errorf("PATH = %q must still contain the original entries %q", pathVal, otherDirs)
+	}
+	// Unrelated keys pass through untouched.
+	if home, ok := envValue(got, "HOME"); !ok || home != "/some/isolated/home" {
+		t.Errorf("HOME = %q (present=%v), want it preserved untouched", home, ok)
+	}
+	if key, ok := envValue(got, "ANTHROPIC_API_KEY"); !ok || key != "sk-ci-api-key" {
+		t.Errorf("ANTHROPIC_API_KEY = %q (present=%v), want it preserved untouched", key, ok)
+	}
+}
+
+// TestWithBinaryOnPathNoExistingPath asserts the helper still works when the child
+// env carries no PATH entry at all: it synthesizes a PATH=<binary dir> entry so the
+// FO can resolve the binary by name even from an env that dropped PATH.
+func TestWithBinaryOnPathNoExistingPath(t *testing.T) {
+	binDir := t.TempDir()
+	binary := filepath.Join(binDir, "spacedock")
+
+	childEnv := []string{"HOME=/some/isolated/home"}
+
+	got := withBinaryOnPath(childEnv, binary)
+
+	pathVal, ok := envValue(got, "PATH")
+	if !ok {
+		t.Fatal("PATH must be synthesized when the child env has none")
+	}
+	dirs := strings.Split(pathVal, string(os.PathListSeparator))
+	if dirs[0] != binDir {
+		t.Errorf("PATH[0] = %q, want the binary's dir %q", dirs[0], binDir)
+	}
+}

--- a/internal/ensigncycle/liveenv_test.go
+++ b/internal/ensigncycle/liveenv_test.go
@@ -138,6 +138,37 @@ func isolatedClaudeEnv(t *testing.T, realHome string) []string {
 	}
 }
 
+// withBinaryOnPath prepends filepath.Dir(binary) as the FIRST element of the
+// child env's PATH entry and returns the augmented env. The live FO subprocess
+// inherits PATH verbatim from this child env and knows `spacedock` only by PATH
+// name (the FO contract's first step is `spacedock --version`, not an env var),
+// so putting the just-built binary's directory first guarantees the FO resolves
+// the binary the test built rather than a stale `spacedock` on PATH (locally) or
+// nothing at all (CI, where the runner PATH never had the build dir). Other env
+// entries pass through untouched; when the child env carries no PATH at all, a
+// PATH=<binary dir> entry is synthesized.
+func withBinaryOnPath(env []string, binary string) []string {
+	binDir := filepath.Dir(binary)
+	out := make([]string, 0, len(env)+1)
+	found := false
+	for _, kv := range env {
+		if rest, ok := strings.CutPrefix(kv, "PATH="); ok {
+			found = true
+			if rest != "" {
+				out = append(out, "PATH="+binDir+string(os.PathListSeparator)+rest)
+			} else {
+				out = append(out, "PATH="+binDir)
+			}
+			continue
+		}
+		out = append(out, kv)
+	}
+	if !found {
+		out = append(out, "PATH="+binDir)
+	}
+	return out
+}
+
 // envOr returns the environment value for key, or def when unset/empty.
 func envOr(key, def string) string {
 	if v := os.Getenv(key); v != "" {

--- a/internal/ensigncycle/livefixture_discover_test.go
+++ b/internal/ensigncycle/livefixture_discover_test.go
@@ -1,0 +1,47 @@
+// ABOUTME: Offline guard that the live cycle's workflow README fixture is
+// ABOUTME: discoverable, so the FO's `status --discover` finds it (no model).
+package ensigncycle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// TestLiveFixtureIsDiscoverable guards the SECOND pre-TeamCreate blocker the audit
+// found on CI run 26839572693's opus leg: even with `spacedock` on PATH, the FO
+// runs `status --discover` (FO contract step 3) and gets ZERO workflows when the
+// staged README lacks `commissioned-by: spacedock@`, then reports "no workflow
+// found" and exits before TeamCreate. Discovery gates on that frontmatter field —
+// both discoverWorkflows (internal/status/handlers.go) and DiscoverWorkflowDir
+// (internal/status/discover_walkup.go) require strings.HasPrefix(commissioned-by,
+// "spacedock@"). This test writes the SAME README the live cycle stages
+// (readmeNonWorktree) and asserts DiscoverWorkflowDir — which uses the same
+// predicate as the FO's --discover — resolves the fixture dir. Red without the
+// commissioned-by line in the fixture, green with it. No model.
+func TestLiveFixtureIsDiscoverable(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte(readmeNonWorktree()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir, found := status.DiscoverWorkflowDir(root)
+	if !found {
+		t.Fatal("live fixture README is not discoverable: DiscoverWorkflowDir found no workflow " +
+			"(the fixture needs a `commissioned-by: spacedock@` frontmatter line, or the FO's " +
+			"`status --discover` reports 0 workflows and exits before TeamCreate)")
+	}
+	wantReal, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		wantReal = root
+	}
+	gotReal, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		gotReal = dir
+	}
+	if gotReal != wantReal {
+		t.Errorf("DiscoverWorkflowDir = %q, want the fixture root %q", dir, root)
+	}
+}


### PR DESCRIPTION
Make the live-e2e FO actually drive headless: put the built `spacedock` on the FO's PATH and make the live fixture discoverable, so the FO gets past the binary gate and workflow discovery to TeamCreate. Root-caused from `3g`'s captured CI jsonl, not speculation.

## What changed
- Prepend the built `spacedock`'s dir to the FO subprocess PATH (a pure child-env helper applied in `live_test.go` + the workflow build step → `$GITHUB_PATH`), so the FO's `spacedock --version` resolves (was: command-not-found → #262 binary-absent abort).
- Add `commissioned-by: spacedock@1` to the live fixture README so `spacedock status --discover` finds the workflow (was: 0 workflows → exit before TeamCreate).
- Offline guards: a PATH-prepend unit test + a fixture-discoverability test (both red-without/green-with).

## Evidence
- Both legs of CI run `26839572693` failed before TeamCreate — sonnet at the binary gate, opus at discovery (0 workflows); the two captured jsonls are the root-cause evidence. Test-infra only — no FO-runtime/frontdoor/status change (the #262 abort was correct; the env was the bug).
- `go test ./...` 740 green; the two offline guards mutation-verified red/green; `vet`/`gofmt` clean (default + `-tags live`).
- Binding proof: this PR's env-approved Linux live-e2e is expected to drive the FO past TeamCreate for the first time.

## Review guidance
- Test-infra: `internal/ensigncycle` + one workflow line. The remaining unverified region (the FO's TeamCreate/dispatch decision under teams+`-p`, old H1) is now reachable and observed by the live run.

---
[hd](/spacedock-dev/spacedock/blob/79b32255da48a39a30e4902dc463df1de1ccf80a/headless-fo-drive-flake/index.md)
