### PR TITLE
Refuse to close a task whose only "proof" is re-reading its own write-up

### DIFF
--- a/internal/status/archive_guard_test.go
+++ b/internal/status/archive_guard_test.go
@@ -4,6 +4,7 @@ package status
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -54,6 +55,118 @@ func TestArchiveAbsoluteDest(t *testing.T) {
 	if nOut != wantNative {
 		t.Fatalf("native narration = %q, want %q (absolute dest spelling)", nOut, wantNative)
 	}
+}
+
+// TestTerminalSetUnderSelfRefRejected locks AC-1: under `require-external-proof:
+// true`, a terminal --set on an entity whose ACs are only self-referentially
+// proven exits 1, leaves the frontmatter byte-identical, prints the guard error
+// in the mod-block idiom, and --force bypasses with the standard warning. A
+// real-proof entity terminalizes cleanly (exit 0). A flip test re-runs --set
+// after editing the self-ref entity's Verified by clause to cite a Go test —
+// the guard now lets it through, confirming it keys on the proof clause not
+// the entity slug.
+func TestTerminalSetUnderSelfRefRejected(t *testing.T) {
+	t.Run("self-ref-rejected", func(t *testing.T) {
+		env := pinnedEnv(t)
+		root := stageExternalProofFixture(t, "require-external-proof: true\n")
+
+		args := []string{"--workflow-dir", root, "--set", "010-self-ref-only", "status=done"}
+		nOut, nErr, nCode := runNative(t, root, env, args...)
+
+		if nCode != 1 {
+			t.Fatalf("guard must reject self-ref terminal --set, got exit=%d", nCode)
+		}
+		if !strings.Contains(nErr, "self-referential proof") {
+			t.Fatalf("stderr should name the rejection cause, got %q", nErr)
+		}
+		if !strings.Contains(nErr, "AC-1") {
+			t.Fatalf("stderr should name the flagged AC, got %q", nErr)
+		}
+		if nOut != "" {
+			t.Fatalf("stdout must be empty on rejection: %q", nOut)
+		}
+		fm := readFrontmatter(t, filepath.Join(root, "010-self-ref-only.md"))
+		if !strings.Contains(fm, "status: implementation") {
+			t.Fatalf("entity was mutated despite guard rejection:\n%s", fm)
+		}
+		if strings.Contains(fm, "status: done") {
+			t.Fatalf("entity advanced to done despite guard rejection:\n%s", fm)
+		}
+	})
+
+	t.Run("real-proof-passes", func(t *testing.T) {
+		env := pinnedEnv(t)
+		root := stageExternalProofFixture(t, "require-external-proof: true\n")
+
+		args := []string{"--workflow-dir", root, "--set", "020-real-proof", "status=done"}
+		_, nErr, nCode := runNative(t, root, env, args...)
+		if nCode != 0 {
+			t.Fatalf("real-proof entity should pass guard, got exit=%d stderr=%q", nCode, nErr)
+		}
+		fm := readFrontmatter(t, filepath.Join(root, "020-real-proof.md"))
+		if !strings.Contains(fm, "status: done") {
+			t.Fatalf("real-proof entity should advance to done, fm=%s", fm)
+		}
+	})
+
+	t.Run("force-bypasses-with-warning", func(t *testing.T) {
+		env := pinnedEnv(t)
+		root := stageExternalProofFixture(t, "require-external-proof: true\n")
+
+		args := []string{"--workflow-dir", root, "--set", "030-force-bypass", "status=done", "--force"}
+		_, nErr, nCode := runNative(t, root, env, args...)
+		if nCode != 0 {
+			t.Fatalf("--force must bypass guard, got exit=%d", nCode)
+		}
+		if !strings.Contains(nErr, "Warning: --force overriding require-external-proof") {
+			t.Fatalf("stderr should carry the bypass warning, got %q", nErr)
+		}
+		fm := readFrontmatter(t, filepath.Join(root, "030-force-bypass.md"))
+		if !strings.Contains(fm, "status: done") {
+			t.Fatalf("force-bypass entity should advance to done, fm=%s", fm)
+		}
+	})
+
+	t.Run("flip-cite-go-test", func(t *testing.T) {
+		env := pinnedEnv(t)
+		root := stageExternalProofFixture(t, "require-external-proof: true\n")
+
+		// Rewrite the self-ref entity's Verified by clause to cite a Go test.
+		path := filepath.Join(root, "010-self-ref-only.md")
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		replaced := strings.Replace(string(body),
+			"Verified by: review of this entity's decision section, which states the\nintent and cites the design rationale.",
+			"Verified by: a Go test `TestSomething` asserts the intent holds.",
+			1)
+		if replaced == string(body) {
+			t.Fatalf("flip rewrite did not match the fixture body")
+		}
+		if err := os.WriteFile(path, []byte(replaced), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		// Re-stage the git index so the entity is committed cleanly.
+		gitCmd := func(args ...string) {
+			cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %v\n%s", args, err, out)
+			}
+		}
+		gitCmd("-c", "user.email=t@t", "-c", "user.name=t", "add", "-A")
+		gitCmd("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "flip")
+
+		args := []string{"--workflow-dir", root, "--set", "010-self-ref-only", "status=done"}
+		_, nErr, nCode := runNative(t, root, env, args...)
+		if nCode != 0 {
+			t.Fatalf("guard should let through a real-proof AC, got exit=%d stderr=%q", nCode, nErr)
+		}
+		fm := readFrontmatter(t, path)
+		if !strings.Contains(fm, "status: done") {
+			t.Fatalf("flipped entity should advance to done, fm=%s", fm)
+		}
+	})
 }
 
 // TestTerminalSetUnderModBlockRejected locks the guard: a terminal --set

--- a/internal/status/external_proof.go
+++ b/internal/status/external_proof.go
@@ -1,0 +1,232 @@
+// ABOUTME: Self-referential-AC classifier + require-external-proof README opt-in,
+// ABOUTME: powering runSet's terminal guard and validateWorkflow's sub-check.
+package status
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ACFlag is one classifier finding: the AC header line, the cleaned proof
+// clause that was scanned, and the self-phrase that triggered the flag. Tests
+// drive the classifier and assert against these fields directly.
+type ACFlag struct {
+	Header        string
+	ProofClause   string
+	MatchedPhrase string
+}
+
+// classifierCallCount is incremented every time ClassifyEntityACs runs. The
+// AC-4 shared-classifier test exercises both integrating callers in one body
+// and asserts both bumped this counter, proving the two surfaces call the
+// same function.
+var classifierCallCount int
+
+// acHeaderRe matches a line opening an `**AC-N — …**` block. The classifier
+// only emits findings for blocks that match this shape; free-form prose is
+// never scanned.
+var acHeaderRe = regexp.MustCompile(`^\*\*AC-`)
+
+// proofMarkerRe locates the first proof-clause marker within an AC block:
+// `Verified by`, `Oracle:`, `Proof:`, or `End state:` / `End state.`.
+// Case-insensitive. The match is the boundary between the body and the proof
+// clause taken to block end.
+var proofMarkerRe = regexp.MustCompile(`(?i)(verified by|oracle:|proof:|end state[:.])`)
+
+// quotedSpanRe matches every double-quoted span (`"..."`) and backtick-fenced
+// span (`` `...` ``) so a quoted example of the antipattern is excluded from
+// the self-phrase match.
+var quotedSpanRe = regexp.MustCompile("\"[^\"]*\"|`[^`]*`")
+
+// selfPhraseRes are the case-insensitive self-reference phrases the
+// classifier flags. The order is stable so a test can inspect MatchedPhrase
+// against the literal alternative.
+var selfPhraseRes = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)this entity'?s`),
+	regexp.MustCompile(`(?i)review of (this|the) (entity|decision|design)[^.]*section`),
+	regexp.MustCompile(`(?i)the entity'?s own (prose|decision|section)`),
+	regexp.MustCompile(`(?i)re-reading (this|the) (entity|task|body)`),
+}
+
+// externalTokenRe captures any token that proves the AC's proof cites
+// something runnable / observable outside the entity body. Presence of ANY
+// token clears the AC, so a CI run on the entity's PR no longer false-positives
+// even when the prose says "this entity's own PR".
+var externalTokenRe = regexp.MustCompile(`(?i)` + strings.Join([]string{
+	`\btest\b`, `\.go\b`, `exit\s`, `exit-code`, `exit code`, `command`, `\bstatus\b`,
+	`--\w+`, `fixture`, `golden`, `byte`, `on-disk`, `stdout`, `stderr`, `assert`, `parser`,
+	`mutator`, `frontmatter`, `code path`, `command/parser`,
+	`runs? the`, `running the`, `invok`, `drive the`, `driving the`,
+	`\bCI\b`, `\bPR\b`, `live job`, `green`, `workflow file`,
+}, "|"))
+
+// stripFrontmatter returns the body of an entity file — the bytes after the
+// closing `---` fence. A file with no opening fence returns its bytes
+// unchanged; a file with only an opening fence returns the empty string.
+func stripFrontmatter(data []byte) string {
+	if !contentHasOpeningFence(data) {
+		return string(data)
+	}
+	lines := splitLines(string(data))
+	var body []string
+	fences := 0
+	first := true
+	for _, raw := range lines {
+		line := raw
+		if first {
+			line = strings.TrimPrefix(line, utf8BOM)
+			first = false
+		}
+		if line == "---" {
+			fences++
+			continue
+		}
+		if fences >= 2 {
+			body = append(body, line)
+		}
+	}
+	return strings.Join(body, "\n")
+}
+
+// ClassifyEntityACs scans an entity body and flags every AC whose proof clause
+// names the entity itself (and only the entity itself) as the verification. The
+// five-step algorithm: extract `**AC-N` blocks → isolate the clause from the
+// first proof marker onward → strip quoted spans → match a self-phrase →
+// require external-token absence. The classifier is pure — no I/O — so tests
+// drive it with literal strings.
+func ClassifyEntityACs(body string) []ACFlag {
+	classifierCallCount++
+
+	var flags []ACFlag
+
+	lines := splitLines(body)
+	var current []string
+	var currentHeader string
+
+	flush := func() {
+		if currentHeader == "" {
+			return
+		}
+		block := strings.Join(current, "\n")
+		clause := isolateProofClause(block)
+		cleaned := quotedSpanRe.ReplaceAllString(clause, " ")
+		matched := matchSelfPhrase(cleaned)
+		if matched == "" {
+			return
+		}
+		if externalTokenRe.MatchString(cleaned) {
+			return
+		}
+		flags = append(flags, ACFlag{
+			Header:        currentHeader,
+			ProofClause:   strings.TrimSpace(clause),
+			MatchedPhrase: matched,
+		})
+	}
+
+	for _, line := range lines {
+		if acHeaderRe.MatchString(line) {
+			flush()
+			currentHeader = line
+			current = nil
+			continue
+		}
+		if strings.HasPrefix(line, "## ") {
+			flush()
+			currentHeader = ""
+			current = nil
+			continue
+		}
+		if currentHeader != "" {
+			current = append(current, line)
+		}
+	}
+	flush()
+
+	return flags
+}
+
+// isolateProofClause returns the slice of an AC block from the first proof
+// marker to the block end. When no marker is present the entire block is
+// returned (the absence-of-proof case is a separate failure mode the
+// downstream FO cross-check catches).
+func isolateProofClause(block string) string {
+	loc := proofMarkerRe.FindStringIndex(block)
+	if loc == nil {
+		return block
+	}
+	return block[loc[0]:]
+}
+
+// matchSelfPhrase returns the literal substring of clause that matched a
+// self-phrase regex, or "" when none matched. The returned phrase populates
+// ACFlag.MatchedPhrase for test introspection.
+func matchSelfPhrase(clause string) string {
+	for _, re := range selfPhraseRes {
+		if m := re.FindString(clause); m != "" {
+			return m
+		}
+	}
+	return ""
+}
+
+// externalProofPolicy is a workflow's declared external-proof opt-in, read
+// from the README's top-level `require-external-proof:` key. Default OFF
+// (byte-identical to absent) leaves non-dev workflows untouched.
+type externalProofPolicy int
+
+const (
+	externalProofOff externalProofPolicy = iota
+	externalProofOn
+)
+
+// resolveExternalProofPolicy reads the README's top-level
+// `require-external-proof:` key and returns the declared policy. An absent or
+// empty key, or an explicit `false`, defaults to externalProofOff —
+// byte-identical to a workflow that never declared the key. An unknown value
+// is rejected loudly rather than silently coerced, so a typo
+// (`require-external-proof: tru`) fails fast instead of silently allowing the
+// close.
+func resolveExternalProofPolicy(definitionDir string) (externalProofPolicy, error) {
+	value := strings.TrimSpace(ParseFrontmatter(filepath.Join(definitionDir, "README.md"))["require-external-proof"])
+	switch value {
+	case "", "false":
+		return externalProofOff, nil
+	case "true":
+		return externalProofOn, nil
+	default:
+		return externalProofOff, fmt.Errorf("README require-external-proof: must be 'true' or 'false' (or absent for the default 'false'), not '%s'", value)
+	}
+}
+
+// classifyEntityFile reads the entity file at path and returns the classifier
+// findings against its body. A missing or unreadable file yields no flags
+// (the FO surfaces a missing-entity defect elsewhere; the classifier is not
+// the right layer to escalate I/O errors).
+func classifyEntityFile(path string) []ACFlag {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	return ClassifyEntityACs(stripFrontmatter(data))
+}
+
+// flaggedACLabels returns a `[AC-1,AC-3]` shaped string for an error message,
+// pulled from the leading `**AC-N — ...` of each header.
+func flaggedACLabels(flags []ACFlag) string {
+	labels := make([]string, 0, len(flags))
+	for _, f := range flags {
+		labels = append(labels, acLabel(f.Header))
+	}
+	return strings.Join(labels, ",")
+}
+
+// acLabelRe extracts `AC-N` from a `**AC-N — …**` header line.
+var acLabelRe = regexp.MustCompile(`AC-[0-9]+`)
+
+func acLabel(header string) string {
+	return acLabelRe.FindString(header)
+}

--- a/internal/status/external_proof.go
+++ b/internal/status/external_proof.go
@@ -54,13 +54,20 @@ var selfPhraseRes = []*regexp.Regexp{
 // externalTokenRe captures any token that proves the AC's proof cites
 // something runnable / observable outside the entity body. Presence of ANY
 // token clears the AC, so a CI run on the entity's PR no longer false-positives
-// even when the prose says "this entity's own PR".
+// even when the prose says "this entity's own PR". The build/compile/lint and
+// generalized live-pilot families (no literal-article dependency) clear the
+// adversarial families the cycle-1 audit surfaced; the release-artifact and
+// commit/GitHub families cover macOS-release and post-merge proof shapes.
 var externalTokenRe = regexp.MustCompile(`(?i)` + strings.Join([]string{
 	`\btest\b`, `\.go\b`, `exit\s`, `exit-code`, `exit code`, `command`, `\bstatus\b`,
 	`--\w+`, `fixture`, `golden`, `byte`, `on-disk`, `stdout`, `stderr`, `assert`, `parser`,
 	`mutator`, `frontmatter`, `code path`, `command/parser`,
-	`runs? the`, `running the`, `invok`, `drive the`, `driving the`,
+	`runs? the`, `running the`, `invok`,
+	`\bdrives?\b`, `\bdriving\b`, `\bpilots?\b`, `behavioral pilot`, `runtime behavior`,
 	`\bCI\b`, `\bPR\b`, `live job`, `green`, `workflow file`,
+	`\bbuild\b`, `\bcompil`, `\bvet\b`, `\bgofmt\b`, `\blint\b`,
+	`\bbrew\b`, `\bspctl\b`, `\bgoreleaser\b`, `\bnotariz`, `\bcask\b`, `\brelease\b`, `\bbinary\b`,
+	`\bcommit\b`, `\bURL\b`, `\bGitHub\b`, `\bGH\b`, `\bmerged\b`, `\blanded\b`, `\b[a-f0-9]{7,}\b`,
 }, "|"))
 
 // stripFrontmatter returns the body of an entity file — the bytes after the
@@ -112,12 +119,20 @@ func ClassifyEntityACs(body string) []ACFlag {
 		}
 		block := strings.Join(current, "\n")
 		clause := isolateProofClause(block)
+		// Quote-stripping protects the self-phrase match from a QUOTED example
+		// of the antipattern (a clause that quotes "this entity's decision
+		// section" as a fixture is not itself self-referential).
 		cleaned := quotedSpanRe.ReplaceAllString(clause, " ")
 		matched := matchSelfPhrase(cleaned)
 		if matched == "" {
 			return
 		}
-		if externalTokenRe.MatchString(cleaned) {
+		// External-token scanning runs over the UNSTRIPPED clause so a backtick-
+		// fenced external token (the corpus convention for `--cask` / `spctl` /
+		// `goreleaser` references) still clears the AC. Self-phrase matching
+		// against the stripped clause + external-token matching against the
+		// unstripped clause give the precision we want on both sides.
+		if externalTokenRe.MatchString(clause) {
 			return
 		}
 		flags = append(flags, ACFlag{
@@ -185,20 +200,22 @@ const (
 
 // resolveExternalProofPolicy reads the README's top-level
 // `require-external-proof:` key and returns the declared policy. An absent or
-// empty key, or an explicit `false`, defaults to externalProofOff —
-// byte-identical to a workflow that never declared the key. An unknown value
-// is rejected loudly rather than silently coerced, so a typo
-// (`require-external-proof: tru`) fails fast instead of silently allowing the
-// close.
+// empty key (including `key: # comment` and `key: null`, which yaml.v3
+// decodes to an empty scalar), or an explicit `false`, defaults to
+// externalProofOff — byte-identical to a workflow that never declared the
+// key. An unknown value is rejected loudly rather than silently coerced, so a
+// typo (`require-external-proof: tru`) fails fast instead of silently allowing
+// the close. The error message enumerates the absent-equivalent shapes so a
+// reader who hits the typo guard understands `key:` / `key: null` are valid.
 func resolveExternalProofPolicy(definitionDir string) (externalProofPolicy, error) {
 	value := strings.TrimSpace(ParseFrontmatter(filepath.Join(definitionDir, "README.md"))["require-external-proof"])
 	switch value {
-	case "", "false":
+	case "", "false", "null", "~":
 		return externalProofOff, nil
 	case "true":
 		return externalProofOn, nil
 	default:
-		return externalProofOff, fmt.Errorf("README require-external-proof: must be 'true' or 'false' (or absent for the default 'false'), not '%s'", value)
+		return externalProofOff, fmt.Errorf("README require-external-proof: must be 'true' or 'false' (or absent / empty / null for the default 'false'), not '%s'", value)
 	}
 }
 

--- a/internal/status/external_proof_test.go
+++ b/internal/status/external_proof_test.go
@@ -174,6 +174,194 @@ func TestClassifierPrecisionRecallOnLiveCorpus(t *testing.T) {
 	}
 }
 
+// TestNoExternalProofGuardOnReadPaths locks the cycle-2 F1 regression: under
+// `require-external-proof: true` AND with a self-referential entity present,
+// the read surfaces (`sd status`, `--next`, `--boot`, `--next-id`) must exit 0.
+// The classifier gate fires only on the mutation surface (runSet terminal-set)
+// and the explicit `--validate` command; a read path failing on a flagged AC
+// would lock the FO out of the very listing they need to see the broken entity.
+func TestNoExternalProofGuardOnReadPaths(t *testing.T) {
+	env := pinnedEnv(t)
+	root := stageExternalProofFixture(t, "require-external-proof: true\n")
+
+	for _, args := range [][]string{
+		{"--workflow-dir", root},
+		{"--workflow-dir", root, "--next"},
+		{"--workflow-dir", root, "--boot"},
+		{"--workflow-dir", root, "--next-id"},
+	} {
+		name := strings.Join(args[2:], " ")
+		if name == "" {
+			name = "default-table"
+		}
+		t.Run(name, func(t *testing.T) {
+			nOut, nErr, nCode := runNative(t, root, env, args...)
+			if nCode != 0 {
+				t.Fatalf("read path %q must exit 0 under require-external-proof: true, got %d\nstdout=%q\nstderr=%q",
+					args, nCode, nOut, nErr)
+			}
+			if strings.Contains(nErr, "self-referential AC proof") {
+				t.Fatalf("read path %q must not emit the self-referential guard error, stderr=%q", args, nErr)
+			}
+		})
+	}
+
+	// --validate, on the other hand, MUST still fire — it's the explicit
+	// surface the gate keys on.
+	_, vErr, vCode := runNative(t, root, env, "--workflow-dir", root, "--validate")
+	if vCode != 1 || !strings.Contains(vErr, "self-referential AC proof") {
+		t.Fatalf("--validate must opt INTO the external-proof check, got code=%d stderr=%q", vCode, vErr)
+	}
+}
+
+// TestExternalTokensClearSelfPhrase locks the cycle-2 L3-F1/L3-F2/L3-F3/L3-F4
+// vocabulary additions: a self-phrased AC whose proof clause cites any of the
+// build/compile/lint, live-pilot (no literal-article dependency), release-
+// artifact, or commit/URL/GitHub families must NOT flag. Each subtest is a
+// minimal classifier-level body fixture proving the relevant token clears the
+// self-phrase.
+func TestExternalTokensClearSelfPhrase(t *testing.T) {
+	cases := []struct {
+		name   string
+		clause string
+	}{
+		// L3-F1: build/compile/vet/gofmt/lint.
+		{"go-build", "Verified by: `go build ./...` succeeds against this entity's renamed files."},
+		{"gofmt", "Verified by: `gofmt -l .` returns empty on this entity's tree."},
+		{"go-vet", "Verified by: `go vet ./...` succeeds on this entity's package."},
+		{"compile", "Verified by: a downstream caller compiles cleanly against this entity's new API."},
+		{"lint", "Verified by: a lint pass clears this entity's renamed identifiers."},
+
+		// L3-F2: generalized live-pilot vocabulary (no literal-article dependency).
+		{"drives-lifecycle", "Verified by: a behavioral pilot on a real entity drives this entity's lifecycle."},
+		{"pilots-merge", "Verified by: the FO pilots this entity through merge."},
+		{"runtime-behavior", "Verified by: runtime behavior of the registry drives this entity's mod-block clear."},
+
+		// L3-F3: release-artifact vocabulary.
+		{"brew", "Verified by: a `brew install` against this entity's cask succeeds."},
+		{"spctl", "Verified by: `spctl --assess --type execute` clears this entity's binary."},
+		{"goreleaser", "Verified by: a `goreleaser` run produces this entity's artifact."},
+		{"notarize", "Verified by: notarize a binary derived from this entity's commit."},
+
+		// L3-F4: commit/URL/GitHub/merged vocabulary.
+		{"commit-url", "Verified by: opening this entity's commit URL on GitHub renders the diff."},
+		{"merged", "Verified by: this entity's PR has merged to main."},
+		{"landed", "Verified by: the change landed on main in this entity's commit."},
+		{"hex-shape", "Verified by: this entity's resulting commit deadbeef carries the rename."},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			body := "**AC-1 — A property of this entity's design.**\n" + tc.clause + "\n"
+			flags := ClassifyEntityACs(body)
+			if len(flags) != 0 {
+				t.Fatalf("clause %q should clear the self-phrase, got flags=%+v", tc.clause, flags)
+			}
+		})
+	}
+}
+
+// TestSelfPhraseStillFlagsWithoutExternalToken locks that the vocabulary
+// additions did not over-correct: a truly self-referential AC (self-phrase
+// present, no external token) still flags. This is the recall side of the
+// precision/recall = 1.0 invariant.
+func TestSelfPhraseStillFlagsWithoutExternalToken(t *testing.T) {
+	cases := []string{
+		"**AC-1 — Intent.**\nVerified by: review of this entity's decision section.\n",
+		"**AC-2 — Intent.**\nVerified by: the entity's own decision states the intent.\n",
+		"**AC-3 — Intent.**\nVerified by: re-reading this entity's body confirms the intent.\n",
+	}
+	for i, body := range cases {
+		body := body
+		t.Run(acLabel(strings.Split(body, "\n")[0]), func(t *testing.T) {
+			flags := ClassifyEntityACs(body)
+			if len(flags) != 1 {
+				t.Fatalf("case %d should flag exactly once, got %+v", i, flags)
+			}
+		})
+	}
+}
+
+// TestExternalTokenInBacktickStillClears locks the cycle-2 L3-F3 strip-order
+// fix: a self-phrased AC whose external token sits inside backticks must
+// still clear. The fix runs externalTokenRe against the UNSTRIPPED clause so
+// `--cask` inside backticks (the corpus convention) is honored.
+func TestExternalTokenInBacktickStillClears(t *testing.T) {
+	body := "**AC-1 — A property of this entity's design.**\n" +
+		"Verified by: `--cask` against this entity's binary.\n"
+	flags := ClassifyEntityACs(body)
+	if len(flags) != 0 {
+		t.Fatalf("backtick-quoted external token must clear the self-phrase, got %+v", flags)
+	}
+}
+
+// TestQuotedSelfPhraseStillDoesNotFlag locks that the strip-order change did
+// not regress the original quote-stripping intent: a clause that QUOTES the
+// self-phrase as an example (not as the live proof) must still NOT flag.
+func TestQuotedSelfPhraseStillDoesNotFlag(t *testing.T) {
+	body := "**AC-1 — A property.**\n" +
+		"Verified by: a Go test refusing \"this entity's decision section\" as proof.\n"
+	flags := ClassifyEntityACs(body)
+	if len(flags) != 0 {
+		t.Fatalf("quoted self-phrase + external token must not flag, got %+v", flags)
+	}
+}
+
+// TestExternalProofPolicyEmptyAfterColonIsOff locks the cycle-2 F2 polish:
+// `require-external-proof:` (empty after colon, including comment-only and
+// null) coerces to OFF, byte-identical to absent. The error message
+// enumerates these as absent-equivalent shapes so a reader who hits the typo
+// guard understands them.
+func TestExternalProofPolicyEmptyAfterColonIsOff(t *testing.T) {
+	cases := []struct {
+		name        string
+		readmeOptIn string
+	}{
+		{"empty-after-colon", "require-external-proof:\n"},
+		{"comment-only", "require-external-proof: # off for now\n"},
+		{"explicit-null", "require-external-proof: null\n"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			readme := "---\nid-style: sequential\n" + tc.readmeOptIn + "---\n\n# Fixture\n"
+			if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(readme), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			policy, err := resolveExternalProofPolicy(dir)
+			if err != nil {
+				t.Fatalf("empty/comment/null after colon should not error, got %v", err)
+			}
+			if policy != externalProofOff {
+				t.Fatalf("empty/comment/null after colon should resolve to OFF, got %v", policy)
+			}
+		})
+	}
+}
+
+// TestExternalProofPolicyTypoErrorEnumeratesShapes locks the cycle-2 F2
+// polish: the typo-rejection error message includes the absent-equivalent
+// shapes so a reader hitting the guard knows `key:` / `key: null` are valid.
+func TestExternalProofPolicyTypoErrorEnumeratesShapes(t *testing.T) {
+	dir := t.TempDir()
+	readme := "---\nid-style: sequential\nrequire-external-proof: tru\n---\n\n# Fixture\n"
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(readme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := resolveExternalProofPolicy(dir)
+	if err == nil {
+		t.Fatal("typo should reject loudly")
+	}
+	msg := err.Error()
+	for _, want := range []string{"'tru'", "absent", "empty", "null"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q should mention %q", msg, want)
+		}
+	}
+}
+
 // stageExternalProofFixture copies testdata/external-proof-workflow into a
 // fresh git-initialized temp dir, then rewrites the README's
 // `require-external-proof:` line to optIn (which is "" for the absent case or

--- a/internal/status/external_proof_test.go
+++ b/internal/status/external_proof_test.go
@@ -1,0 +1,228 @@
+// ABOUTME: External-proof guard tests — opt-in default-off, shared-classifier
+// ABOUTME: invariant, and the live-corpus precision/recall = 1.0 invariant.
+package status
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestExternalProofOptInDefaultOff locks AC-3: under `require-external-proof:
+// false` AND under the absent default, neither the terminal-set guard nor the
+// --validate sub-check fires, and ordinary read flows are never gated.
+func TestExternalProofOptInDefaultOff(t *testing.T) {
+	cases := []struct {
+		name        string
+		readmeOptIn string // the require-external-proof line, or "" for absent
+	}{
+		{"absent", ""},
+		{"explicit-false", "require-external-proof: false\n"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := pinnedEnv(t)
+			root := stageExternalProofFixture(t, tc.readmeOptIn)
+
+			// Terminal --set on the self-ref entity must succeed: the guard is silent.
+			args := []string{"--workflow-dir", root, "--set", "010-self-ref-only", "status=done"}
+			_, nErr, nCode := runNative(t, root, env, args...)
+			if nCode != 0 {
+				t.Fatalf("--set should exit 0 when guard is off, got %d (%q)", nCode, nErr)
+			}
+			fm := readFrontmatter(t, filepath.Join(root, "010-self-ref-only.md"))
+			if !strings.Contains(fm, "status: done") {
+				t.Fatalf("self-ref entity should have advanced to done, fm=%s", fm)
+			}
+
+			// --validate must return VALID when guard is off.
+			vOut, _, vCode := runNative(t, root, env, "--workflow-dir", root, "--validate")
+			if vCode != 0 || !strings.Contains(vOut, "VALID") {
+				t.Fatalf("--validate should return VALID exit 0, got code=%d stdout=%q", vCode, vOut)
+			}
+
+			// Default table read must exit 0; --next and --boot must also exit 0.
+			_, _, rCode := runNative(t, root, env, "--workflow-dir", root)
+			if rCode != 0 {
+				t.Fatalf("default table read should exit 0 when guard is off, got %d", rCode)
+			}
+			_, _, nxCode := runNative(t, root, env, "--workflow-dir", root, "--next")
+			if nxCode != 0 {
+				t.Fatalf("--next should exit 0 when guard is off, got %d", nxCode)
+			}
+			_, _, bCode := runNative(t, root, env, "--workflow-dir", root, "--boot")
+			if bCode != 0 {
+				t.Fatalf("--boot should exit 0 when guard is off, got %d", bCode)
+			}
+		})
+	}
+}
+
+// TestClassifierIsSharedBySetAndValidate locks AC-4: a single shared classifier
+// serves both the terminal-set guard and the --validate sub-check. Verified by
+// (1) a structural single-definition assertion (`grep -c "^func ClassifyEntityACs"`
+// over internal/status/*.go returns 1) and (2) a runtime call-counter that
+// both surfaces bump in one test.
+func TestClassifierIsSharedBySetAndValidate(t *testing.T) {
+	// Structural invariant: exactly one definition site of ClassifyEntityACs
+	// in internal/status/*.go. Reads the real parsed file content.
+	defRe := regexp.MustCompile(`(?m)^func ClassifyEntityACs\b`)
+	matches := 0
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read . : %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		matches += len(defRe.FindAllIndex(data, -1))
+	}
+	if matches != 1 {
+		t.Fatalf("ClassifyEntityACs must be defined exactly once across internal/status/*.go, got %d definitions", matches)
+	}
+
+	// Runtime invariant: both runSet and validateWorkflow exercise the same
+	// classifier — verified by a single test that runs both surfaces against
+	// the same fixture and asserts the shared call counter advanced for each.
+	env := pinnedEnv(t)
+	root := stageExternalProofFixture(t, "require-external-proof: true\n")
+
+	before := classifierCallCount
+	// --validate run touches the classifier per active entity. Use the
+	// counter delta rather than its absolute value (other tests may have run
+	// first and bumped it).
+	_, _, _ = runNative(t, root, env, "--workflow-dir", root, "--validate")
+	afterValidate := classifierCallCount
+	if afterValidate <= before {
+		t.Fatalf("--validate did not exercise the classifier (counter %d → %d)", before, afterValidate)
+	}
+	// --set terminal advance triggers the runSet guard's classifier call on
+	// the targeted entity. Use the real-proof entity so the guard exits 0; we
+	// only care that the classifier ran.
+	_, _, _ = runNative(t, root, env, "--workflow-dir", root, "--set", "020-real-proof", "status=done")
+	afterSet := classifierCallCount
+	if afterSet <= afterValidate {
+		t.Fatalf("--set did not exercise the classifier (counter %d → %d)", afterValidate, afterSet)
+	}
+}
+
+// TestClassifierPrecisionRecallOnLiveCorpus locks AC-5: walk every index.md
+// under docs/dev/.spacedock-state/ (active + _archive/) and assert the flagged
+// set is EXACTLY {external-tracker-checkpoint/index.md AC-6}.
+func TestClassifierPrecisionRecallOnLiveCorpus(t *testing.T) {
+	stateRoot := liveStateRoot(t)
+	if stateRoot == "" {
+		t.Skip("live .spacedock-state corpus not reachable from internal/status test cwd")
+	}
+
+	type hit struct {
+		path  string
+		label string
+	}
+	var hits []hit
+
+	err := filepath.Walk(stateRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			if info.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Base(path) != "index.md" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		for _, f := range ClassifyEntityACs(stripFrontmatter(data)) {
+			rel, _ := filepath.Rel(stateRoot, path)
+			hits = append(hits, hit{path: rel, label: acLabel(f.Header)})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", stateRoot, err)
+	}
+
+	const wantPath = "_archive/external-tracker-checkpoint/index.md"
+	const wantLabel = "AC-6"
+	if len(hits) != 1 {
+		var lines []string
+		for _, h := range hits {
+			lines = append(lines, h.path+" "+h.label)
+		}
+		t.Fatalf("classifier must flag EXACTLY one AC on the live corpus, got %d:\n%s",
+			len(hits), strings.Join(lines, "\n"))
+	}
+	if hits[0].path != wantPath || hits[0].label != wantLabel {
+		t.Fatalf("flagged set mismatch: got {%s %s}, want {%s %s}",
+			hits[0].path, hits[0].label, wantPath, wantLabel)
+	}
+}
+
+// stageExternalProofFixture copies testdata/external-proof-workflow into a
+// fresh git-initialized temp dir, then rewrites the README's
+// `require-external-proof:` line to optIn (which is "" for the absent case or
+// the full line including the newline). Returns the absolute root.
+func stageExternalProofFixture(t *testing.T, optIn string) string {
+	t.Helper()
+	src, err := filepath.Abs(filepath.Join("testdata", "external-proof-workflow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := t.TempDir()
+	cpTree(t, src, dst)
+
+	// Rewrite README to replace the fixture's `require-external-proof: true\n`
+	// with the requested optIn. An empty optIn omits the key entirely.
+	readme := filepath.Join(dst, "README.md")
+	data, err := os.ReadFile(readme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replaced := bytes.Replace(data, []byte("require-external-proof: true\n"), []byte(optIn), 1)
+	if err := os.WriteFile(readme, replaced, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gitInit(t, dst)
+	return dst
+}
+
+// liveStateRoot resolves the live .spacedock-state checkout absolute path
+// relative to the test cwd (internal/status), walking up to the repo root.
+// Returns "" when the corpus is not present (e.g. in a packaging-time build).
+func liveStateRoot(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	dir := cwd
+	for i := 0; i < 6; i++ {
+		candidate := filepath.Join(dir, "docs", "dev", ".spacedock-state")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -324,7 +324,9 @@ func runRead(probe claudeteam.TeamStateProbe, roots roots, args []string, e env,
 		if len(incompatible) > 0 {
 			return errExit(stderr, "--validate cannot be combined with "+strings.Join(incompatible, ", "))
 		}
-		errs := validateWorkflow(roots.definitionDir, roots.entityDir, idStyle, stderr)
+		// Explicit --validate command opts INTO the external-proof sub-check.
+		// The read-path pre-check (failOnValidationErrors) passes false.
+		errs := validateWorkflow(roots.definitionDir, roots.entityDir, idStyle, true, stderr)
 		if len(errs) > 0 {
 			for _, er := range errs {
 				fmt.Fprintln(stderr, er)

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -214,6 +214,29 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 		fmt.Fprintf(stderr, "Warning: --force overriding mod-block (%s) on entity %s\n", modBlock, slug)
 	}
 
+	// require-external-proof guard: when the workflow opts in, a terminal --set
+	// on an entity whose ACs are only self-referentially proven exits 1 and
+	// leaves the frontmatter untouched. Layered after mod-block + merge-hook so
+	// the order of guard messages mirrors the order of declared invariants.
+	// --force bypasses with a warning in the same idiom as the mod-block bypass.
+	proofPolicy, perr := resolveExternalProofPolicy(roots.definitionDir)
+	if perr != nil {
+		return errExit(stderr, perr.Error())
+	}
+	if proofPolicy == externalProofOn && isTerminalUpdate() {
+		flags := classifyEntityFile(entityPath)
+		if len(flags) > 0 {
+			if force {
+				fmt.Fprintf(stderr, "Warning: --force overriding require-external-proof on entity %s\n", slug)
+			} else {
+				return errExit(stderr, fmt.Sprintf(
+					"entity %s cannot advance to terminal — AC(s) [%s] have self-referential proof "+
+						"(no test, command, file, or on-disk-state cited). Add an external-proof clause to each, or use --force to bypass.",
+					slug, flaggedACLabels(flags)))
+			}
+		}
+	}
+
 	resolvedFields, err := updateFrontmatter(entityPath, set.updates)
 	if err != nil {
 		return errExit(stderr, err.Error())

--- a/internal/status/native_runner.go
+++ b/internal/status/native_runner.go
@@ -350,7 +350,12 @@ func dispatch(probe claudeteam.TeamStateProbe, args []string, dir string, e env,
 // failOnValidationErrors prints validation errors to stderr and returns 1 when
 // any exist, else 0. Matches fail_on_validation_errors.
 func failOnValidationErrors(roots roots, idStyle string, stderr io.Writer) int {
-	errs := validateWorkflow(roots.definitionDir, roots.entityDir, idStyle, stderr)
+	// Read-path validation pre-check intentionally omits the external-proof
+	// sub-check: a self-referential AC must not lock the FO out of `sd status`
+	// / `--next` / `--boot` / `--next-id` — those are the surfaces they need to
+	// SEE the broken entity. The terminal-set guard in runSet still classifies
+	// directly, and the explicit `--validate` command opts the check in.
+	errs := validateWorkflow(roots.definitionDir, roots.entityDir, idStyle, false, stderr)
 	if len(errs) > 0 {
 		for _, err := range errs {
 			fmt.Fprintln(stderr, err)

--- a/internal/status/native_validate_test.go
+++ b/internal/status/native_validate_test.go
@@ -5,6 +5,7 @@ package status
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -112,6 +113,50 @@ stages:
 			})
 		})
 	}
+}
+
+// TestValidateFlagsSelfRefACs locks AC-2: under `require-external-proof: true`,
+// `spacedock status --validate` emits one standard `entityEvidence`-shaped line
+// per flagged AC and exits 1; a workflow with no self-referential ACs returns
+// VALID exit 0. Drives the testdata/external-proof-workflow/ fixture.
+func TestValidateFlagsSelfRefACs(t *testing.T) {
+	env := pinnedEnv(t)
+
+	t.Run("flags-self-ref", func(t *testing.T) {
+		root := stageExternalProofFixture(t, "require-external-proof: true\n")
+
+		_, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--validate")
+		if nCode != 1 {
+			t.Fatalf("--validate must exit 1 when self-ref ACs exist, got %d (stderr=%q)", nCode, nErr)
+		}
+		wantSubstr := "Error: self-referential AC proof (AC-1):"
+		if !strings.Contains(nErr, wantSubstr) {
+			t.Fatalf("stderr missing evidence line %q, got %q", wantSubstr, nErr)
+		}
+		for _, want := range []string{"workflow=", "scope=active", "slug=010-self-ref-only", "id=010", "path="} {
+			if !strings.Contains(nErr, want) {
+				t.Fatalf("stderr missing %q in evidence line, got %q", want, nErr)
+			}
+		}
+	})
+
+	t.Run("real-proof-only-valid", func(t *testing.T) {
+		root := stageExternalProofFixture(t, "require-external-proof: true\n")
+		// Delete the self-ref + force entities so only the real-proof one remains.
+		for _, name := range []string{"010-self-ref-only.md", "030-force-bypass.md"} {
+			if err := os.Remove(filepath.Join(root, name)); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		nOut, _, nCode := runNative(t, root, env, "--workflow-dir", root, "--validate")
+		if nCode != 0 {
+			t.Fatalf("--validate should return VALID with no self-ref ACs, got exit=%d", nCode)
+		}
+		if strings.TrimSpace(nOut) != "VALID" {
+			t.Fatalf("stdout should be VALID, got %q", nOut)
+		}
+	})
 }
 
 // TestNativeValidationGatesReads locks that a defect rejects an enumerate op

--- a/internal/status/testdata/external-proof-workflow/010-self-ref-only.md
+++ b/internal/status/testdata/external-proof-workflow/010-self-ref-only.md
@@ -1,0 +1,18 @@
+---
+id: "010"
+title: Self-referential AC only
+status: implementation
+score: "0.50"
+source: roadmap
+---
+
+# Self-referential AC only
+
+A terminal --set on this entity must be refused under
+`require-external-proof: true`.
+
+## Acceptance criteria
+
+**AC-1 — The intent is recorded in this entity's design section.**
+Verified by: review of this entity's decision section, which states the
+intent and cites the design rationale.

--- a/internal/status/testdata/external-proof-workflow/020-real-proof.md
+++ b/internal/status/testdata/external-proof-workflow/020-real-proof.md
@@ -1,0 +1,18 @@
+---
+id: "020"
+title: Real external proof
+status: implementation
+score: "0.50"
+source: roadmap
+---
+
+# Real external proof
+
+A terminal --set on this entity must succeed under
+`require-external-proof: true`.
+
+## Acceptance criteria
+
+**AC-1 — The classifier compiles and runs.**
+Verified by: a Go test `TestClassifierBasic` in `internal/status/external_proof_test.go`
+asserts the classifier returns a single flag for a constructed self-ref body.

--- a/internal/status/testdata/external-proof-workflow/030-force-bypass.md
+++ b/internal/status/testdata/external-proof-workflow/030-force-bypass.md
@@ -1,0 +1,18 @@
+---
+id: "030"
+title: Force-bypass entity
+status: implementation
+score: "0.50"
+source: roadmap
+---
+
+# Force-bypass entity
+
+Identical shape to 010-self-ref-only.md; used with --force to exercise the
+bypass-with-warning path.
+
+## Acceptance criteria
+
+**AC-1 — The intent is recorded in this entity's design section.**
+Verified by: review of this entity's decision section, which states the
+intent and cites the design rationale.

--- a/internal/status/testdata/external-proof-workflow/README.md
+++ b/internal/status/testdata/external-proof-workflow/README.md
@@ -1,0 +1,25 @@
+---
+entity-type: task
+entity-label: task
+entity-label-plural: tasks
+id-style: sequential
+require-external-proof: true
+stages:
+  defaults:
+    worktree: false
+    concurrency: 1
+  states:
+    - name: backlog
+      initial: true
+      gate: true
+    - name: ideation
+      gate: true
+    - name: implementation
+    - name: done
+      terminal: true
+---
+
+# External-Proof Fixture Workflow
+
+A fixture workflow opting into `require-external-proof: true` so the guard's
+terminal-set + --validate sub-check are exercised end to end.

--- a/internal/status/validate.go
+++ b/internal/status/validate.go
@@ -137,8 +137,13 @@ func validateWorkflowStageNames(definitionDir string) []string {
 // entities. Matches validate_workflow. definitionDir/entityDir are the absolute
 // README and entity roots; the workflow= evidence field uses the absolute
 // entityDir (the FO always passes an absolute --workflow-dir for enumerate ops,
-// so absolute == the oracle's literal here).
-func validateWorkflow(definitionDir, entityDir, idStyle string, stderr io.Writer) []string {
+// so absolute == the oracle's literal here). includeExternalProof scopes the
+// require-external-proof sub-check: only the explicit `--validate` command
+// passes true, so the read-path validation pre-check (cwd gate on
+// status/--next/--boot/--next-id) never fires the AC classifier. A read path
+// failing on a flagged AC would lock the FO out of the very listing they need
+// to see the broken entity.
+func validateWorkflow(definitionDir, entityDir, idStyle string, includeExternalProof bool, stderr io.Writer) []string {
 	var errs []string
 	errs = append(errs, findEntityFormConflicts(entityDir, entityDir, "active")...)
 	errs = append(errs, findEntityFormConflicts(filepath.Join(entityDir, "_archive"), PyJoin(entityDir, "_archive"), "archived")...)
@@ -157,6 +162,10 @@ func validateWorkflow(definitionDir, entityDir, idStyle string, stderr io.Writer
 		errs = append(errs, validateSlug(entities, entityDir)...)
 	case "sd-b32":
 		errs = append(errs, validateSDB32(entities, entityDir, sdDisplay)...)
+	}
+
+	if !includeExternalProof {
+		return errs
 	}
 
 	// require-external-proof sub-check: when the workflow opts in, every

--- a/internal/status/validate.go
+++ b/internal/status/validate.go
@@ -158,6 +158,32 @@ func validateWorkflow(definitionDir, entityDir, idStyle string, stderr io.Writer
 	case "sd-b32":
 		errs = append(errs, validateSDB32(entities, entityDir, sdDisplay)...)
 	}
+
+	// require-external-proof sub-check: when the workflow opts in, every
+	// active entity is classified and each flagged AC is emitted as a standard
+	// entityEvidence line. A typo in the README key is surfaced as the same
+	// kind of loud rejection findEntityFormConflicts uses for its own defects.
+	policy, perr := resolveExternalProofPolicy(definitionDir)
+	if perr != nil {
+		errs = append(errs, "Error: "+perr.Error())
+		return errs
+	}
+	if policy == externalProofOn {
+		for _, e := range entities {
+			if e.scope != "active" {
+				continue
+			}
+			for _, f := range classifyEntityFile(e.path) {
+				display := ""
+				if idStyle == "sd-b32" {
+					display = sdDisplay[e.storedID]
+				}
+				errs = append(errs, entityEvidence(e, entityDir,
+					"self-referential AC proof ("+acLabel(f.Header)+")", display))
+			}
+		}
+	}
+
 	return errs
 }
 


### PR DESCRIPTION
Block the spacedock binary from terminalizing or validating a dev-workflow task whose AC has no proof that can fail — a real test, command exit, file produced, or on-disk state — under a workflow-opt-in flag, with `--force` as the deliberate-exception bypass.

## What changed
- Add `ClassifyEntityACs` in `internal/status/external_proof.go` — a 5-step pure classifier (AC extract → proof-clause isolate → quote strip → self-phrase match → external-token absence) with a deny-vocabulary tuned against the live 271-AC corpus.
- Wire the classifier into `runSet`'s terminal-set guard (handlers.go) and `validateWorkflow`'s `--validate` sub-check (validate.go); read paths (`status`/`--next`/`--boot`/`--next-id`) are NOT gated.
- Opt-in via README top-level `require-external-proof: true` (default FALSE, byte-identical to absent); typo'd values fail loudly enumerating absent/empty/null.

## Evidence
- `go test ./...` 853/853 across 12 packages; `-race ./internal/status` 404/404.
- `TestClassifierPrecisionRecallOnLiveCorpus` pins precision/recall = 1.0 on the live 271-AC corpus (sole flag: `_archive/external-tracker-checkpoint AC-6`).
- `TestNoExternalProofGuardOnReadPaths` locks read-path bypass under opt-in.

---

[2a](/spacedock-dev/spacedock/blob/128041a9/require-external-proof-guard/index.md)