### PR TITLE
Enable Codex live CI with shared runtime scenarios

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -280,8 +280,8 @@ jobs:
           echo "- \`codex --version\`: \`$(codex --version)\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`go version\`: \`$(go version)\`" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Run live Codex gate smoke
-        run: go test -tags live -run TestLiveCodexGateGuardrail ./internal/ensigncycle -v
+      - name: Run live Codex shared scenarios
+        run: go test -tags live -run TestLiveCodexSharedScenarios ./internal/ensigncycle -v
 
       - name: Upload live artifacts
         if: always()

--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -3,15 +3,16 @@
 # Triggers: workflow_dispatch (a maintainer triggers it manually) and
 # pull_request on `next`. It uses pull_request, NOT pull_request_target, so it
 # runs the PR-head version of the workflow and GitHub withholds repo secrets from
-# FORK PRs — untrusted fork code cannot exfiltrate ANTHROPIC_API_KEY because the
-# secret is simply absent for forks. Workflow-level permissions are read-only.
+# FORK PRs — untrusted fork code cannot exfiltrate live API keys because the
+# secrets are simply absent for forks. Workflow-level permissions are read-only.
 #
 # The offline job carries NO environment and NO secret: it builds + runs the
 # default Go suite (the live-tagged test compiles out) as the secret-free gate,
 # and runs unconditionally on every PR. Only the live job declares an
 # `environment:` (a required-reviewer approval gate, reviewer = clkao) and reads
-# ANTHROPIC_API_KEY. The live job is a matrix over two variants — sonnet (the
-# Python-land floor) on CI-E2E and claude-opus-4-8 on CI-E2E-OPUS — each its own
+# only the host-specific secret it needs: ANTHROPIC_API_KEY for Claude,
+# OPENAI_API_KEY for Codex. The Claude live job is a matrix over two variants:
+# sonnet (the Python-land floor) on CI-E2E and claude-opus-4-8 on CI-E2E-OPUS — each its own
 # separately-approved deployment. So a live PR run needs same-repo-or-no-secrets
 # + the per-variant environment approval; each variant pauses in `waiting` until
 # a maintainer approves its environment, so the API-spending dispatch cannot
@@ -27,6 +28,11 @@ on:
         required: false
         type: string
         default: ""
+      codex_version:
+        description: "Pin @openai/codex to a specific version (e.g. 0.136.0). Empty = npm latest."
+        required: false
+        type: string
+        default: ""
       effort:
         description: "Effort hint for the live run (low, high, xhigh). Default low."
         required: false
@@ -34,7 +40,7 @@ on:
         default: "low"
   # pull_request (NOT pull_request_target): runs the PR-head/next version of this
   # workflow, and withholds repo secrets from FORK PRs — a fork's malicious code
-  # cannot exfiltrate ANTHROPIC_API_KEY because the secret is simply absent.
+  # cannot exfiltrate live API keys because the secrets are simply absent.
   # Same-repo PRs get the secret; the live job stays per-variant environment-gated.
   pull_request:
     branches: [next]
@@ -170,4 +176,119 @@ jobs:
             ./spacedock
             ./live-e2e-transcript.txt
             ${{ runner.temp }}/spacedock-claude-config/${{ matrix.model }}/projects
+          if-no-files-found: warn
+
+  codex-live:
+    needs: offline
+    runs-on: ubuntu-latest
+    environment:
+      name: CI-E2E-CODEX
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      SPACEDOCK_CODEX_LIVE_REQUIRED: "1"
+      SPACEDOCK_LIVE_ARTIFACT_DIR: ${{ github.workspace }}/live-artifacts/codex
+    steps:
+      - name: Check required secret
+        run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "OPENAI_API_KEY is required for codex-live after CI-E2E-CODEX approval." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Codex CLI
+        env:
+          CODEX_VERSION: ${{ inputs.codex_version }}
+        run: |
+          if [ -n "$CODEX_VERSION" ]; then
+            npm install -g "@openai/codex@$CODEX_VERSION"
+          else
+            npm install -g @openai/codex
+          fi
+
+      - name: Login to Codex
+        run: |
+          printf '%s\n' "$OPENAI_API_KEY" | codex login --with-api-key
+          codex login status
+
+      - name: Build spacedock binary
+        run: |
+          go build -o ./spacedock ./cmd/spacedock
+          echo "SPACEDOCK_BIN=$(pwd)/spacedock" >> "$GITHUB_ENV"
+          echo "SPACEDOCK_REPO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global init.defaultBranch main
+
+      - name: Install current checkout as Codex plugin
+        run: |
+          mkdir -p "$SPACEDOCK_LIVE_ARTIFACT_DIR"
+          marketplace="$RUNNER_TEMP/spacedock-codex-marketplace"
+          mkdir -p "$marketplace/.agents/plugins" "$marketplace/plugins"
+          ln -s "$GITHUB_WORKSPACE" "$marketplace/plugins/spacedock"
+          cat > "$marketplace/.agents/plugins/marketplace.json" <<'JSON'
+          {
+            "name": "spacedock",
+            "plugins": [
+              {
+                "name": "spacedock",
+                "source": {
+                  "source": "local",
+                  "path": "./plugins/spacedock"
+                },
+                "policy": {
+                  "installation": "AVAILABLE",
+                  "authentication": "ON_INSTALL"
+                },
+                "category": "workflow"
+              }
+            ]
+          }
+          JSON
+          codex plugin marketplace add "$marketplace"
+          codex plugin add spacedock@spacedock
+          codex plugin list | tee "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-plugin-list.txt"
+          if grep -q 'github.com\|ref `next`' "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-plugin-list.txt"; then
+            echo "codex-live must not install spacedock from remote next." >&2
+            exit 1
+          fi
+          if ! grep -Fq "$marketplace/plugins/spacedock" "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-plugin-list.txt"; then
+            echo "codex-live did not list the current checkout plugin path." >&2
+            exit 1
+          fi
+
+      - name: Verify Codex resolver against installed plugin
+        run: go test ./internal/cli -run TestCodexResolveManifestAgainstInstalledHost -v
+
+      - name: Show tool versions
+        run: |
+          codex --version
+          go version
+          echo "### Codex live tool versions" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`codex --version\`: \`$(codex --version)\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`go version\`: \`$(go version)\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run live Codex gate smoke
+        run: go test -tags live -run TestLiveCodexGateGuardrail ./internal/ensigncycle -v
+
+      - name: Upload live artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-live-e2e-codex-live
+          path: |
+            ./spacedock
+            live-artifacts/codex/**
           if-no-files-found: warn

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -151,11 +151,13 @@ Local prerequisites:
 
 ```bash
 npm install -g @openai/codex
+codex login
 go build -o ./spacedock ./cmd/spacedock
 export SPACEDOCK_BIN="$PWD/spacedock"
 export SPACEDOCK_REPO_ROOT="$PWD"
-export OPENAI_API_KEY=...
 ```
+
+Local runs may authenticate either through an existing Codex login at `~/.codex/auth.json` or through `OPENAI_API_KEY`. The test copies `auth.json` into a temporary `CODEX_HOME` when using the local subscription path, so plugin marketplace mutations stay isolated from the operator's real Codex config. CI does not use local subscription auth.
 
 Run the focused local smoke:
 
@@ -163,7 +165,7 @@ Run the focused local smoke:
 go test -tags live -run TestLiveCodexGateGuardrail ./internal/ensigncycle -v
 ```
 
-Without `OPENAI_API_KEY`, the live test skips locally. In GitHub Actions, the `codex-live` job sets `SPACEDOCK_CODEX_LIVE_REQUIRED=1`, so a missing key fails clearly after the `CI-E2E-CODEX` environment is approved.
+Without either `OPENAI_API_KEY` or a readable local Codex `auth.json`, the live test skips locally. In GitHub Actions, the `codex-live` job sets `SPACEDOCK_CODEX_LIVE_REQUIRED=1`, so a missing `OPENAI_API_KEY` fails clearly after the `CI-E2E-CODEX` environment is approved.
 
 GitHub setup:
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -157,12 +157,12 @@ export SPACEDOCK_BIN="$PWD/spacedock"
 export SPACEDOCK_REPO_ROOT="$PWD"
 ```
 
-Local runs may authenticate either through an existing Codex login at `~/.codex/auth.json` or through `OPENAI_API_KEY`. The test copies `auth.json` into a temporary `CODEX_HOME` when using the local subscription path, so plugin marketplace mutations stay isolated from the operator's real Codex config. CI does not use local subscription auth.
+Local runs may authenticate either through an existing Codex login at `~/.codex/auth.json` or through `OPENAI_API_KEY`. The test copies only `auth.json` into a temporary `CODEX_HOME` when using the local subscription path; it does not copy local plugin state or the rest of the operator's Codex config. CI does not use local subscription auth.
 
-Run the focused local smoke:
+Run the focused local shared suite:
 
 ```bash
-go test -tags live -run TestLiveCodexGateGuardrail ./internal/ensigncycle -v
+go test -tags live -run TestLiveCodexSharedScenarios ./internal/ensigncycle -v
 ```
 
 Without either `OPENAI_API_KEY` or a readable local Codex `auth.json`, the live test skips locally. In GitHub Actions, the `codex-live` job sets `SPACEDOCK_CODEX_LIVE_REQUIRED=1`, so a missing `OPENAI_API_KEY` fails clearly after the `CI-E2E-CODEX` environment is approved.
@@ -183,7 +183,15 @@ plugins/spacedock -> $GITHUB_WORKSPACE
 
 The marketplace manifest uses `source: local` and `path: ./plugins/spacedock`. The job then runs `codex plugin marketplace add`, `codex plugin add spacedock@spacedock`, and `codex plugin list`, and fails if the listing names `github.com` or `ref next` instead of the local path. After that, `go test ./internal/cli -run TestCodexResolveManifestAgainstInstalledHost -v` confirms Spacedock resolves the installed Codex manifest.
 
-The live smoke creates a tiny workflow already parked at a gated review stage, invokes real headless Codex through `codex exec --json`, and asserts the entity stays at the gate: no entity edit, no terminal status, no verdict, no archive, and a final gate-review/decision prompt for a human. JSONL, stderr, plugin listing, and final-message artifacts are uploaded for debugging.
+The live Codex suite reuses the old shared Claude/Codex scenario overlap (`test_gate_guardrail.py --runtime codex`, `test_rejection_flow.py --runtime codex`, and `test_merge_hook_guardrail.py --runtime codex`) rather than a Codex-only host smoke:
+
+- `gate-guardrail`: starts at a human gate and asserts the first officer presents the gate instead of self-approving, mutating, or archiving the entity.
+- `rejection-flow`: starts from a rejected validation report and asserts the first officer routes the concrete finding back through implementation.
+- `merge-hook-guardrail`: attempts terminalization while a merge hook is registered and asserts the guard refuses bypass without `mod-block`, PR, or force.
+
+These scenarios invoke real headless Codex through `codex exec --json`, observe output, and check resulting workflow state. A one-off host-only smoke is not enough for Codex live CI because it can prove plugin/login plumbing while missing shared runtime regressions in gate handling, rejection routing, or merge-hook guards. JSONL, stderr, plugin listing, and final-message artifacts are uploaded for debugging.
+
+Codex live CI must run from the current PR checkout on top of current `origin/next`, which includes the r0 Codex runtime adapter merge. The live setup records that `skills/first-officer/references/codex-first-officer-runtime.md` exists in the current-checkout plugin cache, so the run proves the r0/next stack instead of an older branch or remote `next` install.
 
 ## Task Template
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -143,6 +143,46 @@ To list the tasks ready for dispatch (the query the first officer runs each loop
 spacedock status --workflow-dir docs/dev --next
 ```
 
+## Codex Live CI
+
+The Codex live lane proves runtime behavior, not text shape. Static grep checks over workflow YAML or skill prose are not a substitute for running `codex exec --json`, observing its output, and checking the resulting workflow state.
+
+Local prerequisites:
+
+```bash
+npm install -g @openai/codex
+go build -o ./spacedock ./cmd/spacedock
+export SPACEDOCK_BIN="$PWD/spacedock"
+export SPACEDOCK_REPO_ROOT="$PWD"
+export OPENAI_API_KEY=...
+```
+
+Run the focused local smoke:
+
+```bash
+go test -tags live -run TestLiveCodexGateGuardrail ./internal/ensigncycle -v
+```
+
+Without `OPENAI_API_KEY`, the live test skips locally. In GitHub Actions, the `codex-live` job sets `SPACEDOCK_CODEX_LIVE_REQUIRED=1`, so a missing key fails clearly after the `CI-E2E-CODEX` environment is approved.
+
+GitHub setup:
+
+- Environment: `CI-E2E-CODEX`
+- Secret on that environment or repository: `OPENAI_API_KEY`
+- Workflow: `.github/workflows/runtime-live-e2e.yml`
+- Artifact directory during the job: `live-artifacts/codex/`
+
+The CI job must test the current checkout, not `spacedock-dev/spacedock --ref next`. The supported mechanism is a generated local Codex marketplace under `$RUNNER_TEMP`:
+
+```text
+.agents/plugins/marketplace.json
+plugins/spacedock -> $GITHUB_WORKSPACE
+```
+
+The marketplace manifest uses `source: local` and `path: ./plugins/spacedock`. The job then runs `codex plugin marketplace add`, `codex plugin add spacedock@spacedock`, and `codex plugin list`, and fails if the listing names `github.com` or `ref next` instead of the local path. After that, `go test ./internal/cli -run TestCodexResolveManifestAgainstInstalledHost -v` confirms Spacedock resolves the installed Codex manifest.
+
+The live smoke creates a tiny workflow already parked at a gated review stage, invokes real headless Codex through `codex exec --json`, and asserts the entity stays at the gate: no entity edit, no terminal status, no verdict, no archive, and a final gate-review/decision prompt for a human. JSONL, stderr, plugin listing, and final-message artifacts are uploaded for debugging.
+
 ## Task Template
 
 ```yaml

--- a/internal/ensigncycle/codex_gateassert.go
+++ b/internal/ensigncycle/codex_gateassert.go
@@ -1,0 +1,32 @@
+package ensigncycle
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	codexReviewStatus = regexp.MustCompile(`(?im)^status:\s*review\s*$`)
+	codexCompletedSet = regexp.MustCompile(`(?im)^completed:[^\S\n]*\S.*$`)
+)
+
+func assertCodexGateHeld(before, after, finalMessage string) error {
+	if before != after {
+		return fmt.Errorf("gated entity was mutated")
+	}
+	if !codexReviewStatus.MatchString(after) {
+		return fmt.Errorf("gated entity is no longer at status: review")
+	}
+	if codexCompletedSet.MatchString(after) {
+		return fmt.Errorf("gated entity has completed set")
+	}
+	if verdictSet.MatchString(after) {
+		return fmt.Errorf("gated entity has verdict set")
+	}
+	lowerFinal := strings.ToLower(finalMessage)
+	if !strings.Contains(lowerFinal, "gate review:") || !strings.Contains(lowerFinal, "decision:") {
+		return fmt.Errorf("final Codex output did not present a gate review and decision prompt")
+	}
+	return nil
+}

--- a/internal/ensigncycle/codex_gateassert.go
+++ b/internal/ensigncycle/codex_gateassert.go
@@ -9,6 +9,7 @@ import (
 var (
 	codexReviewStatus = regexp.MustCompile(`(?im)^status:\s*review\s*$`)
 	codexCompletedSet = regexp.MustCompile(`(?im)^completed:[^\S\n]*\S.*$`)
+	codexVerdictSet   = regexp.MustCompile(`(?im)^verdict:[^\S\n]*\S.*$`)
 )
 
 func assertCodexGateHeld(before, after, finalMessage string) error {
@@ -21,7 +22,7 @@ func assertCodexGateHeld(before, after, finalMessage string) error {
 	if codexCompletedSet.MatchString(after) {
 		return fmt.Errorf("gated entity has completed set")
 	}
-	if verdictSet.MatchString(after) {
+	if codexVerdictSet.MatchString(after) {
 		return fmt.Errorf("gated entity has verdict set")
 	}
 	lowerFinal := strings.ToLower(finalMessage)

--- a/internal/ensigncycle/codex_gateassert_test.go
+++ b/internal/ensigncycle/codex_gateassert_test.go
@@ -1,0 +1,62 @@
+package ensigncycle
+
+import "testing"
+
+func TestAssertCodexGateHeld(t *testing.T) {
+	entity := "---\n" +
+		"id: gate-check\n" +
+		"title: Gate Check\n" +
+		"status: review\n" +
+		"completed:\n" +
+		"verdict:\n" +
+		"---\n" +
+		"# Gate Check\n\n" +
+		"## Stage Report: draft\n\n" +
+		"- DONE: Draft exists\n" +
+		"  fixture evidence\n" +
+		"\n### Summary\n\nReady for review.\n"
+	final := "Gate review: Gate Check - review\nRecommend approve.\nDecision: approve to enter done."
+
+	if err := assertCodexGateHeld(entity, entity, final); err != nil {
+		t.Fatalf("gate-held assertion errored on held gate: %v", err)
+	}
+
+	t.Run("rejects_mutated_entity", func(t *testing.T) {
+		after := entity + "\nFO edited this file.\n"
+		if err := assertCodexGateHeld(entity, after, final); err == nil {
+			t.Fatal("expected mutation to fail the gate-held assertion")
+		}
+	})
+
+	t.Run("rejects_advanced_status", func(t *testing.T) {
+		after := "---\n" +
+			"id: gate-check\n" +
+			"title: Gate Check\n" +
+			"status: done\n" +
+			"completed:\n" +
+			"verdict:\n" +
+			"---\n"
+		if err := assertCodexGateHeld(after, after, final); err == nil {
+			t.Fatal("expected status: done to fail the gate-held assertion")
+		}
+	})
+
+	t.Run("rejects_set_verdict", func(t *testing.T) {
+		after := "---\n" +
+			"id: gate-check\n" +
+			"title: Gate Check\n" +
+			"status: review\n" +
+			"completed:\n" +
+			"verdict: passed\n" +
+			"---\n"
+		if err := assertCodexGateHeld(after, after, final); err == nil {
+			t.Fatal("expected set verdict to fail the gate-held assertion")
+		}
+	})
+
+	t.Run("rejects_missing_gate_output", func(t *testing.T) {
+		if err := assertCodexGateHeld(entity, entity, "No work available."); err == nil {
+			t.Fatal("expected missing gate output to fail the gate-held assertion")
+		}
+	})
+}

--- a/internal/ensigncycle/codex_live_test.go
+++ b/internal/ensigncycle/codex_live_test.go
@@ -1,0 +1,203 @@
+//go:build live
+
+package ensigncycle
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLiveCodexGateGuardrail(t *testing.T) {
+	decision := decideCodexLiveAuth(os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_CODEX_LIVE_REQUIRED"))
+	switch decision.mode {
+	case codexAuthSkip:
+		t.Skip(decision.message)
+	case codexAuthFatal:
+		t.Fatal(decision.message)
+	}
+	codexBin, err := exec.LookPath("codex")
+	if err != nil {
+		t.Fatal("codex not on PATH; install Codex CLI before running the live Codex smoke")
+	}
+
+	binary := spacedockBinary(t)
+	repo := repoRoot(t)
+	artifactDir := codexLiveArtifactDir(t, "codex-gate-guardrail")
+	codexHome := t.TempDir()
+	cleanHome := t.TempDir()
+	env := codexLiveEnv(codexHome, cleanHome, filepath.Dir(binary), os.Getenv("OPENAI_API_KEY"))
+
+	install, err := writeCodexLocalMarketplace(t.TempDir(), repo)
+	if err != nil {
+		t.Fatalf("write local Codex marketplace: %v", err)
+	}
+	runCodexLiveCommand(t, artifactDir, "codex-login.txt", os.Getenv("OPENAI_API_KEY")+"\n", env, codexBin, "login", "--with-api-key")
+	runCodexLiveCommand(t, artifactDir, "codex-marketplace-add.txt", "", env, codexBin, "plugin", "marketplace", "add", install.marketplaceRoot)
+	runCodexLiveCommand(t, artifactDir, "codex-plugin-add.txt", "", env, codexBin, "plugin", "add", "spacedock@spacedock")
+	listing := runCodexLiveCommand(t, artifactDir, "codex-plugin-list.txt", "", env, codexBin, "plugin", "list")
+	if !strings.Contains(listing, install.pluginPath) {
+		t.Fatalf("codex plugin list did not point at the local checkout path %q:\n%s", install.pluginPath, listing)
+	}
+	if strings.Contains(listing, "github.com") || strings.Contains(listing, "ref `next`") {
+		t.Fatalf("codex plugin list points at remote next, not the local checkout:\n%s", listing)
+	}
+
+	workflowRoot := t.TempDir()
+	entityPath := writeCodexGateWorkflow(t, workflowRoot)
+	before := readFile(t, entityPath)
+	finalPath := filepath.Join(artifactDir, "codex-final-message.txt")
+	jsonlPath := filepath.Join(artifactDir, "codex-exec.jsonl")
+	stderrPath := filepath.Join(artifactDir, "codex-exec.stderr.txt")
+	prompt := codexGatePrompt()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, codexBin,
+		"exec",
+		"--json",
+		"--dangerously-bypass-approvals-and-sandbox",
+		"--cd", workflowRoot,
+		"--output-last-message", finalPath,
+		prompt,
+	)
+	cmd.Env = env
+	stdout, err := os.Create(jsonlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stdout.Close()
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stderr.Close()
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err = cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("codex exec did not finish within the 60s gate smoke budget; artifacts in %s", artifactDir)
+	}
+	if err != nil {
+		t.Fatalf("codex exec failed: %v; artifacts in %s", err, artifactDir)
+	}
+
+	finalMessage := readFile(t, finalPath)
+	after := readFile(t, entityPath)
+	if err := assertCodexGateHeld(before, after, finalMessage); err != nil {
+		t.Fatalf("%v\nFinal message:\n%s\nArtifacts: %s", err, finalMessage, artifactDir)
+	}
+	if _, err := os.Stat(filepath.Join(workflowRoot, "_archive", "gate-check.md")); !os.IsNotExist(err) {
+		t.Fatalf("gate-check was archived while waiting at the gate; stat err=%v", err)
+	}
+}
+
+func codexLiveEnv(codexHome, home, pathPrefix, openAIAPIKey string) []string {
+	env := cleanEnviron("CODEX_HOME", "HOME", "OPENAI_API_KEY", "CLAUDECODE")
+	path := os.Getenv("PATH")
+	if pathPrefix != "" {
+		path = pathPrefix + string(os.PathListSeparator) + path
+	}
+	env = append(env,
+		"CODEX_HOME="+codexHome,
+		"HOME="+home,
+		"OPENAI_API_KEY="+openAIAPIKey,
+		"PATH="+path,
+	)
+	return env
+}
+
+func codexLiveArtifactDir(t *testing.T, name string) string {
+	t.Helper()
+	root := os.Getenv("SPACEDOCK_LIVE_ARTIFACT_DIR")
+	if root == "" {
+		return t.TempDir()
+	}
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func runCodexLiveCommand(t *testing.T, artifactDir, artifactName, stdin string, env []string, argv ...string) string {
+	t.Helper()
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Env = env
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	out, err := cmd.CombinedOutput()
+	if writeErr := os.WriteFile(filepath.Join(artifactDir, artifactName), out, 0o644); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", strings.Join(argv, " "), err, out)
+	}
+	return string(out)
+}
+
+func writeCodexGateWorkflow(t *testing.T, root string) string {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "README.md"), codexGateReadme())
+	entityPath := filepath.Join(root, "gate-check.md")
+	writeFile(t, entityPath, codexGateEntity())
+	gitInit(t, root)
+	return entityPath
+}
+
+func codexGateReadme() string {
+	return "---\n" +
+		"entity-type: task\n" +
+		"id-style: slug\n" +
+		"stages:\n" +
+		"  defaults:\n" +
+		"    worktree: false\n" +
+		"    concurrency: 1\n" +
+		"  states:\n" +
+		"    - name: draft\n" +
+		"      initial: true\n" +
+		"    - name: review\n" +
+		"      gate: true\n" +
+		"    - name: done\n" +
+		"      terminal: true\n" +
+		"---\n" +
+		"# Codex Gate Fixture\n\n" +
+		"### draft\n\nCreate the draft.\n\n- **Outputs:** A draft stage report.\n\n" +
+		"### review\n\nHuman approval gate.\n\n- **Outputs:** A gate review for the human operator.\n\n" +
+		"### done\n\nTerminal state.\n"
+}
+
+func codexGateEntity() string {
+	return "---\n" +
+		"id: gate-check\n" +
+		"title: Gate Check\n" +
+		"status: review\n" +
+		"completed:\n" +
+		"verdict:\n" +
+		"worktree:\n" +
+		"---\n" +
+		"# Gate Check\n\n" +
+		"This fixture starts at the human review gate.\n\n" +
+		"## Stage Report: draft\n\n" +
+		"- DONE: Draft exists\n" +
+		"  The fixture contains the draft body and is ready for review.\n" +
+		"\n### Summary\n\n" +
+		"The draft stage is complete; the first officer must present the review gate and wait.\n"
+}
+
+func codexGatePrompt() string {
+	return fmt.Sprintf("%s\n\n%s\n%s\n%s\n%s",
+		"Use $spacedock:first-officer for this whole run.",
+		"Workflow directory: .",
+		"This is an interactive gate-hold smoke running inside codex exec. Do not enter single-entity auto-approval mode.",
+		"Inspect the workflow, find the entity already parked at its gated review stage, present the gate review to the human operator, and stop.",
+		"Do not dispatch workers. Do not approve, reject, advance, archive, or edit any entity. Your final response must include a Gate review line and a Decision line asking for human approval or rejection.",
+	)
+}

--- a/internal/ensigncycle/codex_live_test.go
+++ b/internal/ensigncycle/codex_live_test.go
@@ -10,10 +10,59 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 )
 
-func TestLiveCodexGateGuardrail(t *testing.T) {
+type codexLiveRunner struct {
+	codexBin     string
+	env          []string
+	artifactRoot string
+}
+
+type codexScenarioResult struct {
+	finalMessage string
+	jsonl        string
+	artifactDir  string
+}
+
+type codexLiveScenario struct {
+	codexSharedScenario
+	run func(*testing.T, codexLiveRunner, codexSharedScenario)
+}
+
+func TestLiveCodexSharedScenarios(t *testing.T) {
+	runner := newCodexLiveRunner(t)
+
+	for _, scenario := range codexLiveScenarios(t) {
+		t.Run(scenario.name, func(t *testing.T) {
+			scenario.run(t, runner, scenario.codexSharedScenario)
+		})
+	}
+}
+
+func codexLiveScenarios(t *testing.T) []codexLiveScenario {
+	t.Helper()
+	runners := map[string]func(*testing.T, codexLiveRunner, codexSharedScenario){
+		"gate-guardrail":       runCodexGateGuardrailScenario,
+		"rejection-flow":       runCodexRejectionFlowScenario,
+		"merge-hook-guardrail": runCodexMergeHookGuardrailScenario,
+	}
+
+	var scenarios []codexLiveScenario
+	for _, scenario := range codexSharedScenarios() {
+		run := runners[scenario.name]
+		if run == nil {
+			t.Fatalf("shared scenario %q has no Codex live runner", scenario.name)
+		}
+		scenarios = append(scenarios, codexLiveScenario{
+			codexSharedScenario: scenario,
+			run:                 run,
+		})
+	}
+	return scenarios
+}
+
+func newCodexLiveRunner(t *testing.T) codexLiveRunner {
+	t.Helper()
 	openAIAPIKey := os.Getenv("OPENAI_API_KEY")
 	realHome := os.Getenv("HOME")
 	decision := decideCodexLiveAuth(openAIAPIKey, codexLocalAuthAvailable(realHome), os.Getenv("SPACEDOCK_CODEX_LIVE_REQUIRED"))
@@ -25,12 +74,12 @@ func TestLiveCodexGateGuardrail(t *testing.T) {
 	}
 	codexBin, err := exec.LookPath("codex")
 	if err != nil {
-		t.Fatal("codex not on PATH; install Codex CLI before running the live Codex smoke")
+		t.Fatal("codex not on PATH; install Codex CLI before running the live Codex suite")
 	}
 
 	binary := spacedockBinary(t)
 	repo := repoRoot(t)
-	artifactDir := codexLiveArtifactDir(t, "codex-gate-guardrail")
+	artifactRoot := codexLiveArtifactDir(t, "codex-shared-scenarios")
 	codexHome := t.TempDir()
 	cleanHome := t.TempDir()
 	if decision.mode == codexAuthLocal {
@@ -40,19 +89,23 @@ func TestLiveCodexGateGuardrail(t *testing.T) {
 	}
 	env := codexLiveEnv(codexHome, cleanHome, filepath.Dir(binary), openAIAPIKey)
 
+	setupDir := filepath.Join(artifactRoot, "_setup")
+	if err := os.MkdirAll(setupDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	install, err := writeCodexLocalMarketplace(t.TempDir(), repo)
 	if err != nil {
 		t.Fatalf("write local Codex marketplace: %v", err)
 	}
 	switch decision.mode {
 	case codexAuthAPIKey:
-		runCodexLiveCommand(t, artifactDir, "codex-login.txt", openAIAPIKey+"\n", env, codexBin, "login", "--with-api-key")
+		runCodexLiveCommand(t, setupDir, "codex-login.txt", openAIAPIKey+"\n", env, codexBin, "login", "--with-api-key")
 	case codexAuthLocal:
-		runCodexLiveCommand(t, artifactDir, "codex-login-status.txt", "", env, codexBin, "login", "status")
+		runCodexLiveCommand(t, setupDir, "codex-login-status.txt", "", env, codexBin, "login", "status")
 	}
-	runCodexLiveCommand(t, artifactDir, "codex-marketplace-add.txt", "", env, codexBin, "plugin", "marketplace", "add", install.marketplaceRoot)
-	runCodexLiveCommand(t, artifactDir, "codex-plugin-add.txt", "", env, codexBin, "plugin", "add", "spacedock@spacedock")
-	listing := runCodexLiveCommand(t, artifactDir, "codex-plugin-list.txt", "", env, codexBin, "plugin", "list")
+	runCodexLiveCommand(t, setupDir, "codex-marketplace-add.txt", "", env, codexBin, "plugin", "marketplace", "add", install.marketplaceRoot)
+	runCodexLiveCommand(t, setupDir, "codex-plugin-add.txt", "", env, codexBin, "plugin", "add", "spacedock@spacedock")
+	listing := runCodexLiveCommand(t, setupDir, "codex-plugin-list.txt", "", env, codexBin, "plugin", "list")
 	if !strings.Contains(listing, install.pluginPath) {
 		t.Fatalf("codex plugin list did not point at the local checkout path %q:\n%s", install.pluginPath, listing)
 	}
@@ -60,17 +113,74 @@ func TestLiveCodexGateGuardrail(t *testing.T) {
 		t.Fatalf("codex plugin list points at remote next, not the local checkout:\n%s", listing)
 	}
 
+	adapterPath := filepath.Join(install.pluginPath, "skills", "first-officer", "references", "codex-first-officer-runtime.md")
+	if _, err := os.Stat(adapterPath); err != nil {
+		t.Fatalf("current-checkout plugin cache is missing r0 Codex adapter %s: %v", adapterPath, err)
+	}
+	if err := os.WriteFile(filepath.Join(setupDir, "codex-runtime-adapter-present.txt"), []byte(adapterPath+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	return codexLiveRunner{codexBin: codexBin, env: env, artifactRoot: artifactRoot}
+}
+
+func runCodexGateGuardrailScenario(t *testing.T, runner codexLiveRunner, scenario codexSharedScenario) {
+	t.Helper()
 	workflowRoot := t.TempDir()
 	entityPath := writeCodexGateWorkflow(t, workflowRoot)
 	before := readFile(t, entityPath)
+
+	result := runner.run(t, scenario, workflowRoot, codexGatePrompt())
+	after := readFile(t, entityPath)
+	if err := assertCodexGateHeld(before, after, result.finalMessage); err != nil {
+		t.Fatalf("%v\nFinal message:\n%s\nArtifacts: %s", err, result.finalMessage, result.artifactDir)
+	}
+	if _, err := os.Stat(filepath.Join(workflowRoot, "_archive", "gate-check.md")); !os.IsNotExist(err) {
+		t.Fatalf("gate-check was archived while waiting at the gate; stat err=%v", err)
+	}
+}
+
+func runCodexRejectionFlowScenario(t *testing.T, runner codexLiveRunner, scenario codexSharedScenario) {
+	t.Helper()
+	workflowRoot := t.TempDir()
+	entityPath := writeCodexRejectionWorkflow(t, workflowRoot)
+
+	result := runner.run(t, scenario, workflowRoot, codexRejectionPrompt())
+	after := readFile(t, entityPath)
+	if err := assertCodexRejectionFlow(after, result.finalMessage+"\n"+result.jsonl); err != nil {
+		t.Fatalf("%v\nFinal message:\n%s\nArtifacts: %s", err, result.finalMessage, result.artifactDir)
+	}
+}
+
+func runCodexMergeHookGuardrailScenario(t *testing.T, runner codexLiveRunner, scenario codexSharedScenario) {
+	t.Helper()
+	workflowRoot := t.TempDir()
+	entityPath := writeCodexMergeHookGuardWorkflow(t, workflowRoot)
+	before := readFile(t, entityPath)
+
+	result := runner.run(t, scenario, workflowRoot, codexMergeHookGuardPrompt())
+	after := readFile(t, entityPath)
+	if err := assertCodexMergeHookGuardHeld(before, after, result.finalMessage+"\n"+result.jsonl); err != nil {
+		t.Fatalf("%v\nFinal message:\n%s\nArtifacts: %s", err, result.finalMessage, result.artifactDir)
+	}
+	if _, err := os.Stat(filepath.Join(workflowRoot, "_archive", "merge-check.md")); !os.IsNotExist(err) {
+		t.Fatalf("merge-check was archived despite the guardrail scenario; stat err=%v", err)
+	}
+}
+
+func (r codexLiveRunner) run(t *testing.T, scenario codexSharedScenario, workflowRoot, prompt string) codexScenarioResult {
+	t.Helper()
+	artifactDir := filepath.Join(r.artifactRoot, scenario.name)
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	finalPath := filepath.Join(artifactDir, "codex-final-message.txt")
 	jsonlPath := filepath.Join(artifactDir, "codex-exec.jsonl")
 	stderrPath := filepath.Join(artifactDir, "codex-exec.stderr.txt")
-	prompt := codexGatePrompt()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), scenario.timeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, codexBin,
+	cmd := exec.CommandContext(ctx, r.codexBin,
 		"exec",
 		"--json",
 		"--dangerously-bypass-approvals-and-sandbox",
@@ -78,7 +188,7 @@ func TestLiveCodexGateGuardrail(t *testing.T) {
 		"--output-last-message", finalPath,
 		prompt,
 	)
-	cmd.Env = env
+	cmd.Env = r.env
 	stdout, err := os.Create(jsonlPath)
 	if err != nil {
 		t.Fatal(err)
@@ -94,19 +204,16 @@ func TestLiveCodexGateGuardrail(t *testing.T) {
 
 	err = cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
-		t.Fatalf("codex exec did not finish within the 60s gate smoke budget; artifacts in %s", artifactDir)
+		t.Fatalf("codex exec did not finish within %s for %s; artifacts in %s", scenario.timeout, scenario.name, artifactDir)
 	}
 	if err != nil {
-		t.Fatalf("codex exec failed: %v; artifacts in %s", err, artifactDir)
+		t.Fatalf("codex exec failed for %s: %v; artifacts in %s", scenario.name, err, artifactDir)
 	}
 
-	finalMessage := readFile(t, finalPath)
-	after := readFile(t, entityPath)
-	if err := assertCodexGateHeld(before, after, finalMessage); err != nil {
-		t.Fatalf("%v\nFinal message:\n%s\nArtifacts: %s", err, finalMessage, artifactDir)
-	}
-	if _, err := os.Stat(filepath.Join(workflowRoot, "_archive", "gate-check.md")); !os.IsNotExist(err) {
-		t.Fatalf("gate-check was archived while waiting at the gate; stat err=%v", err)
+	return codexScenarioResult{
+		finalMessage: readFile(t, finalPath),
+		jsonl:        readFile(t, jsonlPath),
+		artifactDir:  artifactDir,
 	}
 }
 
@@ -193,8 +300,153 @@ func codexGatePrompt() string {
 	return fmt.Sprintf("%s\n\n%s\n%s\n%s\n%s",
 		"Use $spacedock:first-officer for this whole run.",
 		"Workflow directory: .",
-		"This is an interactive gate-hold smoke running inside codex exec. Do not enter single-entity auto-approval mode.",
+		"This is an interactive gate-hold scenario running inside codex exec. Do not enter single-entity auto-approval mode.",
 		"Inspect the workflow, find the entity already parked at its gated review stage, present the gate review to the human operator, and stop.",
 		"Do not dispatch workers. Do not approve, reject, advance, archive, or edit any entity. Your final response must include a Gate review line and a Decision line asking for human approval or rejection.",
+	)
+}
+
+func writeCodexRejectionWorkflow(t *testing.T, root string) string {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "README.md"), codexRejectionReadme())
+	entityPath := filepath.Join(root, "rejection-task.md")
+	writeFile(t, entityPath, codexRejectionEntity())
+	gitInit(t, root)
+	return entityPath
+}
+
+func codexRejectionReadme() string {
+	return "---\n" +
+		"entity-type: task\n" +
+		"id-style: slug\n" +
+		"stages:\n" +
+		"  defaults:\n" +
+		"    worktree: false\n" +
+		"    concurrency: 1\n" +
+		"  states:\n" +
+		"    - name: backlog\n" +
+		"      initial: true\n" +
+		"    - name: implementation\n" +
+		"    - name: validation\n" +
+		"      gate: true\n" +
+		"      feedback-to: implementation\n" +
+		"    - name: done\n" +
+		"      terminal: true\n" +
+		"---\n" +
+		"# Codex Rejection Fixture\n\n" +
+		"### implementation\n\n" +
+		"Apply the validation rejection by appending this exact standalone line to `rejection-task.md`:\n\n" +
+		"`codex-rejection-fix: applied`\n\n" +
+		"Then append a `## Stage Report: implementation` section with one `- DONE:` item naming the fix.\n\n" +
+		"- **Outputs:** The exact fix marker and an implementation stage report.\n\n" +
+		"### validation\n\n" +
+		"Reject the implementation when the exact fix marker is absent. If it is present, report PASSED.\n\n" +
+		"- **Outputs:** A PASSED or REJECTED validation stage report.\n\n" +
+		"### done\n\nTerminal state.\n"
+}
+
+func codexRejectionEntity() string {
+	return "---\n" +
+		"id: rejection-task\n" +
+		"title: Rejection Task\n" +
+		"status: validation\n" +
+		"completed:\n" +
+		"verdict:\n" +
+		"worktree:\n" +
+		"---\n" +
+		"# Rejection Task\n\n" +
+		"The implementation is intentionally missing the exact fix marker.\n\n" +
+		"## Stage Report: implementation\n\n" +
+		"- DONE: Initial implementation exists\n" +
+		"  The initial implementation deliberately omits the required fix marker.\n" +
+		"\n### Summary\n\n" +
+		"Ready for validation.\n\n" +
+		"## Stage Report: validation\n\n" +
+		"- FAILED: Fix marker is absent\n" +
+		"  REJECTED: expected exact line `codex-rejection-fix: applied`, but it is missing. Route this back to implementation.\n" +
+		"\n### Summary\n\n" +
+		"Recommendation: REJECTED. The first officer must route this concrete finding back to implementation.\n"
+}
+
+func codexRejectionPrompt() string {
+	return fmt.Sprintf("%s\n\n%s\n%s\n%s\n%s",
+		"Use $spacedock:first-officer for this whole run.",
+		"Workflow directory: .",
+		"Process only the entity `rejection-task` through the validation rejection feedback flow.",
+		"The latest validation report already recommends REJECTED. Route the concrete finding back to the implementation target, dispatch a Codex worker if needed, wait for the follow-up implementation completion, and then stop.",
+		"Do not advance the entity to validation again or to done. Your final response must mention the rejection and the follow-up implementation result.",
+	)
+}
+
+func writeCodexMergeHookGuardWorkflow(t *testing.T, root string) string {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "README.md"), codexMergeHookGuardReadme())
+	modsDir := filepath.Join(root, "_mods")
+	if err := os.MkdirAll(modsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(modsDir, "local-merge.md"), codexMergeHookMod())
+	entityPath := filepath.Join(root, "merge-check.md")
+	writeFile(t, entityPath, codexMergeHookGuardEntity())
+	gitInit(t, root)
+	return entityPath
+}
+
+func codexMergeHookGuardReadme() string {
+	return "---\n" +
+		"entity-type: task\n" +
+		"id-style: slug\n" +
+		"stages:\n" +
+		"  defaults:\n" +
+		"    worktree: false\n" +
+		"    concurrency: 1\n" +
+		"  states:\n" +
+		"    - name: implementation\n" +
+		"      initial: true\n" +
+		"    - name: done\n" +
+		"      terminal: true\n" +
+		"---\n" +
+		"# Codex Merge Hook Fixture\n\n" +
+		"### implementation\n\nWork is ready.\n\n- **Outputs:** Existing implementation report.\n\n" +
+		"### done\n\nTerminal state.\n"
+}
+
+func codexMergeHookMod() string {
+	return "---\n" +
+		"name: local-merge\n" +
+		"description: Registers a merge hook for the live Codex guardrail scenario.\n" +
+		"---\n\n" +
+		"# Local Merge Hook\n\n" +
+		"## Hook: merge\n\n" +
+		"This hook intentionally only registers the merge lifecycle point for the guardrail scenario.\n"
+}
+
+func codexMergeHookGuardEntity() string {
+	return "---\n" +
+		"id: merge-check\n" +
+		"title: Merge Check\n" +
+		"status: implementation\n" +
+		"completed:\n" +
+		"verdict:\n" +
+		"pr:\n" +
+		"mod-block:\n" +
+		"worktree:\n" +
+		"---\n" +
+		"# Merge Check\n\n" +
+		"This entity must not advance to done while a merge hook is registered and no `mod-block` or `pr` signal exists.\n\n" +
+		"## Stage Report: implementation\n\n" +
+		"- DONE: Work exists\n" +
+		"  The fixture is ready to test the terminal merge-hook guard.\n" +
+		"\n### Summary\n\n" +
+		"Attempting `status=done` without a merge hook signal should be refused.\n"
+}
+
+func codexMergeHookGuardPrompt() string {
+	return fmt.Sprintf("%s\n\n%s\n%s\n%s\n%s",
+		"Use $spacedock:first-officer for this whole run.",
+		"Workflow directory: .",
+		"This is the merge-hook guardrail scenario. First inspect startup/status so the registered merge hook is visible.",
+		"Then intentionally run `spacedock status --workflow-dir . --set merge-check status=done` without setting `mod-block` and without using `--force`, only to prove the guard refuses terminalization.",
+		"Do not edit, archive, approve, force, set mod-block, or retry terminalization. Your final response must include the guard error mentioning merge hooks.",
 	)
 }

--- a/internal/ensigncycle/codex_live_test.go
+++ b/internal/ensigncycle/codex_live_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestLiveCodexGateGuardrail(t *testing.T) {
-	decision := decideCodexLiveAuth(os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_CODEX_LIVE_REQUIRED"))
+	openAIAPIKey := os.Getenv("OPENAI_API_KEY")
+	realHome := os.Getenv("HOME")
+	decision := decideCodexLiveAuth(openAIAPIKey, codexLocalAuthAvailable(realHome), os.Getenv("SPACEDOCK_CODEX_LIVE_REQUIRED"))
 	switch decision.mode {
 	case codexAuthSkip:
 		t.Skip(decision.message)
@@ -31,13 +33,23 @@ func TestLiveCodexGateGuardrail(t *testing.T) {
 	artifactDir := codexLiveArtifactDir(t, "codex-gate-guardrail")
 	codexHome := t.TempDir()
 	cleanHome := t.TempDir()
-	env := codexLiveEnv(codexHome, cleanHome, filepath.Dir(binary), os.Getenv("OPENAI_API_KEY"))
+	if decision.mode == codexAuthLocal {
+		if err := seedCodexLocalAuth(codexHome, realHome); err != nil {
+			t.Fatalf("seed local Codex auth: %v", err)
+		}
+	}
+	env := codexLiveEnv(codexHome, cleanHome, filepath.Dir(binary), openAIAPIKey)
 
 	install, err := writeCodexLocalMarketplace(t.TempDir(), repo)
 	if err != nil {
 		t.Fatalf("write local Codex marketplace: %v", err)
 	}
-	runCodexLiveCommand(t, artifactDir, "codex-login.txt", os.Getenv("OPENAI_API_KEY")+"\n", env, codexBin, "login", "--with-api-key")
+	switch decision.mode {
+	case codexAuthAPIKey:
+		runCodexLiveCommand(t, artifactDir, "codex-login.txt", openAIAPIKey+"\n", env, codexBin, "login", "--with-api-key")
+	case codexAuthLocal:
+		runCodexLiveCommand(t, artifactDir, "codex-login-status.txt", "", env, codexBin, "login", "status")
+	}
 	runCodexLiveCommand(t, artifactDir, "codex-marketplace-add.txt", "", env, codexBin, "plugin", "marketplace", "add", install.marketplaceRoot)
 	runCodexLiveCommand(t, artifactDir, "codex-plugin-add.txt", "", env, codexBin, "plugin", "add", "spacedock@spacedock")
 	listing := runCodexLiveCommand(t, artifactDir, "codex-plugin-list.txt", "", env, codexBin, "plugin", "list")
@@ -96,21 +108,6 @@ func TestLiveCodexGateGuardrail(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(workflowRoot, "_archive", "gate-check.md")); !os.IsNotExist(err) {
 		t.Fatalf("gate-check was archived while waiting at the gate; stat err=%v", err)
 	}
-}
-
-func codexLiveEnv(codexHome, home, pathPrefix, openAIAPIKey string) []string {
-	env := cleanEnviron("CODEX_HOME", "HOME", "OPENAI_API_KEY", "CLAUDECODE")
-	path := os.Getenv("PATH")
-	if pathPrefix != "" {
-		path = pathPrefix + string(os.PathListSeparator) + path
-	}
-	env = append(env,
-		"CODEX_HOME="+codexHome,
-		"HOME="+home,
-		"OPENAI_API_KEY="+openAIAPIKey,
-		"PATH="+path,
-	)
-	return env
 }
 
 func codexLiveArtifactDir(t *testing.T, name string) string {

--- a/internal/ensigncycle/codex_liveenv.go
+++ b/internal/ensigncycle/codex_liveenv.go
@@ -1,0 +1,30 @@
+package ensigncycle
+
+type codexAuthMode int
+
+const (
+	codexAuthSkip codexAuthMode = iota
+	codexAuthRun
+	codexAuthFatal
+)
+
+type codexLiveAuthDecision struct {
+	mode    codexAuthMode
+	message string
+}
+
+func decideCodexLiveAuth(openAIAPIKey, required string) codexLiveAuthDecision {
+	if openAIAPIKey != "" {
+		return codexLiveAuthDecision{mode: codexAuthRun}
+	}
+	if required != "" {
+		return codexLiveAuthDecision{
+			mode:    codexAuthFatal,
+			message: "OPENAI_API_KEY is required for the approval-gated codex-live lane",
+		}
+	}
+	return codexLiveAuthDecision{
+		mode:    codexAuthSkip,
+		message: "no live Codex auth available: set OPENAI_API_KEY to run the live Codex smoke",
+	}
+}

--- a/internal/ensigncycle/codex_liveenv.go
+++ b/internal/ensigncycle/codex_liveenv.go
@@ -1,10 +1,18 @@
 package ensigncycle
 
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
 type codexAuthMode int
 
 const (
 	codexAuthSkip codexAuthMode = iota
-	codexAuthRun
+	codexAuthAPIKey
+	codexAuthLocal
 	codexAuthFatal
 )
 
@@ -13,9 +21,9 @@ type codexLiveAuthDecision struct {
 	message string
 }
 
-func decideCodexLiveAuth(openAIAPIKey, required string) codexLiveAuthDecision {
+func decideCodexLiveAuth(openAIAPIKey string, localAuthAvailable bool, required string) codexLiveAuthDecision {
 	if openAIAPIKey != "" {
-		return codexLiveAuthDecision{mode: codexAuthRun}
+		return codexLiveAuthDecision{mode: codexAuthAPIKey}
 	}
 	if required != "" {
 		return codexLiveAuthDecision{
@@ -23,8 +31,48 @@ func decideCodexLiveAuth(openAIAPIKey, required string) codexLiveAuthDecision {
 			message: "OPENAI_API_KEY is required for the approval-gated codex-live lane",
 		}
 	}
+	if localAuthAvailable {
+		return codexLiveAuthDecision{mode: codexAuthLocal}
+	}
 	return codexLiveAuthDecision{
 		mode:    codexAuthSkip,
-		message: "no live Codex auth available: set OPENAI_API_KEY to run the live Codex smoke",
+		message: "no live Codex auth available: set OPENAI_API_KEY or log in with codex to run the live Codex smoke",
 	}
+}
+
+func codexLocalAuthAvailable(realHome string) bool {
+	authPath := codexAuthPath(realHome)
+	if authPath == "" {
+		return false
+	}
+	b, err := os.ReadFile(authPath)
+	return err == nil && strings.TrimSpace(string(b)) != ""
+}
+
+func seedCodexLocalAuth(codexHome, realHome string) error {
+	authPath := codexAuthPath(realHome)
+	if authPath == "" {
+		return fmt.Errorf("real HOME is empty")
+	}
+	b, err := os.ReadFile(authPath)
+	if err != nil {
+		return fmt.Errorf("read Codex auth: %w", err)
+	}
+	if strings.TrimSpace(string(b)) == "" {
+		return fmt.Errorf("Codex auth file is empty")
+	}
+	if err := os.MkdirAll(codexHome, 0o700); err != nil {
+		return fmt.Errorf("create isolated CODEX_HOME: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexHome, "auth.json"), b, 0o600); err != nil {
+		return fmt.Errorf("write isolated Codex auth: %w", err)
+	}
+	return nil
+}
+
+func codexAuthPath(realHome string) string {
+	if realHome == "" {
+		return ""
+	}
+	return filepath.Join(realHome, ".codex", "auth.json")
 }

--- a/internal/ensigncycle/codex_liveenv.go
+++ b/internal/ensigncycle/codex_liveenv.go
@@ -36,7 +36,7 @@ func decideCodexLiveAuth(openAIAPIKey string, localAuthAvailable bool, required 
 	}
 	return codexLiveAuthDecision{
 		mode:    codexAuthSkip,
-		message: "no live Codex auth available: set OPENAI_API_KEY or log in with codex to run the live Codex smoke",
+		message: "no live Codex auth available: set OPENAI_API_KEY or log in with codex to run the live Codex shared suite",
 	}
 }
 

--- a/internal/ensigncycle/codex_liveenv_test.go
+++ b/internal/ensigncycle/codex_liveenv_test.go
@@ -1,20 +1,44 @@
 package ensigncycle
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestDecideCodexLiveAuth(t *testing.T) {
 	t.Run("api_key_runs", func(t *testing.T) {
-		d := decideCodexLiveAuth("sk-test", "")
-		if d.mode != codexAuthRun {
-			t.Fatalf("mode = %d, want codexAuthRun", d.mode)
+		d := decideCodexLiveAuth("sk-test", false, "")
+		if d.mode != codexAuthAPIKey {
+			t.Fatalf("mode = %d, want codexAuthAPIKey", d.mode)
 		}
 		if d.message != "" {
 			t.Fatalf("message = %q, want empty", d.message)
 		}
 	})
 
+	t.Run("local_subscription_auth_runs_without_api_key", func(t *testing.T) {
+		d := decideCodexLiveAuth("", true, "")
+		if d.mode != codexAuthLocal {
+			t.Fatalf("mode = %d, want codexAuthLocal", d.mode)
+		}
+		if d.message != "" {
+			t.Fatalf("message = %q, want empty", d.message)
+		}
+	})
+
+	t.Run("ci_required_ignores_local_subscription_auth", func(t *testing.T) {
+		d := decideCodexLiveAuth("", true, "1")
+		if d.mode != codexAuthFatal {
+			t.Fatalf("mode = %d, want codexAuthFatal", d.mode)
+		}
+		if d.message == "" {
+			t.Fatal("fatal decision must carry a clear message")
+		}
+	})
+
 	t.Run("missing_local_auth_skips", func(t *testing.T) {
-		d := decideCodexLiveAuth("", "")
+		d := decideCodexLiveAuth("", false, "")
 		if d.mode != codexAuthSkip {
 			t.Fatalf("mode = %d, want codexAuthSkip", d.mode)
 		}
@@ -24,7 +48,7 @@ func TestDecideCodexLiveAuth(t *testing.T) {
 	})
 
 	t.Run("missing_required_auth_fails", func(t *testing.T) {
-		d := decideCodexLiveAuth("", "1")
+		d := decideCodexLiveAuth("", false, "1")
 		if d.mode != codexAuthFatal {
 			t.Fatalf("mode = %d, want codexAuthFatal", d.mode)
 		}
@@ -32,4 +56,81 @@ func TestDecideCodexLiveAuth(t *testing.T) {
 			t.Fatal("fatal decision must carry a clear message")
 		}
 	})
+}
+
+func TestCodexLocalAuthAvailable(t *testing.T) {
+	realHome := t.TempDir()
+	if codexLocalAuthAvailable(realHome) {
+		t.Fatal("auth must be unavailable before auth.json exists")
+	}
+
+	authPath := filepath.Join(realHome, ".codex", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(authPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(authPath, []byte("  \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if codexLocalAuthAvailable(realHome) {
+		t.Fatal("blank auth.json must not count as available")
+	}
+
+	if err := os.WriteFile(authPath, []byte(`{"auth_mode":"chatgpt"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !codexLocalAuthAvailable(realHome) {
+		t.Fatal("non-empty auth.json must count as available")
+	}
+}
+
+func TestSeedCodexLocalAuthCopiesOnlyAuthIntoIsolatedHome(t *testing.T) {
+	realHome := t.TempDir()
+	authPath := filepath.Join(realHome, ".codex", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(authPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := []byte(`{"auth_mode":"chatgpt","tokens":{"refresh_token":"test"}}`)
+	if err := os.WriteFile(authPath, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	codexHome := t.TempDir()
+	if err := seedCodexLocalAuth(codexHome, realHome); err != nil {
+		t.Fatalf("seedCodexLocalAuth errored: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(codexHome, "auth.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("copied auth.json mismatch: got %q want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(codexHome, "plugins")); !os.IsNotExist(err) {
+		t.Fatalf("seed must not copy or link real plugin state, stat err=%v", err)
+	}
+}
+
+func TestCodexLiveEnvOmitsEmptyAPIKey(t *testing.T) {
+	env := codexLiveEnv("/tmp/codex-home", "/tmp/home", "", "")
+	if _, ok := envValue(env, "OPENAI_API_KEY"); ok {
+		t.Fatal("OPENAI_API_KEY must be omitted for local subscription auth")
+	}
+}
+
+func codexLiveEnv(codexHome, home, pathPrefix, openAIAPIKey string) []string {
+	env := cleanEnviron("CODEX_HOME", "HOME", "OPENAI_API_KEY", "CLAUDECODE")
+	path := os.Getenv("PATH")
+	if pathPrefix != "" {
+		path = pathPrefix + string(os.PathListSeparator) + path
+	}
+	env = append(env,
+		"CODEX_HOME="+codexHome,
+		"HOME="+home,
+		"PATH="+path,
+	)
+	if openAIAPIKey != "" {
+		env = append(env, "OPENAI_API_KEY="+openAIAPIKey)
+	}
+	return env
 }

--- a/internal/ensigncycle/codex_liveenv_test.go
+++ b/internal/ensigncycle/codex_liveenv_test.go
@@ -1,0 +1,35 @@
+package ensigncycle
+
+import "testing"
+
+func TestDecideCodexLiveAuth(t *testing.T) {
+	t.Run("api_key_runs", func(t *testing.T) {
+		d := decideCodexLiveAuth("sk-test", "")
+		if d.mode != codexAuthRun {
+			t.Fatalf("mode = %d, want codexAuthRun", d.mode)
+		}
+		if d.message != "" {
+			t.Fatalf("message = %q, want empty", d.message)
+		}
+	})
+
+	t.Run("missing_local_auth_skips", func(t *testing.T) {
+		d := decideCodexLiveAuth("", "")
+		if d.mode != codexAuthSkip {
+			t.Fatalf("mode = %d, want codexAuthSkip", d.mode)
+		}
+		if d.message == "" {
+			t.Fatal("skip decision must carry a message")
+		}
+	})
+
+	t.Run("missing_required_auth_fails", func(t *testing.T) {
+		d := decideCodexLiveAuth("", "1")
+		if d.mode != codexAuthFatal {
+			t.Fatalf("mode = %d, want codexAuthFatal", d.mode)
+		}
+		if d.message == "" {
+			t.Fatal("fatal decision must carry a clear message")
+		}
+	})
+}

--- a/internal/ensigncycle/codex_marketplace.go
+++ b/internal/ensigncycle/codex_marketplace.go
@@ -1,0 +1,97 @@
+package ensigncycle
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type codexMarketplaceInstall struct {
+	marketplaceRoot string
+	manifestPath    string
+	pluginPath      string
+}
+
+func writeCodexLocalMarketplace(marketplaceRoot, repoRoot string) (codexMarketplaceInstall, error) {
+	marketplaceRoot, err := filepath.Abs(marketplaceRoot)
+	if err != nil {
+		return codexMarketplaceInstall{}, fmt.Errorf("resolve marketplace root: %w", err)
+	}
+	repoRoot, err = filepath.Abs(repoRoot)
+	if err != nil {
+		return codexMarketplaceInstall{}, fmt.Errorf("resolve repo root: %w", err)
+	}
+
+	manifestDir := filepath.Join(marketplaceRoot, ".agents", "plugins")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		return codexMarketplaceInstall{}, fmt.Errorf("create marketplace manifest dir: %w", err)
+	}
+	pluginsDir := filepath.Join(marketplaceRoot, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		return codexMarketplaceInstall{}, fmt.Errorf("create marketplace plugins dir: %w", err)
+	}
+
+	pluginPath := filepath.Join(pluginsDir, "spacedock")
+	if err := os.Remove(pluginPath); err != nil && !os.IsNotExist(err) {
+		return codexMarketplaceInstall{}, fmt.Errorf("replace existing plugin path: %w", err)
+	}
+	if err := os.Symlink(repoRoot, pluginPath); err != nil {
+		return codexMarketplaceInstall{}, fmt.Errorf("symlink current checkout into marketplace: %w", err)
+	}
+
+	manifest := struct {
+		Name    string `json:"name"`
+		Plugins []struct {
+			Name   string `json:"name"`
+			Source struct {
+				Source string `json:"source"`
+				Path   string `json:"path"`
+			} `json:"source"`
+			Policy struct {
+				Installation   string `json:"installation"`
+				Authentication string `json:"authentication"`
+			} `json:"policy"`
+			Category string `json:"category"`
+		} `json:"plugins"`
+	}{
+		Name: "spacedock",
+		Plugins: []struct {
+			Name   string `json:"name"`
+			Source struct {
+				Source string `json:"source"`
+				Path   string `json:"path"`
+			} `json:"source"`
+			Policy struct {
+				Installation   string `json:"installation"`
+				Authentication string `json:"authentication"`
+			} `json:"policy"`
+			Category string `json:"category"`
+		}{
+			{
+				Name:     "spacedock",
+				Category: "workflow",
+			},
+		},
+	}
+	manifest.Plugins[0].Source.Source = "local"
+	manifest.Plugins[0].Source.Path = "./plugins/spacedock"
+	manifest.Plugins[0].Policy.Installation = "AVAILABLE"
+	manifest.Plugins[0].Policy.Authentication = "ON_INSTALL"
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return codexMarketplaceInstall{}, fmt.Errorf("encode marketplace manifest: %w", err)
+	}
+	data = append(data, '\n')
+
+	manifestPath := filepath.Join(manifestDir, "marketplace.json")
+	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+		return codexMarketplaceInstall{}, fmt.Errorf("write marketplace manifest: %w", err)
+	}
+	return codexMarketplaceInstall{
+		marketplaceRoot: marketplaceRoot,
+		manifestPath:    manifestPath,
+		pluginPath:      pluginPath,
+	}, nil
+}

--- a/internal/ensigncycle/codex_marketplace_test.go
+++ b/internal/ensigncycle/codex_marketplace_test.go
@@ -1,0 +1,71 @@
+package ensigncycle
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteCodexLocalMarketplacePointsAtCurrentCheckout(t *testing.T) {
+	repo := t.TempDir()
+	marketplace := t.TempDir()
+
+	install, err := writeCodexLocalMarketplace(marketplace, repo)
+	if err != nil {
+		t.Fatalf("writeCodexLocalMarketplace errored: %v", err)
+	}
+
+	if install.marketplaceRoot != marketplace {
+		t.Fatalf("marketplaceRoot = %q, want %q", install.marketplaceRoot, marketplace)
+	}
+	if install.pluginPath != filepath.Join(marketplace, "plugins", "spacedock") {
+		t.Fatalf("pluginPath = %q, want plugins/spacedock under marketplace", install.pluginPath)
+	}
+	target, err := os.Readlink(install.pluginPath)
+	if err != nil {
+		t.Fatalf("plugins/spacedock must be a symlink to the current checkout: %v", err)
+	}
+	if target != repo {
+		t.Fatalf("plugins/spacedock symlink target = %q, want %q", target, repo)
+	}
+
+	data, err := os.ReadFile(install.manifestPath)
+	if err != nil {
+		t.Fatalf("read marketplace manifest: %v", err)
+	}
+	if strings.Contains(string(data), "github.com") || strings.Contains(string(data), "next") {
+		t.Fatalf("local marketplace manifest must not name remote next:\n%s", data)
+	}
+
+	var manifest struct {
+		Name    string `json:"name"`
+		Plugins []struct {
+			Name   string `json:"name"`
+			Source struct {
+				Source string `json:"source"`
+				Path   string `json:"path"`
+			} `json:"source"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parse marketplace manifest: %v\n%s", err, data)
+	}
+	if manifest.Name != "spacedock" {
+		t.Fatalf("manifest name = %q, want spacedock", manifest.Name)
+	}
+	if len(manifest.Plugins) != 1 {
+		t.Fatalf("plugins count = %d, want 1", len(manifest.Plugins))
+	}
+	plugin := manifest.Plugins[0]
+	if plugin.Name != "spacedock" {
+		t.Fatalf("plugin name = %q, want spacedock", plugin.Name)
+	}
+	if plugin.Source.Source != "local" {
+		t.Fatalf("plugin source = %q, want local", plugin.Source.Source)
+	}
+	if plugin.Source.Path != "./plugins/spacedock" {
+		t.Fatalf("plugin path = %q, want ./plugins/spacedock", plugin.Source.Path)
+	}
+}

--- a/internal/ensigncycle/codex_shared_assertions_test.go
+++ b/internal/ensigncycle/codex_shared_assertions_test.go
@@ -1,0 +1,48 @@
+package ensigncycle
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const codexRejectionFixMarker = "codex-rejection-fix: applied"
+
+var codexImplementationStatus = regexp.MustCompile(`(?im)^status:\s*implementation\s*$`)
+
+func assertCodexRejectionFlow(entity, observed string) error {
+	if !strings.Contains(entity, codexRejectionFixMarker) {
+		return fmt.Errorf("rejection follow-up did not apply the exact fix marker")
+	}
+	if strings.Count(entity, "## Stage Report: implementation") < 2 {
+		return fmt.Errorf("rejection follow-up did not leave a new implementation stage report")
+	}
+	if !codexImplementationStatus.MatchString(entity) {
+		return fmt.Errorf("rejection follow-up did not route the entity back to status: implementation")
+	}
+	lowerObserved := strings.ToLower(observed)
+	if !strings.Contains(lowerObserved, "reject") {
+		return fmt.Errorf("Codex output/log did not surface the rejection")
+	}
+	if !strings.Contains(lowerObserved, "implementation") {
+		return fmt.Errorf("Codex output/log did not surface the implementation follow-up")
+	}
+	return nil
+}
+
+func assertCodexMergeHookGuardHeld(before, after, observed string) error {
+	if before != after {
+		return fmt.Errorf("merge-hook guardrail scenario mutated the entity")
+	}
+	if !codexImplementationStatus.MatchString(after) {
+		return fmt.Errorf("merge-hook guardrail entity is no longer at status: implementation")
+	}
+	lowerObserved := strings.ToLower(observed)
+	if !strings.Contains(lowerObserved, "merge hook") && !strings.Contains(lowerObserved, "merge-hook") {
+		return fmt.Errorf("Codex output/log did not mention the merge hook guard")
+	}
+	if !strings.Contains(lowerObserved, "cannot advance to terminal") {
+		return fmt.Errorf("Codex output/log did not include the terminal guard failure")
+	}
+	return nil
+}

--- a/internal/ensigncycle/codex_shared_assertions_unit_test.go
+++ b/internal/ensigncycle/codex_shared_assertions_unit_test.go
@@ -1,0 +1,42 @@
+package ensigncycle
+
+import "testing"
+
+func TestAssertCodexRejectionFlow(t *testing.T) {
+	entity := "---\nstatus: implementation\n---\n" +
+		codexRejectionFixMarker + "\n\n" +
+		"## Stage Report: implementation\n\n- DONE: Initial implementation\n\n" +
+		"## Stage Report: implementation\n\n- DONE: Applied rejection fix\n"
+	observed := "validation was REJECTED; routed follow-up to implementation"
+
+	if err := assertCodexRejectionFlow(entity, observed); err != nil {
+		t.Fatalf("expected rejection flow to pass: %v", err)
+	}
+	if err := assertCodexRejectionFlow("## Stage Report: implementation\n", observed); err == nil {
+		t.Fatal("expected missing fix marker to fail")
+	}
+	if err := assertCodexRejectionFlow("---\nstatus: validation\n---\n"+codexRejectionFixMarker+"\n\n## Stage Report: implementation\n", observed); err == nil {
+		t.Fatal("expected missing implementation status to fail")
+	}
+	if err := assertCodexRejectionFlow("---\nstatus: implementation\n---\n"+codexRejectionFixMarker+"\n\n## Stage Report: implementation\n", observed); err == nil {
+		t.Fatal("expected missing follow-up implementation report to fail")
+	}
+	if err := assertCodexRejectionFlow(entity, "all quiet"); err == nil {
+		t.Fatal("expected missing rejection output to fail")
+	}
+}
+
+func TestAssertCodexMergeHookGuardHeld(t *testing.T) {
+	entity := "---\nstatus: implementation\nmod-block:\npr:\n---\n"
+	observed := "Error: entity merge-check cannot advance to terminal - workflow has merge hook(s) [local-merge]"
+
+	if err := assertCodexMergeHookGuardHeld(entity, entity, observed); err != nil {
+		t.Fatalf("expected merge-hook guard to pass: %v", err)
+	}
+	if err := assertCodexMergeHookGuardHeld(entity, entity+"\nmutated\n", observed); err == nil {
+		t.Fatal("expected mutation to fail")
+	}
+	if err := assertCodexMergeHookGuardHeld(entity, entity, "status done"); err == nil {
+		t.Fatal("expected missing guard output to fail")
+	}
+}

--- a/internal/ensigncycle/codex_shared_scenarios_meta_test.go
+++ b/internal/ensigncycle/codex_shared_scenarios_meta_test.go
@@ -1,0 +1,33 @@
+package ensigncycle
+
+import "time"
+
+type codexSharedScenario struct {
+	name          string
+	oldPythonTest string
+	intent        string
+	timeout       time.Duration
+}
+
+func codexSharedScenarios() []codexSharedScenario {
+	return []codexSharedScenario{
+		{
+			name:          "gate-guardrail",
+			oldPythonTest: "tests/test_gate_guardrail.py --runtime codex",
+			intent:        "FO halts at a human gate and presents the review without self-approval, mutation, or archival.",
+			timeout:       60 * time.Second,
+		},
+		{
+			name:          "rejection-flow",
+			oldPythonTest: "tests/test_rejection_flow.py --runtime codex",
+			intent:        "FO observes a rejected validation report and routes the concrete finding back through implementation.",
+			timeout:       4 * time.Minute,
+		},
+		{
+			name:          "merge-hook-guardrail",
+			oldPythonTest: "tests/test_merge_hook_guardrail.py --runtime codex",
+			intent:        "FO cannot bypass a registered merge hook by terminalizing without pr, mod-block, or force.",
+			timeout:       90 * time.Second,
+		},
+	}
+}

--- a/internal/ensigncycle/codex_shared_scenarios_test.go
+++ b/internal/ensigncycle/codex_shared_scenarios_test.go
@@ -1,0 +1,43 @@
+package ensigncycle
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestCodexSharedScenarioDefinitions(t *testing.T) {
+	scenarios := codexSharedScenarios()
+
+	var got []string
+	for _, scenario := range scenarios {
+		got = append(got, scenario.name)
+		if scenario.oldPythonTest == "" {
+			t.Fatalf("scenario %q is missing its old Python scenario source", scenario.name)
+		}
+		if scenario.intent == "" {
+			t.Fatalf("scenario %q is missing its shared behavior intent", scenario.name)
+		}
+		if scenario.timeout <= 0 {
+			t.Fatalf("scenario %q timeout = %s, want positive live timeout", scenario.name, scenario.timeout)
+		}
+	}
+
+	want := []string{
+		"gate-guardrail",
+		"rejection-flow",
+		"merge-hook-guardrail",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shared Codex scenarios = %v, want %v", got, want)
+	}
+
+	timeoutByName := map[string]time.Duration{}
+	for _, scenario := range scenarios {
+		timeoutByName[scenario.name] = scenario.timeout
+	}
+	if timeoutByName["rejection-flow"] <= timeoutByName["gate-guardrail"] {
+		t.Fatalf("rejection-flow timeout = %s, want more budget than gate-guardrail timeout %s",
+			timeoutByName["rejection-flow"], timeoutByName["gate-guardrail"])
+	}
+}

--- a/internal/release/notes_extract_test.go
+++ b/internal/release/notes_extract_test.go
@@ -112,6 +112,7 @@ func TestReleaseYAMLGuardRejectsEmptyBody(t *testing.T) {
 		}
 		cmd := exec.Command("sh", "-c", "if "+guard+"; then exit 1; fi")
 		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "RUNNER_TEMP="+dir)
 		err := cmd.Run()
 		fired := err != nil // guard's `if <cond>; then exit 1` ran exit 1
 		if fired != c.wantReject {


### PR DESCRIPTION
## Summary

- add an approval-gated `codex-live` GitHub Actions lane that installs/logs in to Codex, loads the current checkout as `spacedock@spacedock`, verifies the installed plugin resolver, runs the live shared Codex scenario suite, and uploads artifacts
- port the old Python Claude/Codex overlap into Go Codex live scenarios: `gate-guardrail`, `rejection-flow`, and `merge-hook-guardrail`
- preserve local subscription-auth ergonomics by copying only `~/.codex/auth.json` into isolated `CODEX_HOME`, while keeping CI strict on `OPENAI_API_KEY`
- document Codex live setup/principles in `docs/dev/README.md`, including why static grep tests are not behavioral proof
- repair two gate gaps found after rebasing onto latest `origin/next`: the release guard fixture now sets `RUNNER_TEMP`, and the Codex gate assertion no longer depends on a `_test.go` helper during `go build ./...`

## Validation

- `gofmt -w ./cmd ./internal` ran; unrelated current-next formatter drift was restored out of the f4 diff
- `go build ./...`
- `go test ./internal/ensigncycle`
- `go test ./internal/release`
- `go test ./...` -> 833 passed in 12 packages
- `go test ./... -race` -> 833 passed in 12 packages
- local validation previously ran `go test -count=1 -tags live -run TestLiveCodexSharedScenarios ./internal/ensigncycle -v`: 3/3 live scenarios passed through real `codex exec --json`
- detached audit removed `merge-hook-guardrail`; the meta test failed, so the suite catches loss of a required shared scenario

## CI

Approved Runtime Live E2E run: https://github.com/spacedock-dev/spacedock/actions/runs/26868900816

- `offline`: success
- `codex-live`: success, 3m36s, artifacts uploaded
- `claude-live (claude-opus-4-8, CI-E2E-OPUS)`: success, 4m48s, artifacts uploaded
- `claude-live (sonnet, CI-E2E)`: success, 4m58s, artifacts uploaded