### PR TITLE
spacedock state new — one-command split-root onboarding

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -303,25 +303,36 @@ func newNewCommand(ctx context.Context, env []string, dir string, stdin io.Reade
 	}
 }
 
-// newStateCommand wires `spacedock state init` for split-root state-checkout
+// newStateCommand wires `spacedock state init|new` for split-root state-checkout
 // management. Flag parsing is disabled so the post-subcommand argv (the optional
-// --workflow-dir) reaches runStateInit verbatim. `init` is the only subcommand;
-// an unknown or missing subcommand is a usage error (exit 2).
+// --workflow-dir) reaches the handler verbatim. `init` resumes a cloned workflow's
+// state checkout; `new` births one around a present split-root README. An unknown
+// or missing subcommand is a usage error (exit 2).
 func newStateCommand(ctx context.Context, env []string, dir string, stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
-		Use:                "state init [--workflow-dir DIR]",
-		Short:              "Initialize a cloned split-root workflow's state checkout",
+		Use:                "state init|new [--workflow-dir DIR]",
+		Short:              "Manage a split-root workflow's state checkout (init resumes, new births)",
 		GroupID:            "workflow",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if wantsHelp(args) {
 				return cmd.Help()
 			}
-			if len(args) == 0 || args[0] != "init" {
-				fmt.Fprintln(stderr, "spacedock state: unknown subcommand (want: init)")
+			if len(args) == 0 {
+				fmt.Fprintln(stderr, "spacedock state: unknown subcommand (want: init or new)")
 				return exitCodeError{2}
 			}
-			if code := runStateInit(ctx, args[1:], env, dir, stdout, stderr); code != 0 {
+			var code int
+			switch args[0] {
+			case "init":
+				code = runStateInit(ctx, args[1:], env, dir, stdout, stderr)
+			case "new":
+				code = runStateNew(ctx, args[1:], env, dir, stdout, stderr)
+			default:
+				fmt.Fprintln(stderr, "spacedock state: unknown subcommand (want: init or new)")
+				return exitCodeError{2}
+			}
+			if code != 0 {
 				return exitCodeError{code}
 			}
 			return nil

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -1,5 +1,5 @@
-// ABOUTME: `spacedock state init` — resume a cloned split-root workflow by fetching
-// ABOUTME: the orphan state branch and adding it as a linked worktree at state:.
+// ABOUTME: `spacedock state init` resumes a cloned split-root workflow; `state new`
+// ABOUTME: births the orphan state branch + linked worktree around a present README.
 package cli
 
 import (
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/spacedock-dev/spacedock/internal/status"
 )
@@ -96,6 +97,266 @@ func parseStateInitArgs(args []string, dir string, stderr io.Writer) (workflowDi
 		discovered, ok := status.DiscoverWorkflowDir(dir)
 		if !ok {
 			fmt.Fprintln(stderr, "spacedock state init: no workflow here — pass --workflow-dir or run inside a workflow")
+			return "", 1
+		}
+		workflowDir = discovered
+	} else if !filepath.IsAbs(workflowDir) {
+		workflowDir = filepath.Join(dir, workflowDir)
+	}
+	return workflowDir, 0
+}
+
+// runStateNew implements `spacedock state new`. It is the BIRTH half of the
+// split-root lifecycle and the mechanical inverse of `state init`: reading the same
+// README `state:`/`state-branch:`, it appends the `.gitignore` entry, births the
+// orphan state branch, and checks it out as a linked worktree at the state path.
+// The README is a precondition (commission's interactive job), not an output. The
+// prechecks refuse an already-birthed or already-remote workflow instead of letting
+// git fatal, and an inline README is an operator error (a mutating verb cannot
+// no-op the way `state init` does). The orphan push is best-effort: a repo with no
+// origin births locally and warns the operator to push later.
+func runStateNew(ctx context.Context, args []string, env []string, dir string, stdout, stderr io.Writer) int {
+	workflowDir, code := parseStateNewArgs(args, dir, stderr)
+	if code != 0 {
+		return code
+	}
+
+	readme := filepath.Join(workflowDir, "README.md")
+	if !fileExists(readme) {
+		fmt.Fprintf(stderr, "spacedock state new: no README.md at %s\n", workflowDir)
+		return 1
+	}
+	fm := status.ParseFrontmatter(readme)
+	mode, relPath, err := status.ClassifyState(fm["state"])
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock state new: %v\n", err)
+		return 1
+	}
+	if mode == status.StateInline {
+		fmt.Fprintf(stderr, "spacedock state new: %s is an inline workflow — `state new` only births split-root workflows (set `state:` to a checkout path in the README first).\n", workflowDir)
+		return 1
+	}
+
+	branch, err := status.StateBranch(workflowDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock state new: %v\n", err)
+		return 1
+	}
+	statePath := filepath.Join(workflowDir, relPath)
+
+	// Refusal prechecks (AC-3): an occupied path or an existing orphan (local or
+	// remote) means the workflow is already birthed; refuse with a tailored message
+	// rather than letting git fatal. The remote case redirects to `state init`.
+	if dirExists(statePath) {
+		fmt.Fprintf(stderr, "spacedock state new: %s already present — the workflow is already birthed here. Run `spacedock status` to inspect it.\n", statePath)
+		return 1
+	}
+	if ok, _ := runGit(workflowDir, "rev-parse", "--verify", "refs/heads/"+branch); ok {
+		fmt.Fprintf(stderr, "spacedock state new: orphan branch %s already present in local refs — the workflow is already birthed. Run `spacedock state init` to check it out at %s.\n", branch, statePath)
+		return 1
+	}
+	if orphanOnRemote(workflowDir, branch) {
+		fmt.Fprintf(stderr, "spacedock state new: orphan branch %s already present on origin — this workflow was birthed elsewhere. Run `spacedock state init --workflow-dir %s` to resume it.\n", branch, workflowDir)
+		return 1
+	}
+
+	// Birth: append the gitignore entry (idempotent), then create the orphan branch
+	// + linked worktree.
+	if err := appendGitignoreEntry(workflowDir, relPath); err != nil {
+		fmt.Fprintf(stderr, "spacedock state new: %v\n", err)
+		return 1
+	}
+	pushed, err := birthOrphanState(workflowDir, statePath, branch)
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock state new: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "Birthed split-root state at %s (branch %s).\n", statePath, branch)
+	fmt.Fprintf(stdout, "Next: commit the .gitignore edit on your code branch (git add .gitignore && git commit).\n")
+	if !pushed {
+		fmt.Fprintf(stdout, "Warning: could not push %s to origin (no remote or push failed). Push the orphan branch later to share state: git -C %s push origin %s.\n", branch, statePath, branch)
+	}
+	return 0
+}
+
+// orphanOnRemote reports whether branch exists on origin, parsing `git ls-remote
+// --heads origin {branch}`. A missing origin or any ls-remote failure reports false
+// — the local birth still proceeds best-effort.
+func orphanOnRemote(workflowDir, branch string) bool {
+	ok, out := runGit(workflowDir, "ls-remote", "--heads", "origin", branch)
+	return ok && lsRemoteHasBranch(out, branch)
+}
+
+// lsRemoteHasBranch reports whether `git ls-remote --heads` output names branch.
+// ls-remote prints one `<sha>\trefs/heads/<branch>` line per matching head, so a
+// `refs/heads/<branch>` reference in any line is a match. Empty output (no such
+// head, the common case) is no match. Branch names can contain `/`
+// (spacedock-state/dev), so the whole `refs/heads/<branch>` ref-path is matched,
+// not a bare suffix.
+func lsRemoteHasBranch(lsRemoteOutput, branch string) bool {
+	ref := "refs/heads/" + branch
+	for _, line := range strings.Split(lsRemoteOutput, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == ref {
+			return true
+		}
+	}
+	return false
+}
+
+// appendGitignoreEntry idempotently appends `{relPath}/` to the code branch's
+// tracked .gitignore (repo root), so collaborators and fresh clones ignore the
+// state checkout. The entry is left uncommitted for the operator to commit
+// alongside their README — committing on the operator's code branch is an
+// outward-facing side effect the operator should own.
+func appendGitignoreEntry(workflowDir, relPath string) error {
+	root, err := repoRoot(workflowDir)
+	if err != nil {
+		return err
+	}
+	// The .gitignore entry is the workflow's repo-relative prefix + the state
+	// relPath, so a docs/dev workflow ignores docs/dev/.spacedock-state/. Derive the
+	// prefix from git's `--show-prefix` rather than filepath.Rel against the
+	// toplevel: git resolves symlinks in --show-toplevel (e.g. /var → /private/var
+	// on macOS) while workflowDir is the caller's unresolved path, so Rel between the
+	// two divergent prefixes yields a garbage `../../…` path.
+	prefix, err := repoRelPrefix(workflowDir)
+	if err != nil {
+		return err
+	}
+	entry := filepath.ToSlash(filepath.Join(prefix, relPath)) + "/"
+
+	gitignore := filepath.Join(root, ".gitignore")
+	existing, err := os.ReadFile(gitignore)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for _, line := range strings.Split(string(existing), "\n") {
+		if strings.TrimSpace(line) == entry {
+			return nil // already present — idempotent
+		}
+	}
+	body := string(existing)
+	if len(body) > 0 && !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	body += entry + "\n"
+	return os.WriteFile(gitignore, []byte(body), 0o644)
+}
+
+// birthOrphanState creates the orphan branch in a temp detached worktree (clearing
+// the inherited tree so the orphan starts empty), seeds an empty commit, pushes
+// best-effort to origin, then checks the branch out as a linked worktree at
+// statePath. Returns whether the orphan branch reached origin. `worktree add
+// --detach` tolerates a dirty code tree (it is a separate checkout), so the birth
+// does not require a clean working tree.
+func birthOrphanState(workflowDir, statePath, branch string) (pushed bool, err error) {
+	root, err := repoRoot(workflowDir)
+	if err != nil {
+		return false, err
+	}
+	tmpWT, err := os.MkdirTemp("", "spacedock-orphan-birth-")
+	if err != nil {
+		return false, fmt.Errorf("creating temp worktree dir: %w", err)
+	}
+	// os.MkdirTemp creates the dir, but `git worktree add` needs a non-existent
+	// path; remove the placeholder so git owns the checkout.
+	if err := os.Remove(tmpWT); err != nil {
+		return false, fmt.Errorf("preparing temp worktree path: %w", err)
+	}
+	defer runGit(root, "worktree", "remove", "--force", tmpWT)
+
+	if ok, out := runGit(root, "worktree", "add", "--detach", tmpWT); !ok {
+		return false, fmt.Errorf("git worktree add --detach failed:\n%s", out)
+	}
+	if ok, out := runGit(tmpWT, "checkout", "--orphan", branch); !ok {
+		return false, fmt.Errorf("git checkout --orphan %s failed:\n%s", branch, out)
+	}
+	// Clear the inherited index and working tree so the orphan branch starts empty.
+	if ok, out := runGit(tmpWT, "rm", "-rf", "--cached", "."); !ok {
+		return false, fmt.Errorf("git rm --cached failed:\n%s", out)
+	}
+	if err := clearWorktreeFiles(tmpWT); err != nil {
+		return false, err
+	}
+	if ok, out := runGit(tmpWT, "commit", "-q", "--allow-empty", "-m", "seed state"); !ok {
+		return false, fmt.Errorf("git commit (seed state) failed:\n%s", out)
+	}
+	pushed, _ = runGit(tmpWT, "push", "origin", branch)
+
+	// Remove the temp worktree before adding the real one — git refuses a 2nd
+	// worktree on the same branch.
+	if ok, out := runGit(root, "worktree", "remove", "--force", tmpWT); !ok {
+		return pushed, fmt.Errorf("git worktree remove failed:\n%s", out)
+	}
+	if ok, out := runGit(root, "worktree", "add", statePath, branch); !ok {
+		return pushed, fmt.Errorf("git worktree add %s %s failed:\n%s", statePath, branch, out)
+	}
+	return pushed, nil
+}
+
+// clearWorktreeFiles removes every entry in dir except .git, leaving the orphan
+// branch's working tree empty.
+func clearWorktreeFiles(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.Name() == ".git" {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(dir, e.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// repoRoot returns the absolute path of the git repository containing workflowDir.
+func repoRoot(workflowDir string) (string, error) {
+	ok, out := runGit(workflowDir, "rev-parse", "--show-toplevel")
+	if !ok {
+		return "", fmt.Errorf("not a git repository at %s:\n%s", workflowDir, out)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// repoRelPrefix returns workflowDir's path relative to its repo root, as git sees
+// it (`git rev-parse --show-prefix`) — a trailing-slashed path for a subdir, empty
+// when workflowDir is the repo root. Unlike filepath.Rel against --show-toplevel,
+// this is symlink-resolution-safe (both sides are git's own view).
+func repoRelPrefix(workflowDir string) (string, error) {
+	ok, out := runGit(workflowDir, "rev-parse", "--show-prefix")
+	if !ok {
+		return "", fmt.Errorf("not a git repository at %s:\n%s", workflowDir, out)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// parseStateNewArgs reads `--workflow-dir DIR`, resolving a relative path against
+// dir. With no flag it discovers the enclosing workflow from dir. (Mirrors
+// parseStateInitArgs — the two commands take the same arguments.)
+func parseStateNewArgs(args []string, dir string, stderr io.Writer) (workflowDir string, code int) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--workflow-dir":
+			if i+1 >= len(args) {
+				fmt.Fprintln(stderr, "spacedock state new: --workflow-dir requires a path")
+				return "", 2
+			}
+			workflowDir = args[i+1]
+			i++
+		default:
+			fmt.Fprintf(stderr, "spacedock state new: unknown argument %q\n", args[i])
+			return "", 2
+		}
+	}
+	if workflowDir == "" {
+		discovered, ok := status.DiscoverWorkflowDir(dir)
+		if !ok {
+			fmt.Fprintln(stderr, "spacedock state new: no workflow here — pass --workflow-dir or run inside a workflow")
 			return "", 1
 		}
 		workflowDir = discovered

--- a/internal/cli/state_new_test.go
+++ b/internal/cli/state_new_test.go
@@ -1,0 +1,331 @@
+// ABOUTME: Real-git e2e for `spacedock state new` — birth the orphan state branch
+// ABOUTME: + linked worktree around an already-present split-root README, no mocks.
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// writeSplitReadmeRepo sets up the PRE-birth state `state new` onboards: a cloned
+// repo whose code branch carries a split-root README at docs/dev, committed and
+// pushed, but with NO .gitignore state entry and NO orphan branch yet. Returns the
+// host clone root and its workflow dir. This is the input commission has NOT yet
+// run the birth half on.
+func writeSplitReadmeRepo(t *testing.T) (hostClone, workflowDir string) {
+	t.Helper()
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+
+	hostClone = filepath.Join(t.TempDir(), "host")
+	git(t, t.TempDir(), "clone", "-q", bare, hostClone)
+	git(t, hostClone, "config", "user.email", "t@t")
+	git(t, hostClone, "config", "user.name", "t")
+
+	workflowDir = filepath.Join(hostClone, "docs", "dev")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "README.md"), []byte(splitWorkflowReadme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, hostClone, "add", "docs/dev/README.md")
+	git(t, hostClone, "commit", "-q", "-m", "add split-root README")
+	git(t, hostClone, "push", "-q", "origin", "HEAD")
+	return hostClone, workflowDir
+}
+
+// execStateNew runs `spacedock state new --workflow-dir workflowDir` from dir,
+// returning exit code, stdout, stderr.
+func execStateNew(t *testing.T, dir, workflowDir string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errBuf strings.Builder
+	code = run(context.Background(), []string{"state", "new", "--workflow-dir", workflowDir},
+		os.Environ(), dir, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	return code, out.String(), errBuf.String()
+}
+
+// TestStateNewBirthsSplitRoot pins AC-1: one `state new` against a code branch
+// carrying a split-root README births the orphan branch, appends the .gitignore
+// entry, and checks out the linked state worktree. After it returns the orphan
+// branch is in local refs, worktree list has the state path, .gitignore carries
+// the path line, and boot shows split-root + present: true.
+func TestStateNewBirthsSplitRoot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	hostClone, workflowDir := writeSplitReadmeRepo(t)
+	statePath := filepath.Join(workflowDir, ".spacedock-state")
+	stateBranch := "spacedock-state/dev"
+
+	code, stdout, stderr := execStateNew(t, hostClone, workflowDir)
+	if code != 0 {
+		t.Fatalf("state new exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+
+	// Orphan branch present in local refs.
+	if out, ok := gitOK(t, hostClone, "rev-parse", "--verify", "refs/heads/"+stateBranch); !ok {
+		t.Fatalf("orphan branch %q not in local refs; rev-parse=%q", stateBranch, out)
+	}
+	// State path is a linked worktree.
+	if out := git(t, hostClone, "worktree", "list"); !strings.Contains(out, statePath) {
+		t.Fatalf("state path is not a linked worktree; worktree list=%q", out)
+	}
+	// .gitignore carries the state path as an exact line — not a substring of a
+	// mangled path (a symlink-resolution bug once produced `../../…/docs/dev/.spacedock-state/`,
+	// which a substring check would have passed).
+	gi, err := os.ReadFile(filepath.Join(hostClone, ".gitignore"))
+	if err != nil {
+		t.Fatalf("reading .gitignore: %v", err)
+	}
+	if !gitignoreHasLine(string(gi), "docs/dev/.spacedock-state/") {
+		t.Fatalf(".gitignore missing the exact state path line; got %q", string(gi))
+	}
+	// The entry actually functions as an ignore rule (zero-churn R1: the state
+	// checkout never shows in the code branch porcelain). git check-ignore exits 0
+	// only when the path is ignored.
+	if _, ok := gitOK(t, hostClone, "check-ignore", "docs/dev/.spacedock-state"); !ok {
+		t.Fatalf("git check-ignore says the state path is NOT ignored — the .gitignore entry is wrong")
+	}
+	// Boot renders against the state checkout: split-root + present: true.
+	bootOut := runStatusBoot(t, workflowDir)
+	if !strings.Contains(bootOut, "STATE_BACKEND: split-root") {
+		t.Fatalf("boot should show split-root; got\n%s", bootOut)
+	}
+	if !strings.Contains(bootOut, "present: true") {
+		t.Fatalf("boot should show present: true after birth; got\n%s", bootOut)
+	}
+}
+
+// TestStateNewRoundTripsWithStateInit pins AC-2: after `state new` on repo A and a
+// code+orphan push, a fresh clone of A runs `state init` and lands in the same
+// working state — worktree list has the state path, boot present: true, status
+// renders. state new and state init are inverses reading the same README.
+func TestStateNewRoundTripsWithStateInit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	hostClone, workflowDir := writeSplitReadmeRepo(t)
+
+	code, stdout, stderr := execStateNew(t, hostClone, workflowDir)
+	if code != 0 {
+		t.Fatalf("state new exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	// Commit the .gitignore edit (the operator's step) and push the code branch so
+	// a fresh clone sees the split-root README and ignore entry. The orphan branch
+	// was best-effort pushed by state new.
+	git(t, hostClone, "add", ".gitignore")
+	git(t, hostClone, "commit", "-q", "-m", "gitignore state path")
+	git(t, hostClone, "push", "-q", "origin", "HEAD")
+
+	// Fresh clone resumes via state init.
+	origin := git(t, hostClone, "remote", "get-url", "origin")
+	bare := strings.TrimSpace(origin)
+	fresh := filepath.Join(t.TempDir(), "fresh")
+	git(t, t.TempDir(), "clone", "-q", bare, fresh)
+	git(t, fresh, "config", "user.email", "t@t")
+	git(t, fresh, "config", "user.name", "t")
+	freshWorkflow := filepath.Join(fresh, "docs", "dev")
+	freshState := filepath.Join(freshWorkflow, ".spacedock-state")
+
+	if _, err := os.Stat(freshState); !os.IsNotExist(err) {
+		t.Fatalf("fresh clone should NOT have the state path yet (err=%v)", err)
+	}
+
+	var out, errBuf strings.Builder
+	initCode := run(context.Background(), []string{"state", "init", "--workflow-dir", freshWorkflow},
+		os.Environ(), fresh, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if initCode != 0 {
+		t.Fatalf("state init exit=%d stdout=%q stderr=%q", initCode, out.String(), errBuf.String())
+	}
+	if _, err := os.Stat(freshState); err != nil {
+		t.Fatalf("state init did not create the state worktree: %v", err)
+	}
+	bootOut := runStatusBoot(t, freshWorkflow)
+	if !strings.Contains(bootOut, "present: true") {
+		t.Fatalf("post-init boot should show present: true; got\n%s", bootOut)
+	}
+}
+
+// TestStateNewRefusesAlreadyBirthed pins AC-3: state new refuses (a) an occupied
+// state path, (b) a local orphan branch, and (c) an orphan on origin — each
+// non-zero with a tailored message, case (c) naming `state init`. No raw git
+// `already exists` / `fatal:` leaks to stderr.
+func TestStateNewRefusesAlreadyBirthed(t *testing.T) {
+	t.Run("occupied-state-path", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		hostClone, workflowDir := writeSplitReadmeRepo(t)
+		// First birth succeeds.
+		if code, _, stderr := execStateNew(t, hostClone, workflowDir); code != 0 {
+			t.Fatalf("first state new should succeed; exit=%d stderr=%q", code, stderr)
+		}
+		// Second birth: the path now exists → refusal.
+		code, _, stderr := execStateNew(t, hostClone, workflowDir)
+		if code == 0 {
+			t.Fatalf("second state new on an occupied path must refuse (non-zero)")
+		}
+		assertNoGitFatal(t, stderr)
+		if !strings.Contains(stderr, "already") {
+			t.Fatalf("occupied-path refusal should mention the path already exists; stderr=%q", stderr)
+		}
+	})
+
+	t.Run("local-orphan-branch", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		hostClone, workflowDir := writeSplitReadmeRepo(t)
+		// Birth the orphan branch in a temp worktree but DO NOT check out the state
+		// path, so only the local-orphan precheck (not the path guard) trips.
+		tmpWT := filepath.Join(t.TempDir(), "orphan")
+		git(t, hostClone, "worktree", "add", "--detach", tmpWT)
+		git(t, tmpWT, "checkout", "--orphan", "spacedock-state/dev")
+		git(t, tmpWT, "rm", "-rf", "--cached", ".")
+		git(t, tmpWT, "commit", "-q", "--allow-empty", "-m", "seed")
+		git(t, hostClone, "worktree", "remove", "--force", tmpWT)
+
+		code, _, stderr := execStateNew(t, hostClone, workflowDir)
+		if code == 0 {
+			t.Fatalf("state new with a local orphan branch must refuse (non-zero)")
+		}
+		assertNoGitFatal(t, stderr)
+		if !strings.Contains(stderr, "state init") {
+			t.Fatalf("local-orphan refusal should redirect to `state init`; stderr=%q", stderr)
+		}
+	})
+
+	t.Run("remote-orphan-branch", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		hostClone, workflowDir := writeSplitReadmeRepo(t)
+		// Push an orphan branch to origin from a temp worktree, then drop the local
+		// ref so only the remote ls-remote precheck trips.
+		tmpWT := filepath.Join(t.TempDir(), "orphan")
+		git(t, hostClone, "worktree", "add", "--detach", tmpWT)
+		git(t, tmpWT, "checkout", "--orphan", "spacedock-state/dev")
+		git(t, tmpWT, "rm", "-rf", "--cached", ".")
+		git(t, tmpWT, "commit", "-q", "--allow-empty", "-m", "seed")
+		git(t, tmpWT, "push", "-q", "origin", "spacedock-state/dev")
+		git(t, hostClone, "worktree", "remove", "--force", tmpWT)
+		git(t, hostClone, "branch", "-D", "spacedock-state/dev")
+
+		code, _, stderr := execStateNew(t, hostClone, workflowDir)
+		if code == 0 {
+			t.Fatalf("state new with a remote orphan branch must refuse (non-zero)")
+		}
+		assertNoGitFatal(t, stderr)
+		if !strings.Contains(stderr, "state init") {
+			t.Fatalf("remote-orphan refusal should name `state init` as the right command; stderr=%q", stderr)
+		}
+	})
+}
+
+// TestStateNewNoRemoteBestEffort pins AC-4: in a repo with no origin, state new
+// births the orphan branch + worktree locally, exits 0, and warns the operator to
+// push the orphan branch to share state.
+func TestStateNewNoRemoteBestEffort(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	git(t, root, "init", "-q")
+	git(t, root, "config", "user.email", "t@t")
+	git(t, root, "config", "user.name", "t")
+	workflowDir := filepath.Join(root, "docs", "dev")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "README.md"), []byte(splitWorkflowReadme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, root, "add", "docs/dev/README.md")
+	git(t, root, "commit", "-q", "-m", "add split-root README")
+
+	code, stdout, stderr := execStateNew(t, root, workflowDir)
+	if code != 0 {
+		t.Fatalf("no-remote state new must exit 0 (best-effort push); exit=%d stderr=%q", code, stderr)
+	}
+	assertNoGitFatal(t, stderr)
+	statePath := filepath.Join(workflowDir, ".spacedock-state")
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("no-remote state new did not create the state worktree: %v", err)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "push") {
+		t.Fatalf("no-remote state new should warn the operator to push the orphan branch; got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+// TestStateNewInlineErrors pins AC-5: state new against an inline / non-split
+// README exits non-zero with a message explaining state new only births split-root
+// workflows. (state init prints a benign one-liner; new is a mutating verb, so a
+// mismatched backend is an operator error.)
+func TestStateNewInlineErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	wf := filepath.Join(root, "wf")
+	if err := os.MkdirAll(wf, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wf, "README.md"),
+		[]byte("---\ncommissioned-by: spacedock@1\nid-style: slug\nstate: $inline\nstages:\n  states:\n    - name: ideation\n      initial: true\n    - name: done\n      terminal: true\n---\n\n# Inline WF\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, root, "init", "-q")
+	git(t, root, "add", "-A")
+	git(t, root, "commit", "-q", "-m", "init")
+
+	code, _, stderr := execStateNew(t, root, wf)
+	if code == 0 {
+		t.Fatalf("inline state new must exit non-zero (mutating verb on a non-split backend)")
+	}
+	if !strings.Contains(stderr, "split-root") {
+		t.Fatalf("inline state new should explain it only births split-root workflows; stderr=%q", stderr)
+	}
+}
+
+// gitignoreHasLine reports whether content carries want as a complete line, so a
+// mangled path that merely contains want as a substring does not pass.
+func gitignoreHasLine(content, want string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// assertNoGitFatal fails if stderr leaked a raw git porcelain fatal — state new
+// must translate git failures into operator-facing messages, never pass through
+// `fatal:` or `already exists`.
+func assertNoGitFatal(t *testing.T, stderr string) {
+	t.Helper()
+	for _, leak := range []string{"fatal:", "already exists"} {
+		if strings.Contains(stderr, leak) {
+			t.Fatalf("stderr leaked raw git output %q: %s", leak, stderr)
+		}
+	}
+}
+
+// TestLsRemoteHasBranch is the pure table test for the remote-orphan precheck's
+// ls-remote parser: it must match the full refs/heads/<branch> ref-path (branch
+// names carry slashes), treat empty output as no-match, and not be fooled by a
+// similarly-prefixed branch.
+func TestLsRemoteHasBranch(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		branch string
+		want   bool
+	}{
+		{"empty output", "", "spacedock-state/dev", false},
+		{"exact match", "abc123\trefs/heads/spacedock-state/dev\n", "spacedock-state/dev", true},
+		{"no trailing newline", "abc123\trefs/heads/spacedock-state/dev", "spacedock-state/dev", true},
+		{"different branch", "abc123\trefs/heads/main\n", "spacedock-state/dev", false},
+		{"prefix is not a match", "abc123\trefs/heads/spacedock-state/dev-2\n", "spacedock-state/dev", false},
+		{"match among several heads", "a\trefs/heads/main\nb\trefs/heads/spacedock-state/dev\n", "spacedock-state/dev", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lsRemoteHasBranch(tc.output, tc.branch); got != tc.want {
+				t.Fatalf("lsRemoteHasBranch(%q, %q) = %v, want %v", tc.output, tc.branch, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
One command births a split-root state checkout on an existing repo — the missing inverse of `state init`.

## What changed
- Add `spacedock state new` — births the orphan state branch + linked worktree at the README `state:` path.
- Reuse `ClassifyState`/`StateBranch`/`DiscoverWorkflowDir` + the `commissionSplitWorkflow` birth mechanic.
- Refuse occupied path / existing local-or-remote orphan (redirect to `state init`) with clear, no-`fatal:`-leak messages.
- Derive the `.gitignore` entry from `git rev-parse --show-prefix` (symlink-safe), left for the operator to commit.

## Evidence
- `internal/cli/state_new_test.go`: 15/15 real-git e2e (no mocks) passed; full suite 848/848; `go vet`/`gofmt` clean.
- Detached adversarial audit: 7/7 claim-breaking edits caught by the deliverable's own tests.

---
[kj](/spacedock-dev/spacedock/blob/ccf2e6a975ad04e7f3ae5a46236b77bdee8a80d4/split-root-onboarding-command/index.md)
