### PR TITLE
Make the Codex no-wait subagent completion behavior retryable

### DIFF
--- a/docs/dev/_evidence/codex-idle-notification-probe/2026-06-03-dogfood.json
+++ b/docs/dev/_evidence/codex-idle-notification-probe/2026-06-03-dogfood.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "run_id": "2026-06-03-dogfood",
+  "host": "codex",
+  "codex_cli_version": "codex-cli 0.136.0",
+  "session_started_at_utc": null,
+  "worker_handle": "Dalton (019e8e34-ec78-7691-b56d-14528a0a9f71)",
+  "worker_prompt": "You are a no-write Codex idle-wake probe. Do not read or write files, do not run tools, and do not modify state. Sleep for 30 seconds, then reply exactly: Done: idle-wake Codex notification probe completed.",
+  "worker_delay_seconds": 30,
+  "spawned_at_utc": null,
+  "fo_turn_ended_at_utc": null,
+  "idle_window_seconds": 90,
+  "first_user_activity_at_utc": null,
+  "final_status_notification_at_utc": null,
+  "notification_delivered_before_user_message": true,
+  "autonomous_wake_observed": false,
+  "classification": "queued_flush",
+  "interpretation": "The run proves queued mailbox delivery before the next captain message, not autonomous idle wake-up."
+}

--- a/docs/dev/codex-idle-notification-probe.md
+++ b/docs/dev/codex-idle-notification-probe.md
@@ -1,0 +1,68 @@
+# Codex Idle Notification Probe
+
+Use this recipe when checking whether Codex can resume a first-officer turn from
+a background worker final-status notification without an explicit foreground
+wait. The probe separates foreground waiting, queued notification delivery, and
+autonomous idle wake-up.
+
+Use this exact no-write worker prompt:
+
+```text
+You are a no-write Codex idle-wake probe. Do not read or write files, do not run tools, and do not modify state. Sleep for 30 seconds, then reply exactly: Done: idle-wake Codex notification probe completed.
+```
+
+Record `worker_delay_seconds` as `30`. The minimum idle window is 90 seconds
+after the FO turn ends.
+
+During a no-wait idle window, avoid captain messages, shell-outs, terminal jobs,
+and tool calls. Any such activity can flush a queued mailbox notification and
+must be treated as operator activity, not idle wake evidence.
+
+## Foreground wait comparison
+
+1. Dispatch a worker with the exact no-write prompt and record its handle.
+2. When there is no ready workflow work, call `wait_agent(handle)`.
+3. Record whether the call returns a timeout or a final status.
+4. If captain input or another non-stopping interruption occurs, retry the same
+   handle and record the next timeout or final status.
+5. Classify a final status observed through this explicit wait path as
+   `foreground_wait`.
+
+## No-wait idle probe
+
+1. Dispatch a worker with the exact no-write prompt and record its handle.
+2. Do not call `wait_agent`; end the FO turn.
+3. Keep the session idle for the minimum idle window of 90 seconds after the FO
+   turn ends.
+4. During that idle window, avoid captain messages, shell-outs, terminal jobs,
+   and tool calls.
+5. If Codex starts a new assistant turn from the worker final-status
+   notification alone, classify the run as `autonomous_idle_wake`.
+6. If no notification appears during the idle window, classify the idle portion
+   as `no_notification_observed` unless later activity reveals a queued
+   notification.
+
+## Queued-notification flush check
+
+1. After a no-wait idle window without autonomous wake-up, perform one explicit
+   activity: a captain message, tool action, or shell-out.
+2. If Codex then delivers the worker final-status notification, record that the
+   notification was delivered after later activity.
+3. A queued notification flushed by later activity is `queued_flush`, not
+   `autonomous_idle_wake`.
+
+## Interpretation Rules
+
+- `foreground_wait`: `wait_agent(handle)` returned the worker timeout or final
+  status path, and any interruption was followed by a retry of the same handle.
+- `queued_flush`: no foreground wait was used, but later captain, tool, or
+  shell-out activity caused a queued worker final-status notification to appear.
+- `autonomous_idle_wake`: no foreground wait and no later activity occurred, and
+  Codex began a new assistant turn from the worker final-status notification
+  alone.
+- `no_notification_observed`: no foreground wait was used and no final-status
+  notification appeared during the minimum idle window.
+
+Store run records as JSON under
+`docs/dev/_evidence/codex-idle-notification-probe/`. Use RFC3339 UTC timestamps
+when known, and `null` when the observation did not capture an exact timestamp.

--- a/internal/hostneutrality/prose_inflator_locks_test.go
+++ b/internal/hostneutrality/prose_inflator_locks_test.go
@@ -146,8 +146,8 @@ func TestNoCrossFileRestatement(t *testing.T) {
 
 // proseSpan is one span with location and exception-class info.
 type proseSpan struct {
-	text         string
-	startLine    int
+	text           string
+	startLine      int
 	excludeOverlap bool
 }
 

--- a/internal/status/fence_helpers_test.go
+++ b/internal/status/fence_helpers_test.go
@@ -185,4 +185,3 @@ func fenceHelpersEqualStrings(a, b []string) bool {
 	}
 	return true
 }
-

--- a/internal/status/mutate.go
+++ b/internal/status/mutate.go
@@ -238,7 +238,6 @@ func needsExplicitQuoting(val string) bool {
 	return false
 }
 
-
 // atomicWrite writes data to a temp file in the same directory and renames it
 // into place, so a reader never observes a half-written entity. The principle
 // stated in decision B applied to --set, --archive's stamp, and --new.

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -33,13 +33,44 @@ context; otherwise dispatch a fresh worker from entity state.
 
 ## Awaiting Completion
 
-The Codex completion signal is the async final-status notification in the FO mailbox. `wait_agent` is only an optional accelerator when a critical-path step is blocked on the worker result.
+The Codex completion signal is the async final-status notification in the FO mailbox.
+`wait_agent` is an explicit foreground wait action, not the completion signal
+itself.
 
-A wait_agent timeout return is normal. It means no final-status mailbox update
-arrived before the deadline; it is not a failure, a zombie signal, or a teardown
-trigger.
+Before calling `wait_agent`, finish the available dispatch sequence: process
+ready final-status notifications, make gate decisions, apply resulting state
+transitions, and dispatch any newly dispatchable work. Call `wait_agent` only
+when no other dispatchable or gate-processing work is available and an
+unresolved worker completion is the next useful idle action. Non-critical
+background work may still end the FO turn and rely on the mailbox.
 
-Between dispatch and the async final-status notification, do not poll, re-dispatch, or close the worker. End the turn and let Codex deliver the mailbox notification. Close workers only after completion has been observed or when the captain explicitly requests shutdown.
+### Foreground wait
+
+The FO calls `wait_agent(handle)` as the next useful idle action after the
+scheduling priority above is exhausted. A wait_agent timeout return is normal and
+retryable with the same handle. It means no final-status mailbox update arrived
+before the deadline; it is not a failure, a zombie signal, or a teardown trigger.
+A captain message or shell-out during the wait is operator activity, not idle
+wake evidence.
+
+### Queued notification flushed by later activity
+
+The FO does not call `wait_agent`, ends the turn, and a later captain message,
+tool action, or shell-out causes Codex to deliver a worker final-status
+notification that had already been queued. This proves mailbox ordering, not
+autonomous FO wake-up.
+
+### Autonomous idle FO wake-up
+
+The FO does not call `wait_agent`, performs no later captain message, tool
+action, shell-out, or terminal job, and Codex starts a new assistant turn from
+the worker final-status notification alone. This is the only observation that
+proves no-wait idle wake-up.
+
+Between dispatch and the async final-status notification, do not poll, re-dispatch, or close the worker.
+Continue ready workflow work, foreground-wait only under the rule above, or end
+the turn and let Codex deliver the mailbox notification. Close workers only after
+completion has been observed or when the captain explicitly requests shutdown.
 
 ## Completion Signal
 

--- a/skills/integration/codex_idle_notification_test.go
+++ b/skills/integration/codex_idle_notification_test.go
@@ -1,0 +1,294 @@
+// ABOUTME: Contract tests for Codex no-wait completion evidence and runtime wording.
+// ABOUTME: Keeps queued notifications distinct from autonomous idle wake-up.
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+const codexIdleNotificationProbePrompt = "You are a no-write Codex idle-wake probe. Do not read or write files, do not run tools, and do not modify state. Sleep for 30 seconds, then reply exactly: Done: idle-wake Codex notification probe completed."
+
+var codexIdleNotificationClassifications = map[string]bool{
+	"foreground_wait":          true,
+	"queued_flush":             true,
+	"autonomous_idle_wake":     true,
+	"no_notification_observed": true,
+}
+
+func TestCodexIdleNotificationRuntimeContract(t *testing.T) {
+	root := skillsRoot(t)
+	path := filepath.Join(root, "first-officer", "references", "codex-first-officer-runtime.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	region := sectionAfter(string(data), "## Awaiting Completion")
+	if region == "" {
+		t.Fatal("Codex runtime missing `## Awaiting Completion` section")
+	}
+
+	for _, required := range []string{
+		"### Foreground wait",
+		"### Queued notification flushed by later activity",
+		"### Autonomous idle FO wake-up",
+	} {
+		if !strings.Contains(region, required) {
+			t.Errorf("Awaiting Completion missing outcome heading %q", required)
+		}
+	}
+
+	scheduling := paragraphContaining(region, "Before calling `wait_agent`")
+	if scheduling == "" {
+		t.Fatal("Awaiting Completion missing scheduling priority paragraph before `wait_agent`")
+	}
+	scheduling = squashWhitespace(scheduling)
+	for _, required := range []string{
+		"ready final-status notifications",
+		"gate decisions",
+		"state transitions",
+		"newly dispatchable work",
+		"no other dispatchable or gate-processing work is available",
+		"unresolved worker completion is the next useful idle action",
+	} {
+		if !strings.Contains(scheduling, required) {
+			t.Errorf("wait_agent scheduling paragraph missing %q", required)
+		}
+	}
+
+	lower := strings.ToLower(squashWhitespace(region))
+	for _, forbidden := range []string{
+		"must call `wait_agent` after every dispatch",
+		"must call wait_agent after every dispatch",
+		"always call `wait_agent`",
+		"always call wait_agent",
+		"foreground-wait after every dispatch",
+		"wait after every dispatch",
+	} {
+		if strings.Contains(lower, forbidden) {
+			t.Errorf("Awaiting Completion contains blanket foreground-wait wording %q", forbidden)
+		}
+	}
+}
+
+func TestCodexIdleNotificationRecipeShape(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "docs", "dev", "codex-idle-notification-probe.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	content := string(data)
+	contentFlat := squashWhitespace(content)
+
+	for _, heading := range []string{
+		"## Foreground wait comparison",
+		"## No-wait idle probe",
+		"## Queued-notification flush check",
+	} {
+		if sectionAfter(content, heading) == "" {
+			t.Errorf("recipe missing section %q", heading)
+		}
+	}
+	if !strings.Contains(content, codexIdleNotificationProbePrompt) {
+		t.Errorf("recipe missing exact no-write worker prompt %q", codexIdleNotificationProbePrompt)
+	}
+	if idleWindowSeconds(content) < 90 {
+		t.Errorf("recipe idle window is less than 90 seconds")
+	}
+	for _, required := range []string{
+		"avoid captain messages",
+		"shell-outs",
+		"terminal jobs",
+		"tool calls",
+		"retry the same handle",
+		"A queued notification flushed by later activity is `queued_flush`, not `autonomous_idle_wake`.",
+	} {
+		if !strings.Contains(contentFlat, required) {
+			t.Errorf("recipe missing %q", required)
+		}
+	}
+	for classification := range codexIdleNotificationClassifications {
+		if !strings.Contains(content, "`"+classification+"`") {
+			t.Errorf("recipe missing interpretation classification %q", classification)
+		}
+	}
+}
+
+func TestCodexIdleNotificationEvidenceSchema(t *testing.T) {
+	dir := filepath.Join(repoRoot(t), "docs", "dev", "_evidence", "codex-idle-notification-probe")
+	paths, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		t.Fatalf("glob evidence: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no Codex idle-notification evidence JSON files in %s", dir)
+	}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", path, err)
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal(data, &record); err != nil {
+			t.Errorf("parse %s: %v", path, err)
+			continue
+		}
+
+		if got := requireInt(t, path, record, "schema_version"); got != 1 {
+			t.Errorf("%s: schema_version = %d, want 1", path, got)
+		}
+		runID := requireString(t, path, record, "run_id")
+		requireStringEqual(t, path, record, "host", "codex")
+		requireString(t, path, record, "codex_cli_version")
+		requireString(t, path, record, "worker_handle")
+		requireString(t, path, record, "worker_prompt")
+		requireInt(t, path, record, "worker_delay_seconds")
+		requireInt(t, path, record, "idle_window_seconds")
+		requireOptionalBool(t, path, record, "notification_delivered_before_user_message")
+		autonomousWake := requireBool(t, path, record, "autonomous_wake_observed")
+		classification := requireString(t, path, record, "classification")
+		if !codexIdleNotificationClassifications[classification] {
+			t.Errorf("%s: classification %q is outside the allowed enum", path, classification)
+		}
+		requireString(t, path, record, "interpretation")
+
+		for _, field := range []string{
+			"session_started_at_utc",
+			"spawned_at_utc",
+			"fo_turn_ended_at_utc",
+			"first_user_activity_at_utc",
+			"final_status_notification_at_utc",
+		} {
+			requireOptionalRFC3339(t, path, record, field)
+		}
+
+		if runID == "2026-06-03-dogfood" && (!autonomousWake || record["first_user_activity_at_utc"] != nil) && classification == "autonomous_idle_wake" {
+			t.Errorf("%s: dogfood queued-delivery evidence must not be classified as autonomous idle wake-up", path)
+		}
+	}
+}
+
+func paragraphContaining(text, needle string) string {
+	for _, paragraph := range strings.Split(text, "\n\n") {
+		if strings.Contains(paragraph, needle) {
+			return paragraph
+		}
+	}
+	return ""
+}
+
+func idleWindowSeconds(text string) int {
+	re := regexp.MustCompile(`(?i)(?:minimum idle window|idle window)[^0-9\n]*(\d+)\s+seconds`)
+	best := 0
+	for _, match := range re.FindAllStringSubmatch(text, -1) {
+		if len(match) != 2 {
+			continue
+		}
+		var n int
+		for _, r := range match[1] {
+			n = n*10 + int(r-'0')
+		}
+		if n > best {
+			best = n
+		}
+	}
+	return best
+}
+
+func squashWhitespace(text string) string {
+	return strings.Join(strings.Fields(text), " ")
+}
+
+func requireString(t *testing.T, path string, record map[string]any, field string) string {
+	t.Helper()
+	value, ok := record[field]
+	if !ok {
+		t.Errorf("%s: missing required field %q", path, field)
+		return ""
+	}
+	s, ok := value.(string)
+	if !ok || s == "" {
+		t.Errorf("%s: field %q must be a non-empty string", path, field)
+		return ""
+	}
+	return s
+}
+
+func requireStringEqual(t *testing.T, path string, record map[string]any, field, want string) {
+	t.Helper()
+	if got := requireString(t, path, record, field); got != "" && got != want {
+		t.Errorf("%s: field %q = %q, want %q", path, field, got, want)
+	}
+}
+
+func requireInt(t *testing.T, path string, record map[string]any, field string) int {
+	t.Helper()
+	value, ok := record[field]
+	if !ok {
+		t.Errorf("%s: missing required field %q", path, field)
+		return 0
+	}
+	f, ok := value.(float64)
+	if !ok || f != float64(int(f)) {
+		t.Errorf("%s: field %q must be an integer", path, field)
+		return 0
+	}
+	return int(f)
+}
+
+func requireBool(t *testing.T, path string, record map[string]any, field string) bool {
+	t.Helper()
+	value, ok := record[field]
+	if !ok {
+		t.Errorf("%s: missing required field %q", path, field)
+		return false
+	}
+	b, ok := value.(bool)
+	if !ok {
+		t.Errorf("%s: field %q must be a boolean", path, field)
+		return false
+	}
+	return b
+}
+
+func requireOptionalBool(t *testing.T, path string, record map[string]any, field string) {
+	t.Helper()
+	value, ok := record[field]
+	if !ok {
+		t.Errorf("%s: missing required field %q", path, field)
+		return
+	}
+	if value == nil {
+		return
+	}
+	if _, ok := value.(bool); !ok {
+		t.Errorf("%s: field %q must be a boolean or null", path, field)
+	}
+}
+
+func requireOptionalRFC3339(t *testing.T, path string, record map[string]any, field string) {
+	t.Helper()
+	value, ok := record[field]
+	if !ok {
+		t.Errorf("%s: missing required field %q", path, field)
+		return
+	}
+	if value == nil {
+		return
+	}
+	s, ok := value.(string)
+	if !ok || s == "" {
+		t.Errorf("%s: field %q must be an RFC3339 string or null", path, field)
+		return
+	}
+	if _, err := time.Parse(time.RFC3339, s); err != nil {
+		t.Errorf("%s: field %q is not RFC3339: %v", path, field, err)
+	}
+}


### PR DESCRIPTION
Codex first-officer sessions now have a retryable way to distinguish queued worker notifications from true idle wake-up.

## What changed
- Documented Codex foreground wait and mailbox outcomes.
- Added a rerunnable idle-notification probe recipe.
- Recorded dogfood evidence as queued-flush, not idle wake.
- Added integration tests for contract, recipe, and evidence schema.

## Evidence
- Focused idle-notification suite: 3/3 passed.
- Full Go suites: 879/879 passed under normal and race runs.

---
[gn](/spacedock-dev/spacedock/blob/520a3030944cd28f16b1d963a578483aa45e6ad8/codex-idle-notification-probe/index.md)
