### PR TITLE
Make dispatch subcommand help reachable without required operational flags

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -25,12 +25,20 @@ func Run(probe claudeteam.TeamStateProbe, args []string, stdin io.Reader, stdout
 
 	switch args[0] {
 	case "build":
+		if wantsHelp(args[1:]) {
+			printBuildUsage(stdout)
+			return 0
+		}
 		workflowDir, code := requireFlag(args[1:], "--workflow-dir", stderr)
 		if code != 0 {
 			return code
 		}
 		return runBuild(probe, workflowDir, stdin, stdout, stderr)
 	case "show-stage-def":
+		if wantsHelp(args[1:]) {
+			printShowStageDefUsage(stdout)
+			return 0
+		}
 		workflowDir, stage, code := requireStageFlags(args[1:], stderr)
 		if code != 0 {
 			return code
@@ -70,6 +78,20 @@ func Run(probe claudeteam.TeamStateProbe, args []string, stdin io.Reader, stdout
 		printUsage(stderr)
 		return 2
 	}
+}
+
+// wantsHelp reports whether args request subcommand help. Stop at -- so future
+// passthrough forms can carry a literal --help without changing this contract.
+func wantsHelp(args []string) bool {
+	for _, a := range args {
+		if a == "--" {
+			return false
+		}
+		if a == "-h" || a == "--help" {
+			return true
+		}
+	}
+	return false
 }
 
 // requireFlag returns the value of a single required `name value` flag. A
@@ -146,5 +168,38 @@ Usage:
   spacedock dispatch build --workflow-dir DIR        (stdin JSON -> stdout JSON)
   spacedock dispatch show-stage-def --workflow-dir DIR --stage STAGE
   spacedock dispatch reconcile --workflow-dir DIR [--team-name NAME] [--repo-root DIR] [--include A,B,C,D,E]
+`)
+}
+
+func printBuildUsage(w io.Writer) {
+	fmt.Fprint(w, `Usage:
+  spacedock dispatch build --workflow-dir DIR
+
+Build an ensign dispatch artifact from stdin JSON and write the JSON envelope to stdout.
+
+Flags:
+  --workflow-dir DIR   Workflow definition directory containing README.md.
+
+Stdin JSON fields:
+  schema_version  Dispatch schema version. The current supported value is 2.
+  entity_path     Path to the entity file for this dispatch.
+  workflow_dir    Workflow directory for the dispatch request.
+  stage           Stage name to dispatch.
+  checklist       Array of checklist strings for the dispatched worker.
+
+Example:
+  {"schema_version":2,"entity_path":"thing.md","workflow_dir":".","stage":"implementation","checklist":["DONE: run tests"]}
+`)
+}
+
+func printShowStageDefUsage(w io.Writer) {
+	fmt.Fprint(w, `Usage:
+  spacedock dispatch show-stage-def --workflow-dir DIR --stage STAGE
+
+Print the workflow README section for a stage.
+
+Flags:
+  --workflow-dir DIR   Workflow definition directory containing README.md.
+  --stage STAGE        Stage name whose definition should be printed.
 `)
 }

--- a/internal/dispatch/guard_test.go
+++ b/internal/dispatch/guard_test.go
@@ -35,20 +35,26 @@ func TestUnknownSubcommandGuard(t *testing.T) {
 func TestRequiredFlagGuard(t *testing.T) {
 	t.Run("build-missing-workflow-dir", func(t *testing.T) {
 		res := runNative(`{}`, "build")
-		if res.exit == 0 {
-			t.Errorf("build without --workflow-dir exited 0")
+		if res.exit != 2 {
+			t.Errorf("build without --workflow-dir exit=%d, want 2", res.exit)
 		}
-		if !strings.Contains(res.stderr, "--workflow-dir") {
-			t.Errorf("build missing-flag diagnostic lacks --workflow-dir:\n%q", res.stderr)
+		if res.stdout != "" {
+			t.Errorf("build without --workflow-dir stdout=%q, want empty", res.stdout)
+		}
+		if !strings.Contains(res.stderr, "requires --workflow-dir") {
+			t.Errorf("build missing-flag diagnostic lacks required text:\n%q", res.stderr)
 		}
 	})
 	t.Run("show-stage-def-missing-stage", func(t *testing.T) {
 		res := runNative("", "show-stage-def", "--workflow-dir", "/tmp")
-		if res.exit == 0 {
-			t.Errorf("show-stage-def without --stage exited 0")
+		if res.exit != 2 {
+			t.Errorf("show-stage-def without --stage exit=%d, want 2", res.exit)
 		}
-		if !strings.Contains(res.stderr, "--stage") {
-			t.Errorf("show-stage-def missing-flag diagnostic lacks --stage:\n%q", res.stderr)
+		if res.stdout != "" {
+			t.Errorf("show-stage-def without --stage stdout=%q, want empty", res.stdout)
+		}
+		if !strings.Contains(res.stderr, "requires --workflow-dir and --stage") {
+			t.Errorf("show-stage-def missing-flag diagnostic lacks required text:\n%q", res.stderr)
 		}
 	})
 }

--- a/internal/dispatch/help_test.go
+++ b/internal/dispatch/help_test.go
@@ -1,0 +1,72 @@
+// ABOUTME: help-routing guards for dispatch subcommands with required runtime flags.
+// ABOUTME: Help must render before operational flag validation runs.
+package dispatch
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDispatchBuildHelpBeforeRequiredFlags(t *testing.T) {
+	for _, helpFlag := range []string{"--help", "-h"} {
+		t.Run(helpFlag, func(t *testing.T) {
+			res := runNative("", "build", helpFlag)
+			if res.exit != 0 {
+				t.Fatalf("dispatch build %s exit=%d, want 0\nstderr=%q", helpFlag, res.exit, res.stderr)
+			}
+			if res.stderr != "" {
+				t.Fatalf("dispatch build %s stderr=%q, want empty", helpFlag, res.stderr)
+			}
+			assertContainsAll(t, res.stdout,
+				"Usage:",
+				"spacedock dispatch build --workflow-dir DIR",
+				"stdin JSON",
+				"--workflow-dir",
+				"schema_version",
+				"entity_path",
+				"workflow_dir",
+				"stage",
+				"checklist",
+			)
+			assertNotContains(t, res.stdout, "requires --workflow-dir")
+		})
+	}
+}
+
+func TestDispatchShowStageDefHelpBeforeRequiredFlags(t *testing.T) {
+	for _, helpFlag := range []string{"--help", "-h"} {
+		t.Run(helpFlag, func(t *testing.T) {
+			res := runNative("", "show-stage-def", helpFlag)
+			if res.exit != 0 {
+				t.Fatalf("dispatch show-stage-def %s exit=%d, want 0\nstderr=%q", helpFlag, res.exit, res.stderr)
+			}
+			if res.stderr != "" {
+				t.Fatalf("dispatch show-stage-def %s stderr=%q, want empty", helpFlag, res.stderr)
+			}
+			assertContainsAll(t, res.stdout,
+				"Usage:",
+				"spacedock dispatch show-stage-def --workflow-dir DIR --stage STAGE",
+				"--workflow-dir",
+				"--stage",
+			)
+			assertNotContains(t, res.stdout, "requires --workflow-dir")
+			assertNotContains(t, res.stdout, "requires --workflow-dir and --stage")
+		})
+	}
+}
+
+func assertContainsAll(t *testing.T, got string, wants ...string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func assertNotContains(t *testing.T, got, bad string) {
+	t.Helper()
+	if strings.Contains(got, bad) {
+		t.Fatalf("output contains %q:\n%s", bad, got)
+	}
+}


### PR DESCRIPTION
Dispatch subcommand help is now reachable before operational flag validation, making the helper inspectable during FO dispatch setup.

## What changed
- Add help-first routing for `dispatch build`
- Add help-first routing for `dispatch show-stage-def`
- Cover help output and missing-flag regressions

## Evidence
- `go test ./...`: 885/885 passed
- `go test ./... -race`: 885/885 passed

---
[bx](/spacedock-dev/spacedock/blob/6072310ec66490b5d06da9a8d0b4778d8b46ab59/dispatch-build-help-ergonomics/index.md)
