### PR TITLE
dispatch build requires a hand-built JSON blob on stdin, and the contract's inline-echo example anchors the FO on shell heredocs (backticks break them) instead of the Write tool

### DIFF
--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -56,37 +56,166 @@ func buildError(stderr io.Writer, code int, format string, a ...any) int {
 	return code
 }
 
-// runBuild reads a dispatch request as JSON on stdin and assembles the dispatch
-// envelope on stdout plus the dispatch-file body written to a deterministic
-// path. It always emits the show-stage-def fetch line and appends the
-// show-standing fetch line when the workflow declares at least one standing
-// teammate. Matches cmd_build.
-func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Reader, stdout, stderr io.Writer) int {
-	raw, err := io.ReadAll(stdin)
-	if err != nil {
-		return buildError(stderr, 1, "failed to read stdin: %s", err)
+// runBuild reads a dispatch request from stdin JSON or the flag/file input mode
+// and assembles the dispatch envelope on stdout plus the dispatch-file body
+// written to a deterministic path. It always emits the show-stage-def fetch line
+// and appends the show-standing fetch line when the workflow declares at least
+// one standing teammate.
+func runBuild(probe claudeteam.TeamStateProbe, opts buildOptions, stdin io.Reader, stdout, stderr io.Writer) int {
+	if opts.PrintSchema {
+		return emitBuildSchema(stdout)
+	}
+
+	fields, code := loadBuildFields(opts, stdin, stderr)
+	if code != 0 {
+		return code
+	}
+
+	return runBuildFields(probe, opts, fields, stdout, stderr)
+}
+
+func loadBuildFields(opts buildOptions, stdin io.Reader, stderr io.Writer) (map[string]json.RawMessage, int) {
+	switch {
+	case opts.ValidateOnly != "":
+		raw, err := os.ReadFile(opts.ValidateOnly)
+		if err != nil {
+			return nil, buildError(stderr, 1, "failed to read validate-only file %q: %s", opts.ValidateOnly, err)
+		}
+		return decodeBuildFields(raw, stderr)
+	case opts.hasRequestFlags():
+		return fieldsFromBuildFlags(opts, stderr)
+	default:
+		raw, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, buildError(stderr, 1, "failed to read stdin: %s", err)
+		}
+		return decodeBuildFields(raw, stderr)
+	}
+}
+
+func decodeBuildFields(raw []byte, stderr io.Writer) (map[string]json.RawMessage, int) {
+	if len(raw) == 0 {
+		raw = []byte{}
 	}
 
 	// Classify the top-level value the way the oracle does (json.loads then
-	// isinstance(inp, dict)): invalid JSON → "invalid JSON on stdin"; a valid
-	// non-object top-level (null, array, scalar) → "stdin must be a JSON object".
-	// A bare-map decode cannot tell these apart — decoding JSON null into a map
+	// isinstance(inp, dict)): invalid JSON -> "invalid JSON on stdin"; a valid
+	// non-object top-level (null, array, scalar) -> "stdin must be a JSON object".
+	// A bare-map decode cannot tell these apart -- decoding JSON null into a map
 	// succeeds with a nil map, masking the non-object case as a missing field.
 	var top interface{}
 	if err := json.Unmarshal(raw, &top); err != nil {
-		return buildError(stderr, 1, "invalid JSON on stdin: %s", err)
+		return nil, buildError(stderr, 1, "invalid JSON on stdin: %s", err)
 	}
 	if _, ok := top.(map[string]interface{}); !ok {
-		return buildError(stderr, 1, "stdin must be a JSON object")
+		return nil, buildError(stderr, 1, "stdin must be a JSON object")
 	}
 
 	// Distinguish present-but-null from absent (the required-field rule fires for
 	// both), so decode into a raw-message map for typed field access.
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &fields); err != nil {
-		return buildError(stderr, 1, "invalid JSON on stdin: %s", err)
+		return nil, buildError(stderr, 1, "invalid JSON on stdin: %s", err)
+	}
+	return fields, 0
+}
+
+func fieldsFromBuildFlags(opts buildOptions, stderr io.Writer) (map[string]json.RawMessage, int) {
+	if opts.EntityPath == "" || opts.Stage == "" || opts.ChecklistFile == "" {
+		return nil, buildError(stderr, 2, "flag/file input requires --entity-path, --stage, and --checklist-file")
+	}
+	checklist, err := readChecklistFile(opts.ChecklistFile)
+	if err != nil {
+		return nil, buildError(stderr, 1, "failed to read checklist file %q: %s", opts.ChecklistFile, err)
+	}
+	fields := map[string]json.RawMessage{
+		"schema_version": rawJSON(schemaVersion),
+		"entity_path":    rawJSON(opts.EntityPath),
+		"workflow_dir":   rawJSON(opts.WorkflowDir),
+		"stage":          rawJSON(opts.Stage),
+		"checklist":      rawJSON(checklist),
+		"bare_mode":      rawJSON(opts.BareMode),
+	}
+	if opts.TeamName != "" {
+		fields["team_name"] = rawJSON(opts.TeamName)
+	}
+	if opts.ScopeNotesFile != "" {
+		scopeNotes, err := os.ReadFile(opts.ScopeNotesFile)
+		if err != nil {
+			return nil, buildError(stderr, 1, "failed to read scope-notes file %q: %s", opts.ScopeNotesFile, err)
+		}
+		fields["scope_notes"] = rawJSON(string(scopeNotes))
+	}
+	if opts.FeedbackContextFile != "" {
+		feedbackContext, err := os.ReadFile(opts.FeedbackContextFile)
+		if err != nil {
+			return nil, buildError(stderr, 1, "failed to read feedback-context file %q: %s", opts.FeedbackContextFile, err)
+		}
+		fields["feedback_context"] = rawJSON(string(feedbackContext))
+	}
+	if opts.FeedbackReflow {
+		fields["is_feedback_reflow"] = rawJSON(true)
+	}
+	return fields, 0
+}
+
+func readChecklistFile(path string) ([]string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out, nil
+}
+
+func rawJSON(v any) json.RawMessage {
+	raw, _ := json.Marshal(v)
+	return raw
+}
+
+func resolveBuildHost(flagHost, jsonHost string, getenv func(string) string) (string, error) {
+	if flagHost != "" && !validBuildHost(flagHost) {
+		return "", fmt.Errorf("unsupported host %q (want claude or codex)", flagHost)
+	}
+	if jsonHost != "" && !validBuildHost(jsonHost) {
+		return "", fmt.Errorf("unsupported host %q (want claude or codex)", jsonHost)
+	}
+	if flagHost != "" && jsonHost != "" && flagHost != jsonHost {
+		return "", fmt.Errorf("conflicting explicit host sources: --host=%q, JSON host=%q", flagHost, jsonHost)
+	}
+	if flagHost != "" {
+		return flagHost, nil
+	}
+	if jsonHost != "" {
+		return jsonHost, nil
 	}
 
+	codex := getenv("CODEX_THREAD_ID") != ""
+	claude := getenv("CLAUDECODE") != ""
+	if codex && claude {
+		return "", fmt.Errorf("ambiguous runtime host sources: CODEX_THREAD_ID and CLAUDECODE are both set; pass --host claude or --host codex")
+	}
+	if codex {
+		return "codex", nil
+	}
+	if claude {
+		return "claude", nil
+	}
+	return "", fmt.Errorf("missing host source: pass --host, set JSON host, or run under CODEX_THREAD_ID or CLAUDECODE")
+}
+
+func validBuildHost(host string) bool {
+	return host == "claude" || host == "codex"
+}
+
+func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields map[string]json.RawMessage, stdout, stderr io.Writer) int {
 	// Rule 1: Required fields present and non-null.
 	for _, field := range buildRequiredFields {
 		v, ok := fields[field]
@@ -105,16 +234,17 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 	}
 
 	entityPath := jsonString(fields["entity_path"])
+	workflowDir := opts.WorkflowDir
+	if workflowDir == "" {
+		workflowDir = jsonString(fields["workflow_dir"])
+	}
 	stage := jsonString(fields["stage"])
 	teamName := optString(fields, "team_name")
 	feedbackContext := optString(fields, "feedback_context")
 	scopeNotes := optString(fields, "scope_notes")
-	host := optString(fields, "host")
-	if host == "" {
-		host = "claude"
-	}
-	if host != "claude" && host != "codex" {
-		return buildError(stderr, 1, "unsupported host %q (want claude or codex)", host)
+	host, err := resolveBuildHost(opts.Host, optString(fields, "host"), os.Getenv)
+	if err != nil {
+		return buildError(stderr, 1, "%s", err)
 	}
 	bareMode := optBool(fields, "bare_mode")
 	isFeedbackReflow := optBool(fields, "is_feedback_reflow")
@@ -263,8 +393,9 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 			"dispatching to feedback target stage '%s' but feedback_context is missing", stage)
 	}
 
-	// Rule 8: Team name non-empty in team mode.
-	if !bareMode && teamName == "" {
+	// Rule 8: Team name non-empty in Claude team mode. Codex has no team
+	// registry, so non-bare Codex dispatches keep a task name and omit team_name.
+	if !bareMode && host == "claude" && teamName == "" {
 		return buildError(stderr, 1, "team mode requires team_name")
 	}
 
@@ -399,8 +530,8 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 	}
 	parts = append(parts, strings.Join(fetchLines, "\n"))
 
-	// 10. Completion signal (team mode only).
-	if !bareMode && teamName != "" {
+	// 10. Completion signal (Claude team mode or Codex named dispatch).
+	if !bareMode && (teamName != "" || host == "codex") {
 		entityFileRef := entityPath
 		if worktreePath != "" && !splitRoot {
 			entityFileRef = worktreeEntityPath
@@ -409,6 +540,9 @@ func runBuild(probe claudeteam.TeamStateProbe, workflowDir string, stdin io.Read
 	}
 
 	dispatchBody := strings.Join(parts, "\n")
+	if opts.ValidateOnly != "" {
+		return 0
+	}
 
 	// v2 file-pointer: write the body to a deterministic path; emit a tiny prompt
 	// the ensign Reads on first action.
@@ -545,4 +679,52 @@ func stateCommitGuidance(stateCheckout, entityPath, stateBranch string) string {
 // including its ensure_ascii escaping of any non-ASCII entity title / prompt.
 func emitBuildJSON(stdout io.Writer, out buildOutput) int {
 	return claudeteam.EmitPythonJSON(stdout, out)
+}
+
+func emitBuildSchema(stdout io.Writer) int {
+	schema := map[string]any{
+		"$schema":              "https://json-schema.org/draft/2020-12/schema",
+		"title":                "spacedock dispatch build request",
+		"type":                 "object",
+		"additionalProperties": true,
+		"required":             buildRequiredFields,
+		"properties": map[string]any{
+			"schema_version": map[string]any{
+				"const": schemaVersion,
+			},
+			"entity_path": map[string]any{
+				"type": "string",
+			},
+			"workflow_dir": map[string]any{
+				"type": "string",
+			},
+			"stage": map[string]any{
+				"type": "string",
+			},
+			"checklist": map[string]any{
+				"type":  "array",
+				"items": map[string]any{"type": "string"},
+			},
+			"team_name": map[string]any{
+				"type": []string{"string", "null"},
+			},
+			"feedback_context": map[string]any{
+				"type": []string{"string", "null"},
+			},
+			"scope_notes": map[string]any{
+				"type": []string{"string", "null"},
+			},
+			"bare_mode": map[string]any{
+				"type": "boolean",
+			},
+			"is_feedback_reflow": map[string]any{
+				"type": "boolean",
+			},
+			"host": map[string]any{
+				"type": "string",
+				"enum": []string{"claude", "codex"},
+			},
+		},
+	}
+	return claudeteam.EmitPythonJSON(stdout, schema)
 }

--- a/internal/dispatch/build_advisory_probe_test.go
+++ b/internal/dispatch/build_advisory_probe_test.go
@@ -32,6 +32,7 @@ func bareBuildFixture(t *testing.T) (root, stdin string) {
 		"stage":          "backlog",
 		"checklist":      []string{"- a", "- b"},
 		"bare_mode":      true,
+		"host":           "claude",
 	}, nil)
 	return root, stdin
 }

--- a/internal/dispatch/build_json_ergonomics_test.go
+++ b/internal/dispatch/build_json_ergonomics_test.go
@@ -1,0 +1,350 @@
+// ABOUTME: dispatch build flag/file input and host-resolution ergonomics.
+package dispatch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildFlagFileInputModePreservesLiteralChecklist(t *testing.T) {
+	t.Setenv("CODEX_THREAD_ID", "")
+	t.Setenv("CLAUDECODE", "1")
+	root, entityPath := buildHostFixture(t)
+	checklistPath := filepath.Join(root, "checklist.txt")
+	scopePath := filepath.Join(root, "scope.md")
+	literalChecklist := "1. keep `sharedRuntimeScenarios()` and $CLAUDE_CODE_SESSION_ID literal"
+	writeFile(t, checklistPath, "\n"+literalChecklist+"\n\n2. preserve Markdown exactly\n")
+	writeFile(t, scopePath, "### Scope\nUse $CLAUDE_CODE_SESSION_ID with `code`.\n")
+
+	native := runNativePreservingHostEnv("", "build",
+		"--workflow-dir", root,
+		"--entity-path", entityPath,
+		"--stage", "backlog",
+		"--checklist-file", checklistPath,
+		"--scope-notes-file", scopePath,
+		"--team-name", "fixture-team",
+	)
+	if native.exit != 0 {
+		t.Fatalf("build exit=%d stderr=%s", native.exit, native.stderr)
+	}
+	var out struct {
+		DispatchFilePath string `json:"dispatch_file_path"`
+	}
+	if err := json.Unmarshal([]byte(native.stdout), &out); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, native.stdout)
+	}
+	body := readDispatchBody(t, out.DispatchFilePath)
+	for _, want := range []string{literalChecklist, "### Scope\nUse $CLAUDE_CODE_SESSION_ID with `code`."} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("dispatch body missing literal %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestBuildHostResolutionFromFlagJSONAndEnv(t *testing.T) {
+	t.Run("derived-codex", func(t *testing.T) {
+		t.Setenv("CODEX_THREAD_ID", "codex-thread")
+		t.Setenv("CLAUDECODE", "")
+		root, _ := buildHostFixture(t)
+
+		native := runNativePreservingHostEnv(buildHostStdin(t, root, nil), "build", "--workflow-dir", root)
+		if native.exit != 0 {
+			t.Fatalf("build exit=%d stderr=%s", native.exit, native.stderr)
+		}
+		out := decodeBuildOutput(t, native.stdout)
+		if strings.Contains(out.Prompt, "Skill(skill=") {
+			t.Fatalf("derived Codex prompt is Claude-shaped: %q", out.Prompt)
+		}
+		body := readDispatchBody(t, out.DispatchFilePath)
+		for _, banned := range []string{"Skill(skill=\"spacedock:ensign\")", "SendMessage(to=\"team-lead\""} {
+			if strings.Contains(body, banned) {
+				t.Fatalf("derived Codex dispatch body contains %q:\n%s", banned, body)
+			}
+		}
+	})
+
+	t.Run("codex-without-team-name", func(t *testing.T) {
+		t.Setenv("CODEX_THREAD_ID", "codex-thread")
+		t.Setenv("CLAUDECODE", "")
+		root, _ := buildHostFixture(t)
+
+		native := runNativePreservingHostEnv(buildHostStdin(t, root, map[string]any{"team_name": nil}), "build", "--workflow-dir", root)
+		if native.exit != 0 {
+			t.Fatalf("build exit=%d stderr=%s", native.exit, native.stderr)
+		}
+		out := decodeBuildOutput(t, native.stdout)
+		if out.Name == "" {
+			t.Fatalf("Codex dispatch should still emit a task name:\n%s", native.stdout)
+		}
+		if out.TeamName != nil {
+			t.Fatalf("Codex dispatch should omit team_name when none was supplied:\n%s", native.stdout)
+		}
+		body := readDispatchBody(t, out.DispatchFilePath)
+		if !strings.Contains(body, "Codex final-status notification") {
+			t.Fatalf("Codex dispatch without team_name missing completion signal:\n%s", body)
+		}
+	})
+
+	t.Run("derived-claude", func(t *testing.T) {
+		t.Setenv("CODEX_THREAD_ID", "")
+		t.Setenv("CLAUDECODE", "1")
+		root, _ := buildHostFixture(t)
+
+		native := runNativePreservingHostEnv(buildHostStdin(t, root, nil), "build", "--workflow-dir", root)
+		if native.exit != 0 {
+			t.Fatalf("build exit=%d stderr=%s", native.exit, native.stderr)
+		}
+		out := decodeBuildOutput(t, native.stdout)
+		if !strings.HasPrefix(out.Prompt, "Skill(skill=\"spacedock:ensign\")") {
+			t.Fatalf("derived Claude prompt lost Skill wrapper: %q", out.Prompt)
+		}
+	})
+
+	t.Run("host-flag", func(t *testing.T) {
+		t.Setenv("CODEX_THREAD_ID", "")
+		t.Setenv("CLAUDECODE", "")
+		root, _ := buildHostFixture(t)
+
+		native := runNativePreservingHostEnv(buildHostStdin(t, root, nil), "build", "--workflow-dir", root, "--host", "codex")
+		if native.exit != 0 {
+			t.Fatalf("build exit=%d stderr=%s", native.exit, native.stderr)
+		}
+		out := decodeBuildOutput(t, native.stdout)
+		if strings.Contains(out.Prompt, "Skill(skill=") {
+			t.Fatalf("--host codex prompt is Claude-shaped: %q", out.Prompt)
+		}
+	})
+
+	t.Run("matching-explicit-sources", func(t *testing.T) {
+		t.Setenv("CODEX_THREAD_ID", "")
+		t.Setenv("CLAUDECODE", "")
+		root, _ := buildHostFixture(t)
+
+		native := runNativePreservingHostEnv(buildHostStdin(t, root, map[string]any{"host": "codex"}), "build", "--workflow-dir", root, "--host", "codex")
+		if native.exit != 0 {
+			t.Fatalf("build exit=%d stderr=%s", native.exit, native.stderr)
+		}
+		out := decodeBuildOutput(t, native.stdout)
+		if strings.Contains(out.Prompt, "Skill(skill=") {
+			t.Fatalf("matching explicit Codex prompt is Claude-shaped: %q", out.Prompt)
+		}
+	})
+
+	t.Run("conflicting-explicit-sources", func(t *testing.T) {
+		t.Setenv("CODEX_THREAD_ID", "")
+		t.Setenv("CLAUDECODE", "")
+		root, _ := buildHostFixture(t)
+
+		native := runNativePreservingHostEnv(buildHostStdin(t, root, map[string]any{"host": "codex"}), "build", "--workflow-dir", root, "--host", "claude")
+		assertBuildHostError(t, native, "--host", "JSON host")
+	})
+
+	t.Run("unsupported-explicit-host", func(t *testing.T) {
+		t.Setenv("CODEX_THREAD_ID", "")
+		t.Setenv("CLAUDECODE", "")
+		root, _ := buildHostFixture(t)
+
+		native := runNativePreservingHostEnv(buildHostStdin(t, root, nil), "build", "--workflow-dir", root, "--host", "banana")
+		assertBuildHostError(t, native, "unsupported host", "claude or codex")
+	})
+
+	t.Run("missing-source", func(t *testing.T) {
+		t.Setenv("CODEX_THREAD_ID", "")
+		t.Setenv("CLAUDECODE", "")
+		root, _ := buildHostFixture(t)
+
+		native := runNativePreservingHostEnv(buildHostStdin(t, root, nil), "build", "--workflow-dir", root)
+		assertBuildHostError(t, native, "host source", "CODEX_THREAD_ID", "CLAUDECODE")
+	})
+
+	t.Run("ambiguous-runtime", func(t *testing.T) {
+		t.Setenv("CODEX_THREAD_ID", "codex-thread")
+		t.Setenv("CLAUDECODE", "1")
+		root, _ := buildHostFixture(t)
+
+		native := runNativePreservingHostEnv(buildHostStdin(t, root, nil), "build", "--workflow-dir", root)
+		assertBuildHostError(t, native, "ambiguous", "CODEX_THREAD_ID", "CLAUDECODE")
+	})
+
+	t.Run("explicit-overrides-runtime", func(t *testing.T) {
+		t.Setenv("CODEX_THREAD_ID", "codex-thread")
+		t.Setenv("CLAUDECODE", "")
+		root, _ := buildHostFixture(t)
+
+		native := runNativePreservingHostEnv(buildHostStdin(t, root, nil), "build", "--workflow-dir", root, "--host", "claude")
+		if native.exit != 0 {
+			t.Fatalf("build exit=%d stderr=%s", native.exit, native.stderr)
+		}
+		out := decodeBuildOutput(t, native.stdout)
+		if !strings.HasPrefix(out.Prompt, "Skill(skill=\"spacedock:ensign\")") {
+			t.Fatalf("explicit Claude override lost Skill wrapper: %q", out.Prompt)
+		}
+	})
+}
+
+func TestBuildSchemaAndValidateOnly(t *testing.T) {
+	t.Run("print-schema", func(t *testing.T) {
+		native := runNativePreservingHostEnv("", "build", "--print-schema")
+		if native.exit != 0 {
+			t.Fatalf("print-schema exit=%d stderr=%s", native.exit, native.stderr)
+		}
+		var schema map[string]any
+		if err := json.Unmarshal([]byte(native.stdout), &schema); err != nil {
+			t.Fatalf("schema is not valid JSON: %v\n%s", err, native.stdout)
+		}
+		props, ok := schema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("schema missing properties object:\n%s", native.stdout)
+		}
+		host, ok := props["host"].(map[string]any)
+		if !ok {
+			t.Fatalf("schema missing host property:\n%s", native.stdout)
+		}
+		if got := strings.Join(anyStrings(host["enum"]), ","); got != "claude,codex" {
+			t.Fatalf("host enum = %q, want claude,codex", got)
+		}
+		if containsAnyString(schema["required"], "host") {
+			t.Fatalf("host must be optional in schema required list:\n%s", native.stdout)
+		}
+	})
+
+	t.Run("validate-only-derived-host-does-not-write-dispatch", func(t *testing.T) {
+		t.Setenv("CODEX_THREAD_ID", "codex-thread")
+		t.Setenv("CLAUDECODE", "")
+		root, _ := buildHostFixture(t)
+		reqPath := filepath.Join(root, "request.json")
+		writeFile(t, reqPath, buildHostStdin(t, root, nil))
+		dispatchPath := filepath.Join(dispatchFileDir, "spacedock-ensign-thing-backlog.md")
+		if err := os.Remove(dispatchPath); err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+
+		native := runNativePreservingHostEnv("", "build", "--validate-only", reqPath)
+		if native.exit != 0 {
+			t.Fatalf("validate-only exit=%d stderr=%s", native.exit, native.stderr)
+		}
+		if native.stdout != "" {
+			t.Fatalf("validate-only success should not emit dispatch JSON, got %q", native.stdout)
+		}
+		if _, err := os.Stat(dispatchPath); !os.IsNotExist(err) {
+			t.Fatalf("validate-only wrote deterministic dispatch file %s (stat err=%v)", dispatchPath, err)
+		}
+	})
+
+	t.Run("validate-only-errors", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			env   map[string]string
+			extra map[string]any
+			body  string
+			want  []string
+		}{
+			{name: "malformed-json", body: `{"schema_version":`, want: []string{"invalid JSON"}},
+			{name: "missing-host", env: map[string]string{"CODEX_THREAD_ID": "", "CLAUDECODE": ""}, want: []string{"host source"}},
+			{name: "ambiguous-env", env: map[string]string{"CODEX_THREAD_ID": "codex-thread", "CLAUDECODE": "1"}, want: []string{"ambiguous", "CODEX_THREAD_ID", "CLAUDECODE"}},
+			{name: "unsupported-host", extra: map[string]any{"host": "banana"}, want: []string{"unsupported host"}},
+			{name: "empty-checklist", extra: map[string]any{"host": "claude", "checklist": []string{}}, want: []string{"checklist must not be empty"}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				for _, key := range []string{"CODEX_THREAD_ID", "CLAUDECODE"} {
+					t.Setenv(key, "")
+				}
+				for key, value := range tc.env {
+					t.Setenv(key, value)
+				}
+				root, _ := buildHostFixture(t)
+				body := tc.body
+				if body == "" {
+					body = buildHostStdin(t, root, tc.extra)
+				}
+				reqPath := filepath.Join(root, "request.json")
+				writeFile(t, reqPath, body)
+
+				native := runNativePreservingHostEnv("", "build", "--validate-only", reqPath)
+				assertBuildHostError(t, native, tc.want...)
+			})
+		}
+	})
+}
+
+func buildHostFixture(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "README.md"), readmeWorktree(false))
+	entityPath := filepath.Join(root, "thing.md")
+	writeFile(t, entityPath, entityFM("Thing", "backlog", ""))
+	gitInit(t, root)
+	return root, entityPath
+}
+
+func buildHostStdin(t *testing.T, root string, extra map[string]any) string {
+	t.Helper()
+	entityPath := filepath.Join(root, "thing.md")
+	return mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    entityPath,
+		"workflow_dir":   root,
+		"stage":          "backlog",
+		"checklist":      []string{"- a", "- b"},
+		"team_name":      "fixture-team",
+		"bare_mode":      false,
+	}, extra)
+}
+
+func decodeBuildOutput(t *testing.T, stdout string) struct {
+	DispatchFilePath string  `json:"dispatch_file_path"`
+	Prompt           string  `json:"prompt"`
+	Name             string  `json:"name"`
+	TeamName         *string `json:"team_name"`
+} {
+	t.Helper()
+	var out struct {
+		DispatchFilePath string  `json:"dispatch_file_path"`
+		Prompt           string  `json:"prompt"`
+		Name             string  `json:"name"`
+		TeamName         *string `json:"team_name"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("stdout is not build JSON: %v\n%s", err, stdout)
+	}
+	return out
+}
+
+func assertBuildHostError(t *testing.T, native runResult, wants ...string) {
+	t.Helper()
+	if native.exit == 0 {
+		t.Fatalf("build unexpectedly exited 0\nstdout=%s\nstderr=%s", native.stdout, native.stderr)
+	}
+	for _, want := range wants {
+		if !strings.Contains(native.stderr, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, native.stderr)
+		}
+	}
+}
+
+func anyStrings(v any) []string {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func containsAnyString(v any, want string) bool {
+	for _, s := range anyStrings(v) {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -25,11 +25,15 @@ func Run(probe claudeteam.TeamStateProbe, args []string, stdin io.Reader, stdout
 
 	switch args[0] {
 	case "build":
-		workflowDir, code := requireFlag(args[1:], "--workflow-dir", stderr)
+		opts, code := parseBuildOptions(args[1:], stderr)
 		if code != 0 {
 			return code
 		}
-		return runBuild(probe, workflowDir, stdin, stdout, stderr)
+		if !opts.PrintSchema && opts.ValidateOnly == "" && opts.WorkflowDir == "" {
+			fmt.Fprintln(stderr, "error: dispatch build requires --workflow-dir")
+			return 2
+		}
+		return runBuild(probe, opts, stdin, stdout, stderr)
 	case "show-stage-def":
 		workflowDir, stage, code := requireStageFlags(args[1:], stderr)
 		if code != 0 {
@@ -69,6 +73,87 @@ func Run(probe claudeteam.TeamStateProbe, args []string, stdin io.Reader, stdout
 		fmt.Fprintf(stderr, "error: unknown dispatch subcommand: %s\n", args[0])
 		printUsage(stderr)
 		return 2
+	}
+}
+
+type buildOptions struct {
+	WorkflowDir         string
+	Host                string
+	EntityPath          string
+	Stage               string
+	ChecklistFile       string
+	ScopeNotesFile      string
+	FeedbackContextFile string
+	TeamName            string
+	BareMode            bool
+	FeedbackReflow      bool
+	PrintSchema         bool
+	ValidateOnly        string
+	requestFlagProvided bool
+}
+
+func (o buildOptions) hasRequestFlags() bool {
+	return o.requestFlagProvided
+}
+
+func parseBuildOptions(args []string, stderr io.Writer) (buildOptions, int) {
+	var opts buildOptions
+	valueFlags := map[string]*string{
+		"--workflow-dir":          &opts.WorkflowDir,
+		"--host":                  &opts.Host,
+		"--entity-path":           &opts.EntityPath,
+		"--stage":                 &opts.Stage,
+		"--checklist-file":        &opts.ChecklistFile,
+		"--scope-notes-file":      &opts.ScopeNotesFile,
+		"--feedback-context-file": &opts.FeedbackContextFile,
+		"--team-name":             &opts.TeamName,
+		"--validate-only":         &opts.ValidateOnly,
+	}
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if eq := indexByte(a, '='); eq > 0 {
+			name := a[:eq]
+			if dst, ok := valueFlags[name]; ok {
+				*dst = a[eq+1:]
+				if isBuildRequestFlag(name) {
+					opts.requestFlagProvided = true
+				}
+			}
+			continue
+		}
+		if dst, ok := valueFlags[a]; ok {
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "error: dispatch build requires value for %s\n", a)
+				return opts, 2
+			}
+			*dst = args[i+1]
+			if isBuildRequestFlag(a) {
+				opts.requestFlagProvided = true
+			}
+			i++
+			continue
+		}
+		switch a {
+		case "--bare-mode":
+			opts.BareMode = true
+			opts.requestFlagProvided = true
+		case "--feedback-reflow":
+			opts.FeedbackReflow = true
+			opts.requestFlagProvided = true
+		case "--print-schema":
+			opts.PrintSchema = true
+		}
+	}
+	return opts, 0
+}
+
+func isBuildRequestFlag(name string) bool {
+	switch name {
+	case "--entity-path", "--stage", "--checklist-file", "--scope-notes-file",
+		"--feedback-context-file", "--team-name":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -144,6 +229,9 @@ func printUsage(w io.Writer) {
 
 Usage:
   spacedock dispatch build --workflow-dir DIR        (stdin JSON -> stdout JSON)
+  spacedock dispatch build --workflow-dir DIR --entity-path FILE --stage STAGE --checklist-file FILE [--host claude|codex]
+  spacedock dispatch build --print-schema
+  spacedock dispatch build --validate-only FILE
   spacedock dispatch show-stage-def --workflow-dir DIR --stage STAGE
   spacedock dispatch reconcile --workflow-dir DIR [--team-name NAME] [--repo-root DIR] [--include A,B,C,D,E]
 `)

--- a/internal/dispatch/native_subcommands_routing_test.go
+++ b/internal/dispatch/native_subcommands_routing_test.go
@@ -62,6 +62,7 @@ func TestBuildEmitsStandingFetchLineUnderMods(t *testing.T) {
 		"checklist":      []string{"- a", "- b"},
 		"team_name":      "fixture-team",
 		"bare_mode":      false,
+		"host":           "claude",
 	}, nil)
 
 	var out, errBuf bytes.Buffer
@@ -104,6 +105,7 @@ func TestBuildOmitsStandingFetchLineWithoutMods(t *testing.T) {
 		"checklist":      []string{"- a", "- b"},
 		"team_name":      "fixture-team",
 		"bare_mode":      false,
+		"host":           "claude",
 	}, nil)
 
 	var out, errBuf bytes.Buffer

--- a/internal/dispatch/parity_harness_test.go
+++ b/internal/dispatch/parity_harness_test.go
@@ -25,9 +25,39 @@ type runResult struct {
 // via the process env (set by the caller through t.Setenv) so the bare-mode
 // team-evidence probe is hermetic.
 func runNative(stdin string, args ...string) runResult {
+	if len(args) > 0 && args[0] == "build" {
+		return runNativeWithDefaultClaudeHost(stdin, args...)
+	}
+	return runNativePreservingHostEnv(stdin, args...)
+}
+
+// runNativePreservingHostEnv drives the native dispatch surface without
+// normalizing host-marker environment. Host-resolution tests use this helper to
+// assert CODEX_THREAD_ID / CLAUDECODE behavior directly.
+func runNativePreservingHostEnv(stdin string, args ...string) runResult {
 	var stdout, stderr bytes.Buffer
 	exit := Run(claudeteam.Probe, args, strings.NewReader(stdin), &stdout, &stderr)
 	return runResult{stdout.String(), stderr.String(), exit}
+}
+
+// runNativeWithDefaultClaudeHost keeps legacy build fixtures deterministic when
+// the developer's real shell happens to carry Codex runtime markers.
+func runNativeWithDefaultClaudeHost(stdin string, args ...string) runResult {
+	oldCodex, hadCodex := os.LookupEnv("CODEX_THREAD_ID")
+	oldClaude, hadClaude := os.LookupEnv("CLAUDECODE")
+	os.Unsetenv("CODEX_THREAD_ID")
+	os.Setenv("CLAUDECODE", "1")
+	defer restoreEnv("CODEX_THREAD_ID", oldCodex, hadCodex)
+	defer restoreEnv("CLAUDECODE", oldClaude, hadClaude)
+	return runNativePreservingHostEnv(stdin, args...)
+}
+
+func restoreEnv(key, value string, had bool) {
+	if had {
+		os.Setenv(key, value)
+		return
+	}
+	os.Unsetenv(key)
 }
 
 // readDispatchBody reads the dispatch body file the run wrote (the path is

--- a/internal/ensigncycle/cycle_test.go
+++ b/internal/ensigncycle/cycle_test.go
@@ -80,6 +80,7 @@ func stageFixture(t *testing.T) cycleFixture {
 		"checklist":      []string{"- Wire the seam", "- Prove it observably"},
 		"team_name":      "fixture-team",
 		"bare_mode":      false,
+		"host":           "claude",
 	})
 
 	var stdout, stderr strings.Builder

--- a/internal/ensigncycle/feedback_test.go
+++ b/internal/ensigncycle/feedback_test.go
@@ -88,6 +88,7 @@ func stageReflowFixture(t *testing.T, reflow bool, feedbackContext string) reflo
 		"checklist": []string{"- Address the rejection findings"},
 		"team_name": "fixture-team",
 		"bare_mode": false,
+		"host":      "claude",
 	}
 	if reflow {
 		fields["is_feedback_reflow"] = true
@@ -176,6 +177,7 @@ func TestFeedbackReflowGoesRedOnBrokenOutput(t *testing.T) {
 			"checklist":          []string{"- Address the rejection findings"},
 			"team_name":          "fixture-team",
 			"bare_mode":          false,
+			"host":               "claude",
 			"is_feedback_reflow": true,
 			"feedback_context":   "",
 		})

--- a/skills/first-officer/references/claude-first-officer-runtime.md
+++ b/skills/first-officer/references/claude-first-officer-runtime.md
@@ -79,31 +79,26 @@ Use the Agent tool to spawn each worker. **Use Agent() for initial dispatch** �
 
 **MANDATORY — Dispatch assembly via `spacedock dispatch build`:**
 
-Do NOT assemble `Agent()` prompts manually. Do NOT construct the `prompt` string yourself. Do NOT invent `name` values. ALWAYS pipe input through `spacedock dispatch build` and forward its output to `Agent()` verbatim. The key fields that MUST come from helper output are `subagent_type`, `name`, `team_name`, `model`, and `prompt` (which contains the completion signal). Manual assembly is a protocol violation except in the documented break-glass fallback below.
+Do NOT assemble `Agent()` prompts manually. Do NOT construct the `prompt` string yourself. Do NOT invent `name` values. ALWAYS route initial-dispatch input through `spacedock dispatch build` and forward its output to `Agent()` verbatim. The key fields that MUST come from helper output are `subagent_type`, `name`, `team_name`, `model`, and `prompt` (which contains the completion signal). Manual assembly is a protocol violation except in the documented break-glass fallback below.
 
 The only permitted path for initial `Agent()` dispatch is:
 
-1. **REQUIRED — Assemble the input JSON** from the entity, stage, and your judgment:
-   ```json
-   {
-     "schema_version": 2,
-     "entity_path": "{absolute path to entity file}",
-     "workflow_dir": "{absolute path to workflow directory}",
-     "stage": "{target stage name}",
-     "checklist": ["1. ...", "2. ..."],
-     "team_name": "{team_name or null if bare mode}",
-     "feedback_context": "{reviewer findings or null}",
-     "scope_notes": "{additional context or null}",
-     "bare_mode": false,
-     "is_feedback_reflow": false
-   }
+1. **REQUIRED — Write dispatch text inputs to files.** Create a checklist file with one checklist item per non-empty line. If scope notes or feedback context are needed, write each to its own file. Use files for Markdown, backticks, shell variables, reviewer text, and any other prose that would be fragile in shell quoting.
+2. **REQUIRED — Build the dispatch through the helper** (do NOT skip this step). `host` is normally derived from `CLAUDECODE`; pass `--host claude` only for deliberate tests or cross-host tooling:
    ```
-   `bare_mode` must reflect the current dispatch context — read it from live team state, never infer it from the stage. Set `is_feedback_reflow` to true only when routing a rejection back to its `feedback-to` target stage.
-2. **REQUIRED — Pipe the JSON to the helper** (do NOT skip this step):
+   spacedock dispatch build \
+     --workflow-dir {workflow_dir} \
+     --entity-path {entity_file_path} \
+     --stage {target_stage_name} \
+     --checklist-file {checklist_file} \
+     [--scope-notes-file {scope_notes_file}] \
+     [--feedback-context-file {feedback_context_file}] \
+     [--team-name {team_name} | --bare-mode] \
+     [--feedback-reflow]
    ```
-   echo '<json>' | spacedock dispatch build --workflow-dir {workflow_dir}
-   ```
-3. **REQUIRED — On exit 0, parse the stdout JSON and call `Agent()` with the emitted fields verbatim.** The `name`, `description`, `prompt`, and `model` fields MUST come from helper output unchanged. The `description` field is REQUIRED by the Agent tool — do not omit it. The `prompt` is a file-pointer (`Skill(...) ; then Read /tmp/spacedock-dispatch/{name}.md and treat its content as your assignment.`); the ensign Reads the file on first action and treats the body (including the SendMessage completion-signal section) as the inline assignment. Do not strip or rewrite the prompt. Forward `output.model` as the `Agent()` `model=` parameter when present; when null, OMIT the `model=` argument entirely (do NOT pass `model=None` — default-inheritance only applies when the argument is absent):
+   `--bare-mode` must reflect the current dispatch context — read it from live team state, never infer it from the stage. Add `--feedback-reflow` only when routing a rejection back to its `feedback-to` target stage.
+3. **JSON compatibility path.** Programmatic callers may still provide the schema-version-2 JSON request object on stdin, and may inspect it with `spacedock dispatch build --print-schema` or validate a file with `spacedock dispatch build --validate-only {request_file}`. For first-officer dispatch, prefer the flag/file form above.
+4. **REQUIRED — On exit 0, parse the stdout JSON and call `Agent()` with the emitted fields verbatim.** The `name`, `description`, `prompt`, and `model` fields MUST come from helper output unchanged. The `description` field is REQUIRED by the Agent tool — do not omit it. The `prompt` is a file-pointer (`Skill(...) ; then Read /tmp/spacedock-dispatch/{name}.md and treat its content as your assignment.`); the ensign Reads the file on first action and treats the body (including the SendMessage completion-signal section) as the inline assignment. Do not strip or rewrite the prompt. Forward `output.model` as the `Agent()` `model=` parameter when present; when null, OMIT the `model=` argument entirely (do NOT pass `model=None` — default-inheritance only applies when the argument is absent):
    ```
    Agent(
        subagent_type=output.subagent_type,
@@ -114,7 +109,7 @@ The only permitted path for initial `Agent()` dispatch is:
        prompt=output.prompt              // ~175 chars; ensign Reads dispatch_file_path on first action
    )
    ```
-4. **On non-zero exit ONLY** (or if the binary is unavailable): read stderr, report the helper failure to the captain, and fall back to Break-Glass Manual Dispatch below. A zero-exit run is never a break-glass trigger.
+5. **On non-zero exit ONLY** (or if the binary is unavailable): read stderr, report the helper failure to the captain, and fall back to Break-Glass Manual Dispatch below. A zero-exit run is never a break-glass trigger.
 
 In bare mode, dispatch blocks until the subagent completes — concurrent dispatch is not possible. Dispatch one entity at a time and process completions inline.
 

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -15,9 +15,25 @@ unless the current task explicitly depends on the previous worker's context.
 ## Dispatch
 
 Use `spawn_agent` for initial worker dispatch. Assemble the dispatch input with
-`spacedock dispatch build` and pass `host: "codex"` in the JSON envelope. Forward
-the emitted prompt exactly as returned; for Codex it is a read-dispatch-file
-prompt and must not be rewritten into `Skill(skill=...)`.
+`spacedock dispatch build`; Codex host is normally derived from
+`CODEX_THREAD_ID`, so pass `--host codex` only for deliberate tests or cross-host
+tooling. Write checklist, scope notes, and feedback context into files, then use
+the flag/file form:
+
+```
+spacedock dispatch build \
+  --workflow-dir {workflow_dir} \
+  --entity-path {entity_file_path} \
+  --stage {target_stage_name} \
+  --checklist-file {checklist_file} \
+  [--scope-notes-file {scope_notes_file}] \
+  [--feedback-context-file {feedback_context_file}] \
+  [--bare-mode] \
+  [--feedback-reflow]
+```
+
+Forward the emitted prompt exactly as returned; for Codex it is a
+read-dispatch-file prompt. The FO must never forward a prompt containing `Skill(skill="spacedock:ensign")` to a Codex worker.
 
 Codex has no team registry, so there is no `team_name` lifecycle to create,
 recover, or tear down. Use Codex task names and mailbox notifications as the

--- a/skills/integration/dispatch_test.go
+++ b/skills/integration/dispatch_test.go
@@ -32,6 +32,9 @@ type buildResult struct {
 // callers can assert on a known-good build.
 func runBuild(t *testing.T, root, workflowDir string, input map[string]any) buildResult {
 	t.Helper()
+	if _, ok := input["host"]; !ok {
+		input["host"] = "claude"
+	}
 	raw, err := json.Marshal(input)
 	if err != nil {
 		t.Fatal(err)

--- a/skills/integration/skill_text_test.go
+++ b/skills/integration/skill_text_test.go
@@ -29,6 +29,7 @@ func vendoredSkillFiles(t *testing.T) map[string]string {
 	rel := []string{
 		"first-officer/references/first-officer-shared-core.md",
 		"first-officer/references/claude-first-officer-runtime.md",
+		"first-officer/references/codex-first-officer-runtime.md",
 		"ensign/references/ensign-shared-core.md",
 	}
 	out := make(map[string]string, len(rel))
@@ -101,6 +102,40 @@ func TestNoPRMergeOrModBehaviorIntroduced(t *testing.T) {
 				t.Errorf("%s introduces a PR-merge invocation %q (out of scope per AC-6)", name, m)
 			}
 		}
+	}
+}
+
+// TestFirstOfficerDispatchDocsUseFlagFileMode locks the dispatch-build
+// ergonomics contract: the FO runtime docs must teach file-backed dispatch input
+// and runtime-derived host selection, not inline shell JSON.
+func TestFirstOfficerDispatchDocsUseFlagFileMode(t *testing.T) {
+	files := vendoredSkillFiles(t)
+	claude := files["first-officer/references/claude-first-officer-runtime.md"]
+	codex := files["first-officer/references/codex-first-officer-runtime.md"]
+
+	for name, content := range map[string]string{
+		"claude-first-officer-runtime.md": claude,
+		"codex-first-officer-runtime.md":  codex,
+	} {
+		for _, want := range []string{"--entity-path", "--stage", "--checklist-file"} {
+			if !strings.Contains(content, want) {
+				t.Errorf("%s primary dispatch docs do not mention %s", name, want)
+			}
+		}
+		for _, banned := range []string{"echo '<json>' | spacedock dispatch build", "python3 <<", "PYEOF"} {
+			if strings.Contains(content, banned) {
+				t.Errorf("%s still teaches fragile inline JSON pattern %q", name, banned)
+			}
+		}
+	}
+	if !strings.Contains(claude, "CLAUDECODE") {
+		t.Errorf("Claude FO runtime does not document CLAUDECODE host derivation")
+	}
+	if !strings.Contains(codex, "CODEX_THREAD_ID") {
+		t.Errorf("Codex FO runtime does not document CODEX_THREAD_ID host derivation")
+	}
+	if !strings.Contains(codex, "must never forward a prompt containing `Skill(skill=\"spacedock:ensign\")`") {
+		t.Errorf("Codex FO runtime lacks the explicit no-Claude-shaped-prompt guard")
 	}
 }
 


### PR DESCRIPTION
Dispatch assembly now avoids fragile shell JSON while deriving the correct runtime host from the active FO session.

## What changed
- Add flag/file dispatch-build input mode
- Derive host from Codex and Claude runtime markers
- Add JSON schema and validate-only support
- Update FO runtime dispatch examples

## Evidence
- `go test ./...`: 901/901 passed
- `go test ./... -race`: 901/901 passed

---
[mt](/spacedock-dev/spacedock/blob/04a9548be868d06a7b484d33177c2cf19abf2d39/dispatch-build-json-ergonomics/index.md)
