### PR TITLE
Terminal-guard verdict=rejected consistency — align contract prose + the --set/--archive asymmetry

### DIFF
--- a/internal/status/merge_policy_guard_test.go
+++ b/internal/status/merge_policy_guard_test.go
@@ -201,6 +201,30 @@ func TestRejectedVerdictModBlockPendingArchiveRefuses(t *testing.T) {
 	}
 }
 
+// TestNonRejectedVerdictArchiveStillRefuses (terminal-guard rejected-consistency,
+// over-wide-exemption complement): the verdict escape is scoped to verdict=rejected
+// ONLY. A NON-rejected, non-empty verdict (verdict: passed) with empty pr/mod-block
+// under the default merge: pr policy must STILL be refused by --archive — this is
+// exactly the case the merge-hook guard exists for (an accepted outcome claimed
+// without the merge ceremony). This pins the exemption against over-widening:
+// changing `verdict != "rejected"` to `verdict == ""` (any non-empty verdict
+// escapes) goes RED here. The existing default-refuse fixture (020-no-sentinel)
+// carries an EMPTY verdict, so it still refuses under that widening and gives no
+// signal — this case supplies the missing one.
+func TestNonRejectedVerdictArchiveStillRefuses(t *testing.T) {
+	code, out, errOut := assertMergeGolden(t, "merge-pr-passed-nosentinel-archive", "merge-pr-workflow",
+		"--archive", "060-passed-nosentinel")
+	if code != 1 {
+		t.Fatalf("non-rejected-verdict --archive must still refuse (exit 1), got %d (stderr=%q)", code, errOut)
+	}
+	if !strings.Contains(errOut, "cannot be archived") {
+		t.Fatalf("stderr should name the merge-hook archive refusal, got %q", errOut)
+	}
+	if out != "" {
+		t.Fatalf("stdout must be empty on rejection, got %q", out)
+	}
+}
+
 // TestSentinelDisplaysAsLocal (AC-2): a pr field of local-merge:{short-sha}
 // renders in the status table as `{short-sha} (local)`, distinguishable from a
 // real PR reference. Native and oracle must agree.

--- a/internal/status/merge_policy_guard_test.go
+++ b/internal/status/merge_policy_guard_test.go
@@ -144,6 +144,63 @@ func TestMergePrDefaultNoSentinelArchiveStillRefuses(t *testing.T) {
 	}
 }
 
+// TestRejectedVerdictArchiveMatchesSet (terminal-guard rejected-consistency AC-1):
+// under the default merge: pr policy with a registered merge hook, a rejected
+// entity (verdict: rejected, empty pr/mod-block) must be treated the SAME by --set
+// and --archive. A rejected entity never ran the merge ceremony, so the merge-hook
+// pr-requirement is vacuous for it: --set already exempts verdict=rejected, and
+// --archive must match. The two commands run on the SAME staged root in sequence
+// (reject → terminalize → archive), and the test asserts the surfaces AGREE.
+// RED on today's code: --set → exit 0, --archive → exit 1 (the asymmetry).
+// GREEN after the fix: both → exit 0.
+func TestRejectedVerdictArchiveMatchesSet(t *testing.T) {
+	env := pinnedEnv(t)
+	root := stageFixture(t, "merge-pr-workflow")
+
+	setArgs := []string{"--workflow-dir", root, "--set", "040-rejected", "status=done"}
+	setOut, setErr, setCode := runNative(t, root, env, setArgs...)
+	assertEnvelopeGolden(t, "merge-pr-rejected-set", goldenEnvelope{
+		stdout: normalize(setOut, root), stderr: normalize(setErr, root), exit: setCode,
+	})
+
+	archiveArgs := []string{"--workflow-dir", root, "--archive", "040-rejected"}
+	archiveOut, archiveErr, archiveCode := runNative(t, root, env, archiveArgs...)
+	assertEnvelopeGolden(t, "merge-pr-rejected-archive", goldenEnvelope{
+		stdout: normalize(archiveOut, root), stderr: normalize(archiveErr, root), exit: archiveCode,
+	})
+
+	if setCode != archiveCode {
+		t.Fatalf("--set and --archive must agree on verdict=rejected, got set=%d (stderr=%q) archive=%d (stderr=%q)",
+			setCode, setErr, archiveCode, archiveErr)
+	}
+	if setCode != 0 {
+		t.Fatalf("rejected-entity terminal --set should succeed (exit 0), got %d (stderr=%q)", setCode, setErr)
+	}
+	if archiveCode != 0 {
+		t.Fatalf("rejected-entity --archive should succeed (exit 0), got %d (stderr=%q)", archiveCode, archiveErr)
+	}
+}
+
+// TestRejectedVerdictModBlockPendingArchiveRefuses (terminal-guard rejected-
+// consistency AC-2): the verdict=rejected escape relaxes ONLY the merge-hook
+// pr-requirement, not the policy-independent mod-block-pending guard. A rejected
+// entity with a live mod-block must still be refused by --archive (exit 1), naming
+// the pending mod-block — the ceremony-separation invariant survives the verdict
+// escape just as it survives merge: local.
+func TestRejectedVerdictModBlockPendingArchiveRefuses(t *testing.T) {
+	code, out, errOut := assertMergeGolden(t, "merge-pr-rejected-pending-archive", "merge-pr-workflow",
+		"--archive", "050-rejected-pending")
+	if code != 1 {
+		t.Fatalf("rejected-but-mod-block-pending --archive must refuse (exit 1), got %d (stderr=%q)", code, errOut)
+	}
+	if !strings.Contains(errOut, "pending mod-block (merge:local-merge)") {
+		t.Fatalf("stderr should name the pending mod-block, got %q", errOut)
+	}
+	if out != "" {
+		t.Fatalf("stdout must be empty on rejection, got %q", out)
+	}
+}
+
 // TestSentinelDisplaysAsLocal (AC-2): a pr field of local-merge:{short-sha}
 // renders in the status table as `{short-sha} (local)`, distinguishable from a
 // real PR reference. Native and oracle must agree.

--- a/internal/status/mutate.go
+++ b/internal/status/mutate.go
@@ -334,13 +334,17 @@ func runArchive(definitionDir, entityDir, spellingDir, slug string, force, quiet
 	// (pr set), is in flight (mod-block set, handled above), or --force. Under
 	// `merge: local` the pr-requirement is exempted — the workflow declared it
 	// merges locally, so an empty pr is expected at archival; the mod-block guard
-	// above (policy-independent) still catches an in-flight ceremony.
+	// above (policy-independent) still catches an in-flight ceremony. A
+	// `verdict: rejected` entity is also exempted: it never ran the merge ceremony
+	// (no PR to require, no merge to gate on), so the requirement is vacuous — this
+	// matches the --set finalize path (runSet), keeping reject-then-archive on the
+	// happy path without --force.
 	policy, perr := resolveMergePolicy(definitionDir)
 	if perr != nil {
 		fmt.Fprintf(stderr, "Error: %s\n", perr)
 		return 1
 	}
-	if !force && policy != mergeLocal && modBlock == "" && pr == "" {
+	if !force && policy != mergeLocal && verdict != "rejected" && modBlock == "" && pr == "" {
 		mergeHooks := scanMods(definitionDir)["merge"]
 		if len(mergeHooks) > 0 {
 			fmt.Fprintf(stderr,

--- a/internal/status/testdata/golden/merge-pr-passed-nosentinel-archive.txt
+++ b/internal/status/testdata/golden/merge-pr-passed-nosentinel-archive.txt
@@ -1,0 +1,6 @@
+===== exit =====
+1
+===== stdout =====
+
+===== stderr =====
+Error: entity 060-passed-nosentinel cannot be archived — workflow has merge hook(s) [local-merge] that have not run (pr field is empty and mod-block is empty). Invoke the hook first, or use --force to bypass.

--- a/internal/status/testdata/golden/merge-pr-rejected-archive.txt
+++ b/internal/status/testdata/golden/merge-pr-rejected-archive.txt
@@ -1,0 +1,6 @@
+===== exit =====
+0
+===== stdout =====
+archived: <ROOT>/_archive/040-rejected.md
+
+===== stderr =====

--- a/internal/status/testdata/golden/merge-pr-rejected-pending-archive.txt
+++ b/internal/status/testdata/golden/merge-pr-rejected-pending-archive.txt
@@ -1,0 +1,6 @@
+===== exit =====
+1
+===== stdout =====
+
+===== stderr =====
+Error: entity 050-rejected-pending has pending mod-block (merge:local-merge). Use --force to override.

--- a/internal/status/testdata/golden/merge-pr-rejected-set.txt
+++ b/internal/status/testdata/golden/merge-pr-rejected-set.txt
@@ -1,0 +1,6 @@
+===== exit =====
+0
+===== stdout =====
+status: implementation -> done
+
+===== stderr =====

--- a/internal/status/testdata/merge-pr-workflow/040-rejected.md
+++ b/internal/status/testdata/merge-pr-workflow/040-rejected.md
@@ -1,0 +1,15 @@
+---
+id: "040"
+title: Rejected entity with no sentinel and no mod-block
+status: implementation
+verdict: rejected
+score: "0.40"
+source: roadmap
+---
+# Rejected entity with no sentinel and no mod-block
+
+`verdict: rejected` with no `pr` sentinel and no `mod-block`. A rejected entity
+never ran the merge ceremony — there is no PR to require, no merge to gate on —
+so the merge-hook requirement is vacuous for it. Both `--set status=done` and
+`--archive` must agree on this entity: under the default `merge: pr` policy each
+surface exempts `verdict: rejected` and lets the entity through without `--force`.

--- a/internal/status/testdata/merge-pr-workflow/050-rejected-pending.md
+++ b/internal/status/testdata/merge-pr-workflow/050-rejected-pending.md
@@ -1,0 +1,15 @@
+---
+id: "050"
+title: Rejected entity with an in-flight mod-block
+status: implementation
+verdict: rejected
+mod-block: merge:local-merge
+score: "0.30"
+source: roadmap
+---
+# Rejected entity with an in-flight mod-block
+
+`verdict: rejected` but a `mod-block` is set: the verdict escape relaxes only the
+merge-hook pr-requirement, NOT the policy-independent mod-block-pending guard. A
+live mod-block must still refuse `--archive` here — mirroring how `merge: local`
+relaxes only the pr-requirement while the mod-block guard survives.

--- a/internal/status/testdata/merge-pr-workflow/060-passed-nosentinel.md
+++ b/internal/status/testdata/merge-pr-workflow/060-passed-nosentinel.md
@@ -1,0 +1,16 @@
+---
+id: "060"
+title: Passed entity with no sentinel and no mod-block
+status: implementation
+verdict: passed
+score: "0.40"
+source: roadmap
+---
+# Passed entity with no sentinel and no mod-block
+
+`verdict: passed` with no `pr` sentinel and no `mod-block`. This is exactly the
+case the merge-hook guard exists for: an entity claiming an accepted outcome
+without having run the merge ceremony. The `verdict: rejected` exemption must NOT
+widen to other verdicts — `--archive` of this entity under the default `merge: pr`
+policy must still refuse without `--force`. Pins the over-wide-exemption
+complement of the rejected-verdict escape.

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -211,7 +211,7 @@ When an entity reaches its terminal stage:
 1. If merge hooks are registered, set the mod-block before invoking:
    `spacedock status --workflow-dir {workflow_dir} --set {slug} mod-block=merge:{mod_name}`
    Commit: `mod-block: {slug} awaiting merge:{mod_name}`.
-   The mechanism enforces this — `status --set` and `status --archive` refuse terminal updates while merge hooks exist with both `pr` and `mod-block` empty. Tagging `mod-block` also lets session resume pick up which mod is blocking.
+   The mechanism enforces this — `status --set` and `status --archive` refuse terminal updates while merge hooks exist with both `pr` and `mod-block` empty, unless `--force`, `merge: local`, or `verdict=rejected` exempts (a rejected entity never ran the merge ceremony). Tagging `mod-block` also lets session resume pick up which mod is blocking.
 2. Run merge hooks before local merge, archival, or status advancement.
 3. Detect hook completion via the state delta. A hook blocks if (a) `pr` is now set, (b) its prose says to wait for captain approval and the captain has not responded, or (c) it declares an external wait. Otherwise it completed.
 4. If blocked, leave `mod-block` set, report the pending state, and do not local-merge.
@@ -321,7 +321,7 @@ Merge hooks can block (captain approval before pushing, waiting for PR merge). T
 - **Set** by the FO before invoking a merge hook: `mod-block=merge:{mod_name}`.
 - **Cleared** after the blocking action completes or the captain force-overrides. The clear runs in its own `--set` — combining `mod-block=` with terminal fields (`status={terminal}`, `completed`, `verdict`, `worktree=`) is refused without `--force`.
 - **Guarded** — `status --set` refuses terminal transitions while `mod-block` is non-empty unless `--force` is passed.
-- **Enforced at the mechanism level** — `status --set` and `status --archive` also refuse terminal transitions and archival when merge hooks (`_mods/*.md` with `## Hook: merge`) are registered AND `pr` is empty AND `mod-block` is empty. `--force` bypasses. `merge: local` exempts only the pr-requirement; the mod-block-pending and combined-clear refusals stay. See the Ship-Local Ceremony.
+- **Enforced at the mechanism level** — `status --set` and `status --archive` also refuse terminal transitions and archival when merge hooks (`_mods/*.md` with `## Hook: merge`) are registered AND `pr` is empty AND `mod-block` is empty. `--force` bypasses. `merge: local` exempts only the pr-requirement; `verdict=rejected` likewise exempts only the pr-requirement on both surfaces (a rejected entity never ran the merge ceremony, so the requirement is vacuous); the mod-block-pending and combined-clear refusals stay. See the Ship-Local Ceremony.
 - **Survives session resume** — the FO reads `mod-block` from frontmatter on boot and resumes the pending action.
 
 ## Standing Teammates


### PR DESCRIPTION
Make `--archive` agree with `--set` on `verdict=rejected` so a rejected entity no longer stalls terminalized-but-unarchived.

## What changed
- Add the `verdict != "rejected"` clause to the `--archive` merge-hook guard, mirroring the `--set` finalize path.
- Align both FO contract terminal-guard enumerations to name the `verdict=rejected` escape alongside `--force` / `merge: local`.
- Add regression tests: set/archive agreement, mod-block-pending still refuses, and the over-widening pin.

## Evidence
- Offline suite: 981/981 passed; `go build`/`go vet` clean.
- Guard test reds on a fix-revert even with goldens regenerated; the over-widening probe (`verdict==""`) is now caught.

---
[6b](/spacedock-dev/spacedock/blob/df903a18475ac4b9ffab3e95182393e41b3244c9/terminal-guard-rejected-consistency/index.md)