### PR TITLE
Universal ensign contract has absorbed dev-workflow assumptions — re-home dev policy out of the shared core

### DIFF
--- a/internal/hostneutrality/ensign_dev_leakage_locks_test.go
+++ b/internal/hostneutrality/ensign_dev_leakage_locks_test.go
@@ -1,0 +1,174 @@
+// ABOUTME: Lock-in oracle that the universal ensign contract carries no dev-only
+// ABOUTME: authoring discipline, and that the dev disciplines survive in their dev homes.
+package hostneutrality
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// devLeakageLiterals are dev-workflow-specific phrases that must NOT appear in
+// the universal shared cores. They fingerprint the test-first authoring bullet
+// and the code-substrate worktree noun that leaked into the portable ensign
+// contract. "failing test" is deliberately absent — it appears legitimately at
+// first-officer-shared-core.md ("enforced by the binary or a failing test"),
+// and a flat all-files table would false-red on that legit FO usage.
+var devLeakageLiterals = []struct {
+	literal       string
+	caseSensitive bool
+}{
+	// AC-1: the test-first authoring bullet's unique fingerprints.
+	{"feature or bugfix", false},
+	{"the test is what the gate judges", false},
+	// AC-3: the code-substrate worktree noun, banned as the exact uppercased
+	// form it appears in today.
+	{"CODE only", true},
+}
+
+// devLeakageCorePaths are the universal cores swept for dev-leakage. The
+// runtime adapters are policed separately by the AC-4 field-enumeration check.
+var devLeakageCorePaths = []string{
+	filepath.Join("..", "..", "skills", "first-officer", "references", "first-officer-shared-core.md"),
+	filepath.Join("..", "..", "skills", "ensign", "references", "ensign-shared-core.md"),
+}
+
+// TestNoDevLeakageInUniversalCore locks AC-1 and AC-3: the universal shared
+// cores must not assert dev-only authoring discipline (test-first) nor name the
+// code substrate in the worktree-isolation clause. A re-introduction of the
+// banned literal fails the test (negative proof of lock-in).
+func TestNoDevLeakageInUniversalCore(t *testing.T) {
+	for _, path := range devLeakageCorePaths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			body, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			text := string(body)
+			lowerText := strings.ToLower(text)
+
+			for _, banned := range devLeakageLiterals {
+				hit := false
+				if banned.caseSensitive {
+					hit = strings.Contains(text, banned.literal)
+				} else {
+					hit = strings.Contains(lowerText, strings.ToLower(banned.literal))
+				}
+				// "feature or bugfix" and "the test is what the gate judges"
+				// uniquely fingerprint the ensign TDD bullet; "CODE only" is in
+				// both cores today. All three must be absent post-sweep.
+				if hit {
+					t.Errorf("%s contains banned dev-leakage literal %q — dev-only discipline re-homed into the universal core", path, banned.literal)
+				}
+			}
+		})
+	}
+}
+
+// TestWorktreeIsolationClauseSurvives locks AC-3's other half: removing the
+// "CODE only" noun must NOT delete the worktree-isolation boundary — both cores
+// must still carry an isolation clause naming the worktree.
+func TestWorktreeIsolationClauseSurvives(t *testing.T) {
+	for _, path := range devLeakageCorePaths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			body, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			lower := strings.ToLower(string(body))
+			if !strings.Contains(lower, "worktree isolate") && !strings.Contains(lower, "isolate") {
+				t.Errorf("%s lost its worktree-isolation clause — neutralizing the substrate noun must not delete the boundary", path)
+			}
+			if !strings.Contains(lower, "worktree") {
+				t.Errorf("%s no longer mentions the worktree — isolation boundary gone", path)
+			}
+		})
+	}
+}
+
+// fieldEnumerationRe captures the runtime-adapter sentence that enumerates the
+// always-present assignment fields, from "authoritative for all assignment
+// fields:" to the end of the sentence. The AC-4 check scopes ONLY to this
+// sentence so the legitimate conditional "if you were given a worktree path"
+// at ensign-shared-core.md:17 stays untouched.
+var fieldEnumerationRe = regexp.MustCompile(`(?i)authoritative for all assignment fields:[^.]*\.`)
+
+// runtimeAdapterFieldPaths are the two ensign runtime adapters whose
+// field-enumeration sentence must use the neutral location vocabulary.
+var runtimeAdapterFieldPaths = []string{
+	filepath.Join("..", "..", "skills", "ensign", "references", "claude-ensign-runtime.md"),
+	filepath.Join("..", "..", "skills", "ensign", "references", "codex-ensign-runtime.md"),
+}
+
+// TestRuntimeAdaptersUseNeutralLocationVocabulary locks AC-4: each runtime
+// adapter's assignment-field enumeration lists "workflow location" and NOT
+// "worktree path". Scoped to the field-enumeration sentence — a file-wide ban
+// would false-fail on the legitimate conditional usage elsewhere.
+func TestRuntimeAdaptersUseNeutralLocationVocabulary(t *testing.T) {
+	for _, path := range runtimeAdapterFieldPaths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			body, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			loc := fieldEnumerationRe.FindString(string(body))
+			if loc == "" {
+				t.Fatalf("%s has no assignment-field enumeration sentence anchored on 'authoritative for all assignment fields:'", path)
+			}
+			lower := strings.ToLower(loc)
+			if strings.Contains(lower, "worktree path") {
+				t.Errorf("%s field enumeration still lists 'worktree path' — use the neutral 'workflow location'; sentence=%q", path, loc)
+			}
+			if !strings.Contains(lower, "workflow location") {
+				t.Errorf("%s field enumeration does not list 'workflow location'; sentence=%q", path, loc)
+			}
+		})
+	}
+}
+
+// devHomePresence maps each dev home to a required clause proving the lift
+// RELOCATED rather than DELETED the dev discipline. Inverse polarity of the
+// banned-literal tables: this errors on ABSENCE.
+var devHomePresence = []struct {
+	path      string
+	required  string
+	sectionRe *regexp.Regexp // when non-nil, the required clause must sit inside this section
+}{
+	{
+		path:      filepath.Join("..", "..", "skills", "commission", "references", "templates", "development.md"),
+		required:  "test-first",
+		sectionRe: regexp.MustCompile(`(?is)## Recommended practices \(opt-in\).*`),
+	},
+	{
+		path:     filepath.Join("..", "..", "docs", "dev", "README.md"),
+		required: "real, checkable change",
+	},
+}
+
+// TestDevDisciplinesSurviveInDevHomes locks AC-2: the re-homed dev guidance is
+// present in its dev-specific home — development.md carries a test-first clause
+// inside its Recommended-practices section, and docs/dev/README.md retains the
+// "real, checkable change" deliverable-proof policy. Fails if a future edit
+// strips a dev home.
+func TestDevDisciplinesSurviveInDevHomes(t *testing.T) {
+	for _, h := range devHomePresence {
+		t.Run(filepath.Base(h.path), func(t *testing.T) {
+			body, err := os.ReadFile(h.path)
+			if err != nil {
+				t.Fatalf("read %s: %v", h.path, err)
+			}
+			scope := string(body)
+			if h.sectionRe != nil {
+				scope = h.sectionRe.FindString(scope)
+				if scope == "" {
+					t.Fatalf("%s missing the section that must hold %q", h.path, h.required)
+				}
+			}
+			if !strings.Contains(strings.ToLower(scope), strings.ToLower(h.required)) {
+				t.Errorf("%s lost the re-homed dev clause %q — the lift must relocate, not delete", h.path, h.required)
+			}
+		})
+	}
+}

--- a/internal/hostneutrality/ensign_dev_leakage_locks_test.go
+++ b/internal/hostneutrality/ensign_dev_leakage_locks_test.go
@@ -137,8 +137,11 @@ var devHomePresence = []struct {
 	sectionRe *regexp.Regexp // when non-nil, the required clause must sit inside this section
 }{
 	{
-		path:      filepath.Join("..", "..", "skills", "commission", "references", "templates", "development.md"),
-		required:  "test-first",
+		path: filepath.Join("..", "..", "skills", "commission", "references", "templates", "development.md"),
+		// A body phrase from the relocated test-first guidance, NOT the
+		// "### Test-first authoring" heading word — so the relocate-not-delete
+		// guarantee rests on the guidance body, not the heading.
+		required:  "watch it fail for the right reason",
 		sectionRe: regexp.MustCompile(`(?is)## Recommended practices \(opt-in\).*`),
 	},
 	{
@@ -148,10 +151,11 @@ var devHomePresence = []struct {
 }
 
 // TestDevDisciplinesSurviveInDevHomes locks AC-2: the re-homed dev guidance is
-// present in its dev-specific home — development.md carries a test-first clause
-// inside its Recommended-practices section, and docs/dev/README.md retains the
-// "real, checkable change" deliverable-proof policy. Fails if a future edit
-// strips a dev home.
+// present in its dev-specific home — development.md carries the test-first
+// guidance BODY (a body phrase, not just the heading word) inside its
+// Recommended-practices section, and docs/dev/README.md retains the "real,
+// checkable change" deliverable-proof policy. Fails if a future edit strips a
+// dev home's guidance.
 func TestDevDisciplinesSurviveInDevHomes(t *testing.T) {
 	for _, h := range devHomePresence {
 		t.Run(filepath.Base(h.path), func(t *testing.T) {

--- a/internal/status/external_proof.go
+++ b/internal/status/external_proof.go
@@ -51,14 +51,18 @@ var selfPhraseRes = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)re-reading (this|the) (entity|task|body)`),
 }
 
-// externalTokenRe captures any token that proves the AC's proof cites
-// something runnable / observable outside the entity body. Presence of ANY
-// token clears the AC, so a CI run on the entity's PR no longer false-positives
-// even when the prose says "this entity's own PR". The build/compile/lint and
-// generalized live-pilot families (no literal-article dependency) clear the
-// adversarial families the cycle-1 audit surfaced; the release-artifact and
-// commit/GitHub families cover macOS-release and post-merge proof shapes.
-var externalTokenRe = regexp.MustCompile(`(?i)` + strings.Join([]string{
+// devExternalTokens is the DEV workflow's reading of "what counts as external"
+// — the proof vocabulary the generic kernel matches against when a dev workflow
+// opts in. It captures any token that proves the AC's proof cites something
+// runnable / observable outside the entity body. Presence of ANY token clears
+// the AC, so a CI run on the entity's PR no longer false-positives even when
+// the prose says "this entity's own PR". It mixes dev-toolchain tokens (the
+// Go/release/commit families) with generic proof-by-exercise tokens; the whole
+// set is the dev answer to "which tokens count". A non-dev workflow that one
+// day opts in supplies its own complete vocabulary rather than inheriting this
+// one. This is the SOLE site naming the dev tokens — the kernel takes the
+// vocabulary as an injected parameter and names none itself.
+var devExternalTokens = regexp.MustCompile(`(?i)` + strings.Join([]string{
 	`\btest\b`, `\.go\b`, `exit\s`, `exit-code`, `exit code`, `command`, `\bstatus\b`,
 	`--\w+`, `fixture`, `golden`, `byte`, `on-disk`, `stdout`, `stderr`, `assert`, `parser`,
 	`mutator`, `frontmatter`, `code path`, `command/parser`,
@@ -102,9 +106,12 @@ func stripFrontmatter(data []byte) string {
 // names the entity itself (and only the entity itself) as the verification. The
 // five-step algorithm: extract `**AC-N` blocks → isolate the clause from the
 // first proof marker onward → strip quoted spans → match a self-phrase →
-// require external-token absence. The classifier is pure — no I/O — so tests
+// require external-token absence. The external-token vocabulary is INJECTED by
+// the caller — the kernel owns the structural rule ("absence of an external
+// token is a flag") but names no domain tokens itself, so a non-dev workflow
+// can supply its own vocabulary. The classifier is pure — no I/O — so tests
 // drive it with literal strings.
-func ClassifyEntityACs(body string) []ACFlag {
+func ClassifyEntityACs(body string, externalTokens *regexp.Regexp) []ACFlag {
 	classifierCallCount++
 
 	var flags []ACFlag
@@ -128,11 +135,11 @@ func ClassifyEntityACs(body string) []ACFlag {
 			return
 		}
 		// External-token scanning runs over the UNSTRIPPED clause so a backtick-
-		// fenced external token (the corpus convention for `--cask` / `spctl` /
-		// `goreleaser` references) still clears the AC. Self-phrase matching
-		// against the stripped clause + external-token matching against the
-		// unstripped clause give the precision we want on both sides.
-		if externalTokenRe.MatchString(clause) {
+		// fenced external token (the corpus convention for fencing external
+		// references) still clears the AC. Self-phrase matching against the
+		// stripped clause + external-token matching against the unstripped
+		// clause give the precision we want on both sides.
+		if externalTokens.MatchString(clause) {
 			return
 		}
 		flags = append(flags, ACFlag{
@@ -228,7 +235,7 @@ func classifyEntityFile(path string) []ACFlag {
 	if err != nil {
 		return nil
 	}
-	return ClassifyEntityACs(stripFrontmatter(data))
+	return ClassifyEntityACs(stripFrontmatter(data), devExternalTokens)
 }
 
 // flaggedACLabels returns a `[AC-1,AC-3]` shaped string for an error message,

--- a/internal/status/external_proof_test.go
+++ b/internal/status/external_proof_test.go
@@ -148,7 +148,7 @@ func TestClassifierPrecisionRecallOnLiveCorpus(t *testing.T) {
 		if err != nil {
 			return nil
 		}
-		for _, f := range ClassifyEntityACs(stripFrontmatter(data)) {
+		for _, f := range ClassifyEntityACs(stripFrontmatter(data), devExternalTokens) {
 			rel, _ := filepath.Rel(stateRoot, path)
 			hits = append(hits, hit{path: rel, label: acLabel(f.Header)})
 		}
@@ -254,7 +254,7 @@ func TestExternalTokensClearSelfPhrase(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			body := "**AC-1 — A property of this entity's design.**\n" + tc.clause + "\n"
-			flags := ClassifyEntityACs(body)
+			flags := ClassifyEntityACs(body, devExternalTokens)
 			if len(flags) != 0 {
 				t.Fatalf("clause %q should clear the self-phrase, got flags=%+v", tc.clause, flags)
 			}
@@ -275,7 +275,7 @@ func TestSelfPhraseStillFlagsWithoutExternalToken(t *testing.T) {
 	for i, body := range cases {
 		body := body
 		t.Run(acLabel(strings.Split(body, "\n")[0]), func(t *testing.T) {
-			flags := ClassifyEntityACs(body)
+			flags := ClassifyEntityACs(body, devExternalTokens)
 			if len(flags) != 1 {
 				t.Fatalf("case %d should flag exactly once, got %+v", i, flags)
 			}
@@ -290,7 +290,7 @@ func TestSelfPhraseStillFlagsWithoutExternalToken(t *testing.T) {
 func TestExternalTokenInBacktickStillClears(t *testing.T) {
 	body := "**AC-1 — A property of this entity's design.**\n" +
 		"Verified by: `--cask` against this entity's binary.\n"
-	flags := ClassifyEntityACs(body)
+	flags := ClassifyEntityACs(body, devExternalTokens)
 	if len(flags) != 0 {
 		t.Fatalf("backtick-quoted external token must clear the self-phrase, got %+v", flags)
 	}
@@ -302,7 +302,7 @@ func TestExternalTokenInBacktickStillClears(t *testing.T) {
 func TestQuotedSelfPhraseStillDoesNotFlag(t *testing.T) {
 	body := "**AC-1 — A property.**\n" +
 		"Verified by: a Go test refusing \"this entity's decision section\" as proof.\n"
-	flags := ClassifyEntityACs(body)
+	flags := ClassifyEntityACs(body, devExternalTokens)
 	if len(flags) != 0 {
 		t.Fatalf("quoted self-phrase + external token must not flag, got %+v", flags)
 	}
@@ -360,6 +360,129 @@ func TestExternalProofPolicyTypoErrorEnumeratesShapes(t *testing.T) {
 			t.Fatalf("error %q should mention %q", msg, want)
 		}
 	}
+}
+
+// TestClassifierKernelTakesInjectedTokens locks AC-6(a): the generic kernel
+// `ClassifyEntityACs` takes the external-token vocabulary as an injected
+// parameter — it is callable with a NON-dev token set and honors it, proving
+// the kernel never reaches for a package-global dev vocabulary. A separate
+// assertion drives the kernel with `devExternalTokens` over the same fixtures
+// TestExternalTokensClearSelfPhrase uses and gets the identical verdicts, so
+// the dev behavior is unchanged.
+func TestClassifierKernelTakesInjectedTokens(t *testing.T) {
+	// A self-phrased clause whose only external token is a NON-dev word
+	// ("p-value") that the dev vocabulary does NOT recognize.
+	body := "**AC-1 — A property of this entity's design.**\n" +
+		"Verified by: the reported p-value falls below this entity's pre-registered threshold.\n"
+
+	// Under the dev vocabulary the clause has no recognized external token, so
+	// the kernel flags it — proving the kernel applies the INJECTED set.
+	devFlags := ClassifyEntityACs(body, devExternalTokens)
+	if len(devFlags) != 1 {
+		t.Fatalf("under dev vocabulary the non-dev clause should flag (no dev token present), got %+v", devFlags)
+	}
+
+	// Inject a non-dev vocabulary that DOES recognize "p-value"; the same clause
+	// must now clear — the kernel honors whatever matcher the caller injects.
+	researchTokens := regexp.MustCompile(`(?i)p-value|dataset|\bDOI\b`)
+	researchFlags := ClassifyEntityACs(body, researchTokens)
+	if len(researchFlags) != 0 {
+		t.Fatalf("with an injected research vocabulary recognizing p-value the clause should clear, got %+v", researchFlags)
+	}
+
+	// Dev-behavior preservation: the kernel driven with devExternalTokens over
+	// TestExternalTokensClearSelfPhrase's fixtures yields the identical clear
+	// verdicts (no flags).
+	devFixtures := []string{
+		"Verified by: `go build ./...` succeeds against this entity's renamed files.",
+		"Verified by: `gofmt -l .` returns empty on this entity's tree.",
+		"Verified by: a `goreleaser` run produces this entity's artifact.",
+		"Verified by: this entity's PR has merged to main.",
+	}
+	for _, clause := range devFixtures {
+		fixtureBody := "**AC-1 — A property of this entity's design.**\n" + clause + "\n"
+		if flags := ClassifyEntityACs(fixtureBody, devExternalTokens); len(flags) != 0 {
+			t.Fatalf("dev clause %q should clear under devExternalTokens, got %+v", clause, flags)
+		}
+	}
+}
+
+// TestDevPathSuppliesDevVocabulary locks AC-6(a)'s supplier half: the dev
+// callers reach the kernel through classifyEntityFile, which must supply
+// devExternalTokens — verified by driving classifyEntityFile over a fixture
+// whose dev token clears the self-phrase. If classifyEntityFile failed to
+// inject the dev vocabulary, the dev clause would flag.
+func TestDevPathSuppliesDevVocabulary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.md")
+	body := "---\nid: x\n---\n\n" +
+		"**AC-1 — A property of this entity's design.**\n" +
+		"Verified by: `go vet ./...` succeeds on this entity's package.\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if flags := classifyEntityFile(path); len(flags) != 0 {
+		t.Fatalf("classifyEntityFile must supply devExternalTokens so the go-vet clause clears, got %+v", flags)
+	}
+}
+
+// kernelSpanNames are the source spans that make up the generic, workflow-
+// agnostic kernel: the classifier function, its generic helpers, and the
+// self-reference phrase table. None of these may name a dev-toolchain token.
+var kernelSpanNames = []string{
+	"func ClassifyEntityACs",
+	"func isolateProofClause",
+	"func matchSelfPhrase",
+	"var selfPhraseRes",
+}
+
+// TestKernelFreeOfDevVocabulary locks AC-6(b): the generic kernel's source
+// spans contain NO Go-toolchain literal. The dev vocabulary must live only in
+// the devExternalTokens var. Negative proof: re-hard-code a dev token inside
+// the kernel and this test goes red.
+func TestKernelFreeOfDevVocabulary(t *testing.T) {
+	data, err := os.ReadFile("external_proof.go")
+	if err != nil {
+		t.Fatalf("read external_proof.go: %v", err)
+	}
+	src := string(data)
+
+	bannedDevLiterals := []string{`gofmt`, `goreleaser`, `\bvet\b`, `\.go\b`, `\bcask\b`}
+
+	for _, name := range kernelSpanNames {
+		span := topLevelSpan(t, src, name)
+		for _, banned := range bannedDevLiterals {
+			if strings.Contains(span, banned) {
+				t.Errorf("kernel span %q contains dev-toolchain literal %q — dev vocabulary leaked back into the generic kernel", name, banned)
+			}
+		}
+	}
+}
+
+// topLevelSpan returns the source of the top-level declaration that begins with
+// decl (e.g. "func ClassifyEntityACs" or "var selfPhraseRes"), from that line
+// to the matching closing brace at column 0. Top-level Go declarations close on
+// a `}` (or `)`) in the first column, so the span ends at the first such line.
+func topLevelSpan(t *testing.T, src, decl string) string {
+	t.Helper()
+	lines := strings.Split(src, "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, decl) {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("declaration %q not found in external_proof.go", decl)
+	}
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "}") || strings.HasPrefix(lines[i], ")") {
+			return strings.Join(lines[start:i+1], "\n")
+		}
+	}
+	t.Fatalf("no top-level close found for %q", decl)
+	return ""
 }
 
 // stageExternalProofFixture copies testdata/external-proof-workflow into a

--- a/internal/status/external_proof_test.go
+++ b/internal/status/external_proof_test.go
@@ -426,20 +426,15 @@ func TestDevPathSuppliesDevVocabulary(t *testing.T) {
 	}
 }
 
-// kernelSpanNames are the source spans that make up the generic, workflow-
-// agnostic kernel: the classifier function, its generic helpers, and the
-// self-reference phrase table. None of these may name a dev-toolchain token.
-var kernelSpanNames = []string{
-	"func ClassifyEntityACs",
-	"func isolateProofClause",
-	"func matchSelfPhrase",
-	"var selfPhraseRes",
-}
-
-// TestKernelFreeOfDevVocabulary locks AC-6(b): the generic kernel's source
-// spans contain NO Go-toolchain literal. The dev vocabulary must live only in
-// the devExternalTokens var. Negative proof: re-hard-code a dev token inside
-// the kernel and this test goes red.
+// TestKernelFreeOfDevVocabulary locks AC-6(b): the dev-toolchain vocabulary
+// lives ONLY in the devExternalTokens var. The whole non-test source of
+// external_proof.go MINUS the devExternalTokens var span (the sole legitimate
+// dev-token site) must contain NO Go-toolchain literal. Scanning whole-source-
+// minus-allowlist rather than a fixed span-name list closes the hole where a
+// future "just add a small helper" (e.g. a devEscapeHatch naming the tokens
+// outside the named kernel spans) re-couples the classification path to dev
+// vocabulary undetected. Negative proof: hard-code a dev token anywhere outside
+// devExternalTokens and this test goes red.
 func TestKernelFreeOfDevVocabulary(t *testing.T) {
 	data, err := os.ReadFile("external_proof.go")
 	if err != nil {
@@ -447,41 +442,45 @@ func TestKernelFreeOfDevVocabulary(t *testing.T) {
 	}
 	src := string(data)
 
-	bannedDevLiterals := []string{`gofmt`, `goreleaser`, `\bvet\b`, `\.go\b`, `\bcask\b`}
+	// Excise the one legitimate dev-token site so the scan is whole-source-
+	// minus-allowlist. The var span runs from its declaration to the closing
+	// `}, "|"))` that ends the regexp.MustCompile(strings.Join(...)) call.
+	devSpan := devExternalTokensSpan(t, src)
+	if devSpan == "" {
+		t.Fatal("could not locate the devExternalTokens var span to allowlist")
+	}
+	scanned := strings.Replace(src, devSpan, "", 1)
 
-	for _, name := range kernelSpanNames {
-		span := topLevelSpan(t, src, name)
-		for _, banned := range bannedDevLiterals {
-			if strings.Contains(span, banned) {
-				t.Errorf("kernel span %q contains dev-toolchain literal %q — dev vocabulary leaked back into the generic kernel", name, banned)
-			}
+	bannedDevLiterals := []string{`gofmt`, `goreleaser`, `\bvet\b`, `\.go\b`, `\bcask\b`}
+	for _, banned := range bannedDevLiterals {
+		if strings.Contains(scanned, banned) {
+			t.Errorf("external_proof.go names dev-toolchain literal %q OUTSIDE the devExternalTokens var — dev vocabulary leaked back into the generic classification path", banned)
 		}
 	}
 }
 
-// topLevelSpan returns the source of the top-level declaration that begins with
-// decl (e.g. "func ClassifyEntityACs" or "var selfPhraseRes"), from that line
-// to the matching closing brace at column 0. Top-level Go declarations close on
-// a `}` (or `)`) in the first column, so the span ends at the first such line.
-func topLevelSpan(t *testing.T, src, decl string) string {
+// devExternalTokensSpan returns the source of the `var devExternalTokens = ...`
+// declaration, from its opening line to the `}, "|"))` line that closes the
+// strings.Join + regexp.MustCompile call. This is the sole site allowed to name
+// dev tokens; TestKernelFreeOfDevVocabulary excises it before scanning.
+func devExternalTokensSpan(t *testing.T, src string) string {
 	t.Helper()
 	lines := strings.Split(src, "\n")
 	start := -1
 	for i, line := range lines {
-		if strings.HasPrefix(line, decl) {
+		if strings.HasPrefix(line, "var devExternalTokens =") {
 			start = i
 			break
 		}
 	}
 	if start < 0 {
-		t.Fatalf("declaration %q not found in external_proof.go", decl)
+		return ""
 	}
-	for i := start + 1; i < len(lines); i++ {
-		if strings.HasPrefix(lines[i], "}") || strings.HasPrefix(lines[i], ")") {
+	for i := start; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], `}, "|"))`) {
 			return strings.Join(lines[start:i+1], "\n")
 		}
 	}
-	t.Fatalf("no top-level close found for %q", decl)
 	return ""
 }
 

--- a/skills/commission/references/templates/development.md
+++ b/skills/commission/references/templates/development.md
@@ -112,6 +112,10 @@ Terminal state. The task's PR is merged and the entity is archived.
 
 These are proven dev-workflow disciplines a captain can adopt into this workflow's validation stage. They are recommended, not mandatory — the universal first-officer contract does not impose them, because a non-development workflow's acceptance proof may legitimately be a published artifact, a metric, or a human review rather than a test or command. Adopt them by copying the guidance into the `validation` stage's Outputs and Bad lists above when commissioning a code-shipping workflow.
 
+### Test-first authoring
+
+For a code or fixture deliverable, write the failing test first: write a test that captures the desired behavior, run it and watch it fail for the right reason, then write the minimum code to make it pass, and refactor green. The test is what the gate judges. This is a dev-workflow discipline — recommended, not mandatory; the universal contract does not impose it, because a non-development workflow's deliverable (a PRD, an analysis verdict, a published artifact) is judged against its own pre-fixed success criteria, not a test-first ritual.
+
 ### External-proof acceptance criteria
 
 At the validation gate, require that each AC's cited evidence comes from a check OUTSIDE the task body — a test, a command's output or exit code, a file the change produces, or the resulting on-disk state. An AC whose only cited proof is review of the task's own prose ("verified by reviewing this task's decision section") proves only that the prose exists; it can never fail, so it does not satisfy the AC. Reject self-referential ACs. If the task's only deliverable is a decision with nothing shipped, do not recommend PASSED — the decision belongs in the roadmap, not a terminal dev task. (Behavioral enforcement of this rule, when a workflow wants it, is a workflow-opt-in `spacedock status --validate` guard — the workflow declares it; it is not universal binary behavior.)

--- a/skills/ensign/references/claude-ensign-runtime.md
+++ b/skills/ensign/references/claude-ensign-runtime.md
@@ -4,7 +4,7 @@ How the shared ensign core executes on Claude Code.
 
 ## Agent Surface
 
-The ensign is dispatched by the first officer via the Agent tool. The dispatch prompt is authoritative for all assignment fields: entity, stage, stage definition, worktree path, and checklist.
+The ensign is dispatched by the first officer via the Agent tool. The dispatch prompt is authoritative for all assignment fields: entity, stage, stage definition, workflow location, and checklist.
 
 ## Clarification
 

--- a/skills/ensign/references/codex-ensign-runtime.md
+++ b/skills/ensign/references/codex-ensign-runtime.md
@@ -4,7 +4,7 @@ How the shared ensign core executes on Codex.
 
 ## Agent Surface
 
-The ensign is dispatched through Codex multi-agent dispatch. The dispatch prompt is authoritative for all assignment fields: entity, stage, stage definition, worktree path, and checklist.
+The ensign is dispatched through Codex multi-agent dispatch. The dispatch prompt is authoritative for all assignment fields: entity, stage, stage definition, workflow location, and checklist.
 
 Codex dispatch build prompts are file pointers. Read the named dispatch file directly and treat its content as the assignment; do not invoke a Claude `Skill(skill=...)` wrapper.
 

--- a/skills/ensign/references/ensign-shared-core.md
+++ b/skills/ensign/references/ensign-shared-core.md
@@ -19,10 +19,9 @@ Read the assignment context provided by the first officer. It defines:
 4. Update the entity file body, not the frontmatter.
 5. Commit your work before signaling completion.
 
-## Working Practices
+## Proving your work
 
-- **Write the failing test first.** For every feature or bugfix, write a test that captures the desired behavior, run it and watch it fail for the right reason, then write the minimum code to make it pass. Refactor green. The test is what the gate judges.
-- **Every task produces a real, checkable change.** Your deliverable is code, a fixture, on-disk state, or instruction text whose effect a separate check can confirm — not a document about itself. If your only output is prose nothing outside can fail, stop and raise it with the first officer; it likely belongs in the roadmap.
+- **Satisfy the proof your stage owes.** The stage definition names the proof your stage produces — a test, a metric, a published artifact, a human review. Satisfy that proof, not a generic authoring ritual.
 - **Prove by exercising, not by re-reading.** Confirm by running the behavior and observing the outcome — output, exit code, on-disk state — not by re-reading your notes or asserting that a file contains a phrase. A substring search is not proof of behavior.
 - **No hidden machine dependencies.** Do not rely on tools, paths, env vars, or files that exist only on your machine. Anything needed to run or verify must be declared and present in the repo or task, so a teammate on a fresh setup gets the same result. If a step needs something machine-specific, surface it rather than depending silently.
 
@@ -32,7 +31,7 @@ For worktree-backed entities, active stage/status/report/body state belongs in t
 
 ### Split-Root State Contract
 
-When the workflow is split-root (README declares `state:` checkout, e.g. `state: .spacedock-state`), the entity body and your stage report live in the state checkout the dispatch hands you as the entity path, NOT alongside the code. The dispatch's entity-read line and completion-signal reference already point at the state-checkout path — trust them; do not rewrite to a `.worktrees/` copy. With a worktree (implementation, validation), the worktree isolates CODE only. Without one (ideation, backlog), you run from the repo root; entity/report still go to the state checkout.
+When the workflow is split-root (README declares `state:` checkout, e.g. `state: .spacedock-state`), the entity body and your stage report live in the state checkout the dispatch hands you as the entity path, NOT alongside the code. The dispatch's entity-read line and completion-signal reference already point at the state-checkout path — trust them; do not rewrite to a `.worktrees/` copy. With a worktree (implementation, validation), the worktree isolates the deliverable work product only. Without one (ideation, backlog), you run from the repo root; entity/report still go to the state checkout.
 
 **Concurrency-safe state commits.** The state checkout is one shared, non-branched git index. A bare `git add -A` / `git commit` sweeps up a sibling writer's staged entity. You MUST commit path-scoped: `git -C {state_checkout} add {entity_path} && git -C {state_checkout} commit -m "…" -- {entity_path}`. Retry on `index.lock` contention after ~2s. Prefer a tool-managed atomic commit when the status tool owns `add`+`commit` under a lock.
 

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -267,7 +267,7 @@ If removal fails on untracked files, the FO MUST:
 
 ### Split-Root Worktree Contract
 
-When the workflow is split-root (README declares `state:` checkout, e.g. `state: .spacedock-state`), a worktree stage isolates **CODE only**. Entities live in a separate, non-branched state checkout that a worktree of the main repo does not contain. The entity body and stage reports are written and committed to that state checkout at the entity's state-checkout path, **never** a worktree copy — the dispatch helper hands workers that path even under a worktree stage. The worktree still owns code: working directory, branch, and "commits MUST be on this branch" apply to code changes only. The `pr:`-mirrored-on-`main` exception is unaffected.
+When the workflow is split-root (README declares `state:` checkout, e.g. `state: .spacedock-state`), a worktree stage isolates **the deliverable work product only**. Entities live in a separate, non-branched state checkout that a worktree of the main repo does not contain. The entity body and stage reports are written and committed to that state checkout at the entity's state-checkout path, **never** a worktree copy — the dispatch helper hands workers that path even under a worktree stage. The worktree still owns the deliverable: working directory, branch, and "commits MUST be on this branch" apply to deliverable-artifact changes only. The `pr:`-mirrored-on-`main` exception is unaffected.
 
 **Concurrency-safe state commits.** The state checkout is a single non-branched git index. A bare `git add -A` / `git commit` sweeps up a sibling writer's staged entity, cross-attributing or clobbering it. Every writer MUST commit concurrency-safe, in preference:
 


### PR DESCRIPTION
Stop the universal ensign contract from asserting dev-only discipline (TDD, code-only deliverables, "CODE only" worktree) as universal, so non-dev workflows are not mis-served.

## What changed
- Re-home the dev-specific Working-Practices bullets out of the universal ensign shared core into `development.md`'s opt-in practices.
- Neutralize "CODE only" to a deliverable-neutral phrase in both shared cores; runtime adapters use "workflow location".
- Split the external-proof classifier: `ClassifyEntityACs` takes the proof vocabulary as an injected param (`devExternalTokens`); the kernel stays workflow-agnostic.
- Lock with Go oracles: banned dev literals absent from the core, positive presence in the dev homes, kernel free of dev vocabulary (whole-source scan).

## Evidence
- Offline suite: 993/993 passed; `go vet` clean. Every oracle negative-half proven by real mutation.
- 2a's live-corpus invariant preserved at the identical flagged set; detached adversarial audit: no material findings (one coverage hole + one anchor, both closed).

---
[ep](/spacedock-dev/spacedock/blob/0934a86007d365ac6b667681bfba54fc770672dd/ensign-contract-dev-leakage/index.md)