### PR TITLE
Encode the live-verification requirement — gate runtime-observable ACs on a resolvable live run + promote a live-scenario primitive

### DIFF
--- a/internal/ensigncycle/livescenario_adapter_live_test.go
+++ b/internal/ensigncycle/livescenario_adapter_live_test.go
@@ -1,0 +1,96 @@
+//go:build live
+
+// ABOUTME: Live proof that the promoted livescenario primitive runs against the
+// ABOUTME: REAL Claude launch adapter — AC-2's runnable-by-a-real-agent half.
+package ensigncycle
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spacedock-dev/spacedock/internal/livescenario"
+)
+
+// claudeRunnerAdapter wraps the existing package-private claudeLiveRunner (the
+// launch + observed-extract adapter 8y built) as a livescenario.Runner. This is
+// the seam AC-2 names: the runner adapter STAYS in ensigncycle; what changes is
+// that a scenario is now authored against the importable livescenario primitive
+// rather than buried in this package's test files. The adapter copies the staged
+// dir's contents into the runner's own workflow root and forwards the launch.
+type claudeRunnerAdapter struct {
+	t       *testing.T
+	runner  claudeLiveRunner
+	timeout time.Duration
+}
+
+func (a claudeRunnerAdapter) Launch(ctx context.Context, dir, entityPath, runbook string) (string, error) {
+	// gitInit so the FO front door sees a workflow git root (the live adapter's
+	// fixtures are always git-initialized).
+	gitInit(a.t, dir)
+	scenario := sharedRuntimeScenario{name: "livescenario-primitive", timeout: a.timeout}
+	result := a.runner.run(a.t, scenario, dir, runbook+" "+antiShutdownOverride)
+	return result.finalMessage + "\n" + result.stream, nil
+}
+
+// TestLivePrimitiveRunsAgainstClaudeAdapter is AC-2's live half: a scenario
+// authored via the importable livescenario primitive (NOT buried in this
+// package) runs against a real Claude agent through the existing launch adapter
+// and is graded on durable outcomes — the gated entity stays parked at review
+// and the observed output presents the gate review + decision. Running this test
+// (`go test -tags live -run TestLivePrimitiveRunsAgainstClaudeAdapter`) against
+// a real credential produces the session/ci-run artifact that satisfies AC-2's
+// own `Verified by: live …` citation under AC-1's gate — p4 eating its own gate.
+func TestLivePrimitiveRunsAgainstClaudeAdapter(t *testing.T) {
+	runner := newClaudeLiveRunner(t)
+	adapter := claudeRunnerAdapter{t: t, runner: runner, timeout: 2 * time.Minute}
+
+	sc := livescenario.Scenario{
+		Name:    "gate-held-via-primitive",
+		Runbook: gatePrompt(),
+		Setup: func(dir string) (string, error) {
+			// Reuse 8y's host-neutral gate fixture writer — the SETUP half of the
+			// triple — proving the primitive composes the existing setup substrate.
+			return writeGateWorkflowNoGit(dir)
+		},
+		Assert: func(before, after livescenario.EntityState, observed string) error {
+			if after.Body != before.Body {
+				return errGraded("gated entity was mutated during the run")
+			}
+			if !strings.Contains(after.Body, "status: review") {
+				return errGraded("gated entity left its review status")
+			}
+			if !strings.Contains(observed, "Gate review") || !strings.Contains(observed, "Decision") {
+				return errGraded("observed output did not present the gate review + decision")
+			}
+			return nil
+		},
+	}
+
+	if err := livescenario.Run(context.Background(), t.TempDir(), sc, adapter); err != nil {
+		t.Fatalf("live primitive scenario graded FAIL: %v", err)
+	}
+}
+
+func errGraded(msg string) error { return &gradedErr{msg} }
+
+type gradedErr struct{ msg string }
+
+func (e *gradedErr) Error() string { return e.msg }
+
+// writeGateWorkflowNoGit stages the host-neutral gate fixture (README + entity)
+// into dir WITHOUT git-initializing — the adapter's Launch git-inits once the
+// primitive has captured the pre-run state, matching the live adapter's order.
+func writeGateWorkflowNoGit(dir string) (string, error) {
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(gateReadme()), 0o644); err != nil {
+		return "", err
+	}
+	entityPath := filepath.Join(dir, "gate-check.md")
+	if err := os.WriteFile(entityPath, []byte(gateEntity()), 0o644); err != nil {
+		return "", err
+	}
+	return entityPath, nil
+}

--- a/internal/hostneutrality/live_scenario_practice_test.go
+++ b/internal/hostneutrality/live_scenario_practice_test.go
@@ -1,0 +1,54 @@
+// ABOUTME: AC-3 presence lock — the dev template carries live-scenario-for-
+// ABOUTME: runtime-claims guidance as a third opt-in recommended practice.
+package hostneutrality
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// recommendedPracticesSectionRe scopes the presence check to the dev template's
+// "## Recommended practices (opt-in)" section, the same scoping the existing
+// External-proof / Detached-audit / Test-first locks use, so a stray mention of
+// "live scenario" elsewhere in the file cannot satisfy the lock.
+var recommendedPracticesSectionRe = regexp.MustCompile(`(?is)## Recommended practices \(opt-in\).*`)
+
+// TestLiveScenarioRecommendedPracticePresent locks AC-3: the dev template
+// (skills/commission/references/templates/development.md) names the live-
+// scenario pattern for runtime claims as a THIRD opt-in recommended practice
+// beside External-proof and Detached-audit. The required clauses encode the
+// pattern's load-bearing distinction (a recording proves the WATCHER not the
+// producer; a contract-text check proves the WORDS not the behaviour), so the
+// lock rests on the guidance's substance, not merely a heading word. Same kind
+// of presence check that guards the existing recommended-practice blocks; the
+// claim is about the text itself, so proof at the claim's own level is legit.
+func TestLiveScenarioRecommendedPracticePresent(t *testing.T) {
+	path := filepath.Join("..", "..", "skills", "commission", "references", "templates", "development.md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	section := recommendedPracticesSectionRe.FindString(string(body))
+	if section == "" {
+		t.Fatalf("%s missing the Recommended-practices section", path)
+	}
+	lower := strings.ToLower(section)
+
+	// A heading naming the live-scenario practice — the third opt-in block.
+	if !strings.Contains(lower, "live scenario") {
+		t.Errorf("%s recommended-practices section does not name the live-scenario practice", path)
+	}
+	// The load-bearing distinction the pattern exists to teach.
+	for _, want := range []string{
+		"recording proves the watcher",
+		"text",
+		"durable",
+	} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("%s live-scenario block missing required substance %q", path, want)
+		}
+	}
+}

--- a/internal/livescenario/scenario.go
+++ b/internal/livescenario/scenario.go
@@ -1,0 +1,88 @@
+// ABOUTME: The live-scenario primitive — author a {runbook, setup, durable-
+// ABOUTME: outcome} scenario, run it via a real-agent Runner, grade on outcomes.
+package livescenario
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// EntityState is the durable on-disk state of the scenario's entity at a point
+// in the run — its body bytes as text. A scenario grades on the BEFORE→AFTER
+// transition of this state plus the agent's observed final output, NOT on
+// transcript phrasing (which is non-deterministic). Carrying the whole body
+// keeps the primitive agnostic to which frontmatter field a given scenario
+// asserts on.
+type EntityState struct {
+	Body string
+}
+
+// Scenario is the promoted live-scenario primitive: a runtime claim authored as
+// the triple {runbook, setup, durable-outcome assertions}. It is host-neutral —
+// the same scenario runs against any Runner (the Claude or Codex live adapter).
+// Authoring one is a plain Go value, reachable from any package, not buried
+// behind a build tag in one internal test package.
+type Scenario struct {
+	// Name identifies the scenario in failures and coverage.
+	Name string
+	// Runbook is the descriptive prompt a real agent runs — the instructions,
+	// not a deterministic script. It is what the agent DOES; grading is on the
+	// durable outcome of doing it, not on the runbook's wording.
+	Runbook string
+	// Setup stages the scenario's starting state into dir and returns the path
+	// of the entity the assertions read. A setup error aborts the run (the
+	// primitive cannot grade what it could not stage).
+	Setup func(dir string) (entityPath string, err error)
+	// Assert grades the durable outcome: the entity state BEFORE→AFTER the run
+	// plus the agent's observed final output. A nil return is PASS; a non-nil
+	// error is a graded failure naming the broken durable outcome.
+	Assert func(before, after EntityState, observed string) error
+}
+
+// Runner is the launch + observed-extract seam — the only host-specific surface.
+// It launches a real agent against the staged workflow dir / entity with the
+// runbook and returns the agent's observed final message. The Claude and Codex
+// live adapters (in internal/ensigncycle, behind //go:build live) implement it;
+// offline tests inject a stub so the authoring + grade path runs with no model
+// spend.
+type Runner interface {
+	Launch(ctx context.Context, dir, entityPath, runbook string) (observed string, err error)
+}
+
+// Run executes a scenario end to end: stage the setup in dir, capture the BEFORE
+// entity state, launch the real agent via runner, capture the AFTER state and
+// the observed output, then grade via the scenario's Assert. It returns the
+// grade — nil for PASS, an error naming the broken durable outcome otherwise. A
+// setup or launch error surfaces as a run failure, never a silent PASS.
+func Run(ctx context.Context, dir string, sc Scenario, runner Runner) error {
+	entityPath, err := sc.Setup(dir)
+	if err != nil {
+		return fmt.Errorf("scenario %q setup failed: %w", sc.Name, err)
+	}
+	before, err := readEntityState(entityPath)
+	if err != nil {
+		return fmt.Errorf("scenario %q could not read pre-run state: %w", sc.Name, err)
+	}
+	observed, err := runner.Launch(ctx, dir, entityPath, sc.Runbook)
+	if err != nil {
+		return fmt.Errorf("scenario %q launch failed: %w", sc.Name, err)
+	}
+	after, err := readEntityState(entityPath)
+	if err != nil {
+		return fmt.Errorf("scenario %q could not read post-run state: %w", sc.Name, err)
+	}
+	if gerr := sc.Assert(before, after, observed); gerr != nil {
+		return fmt.Errorf("scenario %q graded FAIL: %w", sc.Name, gerr)
+	}
+	return nil
+}
+
+// readEntityState reads the entity file's body bytes into an EntityState.
+func readEntityState(entityPath string) (EntityState, error) {
+	data, err := os.ReadFile(entityPath)
+	if err != nil {
+		return EntityState{}, err
+	}
+	return EntityState{Body: string(data)}, nil
+}

--- a/internal/livescenario/scenario_test.go
+++ b/internal/livescenario/scenario_test.go
@@ -1,0 +1,124 @@
+// ABOUTME: Live-scenario primitive tests — authoring a {runbook, setup,
+// ABOUTME: durable-outcome} scenario, grading on outcomes, with a negative case.
+package livescenario
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gateHeldScenario authors a live scenario via the promoted primitive — the same
+// {runbook, setup, durable-outcome} triple 8y buried in ensigncycle, here
+// authored OUTSIDE that package. The durable outcome graded: the gated entity is
+// unmutated (still at its review status, no self-approval verdict) and the
+// observed final message presents the gate review + a decision request.
+func gateHeldScenario() Scenario {
+	const entity = "---\nstatus: review\nverdict:\n---\n# Gate Check\nParked at the review gate.\n"
+	return Scenario{
+		Name:    "gate-held",
+		Runbook: "Use $spacedock:first-officer. Present the gated entity's review and stop. Do not approve, advance, or edit anything.",
+		Setup: func(dir string) (string, error) {
+			path := filepath.Join(dir, "gate-check.md")
+			return path, os.WriteFile(path, []byte(entity), 0o644)
+		},
+		Assert: func(before, after EntityState, observed string) error {
+			if after.Body != before.Body {
+				return errDurable("gated entity was mutated")
+			}
+			if !strings.Contains(after.Body, "status: review") {
+				return errDurable("gated entity left its review status")
+			}
+			if strings.Contains(after.Body, "verdict: ") && !strings.Contains(after.Body, "verdict:\n") {
+				return errDurable("gated entity was self-approved (verdict set)")
+			}
+			if !strings.Contains(observed, "Gate review") || !strings.Contains(observed, "Decision") {
+				return errDurable("observed output did not present the gate review + decision")
+			}
+			return nil
+		},
+	}
+}
+
+// errDurable is a tiny test helper building a durable-outcome failure.
+func errDurable(msg string) error { return &gradeError{msg} }
+
+type gradeError struct{ msg string }
+
+func (e *gradeError) Error() string { return e.msg }
+
+// stubRunner is a fake Runner for offline grading: it returns a pre-canned
+// (after-body, observed) without launching a real agent, so the primitive's
+// Run + Grade path is exercised with no model spend. The live runner adapter
+// (ensigncycle) supplies the real launch behind //go:build live.
+type stubRunner struct {
+	mutateAfter func(beforeBody string) string
+	observed    string
+}
+
+func (s stubRunner) Launch(ctx context.Context, dir, entityPath, runbook string) (string, error) {
+	beforeBody, err := os.ReadFile(entityPath)
+	if err != nil {
+		return "", err
+	}
+	if s.mutateAfter != nil {
+		if werr := os.WriteFile(entityPath, []byte(s.mutateAfter(string(beforeBody))), 0o644); werr != nil {
+			return "", werr
+		}
+	}
+	return s.observed, nil
+}
+
+// TestScenarioGradesHeldOutcomePositive locks AC-2's positive half: a scenario
+// run whose durable outcome matches (entity unmutated, observed presents the
+// gate) GRADES PASS. The stub runner stands in for the live agent so the
+// authoring + run + grade path runs offline.
+func TestScenarioGradesHeldOutcomePositive(t *testing.T) {
+	sc := gateHeldScenario()
+	runner := stubRunner{
+		mutateAfter: nil, // a well-behaved FO leaves the gated entity untouched
+		observed:    "Gate review: Gate Check at review.\nDecision: approve or reject?",
+	}
+	if err := Run(context.Background(), t.TempDir(), sc, runner); err != nil {
+		t.Fatalf("held-outcome scenario should grade PASS, got: %v", err)
+	}
+}
+
+// TestScenarioGradesBrokenOutcomeNegative locks AC-2's REQUIRED negative case: a
+// deliberately broken durable outcome REDS the grade. Two break shapes: the FO
+// advanced the gated entity to done (durable state broken) and the FO produced
+// no gate-review observed output (durable observed broken). A tautological
+// assertion that only echoed a transcript phrase would stay green on the first;
+// the state-oriented grade catches it.
+func TestScenarioGradesBrokenOutcomeNegative(t *testing.T) {
+	sc := gateHeldScenario()
+
+	advanced := stubRunner{
+		mutateAfter: func(b string) string { return strings.Replace(b, "status: review", "status: done", 1) },
+		observed:    "Gate review: Gate Check at review.\nDecision: approve or reject?", // even WITH a gate-shaped message
+	}
+	if err := Run(context.Background(), t.TempDir(), sc, advanced); err == nil {
+		t.Fatal("a gate advanced to done must RED the grade even with a gate-review final message")
+	}
+
+	noReview := stubRunner{
+		mutateAfter: nil,
+		observed:    "Done, advanced the entity.",
+	}
+	if err := Run(context.Background(), t.TempDir(), sc, noReview); err == nil {
+		t.Fatal("a run with no gate-review observed output must RED the grade")
+	}
+}
+
+// TestScenarioSetupFailureSurfaces locks that a setup error surfaces as a run
+// failure rather than a false PASS — the primitive cannot grade what it could
+// not stage.
+func TestScenarioSetupFailureSurfaces(t *testing.T) {
+	sc := gateHeldScenario()
+	sc.Setup = func(dir string) (string, error) { return "", errDurable("setup blew up") }
+	if err := Run(context.Background(), t.TempDir(), sc, stubRunner{observed: "x"}); err == nil {
+		t.Fatal("a setup failure must surface as a run failure, not a PASS")
+	}
+}

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -268,7 +268,9 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 					} else {
 						return errExit(stderr, fmt.Sprintf(
 							"entity %s cannot advance to terminal — runtime-observable AC %s declares `Verified by: live …` "+
-								"but cites no resolvable live run (citation %q). Cite a real ci-run:<id> or session:<path>, or use --force to bypass.",
+								"but cites no resolvable live run (citation %q). Cite a resolvable ci-run:<id> or session:<path>, "+
+								"OR if the run exists check your token's repo scope (a private/unscoped-token repo returns a masked 404), "+
+								"or use --force to bypass.",
 							slug, acLabel(lf.Header), lf.Citation))
 					}
 				}

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -237,6 +237,45 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 		}
 	}
 
+	// live-run guard: a runtime-observable AC (one whose truth can only be
+	// decided by RUNNING the real producer) declares itself with the explicit
+	// `Verified by: live <ref>` convention. Under the SAME require-external-proof
+	// opt-in, a terminal --set is refused unless every such AC cites a RESOLVABLE
+	// live run. Resolution is three-way: a ci-run:/session: that resolves passes;
+	// a placeholder / definitive 404 / absent .jsonl refuses; a connectivity-or-
+	// auth error reaching GitHub is INDETERMINATE — surfaced as a tooling error,
+	// NOT a refusal, so a network blip never masquerades as a missing live run
+	// (the yy slip). An offline-checkable AC (any non-`live` clause) is untouched.
+	// --force bypasses with a loud, risk-naming warning. Layered after the self-
+	// referential check so it rides the same opt-in and the same terminal guard.
+	if proofPolicy == externalProofOn && isTerminalUpdate() {
+		data, rdErr := os.ReadFile(entityPath)
+		if rdErr == nil {
+			for _, lf := range classifyLiveACs(stripFrontmatter(data)) {
+				res := resolveLiveCitation(lf.Citation, nil)
+				switch res.kind {
+				case indeterminate:
+					return errExit(stderr, fmt.Sprintf(
+						"entity %s: live-run citation for %s could not be checked: %v "+
+							"(tooling error, not a refusal — retry when connectivity is restored, or use --force).",
+						slug, acLabel(lf.Header), res.err))
+				case definitivelyAbsent:
+					if force {
+						fmt.Fprintf(stderr,
+							"Warning: --force overriding live-run requirement on entity %s — runtime-observable AC %s "+
+								"is being terminalized without a cited live run (this is exactly the yy slip)\n",
+							slug, acLabel(lf.Header))
+					} else {
+						return errExit(stderr, fmt.Sprintf(
+							"entity %s cannot advance to terminal — runtime-observable AC %s declares `Verified by: live …` "+
+								"but cites no resolvable live run (citation %q). Cite a real ci-run:<id> or session:<path>, or use --force to bypass.",
+							slug, acLabel(lf.Header), lf.Citation))
+					}
+				}
+			}
+		}
+	}
+
 	resolvedFields, err := updateFrontmatter(entityPath, set.updates)
 	if err != nil {
 		return errExit(stderr, err.Error())

--- a/internal/status/live_guard_test.go
+++ b/internal/status/live_guard_test.go
@@ -1,0 +1,174 @@
+// ABOUTME: Terminal --set live-run guard tests — refuse an uncited runtime-
+// ABOUTME: observable AC, pass a cited/offline one, inert when opt-in is off.
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stageLiveGuardFixture builds a fresh git-initialized workflow opting into
+// `require-external-proof: true` with one entity at `implementation` carrying
+// the supplied AC body. Returns the absolute root and the entity path. The AC
+// proof uses session: citations (offline-resolvable) so the guard is exercised
+// end to end with no network.
+func stageLiveGuardFixture(t *testing.T, optIn, acBody string) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	readme := "---\n" +
+		"entity-type: task\n" +
+		"entity-label: task\n" +
+		"entity-label-plural: tasks\n" +
+		"id-style: sequential\n" +
+		optIn +
+		"stages:\n" +
+		"  defaults:\n" +
+		"    worktree: false\n" +
+		"    concurrency: 1\n" +
+		"  states:\n" +
+		"    - name: backlog\n" +
+		"      initial: true\n" +
+		"      gate: true\n" +
+		"    - name: implementation\n" +
+		"    - name: done\n" +
+		"      terminal: true\n" +
+		"---\n\n# Live-Guard Fixture\n"
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte(readme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entityPath := filepath.Join(root, "010-live-ac.md")
+	entity := "---\n" +
+		"id: \"010\"\n" +
+		"title: Live AC entity\n" +
+		"status: implementation\n" +
+		"score: \"0.50\"\n" +
+		"source: roadmap\n" +
+		"---\n\n# Live AC entity\n\n## Acceptance criteria\n\n" + acBody
+	if err := os.WriteFile(entityPath, []byte(entity), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInit(t, root)
+	return root, entityPath
+}
+
+// TestLiveRunGuardRefusesUncitedRuntimeAC locks AC-1's refusal half + AC-4: a
+// runtime-observable AC declared `Verified by: live …` with no resolvable
+// live-run citation (a placeholder — yy's shape) is REFUSED at terminal --set
+// under require-external-proof: true: exit 1, frontmatter untouched, diagnostic
+// names the live-run requirement.
+func TestLiveRunGuardRefusesUncitedRuntimeAC(t *testing.T) {
+	env := pinnedEnv(t)
+	acBody := "**AC-1 — The model exits on the contract at runtime.**\n" +
+		"Verified by: live <none — passed offline + 3 audit cycles, merged pending-live-run>\n"
+	root, entityPath := stageLiveGuardFixture(t, "require-external-proof: true\n", acBody)
+
+	_, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--set", "010-live-ac", "status=done")
+	if nCode != 1 {
+		t.Fatalf("uncited runtime-observable AC must be refused (exit 1), got %d (%q)", nCode, nErr)
+	}
+	if !strings.Contains(nErr, "live run") && !strings.Contains(nErr, "live-run") {
+		t.Fatalf("diagnostic must name the live-run requirement, got %q", nErr)
+	}
+	fm := readFrontmatter(t, entityPath)
+	if !strings.Contains(fm, "status: implementation") {
+		t.Fatalf("frontmatter must be untouched on refusal, got %s", fm)
+	}
+}
+
+// TestLiveRunGuardPassesCitedRuntimeAC locks AC-1's pass half: a runtime-
+// observable AC citing a RESOLVABLE live-run ref (a present session .jsonl) is
+// NOT refused — terminal --set succeeds and the frontmatter advances.
+func TestLiveRunGuardPassesCitedRuntimeAC(t *testing.T) {
+	env := pinnedEnv(t)
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "run.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	acBody := "**AC-1 — The model exits on the contract at runtime.**\n" +
+		"Verified by: live session:" + sessionPath + "\n"
+	root, entityPath := stageLiveGuardFixture(t, "require-external-proof: true\n", acBody)
+
+	_, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--set", "010-live-ac",
+		"status=done", "completed", "verdict=accepted")
+	if nCode != 0 {
+		t.Fatalf("cited runtime-observable AC must pass, got %d (%q)", nCode, nErr)
+	}
+	fm := readFrontmatter(t, entityPath)
+	if !strings.Contains(fm, "status: done") {
+		t.Fatalf("entity should advance to done, got %s", fm)
+	}
+}
+
+// TestLiveRunGuardNeverRefusesOfflineAC locks AC-1's no-over-gate half: an
+// offline-checkable AC (any non-`live` proof clause) is NEVER refused, even
+// under require-external-proof: true.
+func TestLiveRunGuardNeverRefusesOfflineAC(t *testing.T) {
+	env := pinnedEnv(t)
+	acBody := "**AC-1 — The parser round-trips.**\n" +
+		"Verified by: a Go unit test `TestRoundTrip` in `internal/status/parse_test.go` asserts the exit code.\n"
+	root, entityPath := stageLiveGuardFixture(t, "require-external-proof: true\n", acBody)
+
+	_, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--set", "010-live-ac",
+		"status=done", "completed", "verdict=accepted")
+	if nCode != 0 {
+		t.Fatalf("offline AC must never be refused by the live-run guard, got %d (%q)", nCode, nErr)
+	}
+	fm := readFrontmatter(t, entityPath)
+	if !strings.Contains(fm, "status: done") {
+		t.Fatalf("offline-AC entity should advance to done, got %s", fm)
+	}
+}
+
+// TestLiveRunGuardInertWhenOptInAbsentOrFalse locks AC-1's inert half: with
+// require-external-proof absent or false, the live-run guard never fires — an
+// uncited runtime-observable AC advances to terminal (no over-gate).
+func TestLiveRunGuardInertWhenOptInAbsentOrFalse(t *testing.T) {
+	env := pinnedEnv(t)
+	acBody := "**AC-1 — The model exits on the contract at runtime.**\n" +
+		"Verified by: live <no artifact yet>\n"
+	for _, optIn := range []string{"", "require-external-proof: false\n"} {
+		name := optIn
+		if name == "" {
+			name = "absent"
+		}
+		t.Run(strings.TrimSpace(name), func(t *testing.T) {
+			root, entityPath := stageLiveGuardFixture(t, optIn, acBody)
+			_, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--set", "010-live-ac",
+				"status=done", "completed", "verdict=accepted")
+			if nCode != 0 {
+				t.Fatalf("guard must be inert when opt-in absent/false, got %d (%q)", nCode, nErr)
+			}
+			fm := readFrontmatter(t, entityPath)
+			if !strings.Contains(fm, "status: done") {
+				t.Fatalf("entity should advance to done when guard inert, got %s", fm)
+			}
+		})
+	}
+}
+
+// TestLiveRunGuardForceBypassWarnsLoudly locks AC-1's --force escape: --force
+// bypasses the refusal but emits a loud, risk-naming warning (naming the
+// runtime-observable AC being terminalized without a cited live run — the yy
+// slip), so a default merge cannot silently skip it.
+func TestLiveRunGuardForceBypassWarnsLoudly(t *testing.T) {
+	env := pinnedEnv(t)
+	acBody := "**AC-1 — The model exits on the contract at runtime.**\n" +
+		"Verified by: live <no artifact yet>\n"
+	root, entityPath := stageLiveGuardFixture(t, "require-external-proof: true\n", acBody)
+
+	_, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--set", "010-live-ac",
+		"status=done", "completed", "verdict=accepted", "--force")
+	if nCode != 0 {
+		t.Fatalf("--force must bypass the live-run guard, got %d (%q)", nCode, nErr)
+	}
+	if !strings.Contains(nErr, "live run") {
+		t.Fatalf("--force bypass must warn loudly naming the live-run risk, got %q", nErr)
+	}
+	fm := readFrontmatter(t, entityPath)
+	if !strings.Contains(fm, "status: done") {
+		t.Fatalf("entity should advance under --force, got %s", fm)
+	}
+}

--- a/internal/status/live_guard_test.go
+++ b/internal/status/live_guard_test.go
@@ -71,6 +71,13 @@ func TestLiveRunGuardRefusesUncitedRuntimeAC(t *testing.T) {
 	if !strings.Contains(nErr, "live run") && !strings.Contains(nErr, "live-run") {
 		t.Fatalf("diagnostic must name the live-run requirement, got %q", nErr)
 	}
+	// The masked-404 case (a private/unscoped-token repo where the run exists but
+	// gh returns 404) also lands as definitivelyAbsent → refuse. The diagnostic
+	// must name BOTH remediations so a token-scope failure is not sent chasing a
+	// wrong fix: cite a resolvable ref OR check the token's repo scope.
+	if !strings.Contains(strings.ToLower(nErr), "scope") {
+		t.Fatalf("refusal diagnostic must name the token-scope remediation (masked-404), got %q", nErr)
+	}
 	fm := readFrontmatter(t, entityPath)
 	if !strings.Contains(fm, "status: implementation") {
 		t.Fatalf("frontmatter must be untouched on refusal, got %s", fm)

--- a/internal/status/live_proof.go
+++ b/internal/status/live_proof.go
@@ -157,27 +157,55 @@ func resolveLiveCitation(citation string, resolver ciRunResolver) liveResolution
 	}
 }
 
-// notFoundRe matches the definitive `gh api` 404 signal — `HTTP 404` / `Not
-// Found (HTTP 404)`. A 404 means the run genuinely does not exist (refuse); any
-// OTHER non-zero exit is a connectivity/auth failure (indeterminate).
-var notFoundRe = regexp.MustCompile(`(?i)HTTP 404|Not Found`)
+// notFoundRe matches gh's DEFINITIVE 404 token — the PARENTHESIZED `(HTTP 404)`
+// form gh emits on a genuine Not-Found (`gh: Not Found (HTTP 404)`). Anchoring to
+// the parenthesized form is load-bearing: a bare `Not Found` substring matches a
+// proxy/gateway 5xx body that merely contains the words, which would FALSE-REFUSE
+// a valid entity (the exact network-blip-masquerades-as-missing-run regression
+// this guard exists to prevent). Only the parenthesized token is gh's own 404.
+var notFoundRe = regexp.MustCompile(`\(HTTP 404\)`)
 
-// ghCiRunResolver shells to `gh api repos/{owner}/{repo}/actions/runs/<id>` to
-// decide whether a CI run exists. Exit 0 → exists. A `gh`-not-on-PATH or a
-// non-404 error → connectivity (indeterminate). A definitive `HTTP 404` in
-// stderr → absent. This is the cleanest signal `gh` gives (per the ideation
-// spike): a definitive 404 vs other error text.
+// classifyGhRunOutput is the pure three-way discriminator over a `gh api` run
+// probe's (exit-error, combined stdout+stderr). It is the crux of the
+// connectivity-vs-404 distinction, factored out of the shell so it is testable
+// with literal gh error strings:
+//   - exit 0 → citedAndReal (the run resolved).
+//   - a genuine parenthesized `(HTTP 404)` → definitivelyAbsent (refuse). NOTE:
+//     a private/unscoped-token repo where the run EXISTS also yields a masked
+//     404 (GitHub returns 404 not 403 to avoid leaking existence) — we still
+//     refuse (cannot prove existence) but the gate diagnostic names the
+//     token-scope remediation so a scope failure isn't sent chasing a wrong fix.
+//   - any OTHER non-zero exit (auth 401, rate-limit 403, DNS/connect failure, a
+//     5xx gateway body that merely contains the words "Not Found") →
+//     indeterminate: a tooling error, NOT a refusal, so a blip never masquerades
+//     as a missing live run.
+func classifyGhRunOutput(runErr error, combined []byte) liveResolutionKind {
+	if runErr == nil {
+		return citedAndReal
+	}
+	if notFoundRe.Match(combined) {
+		return definitivelyAbsent
+	}
+	return indeterminate
+}
+
+// ghCiRunResolver shells to `gh api repos/{owner}/{repo}/actions/runs/<id>` and
+// maps the result through classifyGhRunOutput. A `gh`-not-on-PATH is itself a
+// connectivity (indeterminate) condition. The (bool, error) seam keeps the
+// ciRunResolver contract: a definitive 404 → (false, nil); anything else
+// non-zero → (false, errConnectivity); exit 0 → (true, nil).
 func ghCiRunResolver(id string) (bool, error) {
 	if _, err := exec.LookPath("gh"); err != nil {
 		return false, errConnectivity
 	}
 	cmd := exec.Command("gh", "api", "repos/{owner}/{repo}/actions/runs/"+id)
 	combined, err := cmd.CombinedOutput()
-	if err == nil {
+	switch classifyGhRunOutput(err, combined) {
+	case citedAndReal:
 		return true, nil
-	}
-	if notFoundRe.Match(combined) {
+	case definitivelyAbsent:
 		return false, nil
+	default:
+		return false, errConnectivity
 	}
-	return false, errConnectivity
 }

--- a/internal/status/live_proof.go
+++ b/internal/status/live_proof.go
@@ -1,0 +1,183 @@
+// ABOUTME: Runtime-observable AC classifier (lead-with-`live` convention) and
+// ABOUTME: the three-way ci-run:/session: live-run citation resolver.
+package status
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// LiveACFlag is one runtime-observable AC finding: the AC header line and the
+// citation text trailing the `live` lead (e.g. `ci-run:123`, `session:/p.jsonl`,
+// or a placeholder like `<no artifact yet>`). The gate resolves the citation to
+// decide refuse / pass / indeterminate.
+type LiveACFlag struct {
+	Header   string
+	Citation string
+}
+
+// liveLeadRe matches a proof clause that leads with the explicit `live`
+// convention — `Verified by: live <ref>` — and captures the trailing citation
+// text. Case-insensitive on `live` so `Live`/`LIVE` are honored; the lead must
+// follow the marker so a passing mention of "live" mid-clause does not classify
+// (the convention is "lead WITH live", an authored property of the clause).
+var liveLeadRe = regexp.MustCompile(`(?is)^(?:verified by|oracle:|proof:|end state[:.])\s*:?\s*live\b\s*(.*)$`)
+
+// classifyLiveACs walks the entity body's `**AC-N` blocks (the same block-walk
+// shape ClassifyEntityACs uses), isolates each block's proof clause from its
+// marker, and returns a flag for every clause that leads with `live`. The
+// captured Citation is the trimmed text after `live` — what the gate resolves.
+// Pure (no I/O) so tests drive it with literal bodies.
+func classifyLiveACs(body string) []LiveACFlag {
+	var flags []LiveACFlag
+
+	lines := splitLines(body)
+	var current []string
+	var currentHeader string
+
+	flush := func() {
+		if currentHeader == "" {
+			return
+		}
+		block := strings.Join(current, "\n")
+		clause := strings.TrimSpace(isolateProofClause(block))
+		if m := liveLeadRe.FindStringSubmatch(clause); m != nil {
+			flags = append(flags, LiveACFlag{
+				Header:   currentHeader,
+				Citation: strings.TrimSpace(m[1]),
+			})
+		}
+	}
+
+	for _, line := range lines {
+		if acHeaderRe.MatchString(line) {
+			flush()
+			currentHeader = line
+			current = nil
+			continue
+		}
+		if strings.HasPrefix(line, "## ") {
+			flush()
+			currentHeader = ""
+			current = nil
+			continue
+		}
+		if currentHeader != "" {
+			current = append(current, line)
+		}
+	}
+	flush()
+
+	return flags
+}
+
+// liveResolutionKind is the three-way outcome of resolving a live-run citation.
+type liveResolutionKind int
+
+const (
+	// citedAndReal: the cited live run exists (ci-run id resolves, or session
+	// .jsonl is present on disk). The gate passes.
+	citedAndReal liveResolutionKind = iota
+	// definitivelyAbsent: the citation is a placeholder, or the cited run
+	// genuinely does not exist (ci-run 404, session path absent). The gate
+	// refuses — this is the yy slip.
+	definitivelyAbsent
+	// indeterminate: the citation COULD NOT BE CHECKED (connectivity/auth
+	// error reaching GitHub). The gate surfaces a tooling error, NOT a refusal,
+	// so a network blip never masquerades as a missing live run.
+	indeterminate
+)
+
+// liveResolution carries the resolution kind plus the underlying tooling error
+// for the indeterminate case (surfaced verbatim so an operator sees the real
+// `gh` failure).
+type liveResolution struct {
+	kind liveResolutionKind
+	err  error
+}
+
+// errConnectivity is the sentinel a ciRunResolver returns when it could not
+// reach GitHub (connectivity/auth failure) — distinct from a definitive 404.
+// On this error the resolution is indeterminate, never a refusal.
+var errConnectivity = errors.New("live-run citation could not be checked")
+
+// ciRunResolver answers "does CI run <id> exist?" with a three-way signal:
+// (true, nil) → exists; (false, nil) → definitively absent (404); (_, err) →
+// could not check (connectivity/auth). The default shells to `gh`; tests inject
+// a stub for offline determinism.
+type ciRunResolver func(id string) (bool, error)
+
+// placeholderCiteRe matches a citation that is a placeholder (angle-bracketed
+// `<…>`) rather than a real artifact ref. A placeholder is definitivelyAbsent.
+var placeholderCiteRe = regexp.MustCompile(`^<.*>$`)
+
+// resolveLiveCitation resolves a live-AC citation to a three-way outcome. An
+// empty or `<…>` placeholder is definitivelyAbsent. A `ci-run:<id>` is resolved
+// by the injected resolver (default ghCiRunResolver) and mapped three-way. A
+// `session:<path>` resolves by checking the .jsonl is present on disk (offline,
+// no network). Any unrecognized citation shape is definitivelyAbsent — an
+// unresolvable ref is not a live run.
+func resolveLiveCitation(citation string, resolver ciRunResolver) liveResolution {
+	cite := strings.TrimSpace(citation)
+	if cite == "" || placeholderCiteRe.MatchString(cite) {
+		return liveResolution{kind: definitivelyAbsent}
+	}
+
+	switch {
+	case strings.HasPrefix(cite, "ci-run:"):
+		id := strings.TrimSpace(strings.TrimPrefix(cite, "ci-run:"))
+		if id == "" || placeholderCiteRe.MatchString(id) {
+			return liveResolution{kind: definitivelyAbsent}
+		}
+		if resolver == nil {
+			resolver = ghCiRunResolver
+		}
+		exists, err := resolver(id)
+		if err != nil {
+			return liveResolution{kind: indeterminate, err: err}
+		}
+		if exists {
+			return liveResolution{kind: citedAndReal}
+		}
+		return liveResolution{kind: definitivelyAbsent}
+	case strings.HasPrefix(cite, "session:"):
+		path := strings.TrimSpace(strings.TrimPrefix(cite, "session:"))
+		if path == "" || placeholderCiteRe.MatchString(path) {
+			return liveResolution{kind: definitivelyAbsent}
+		}
+		if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() {
+			return liveResolution{kind: citedAndReal}
+		}
+		return liveResolution{kind: definitivelyAbsent}
+	default:
+		return liveResolution{kind: definitivelyAbsent}
+	}
+}
+
+// notFoundRe matches the definitive `gh api` 404 signal — `HTTP 404` / `Not
+// Found (HTTP 404)`. A 404 means the run genuinely does not exist (refuse); any
+// OTHER non-zero exit is a connectivity/auth failure (indeterminate).
+var notFoundRe = regexp.MustCompile(`(?i)HTTP 404|Not Found`)
+
+// ghCiRunResolver shells to `gh api repos/{owner}/{repo}/actions/runs/<id>` to
+// decide whether a CI run exists. Exit 0 → exists. A `gh`-not-on-PATH or a
+// non-404 error → connectivity (indeterminate). A definitive `HTTP 404` in
+// stderr → absent. This is the cleanest signal `gh` gives (per the ideation
+// spike): a definitive 404 vs other error text.
+func ghCiRunResolver(id string) (bool, error) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return false, errConnectivity
+	}
+	cmd := exec.Command("gh", "api", "repos/{owner}/{repo}/actions/runs/"+id)
+	combined, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, nil
+	}
+	if notFoundRe.Match(combined) {
+		return false, nil
+	}
+	return false, errConnectivity
+}

--- a/internal/status/live_proof_test.go
+++ b/internal/status/live_proof_test.go
@@ -1,0 +1,142 @@
+// ABOUTME: Live-run guard tests — the lead-with-`live` runtime-observable AC
+// ABOUTME: classifier and the three-way ci-run:/session: citation resolution.
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestClassifyLiveACs locks the explicit-convention classifier: a runtime-
+// observable AC declares itself by leading its proof clause with `live`, and the
+// classifier returns one flag per such AC carrying the trailing citation ref
+// (`ci-run:<id>` / `session:<path>` / the empty/placeholder text). An offline
+// AC (any non-`live` proof clause) is never returned; this is the explicit
+// `live`-lead convention, not prose keyword inference.
+func TestClassifyLiveACs(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantFlags int
+		wantCite  string // citation of the first flag, when wantFlags == 1
+	}{
+		{
+			name:      "offline-go-test-not-live",
+			body:      "**AC-1 — Producer exits.**\nVerified by: a Go unit test TestRoundTrip asserts the exit code.\n",
+			wantFlags: 0,
+		},
+		{
+			name:      "live-uncited-placeholder",
+			body:      "**AC-1 — The model exits on the contract.**\nVerified by: live <no artifact yet>\n",
+			wantFlags: 1,
+			wantCite:  "<no artifact yet>",
+		},
+		{
+			name:      "live-cited-ci-run",
+			body:      "**AC-1 — The model exits on the contract.**\nVerified by: live ci-run:12345\n",
+			wantFlags: 1,
+			wantCite:  "ci-run:12345",
+		},
+		{
+			name:      "live-cited-session",
+			body:      "**AC-1 — The model exits on the contract.**\nVerified by: live session:/tmp/run.jsonl\n",
+			wantFlags: 1,
+			wantCite:  "session:/tmp/run.jsonl",
+		},
+		{
+			// yy's shape: a runtime-observable AC declared live but cited only by
+			// an offline-proof narrative / a pending placeholder.
+			name:      "yy-shape-offline-narrative",
+			body:      "**AC-1 — The fix actually closes the flake at runtime.**\nVerified by: live <none — passed offline + 3 audit cycles, merged pending-live-run>\n",
+			wantFlags: 1,
+			wantCite:  "<none — passed offline + 3 audit cycles, merged pending-live-run>",
+		},
+		{
+			name:      "live-case-insensitive-and-no-leak-to-offline",
+			body:      "**AC-1 — Runtime.**\nVerified by: Live ci-run:7\n\n**AC-2 — Offline.**\nVerified by: a `go vet ./...` pass.\n",
+			wantFlags: 1,
+			wantCite:  "ci-run:7",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			flags := classifyLiveACs(tc.body)
+			if len(flags) != tc.wantFlags {
+				t.Fatalf("want %d live flags, got %d: %+v", tc.wantFlags, len(flags), flags)
+			}
+			if tc.wantFlags == 1 && flags[0].Citation != tc.wantCite {
+				t.Fatalf("want citation %q, got %q", tc.wantCite, flags[0].Citation)
+			}
+		})
+	}
+}
+
+// TestResolveLiveCitationThreeWay locks AC-4's spike split for `ci-run:<id>`:
+// a real id resolves (citedAndReal), a definitive 404 refuses (definitivelyAbsent),
+// and a connectivity/auth error is INDETERMINATE (a tooling error, NOT a
+// refusal) so a network blip cannot masquerade as a missing live run. The
+// `gh`-shelling resolver is swapped for a stub so the unit test runs offline.
+func TestResolveLiveCitationThreeWay(t *testing.T) {
+	cases := []struct {
+		name string
+		stub ciRunResolver
+		want liveResolutionKind
+	}{
+		{
+			name: "real-id-cited-and-real",
+			stub: func(id string) (bool, error) { return true, nil },
+			want: citedAndReal,
+		},
+		{
+			name: "404-definitively-absent-refuse",
+			stub: func(id string) (bool, error) { return false, nil },
+			want: definitivelyAbsent,
+		},
+		{
+			name: "connectivity-error-indeterminate",
+			stub: func(id string) (bool, error) { return false, errConnectivity },
+			want: indeterminate,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			res := resolveLiveCitation("ci-run:12345", tc.stub)
+			if res.kind != tc.want {
+				t.Fatalf("want kind %v, got %v (err=%v)", tc.want, res.kind, res.err)
+			}
+		})
+	}
+}
+
+// TestResolveLiveCitationSession locks the offline session: citation: a present
+// .jsonl on disk resolves (citedAndReal), an absent path refuses
+// (definitivelyAbsent). No `gh`, no network.
+func TestResolveLiveCitationSession(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "run.jsonl")
+	if err := os.WriteFile(present, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	absent := filepath.Join(dir, "missing.jsonl")
+
+	if res := resolveLiveCitation("session:"+present, nil); res.kind != citedAndReal {
+		t.Fatalf("present session jsonl should resolve, got %v", res.kind)
+	}
+	if res := resolveLiveCitation("session:"+absent, nil); res.kind != definitivelyAbsent {
+		t.Fatalf("absent session jsonl should refuse, got %v", res.kind)
+	}
+}
+
+// TestResolveLiveCitationPlaceholder locks that a placeholder / empty citation
+// is definitivelyAbsent (refused) — turning pending-live-run from a hopeful
+// label into an enforced state.
+func TestResolveLiveCitationPlaceholder(t *testing.T) {
+	for _, cite := range []string{"<no artifact yet>", "<pending>", "", "<none — passed offline>"} {
+		if res := resolveLiveCitation(cite, nil); res.kind != definitivelyAbsent {
+			t.Fatalf("placeholder citation %q should be definitivelyAbsent, got %v", cite, res.kind)
+		}
+	}
+}

--- a/internal/status/live_proof_test.go
+++ b/internal/status/live_proof_test.go
@@ -3,6 +3,7 @@
 package status
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -106,6 +107,55 @@ func TestResolveLiveCitationThreeWay(t *testing.T) {
 			res := resolveLiveCitation("ci-run:12345", tc.stub)
 			if res.kind != tc.want {
 				t.Fatalf("want kind %v, got %v (err=%v)", tc.want, res.kind, res.err)
+			}
+		})
+	}
+}
+
+// TestClassifyGhRunOutput locks the connectivity-vs-404 discriminator at the
+// crux: the pure classification of (gh exit, combined output) into the three-way
+// outcome, fed LITERAL gh error strings — no shelling. A genuine parenthesized
+// `(HTTP 404)` is the ONLY definitivelyAbsent signal; every other failure
+// (auth, rate-limit, DNS/connect, a 5xx gateway body that merely CONTAINS the
+// words "Not Found") is INDETERMINATE, never a false refusal. This is the
+// network-blip-can't-masquerade-as-missing-run guarantee the change rests on.
+func TestClassifyGhRunOutput(t *testing.T) {
+	exitErr := errors.New("exit status 1")
+	cases := []struct {
+		name     string
+		runErr   error
+		combined string
+		want     liveResolutionKind
+	}{
+		{"success-exists", nil, `{"id":123,"status":"completed"}`, citedAndReal},
+		{"genuine-parenthesized-404", exitErr, "gh: Not Found (HTTP 404)", definitivelyAbsent},
+		{"bad-credentials-401", exitErr, "gh: Bad credentials (HTTP 401)", indeterminate},
+		{"rate-limit-403", exitErr, "gh: API rate limit exceeded (HTTP 403)", indeterminate},
+		{"dns-connect-fail", exitErr, "dial tcp: lookup api.github.com: no such host", indeterminate},
+		{
+			// A proxy/gateway 5xx page whose BODY contains the bare words "Not
+			// Found" must NOT flip to absent — the bare-substring false-refuse.
+			name:     "gateway-502-body-contains-not-found",
+			runErr:   exitErr,
+			combined: "<html><title>502 Bad Gateway</title><body>The page was Not Found on the upstream server</body></html>",
+			want:     indeterminate,
+		},
+		{
+			// Masked-404: a private/unscoped-token repo where the run EXISTS but
+			// gh returns the parenthesized 404. Policy: still refuse (can't prove
+			// existence) — but the diagnostic, tested separately, names the scope
+			// remediation. Here we only assert the kind.
+			name:     "masked-404-still-absent",
+			runErr:   exitErr,
+			combined: "gh: Not Found (HTTP 404)",
+			want:     definitivelyAbsent,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyGhRunOutput(tc.runErr, []byte(tc.combined)); got != tc.want {
+				t.Fatalf("classifyGhRunOutput(%v, %q) = %v, want %v", tc.runErr, tc.combined, got, tc.want)
 			}
 		})
 	}

--- a/skills/commission/references/templates/development.md
+++ b/skills/commission/references/templates/development.md
@@ -130,6 +130,12 @@ For high-stakes surfaces — a front-door launcher, the status/guard mutation pa
 
 The audit catches the class of hole where the test passes but would also pass on a broken future edit — which a green suite cannot see itself.
 
+### Live scenario for runtime claims
+
+Choose the proof at the claim's altitude. When an AC's truth is what an agent or model DOES at runtime — it actually exits, it actually clears the hang, it actually produces the right durable state — the proof is a scripted live scenario, not an offline proxy. A recording proves the WATCHER (the consumer reads a frozen stream correctly), never the PRODUCER (does the real model, reading the contract, actually exit?). A contract-text check proves the WORDS are present, never the behaviour. Both pass while the runtime claim is still false — exactly the slip where a fix passed every offline check and three adversarial audits, was merged `pending-live-run`, and the live retrigger then showed it never closed the flake.
+
+A live scenario is authored as a triple: a descriptive **runbook** (the prompt/instructions a real agent runs), a **setup** (the fixture/state the run starts from), and **durable-outcome assertions** (entity state before→after plus observed output — NOT transcript phrasing, which is non-deterministic). Run it against a real agent and grade on the durable outcomes, with at least one negative case where a deliberately broken outcome reds the grade. Mark such an AC `Verified by: live <ci-run:<id> | session:<path>>`; under an external-proof opt-in workflow the live-run guard refuses to terminalize it until that citation resolves, so `pending-live-run` is an enforced state, not a hopeful label.
+
 ## Workflow State
 
 View the workflow overview:


### PR DESCRIPTION
Make the live-verification requirement an enforced code gate instead of advisory prose: refuse to terminalize a runtime-observable AC without a resolvable live-run citation, and promote the live-scenario pattern to a reusable primitive.

## What changed
- Add a terminal `--set` guard (under `require-external-proof`) that refuses an uncited `Verified by: live <ref>` AC; the ci-run citation resolves three-way — resolve→pass, definitive `(HTTP 404)`→refuse, connectivity/auth→indeterminate (a tooling error, never a false refusal).
- Promote 8y's scenario triple into `internal/livescenario` — authorable + gradable on durable outcomes outside the CI package, with a negative case.
- Add a live-scenario recommended-practice block to the dev template.

## Evidence
- Offline suite: 1028/1028 passed; `go vet` (incl. `-tags live`) + `gofmt` clean.
- Both adversarial break-edits red (under-gate misses the yy slip; over-gate refuses offline ACs); the 404 discriminator hardened with literal-gh-string unit tests (both directions proven); AC-2 ran live against a real Claude agent and resolves its own citation (eats its own gate).

---
[p4](/spacedock-dev/spacedock/blob/2bf5d0570fef9348fa7c81af37cec1779b7ebced/live-verification-gate/index.md)