### PR TITLE
Front-door warns on a stray positional prompt placed after `--` (advisory, argv unchanged)

### DIFF
--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -276,10 +276,9 @@ func codexResume(passthrough []string) bool {
 // valueTakingHostFlags is the per-host set of host flags whose successor token is
 // the flag's value (space form), so that successor is NOT a stray positional. The
 // assembled argv is unchanged regardless of membership; the set only tunes the
-// advisory's accuracy. `--plugin-dir` appears in BOTH sets because
-// parseFrontDoorArgs re-injects the spacedock-parsed `--plugin-dir <dir>` pair at
-// the FRONT of fd.passthrough — without it the classifier would name the injected
-// dir as the stray positional and shadow the operator's real prompt.
+// advisory's accuracy. The spacedock-injected `--plugin-dir <dir>` prefix is NOT
+// handled here — skipInjectedPrefix strips it structurally before any scan — so
+// the prefix interaction stays in one place rather than threaded through this set.
 var valueTakingHostFlags = map[string]map[string]bool{
 	"claude": {
 		"-p": true, "--print": true,
@@ -291,17 +290,15 @@ var valueTakingHostFlags = map[string]map[string]bool{
 		"--settings":             true,
 		"--session-id":           true,
 		"--output-format":        true,
-		"--plugin-dir":           true,
 	},
 	"codex": {
 		"-m": true, "--model": true,
-		"--config":     true,
-		"-c":           true,
-		"--cd":         true,
-		"--image":      true,
-		"--sandbox":    true,
-		"--profile":    true,
-		"--plugin-dir": true,
+		"--config":  true,
+		"-c":        true,
+		"--cd":      true,
+		"--image":   true,
+		"--sandbox": true,
+		"--profile": true,
 	},
 }
 
@@ -313,6 +310,23 @@ var leadingHostSubcommands = map[string]map[string]bool{
 	"codex": {"exec": true, "resume": true},
 }
 
+// skipInjectedPrefix returns the passthrough slice past the spacedock-injected
+// leading `--plugin-dir <dir>` pairs. parseFrontDoorArgs re-prepends each
+// before-`--` `--plugin-dir` as a `--plugin-dir <dir>` pair at the FRONT of
+// fd.passthrough; that prefix is spacedock-owned, not operator after-`--` tokens,
+// so the classifier's subcommand and value-flag checks must run against the real
+// after-`--` tokens BEHIND it. `--plugin-dir` is the only flag parseFrontDoorArgs
+// re-prepends (the safehouse knobs live in fd.safehouseFlags, the booleans are
+// consumed), so it is the complete injected-prefix set. Skipping a leading
+// `--plugin-dir <dir>` pair is correct regardless of origin: the dir is the flag's
+// value, never a stray prompt.
+func skipInjectedPrefix(passthrough []string) []string {
+	for len(passthrough) >= 2 && passthrough[0] == "--plugin-dir" {
+		passthrough = passthrough[2:]
+	}
+	return passthrough
+}
+
 // strayPromptAfterDash is a pure read over the parsed front-door args that returns
 // the first stray positional in the after-`--` passthrough — an operator prompt
 // that was placed after `--` and so silently degrades to host passthrough instead
@@ -321,11 +335,15 @@ var leadingHostSubcommands = map[string]map[string]bool{
 //
 // It fires only when the operator gave no task before `--` (hasTask == false): a
 // task before `--` means the operator already placed their prompt, so a positional
-// after `--` is a deliberate host positional. A token is a candidate when it is
-// non-flag (does not start with `-`, and is not the bare `--` separator) AND the
-// passthrough does not lead with a known host subcommand whose arguments are
-// legitimate. A candidate is reported as stray only when we can be confident it is
-// NOT a host flag's value:
+// after `--` is a deliberate host positional. The classifier first skips the
+// spacedock-injected leading `--plugin-dir <dir>` prefix, then runs every check
+// against the real after-`--` tokens — so the subcommand exemption, the value-flag
+// scan, and any future per-token rule all see the operator's actual grammar
+// regardless of the injected prefix. A token is a candidate when it is non-flag
+// (does not start with `-`, and is not the bare `--` separator) AND the real tokens
+// do not lead with a known host subcommand whose arguments are legitimate. A
+// candidate is reported as stray only when we can be confident it is NOT a host
+// flag's value:
 //   - preceding a recognized value-taking host flag → it is that flag's value, skip;
 //   - preceding an UNRECOGNIZED `-`-prefixed flag → it MIGHT be that flag's value, so
 //     we suppress rather than give the actively-wrong "put X before --" advice;
@@ -338,17 +356,18 @@ func strayPromptAfterDash(fd frontDoorArgs, host string) (positional string, ok 
 	if fd.hasTask {
 		return "", false
 	}
+	tokens := skipInjectedPrefix(fd.passthrough)
 	subcommands := leadingHostSubcommands[host]
-	if len(fd.passthrough) > 0 && subcommands[fd.passthrough[0]] {
+	if len(tokens) > 0 && subcommands[tokens[0]] {
 		return "", false
 	}
 	valueFlags := valueTakingHostFlags[host]
-	for i, tok := range fd.passthrough {
+	for i, tok := range tokens {
 		if tok == "--" || strings.HasPrefix(tok, "-") {
 			continue
 		}
 		if i > 0 {
-			prev := fd.passthrough[i-1]
+			prev := tokens[i-1]
 			if valueFlags[prev] {
 				continue // the value of a recognized value-taking host flag (space form)
 			}

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -275,18 +275,33 @@ func codexResume(passthrough []string) bool {
 
 // valueTakingHostFlags is the per-host set of host flags whose successor token is
 // the flag's value (space form), so that successor is NOT a stray positional. The
-// set is deliberately small and advisory-only: the assembled argv is unchanged
-// regardless of membership, so an unknown value-taking flag merely risks a
-// harmless extra warning on its value. A flag not in the set is treated as a
-// boolean (its successor is scanned independently).
+// assembled argv is unchanged regardless of membership; the set only tunes the
+// advisory's accuracy. `--plugin-dir` appears in BOTH sets because
+// parseFrontDoorArgs re-injects the spacedock-parsed `--plugin-dir <dir>` pair at
+// the FRONT of fd.passthrough — without it the classifier would name the injected
+// dir as the stray positional and shadow the operator's real prompt.
 var valueTakingHostFlags = map[string]map[string]bool{
 	"claude": {
 		"-p": true, "--print": true,
-		"--model":      true,
-		"--mcp-config": true,
+		"--model":                true,
+		"--mcp-config":           true,
+		"--permission-mode":      true,
+		"--add-dir":              true,
+		"--append-system-prompt": true,
+		"--settings":             true,
+		"--session-id":           true,
+		"--output-format":        true,
+		"--plugin-dir":           true,
 	},
 	"codex": {
 		"-m": true, "--model": true,
+		"--config":     true,
+		"-c":           true,
+		"--cd":         true,
+		"--image":      true,
+		"--sandbox":    true,
+		"--profile":    true,
+		"--plugin-dir": true,
 	},
 }
 
@@ -306,11 +321,19 @@ var leadingHostSubcommands = map[string]map[string]bool{
 //
 // It fires only when the operator gave no task before `--` (hasTask == false): a
 // task before `--` means the operator already placed their prompt, so a positional
-// after `--` is a deliberate host positional. A token is stray when it is non-flag
-// (does not start with `-`, and is not the bare `--` separator) AND it is not the
-// value of a recognized value-taking host flag AND the passthrough does not lead
-// with a known host subcommand whose arguments are legitimate. The check never
-// alters the assembled argv — runClaude/runCodex only write the warning to stderr.
+// after `--` is a deliberate host positional. A token is a candidate when it is
+// non-flag (does not start with `-`, and is not the bare `--` separator) AND the
+// passthrough does not lead with a known host subcommand whose arguments are
+// legitimate. A candidate is reported as stray only when we can be confident it is
+// NOT a host flag's value:
+//   - preceding a recognized value-taking host flag → it is that flag's value, skip;
+//   - preceding an UNRECOGNIZED `-`-prefixed flag → it MIGHT be that flag's value, so
+//     we suppress rather than give the actively-wrong "put X before --" advice;
+//   - otherwise (first token, or preceded by a positional or recognized boolean
+//     flag) → confidently stray.
+//
+// The check never alters the assembled argv — runClaude/runCodex only write the
+// warning to stderr.
 func strayPromptAfterDash(fd frontDoorArgs, host string) (positional string, ok bool) {
 	if fd.hasTask {
 		return "", false
@@ -324,8 +347,18 @@ func strayPromptAfterDash(fd frontDoorArgs, host string) (positional string, ok 
 		if tok == "--" || strings.HasPrefix(tok, "-") {
 			continue
 		}
-		if i > 0 && valueFlags[fd.passthrough[i-1]] {
-			continue // the value of a value-taking host flag (space form)
+		if i > 0 {
+			prev := fd.passthrough[i-1]
+			if valueFlags[prev] {
+				continue // the value of a recognized value-taking host flag (space form)
+			}
+			// An equals-form flag (`--flag=value`) carries its own value, so it never
+			// consumes the next token. Only a space-form `-`-prefixed flag is ambiguous:
+			// it could be a value-taking flag we don't recognize, so suppress rather
+			// than risk prescribing the wrong correction for what may be its value.
+			if strings.HasPrefix(prev, "-") && prev != "--" && !strings.Contains(prev, "=") {
+				continue
+			}
 		}
 		return tok, true
 	}

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -113,6 +113,7 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 			return 1
 		}
 	}
+	warnStrayPromptAfterDash(fd, "claude", "spacedock claude", stderr)
 
 	wrap := safehouse.Present(dir) || fd.forceSafehouse || len(fd.safehouseFlags) > 0
 	resume := containsResume(fd.passthrough)
@@ -140,6 +141,25 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 		return 1
 	}
 	return 0
+}
+
+// warnStrayPromptAfterDash emits an advisory stderr warning when a bare positional
+// appears after `--` with no task before it — almost always an operator prompt that
+// silently degrades to host passthrough so the spacedock launch prompt is never
+// prepended to it. The warning names the stray positional and the corrected form
+// (put the prompt BEFORE `--`). It does NOT alter the assembled host argv; the
+// launch is byte-identical with or without this call. `name` is the front-door
+// verb (`spacedock claude` / `spacedock codex`) so the message names a runnable fix.
+func warnStrayPromptAfterDash(fd frontDoorArgs, host, name string, stderr io.Writer) {
+	pos, ok := strayPromptAfterDash(fd, host)
+	if !ok {
+		return
+	}
+	fmt.Fprintf(stderr,
+		"%s: warning: positional %q after `--` is forwarded to the host as-is; "+
+			"the spacedock launch prompt was NOT prepended to it. "+
+			"To make it the launch prompt, put it BEFORE `--`: `%s %q -- …`\n",
+		name, pos, name, pos)
 }
 
 // launchPrompt returns the inner-argv launch prompt: `base + " " + task` when the
@@ -216,6 +236,7 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 			return 1
 		}
 	}
+	warnStrayPromptAfterDash(fd, "codex", "spacedock codex", stderr)
 
 	wrap := safehouse.Present(dir) || fd.forceSafehouse || len(fd.safehouseFlags) > 0
 	resume := codexResume(fd.passthrough)
@@ -250,6 +271,65 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 // is suppressed.
 func codexResume(passthrough []string) bool {
 	return len(passthrough) > 0 && passthrough[0] == "resume"
+}
+
+// valueTakingHostFlags is the per-host set of host flags whose successor token is
+// the flag's value (space form), so that successor is NOT a stray positional. The
+// set is deliberately small and advisory-only: the assembled argv is unchanged
+// regardless of membership, so an unknown value-taking flag merely risks a
+// harmless extra warning on its value. A flag not in the set is treated as a
+// boolean (its successor is scanned independently).
+var valueTakingHostFlags = map[string]map[string]bool{
+	"claude": {
+		"-p": true, "--print": true,
+		"--model":      true,
+		"--mcp-config": true,
+	},
+	"codex": {
+		"-m": true, "--model": true,
+	},
+}
+
+// leadingHostSubcommands is the per-host set of known leading subcommands whose
+// positional arguments are legitimate (e.g. `codex exec <prompt>`,
+// `codex resume <id>`). When the passthrough leads with one, no after-`--`
+// positional is treated as stray.
+var leadingHostSubcommands = map[string]map[string]bool{
+	"codex": {"exec": true, "resume": true},
+}
+
+// strayPromptAfterDash is a pure read over the parsed front-door args that returns
+// the first stray positional in the after-`--` passthrough — an operator prompt
+// that was placed after `--` and so silently degrades to host passthrough instead
+// of being prepended to the spacedock launch prompt. It returns ("", false) when
+// nothing is stray.
+//
+// It fires only when the operator gave no task before `--` (hasTask == false): a
+// task before `--` means the operator already placed their prompt, so a positional
+// after `--` is a deliberate host positional. A token is stray when it is non-flag
+// (does not start with `-`, and is not the bare `--` separator) AND it is not the
+// value of a recognized value-taking host flag AND the passthrough does not lead
+// with a known host subcommand whose arguments are legitimate. The check never
+// alters the assembled argv — runClaude/runCodex only write the warning to stderr.
+func strayPromptAfterDash(fd frontDoorArgs, host string) (positional string, ok bool) {
+	if fd.hasTask {
+		return "", false
+	}
+	subcommands := leadingHostSubcommands[host]
+	if len(fd.passthrough) > 0 && subcommands[fd.passthrough[0]] {
+		return "", false
+	}
+	valueFlags := valueTakingHostFlags[host]
+	for i, tok := range fd.passthrough {
+		if tok == "--" || strings.HasPrefix(tok, "-") {
+			continue
+		}
+		if i > 0 && valueFlags[fd.passthrough[i-1]] {
+			continue // the value of a value-taking host flag (space form)
+		}
+		return tok, true
+	}
+	return "", false
 }
 
 // frontDoorArgs is the parsed front-door grammar. The launchers read it to

--- a/internal/cli/frontdoor_stray_prompt_test.go
+++ b/internal/cli/frontdoor_stray_prompt_test.go
@@ -1,0 +1,183 @@
+// ABOUTME: Stray-positional-after-`--` advisory guard tests — the warn-not-change
+// ABOUTME: oracle (AC-1 positive, AC-2 negatives) and the classifier unit table (AC-3).
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// strayWarnMarker is the stable substring both the positive and negative oracles
+// key on: it survives benign rewording of the rest of the warning while still
+// failing if the advisory is dropped. The production warning text must contain it.
+const strayWarnMarker = "after `--`"
+
+// TestClaudeStrayPromptAfterDashWarns (AC-1 positive): a bare positional after
+// `--` with no task before `--` is named in a stderr warning AND the assembled
+// inner argv is byte-identical to the pre-guard argv — proving warn-not-change.
+func TestClaudeStrayPromptAfterDashWarns(t *testing.T) {
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), []string{"--", "--model", "gpt-x", "@/tmp/handoff.md"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	warn := stderr.String()
+	if !strings.Contains(warn, strayWarnMarker) {
+		t.Fatalf("stderr missing the stray-positional warning marker %q: %q", strayWarnMarker, warn)
+	}
+	if !strings.Contains(warn, "@/tmp/handoff.md") {
+		t.Fatalf("warning does not name the stray positional: %q", warn)
+	}
+	if !strings.Contains(warn, "BEFORE") {
+		t.Fatalf("warning does not name the corrected form (prompt BEFORE `--`): %q", warn)
+	}
+	want := []string{"claude", "--agent", "spacedock:first-officer", "--model", "gpt-x", "@/tmp/handoff.md", wantBootstrapPrompt}
+	if !equalArgv(fake.launchedArg, want) {
+		t.Fatalf("launch argv = %v, want %v (warn must not change the argv)", fake.launchedArg, want)
+	}
+}
+
+// TestCodexStrayPromptAfterDashWarns (AC-1 positive, codex): the subcommand-less
+// passthrough leading with a value-taking flag still surfaces the stray prompt,
+// and the codex inner argv is unchanged.
+func TestCodexStrayPromptAfterDashWarns(t *testing.T) {
+	dir := safehouseFixtureDir(t)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runCodex(context.Background(), []string{"--", "-m", "gpt-x", "@/tmp/handoff.md"}, dir, fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	warn := stderr.String()
+	if !strings.Contains(warn, strayWarnMarker) {
+		t.Fatalf("stderr missing the stray-positional warning marker %q: %q", strayWarnMarker, warn)
+	}
+	if !strings.Contains(warn, "@/tmp/handoff.md") {
+		t.Fatalf("warning does not name the stray positional: %q", warn)
+	}
+	want := []string{"safehouse", "--trust-workdir-config", "--",
+		"codex", "--dangerously-bypass-approvals-and-sandbox", "-m", "gpt-x", "@/tmp/handoff.md", wantCodexBootstrapPrompt}
+	if !equalArgv(fake.launchedArg, want) {
+		t.Fatalf("launch argv = %v, want %v (warn must not change the argv)", fake.launchedArg, want)
+	}
+}
+
+// TestStrayPromptGuardNegatives (AC-2): a legitimate host positional after `--`
+// does NOT trip the guard, and the argv is unchanged in each case. The three
+// negatives are the value of a value-taking flag (`-p <prompt>`), the argument of
+// a known leading subcommand (`exec <prompt>`), and the hasTask short-circuit.
+func TestStrayPromptGuardNegatives(t *testing.T) {
+	cases := []struct {
+		name string
+		run  func(args []string, dir string, fake *fakeHost, stderr *bytes.Buffer) int
+		args []string
+		want []string
+	}{
+		{
+			name: "claude -p value-of-value-taking-flag",
+			run: func(args []string, dir string, fake *fakeHost, stderr *bytes.Buffer) int {
+				var stdout bytes.Buffer
+				return runClaude(context.Background(), args, dir, fake, lookFound, &stdout, stderr)
+			},
+			args: []string{"--", "-p", "do the thing"},
+			want: []string{"claude", "--agent", "spacedock:first-officer", "-p", "do the thing", wantBootstrapPrompt},
+		},
+		{
+			name: "codex exec subcommand-arg",
+			run: func(args []string, dir string, fake *fakeHost, stderr *bytes.Buffer) int {
+				var stdout bytes.Buffer
+				return runCodex(context.Background(), args, dir, fake, lookFound, &stdout, stderr)
+			},
+			args: []string{"--", "exec", "do the thing"},
+			want: []string{"codex", "exec", "do the thing", wantCodexBootstrapPrompt},
+		},
+		{
+			name: "claude hasTask short-circuit",
+			run: func(args []string, dir string, fake *fakeHost, stderr *bytes.Buffer) int {
+				var stdout bytes.Buffer
+				return runClaude(context.Background(), args, dir, fake, lookFound, &stdout, stderr)
+			},
+			args: []string{"task before", "--", "@/tmp/handoff.md"},
+			want: []string{"claude", "--agent", "spacedock:first-officer", "@/tmp/handoff.md", wantBootstrapPrompt + " task before"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeHost{manifest: compatibleManifest(t)}
+			var stderr bytes.Buffer
+			code := tc.run(tc.args, t.TempDir(), fake, &stderr)
+			if code != 0 {
+				t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+			}
+			if strings.Contains(stderr.String(), strayWarnMarker) {
+				t.Fatalf("guard fired on a legitimate host positional: %q", stderr.String())
+			}
+			if !equalArgv(fake.launchedArg, tc.want) {
+				t.Fatalf("launch argv = %v, want %v", fake.launchedArg, tc.want)
+			}
+		})
+	}
+}
+
+// TestStrayPromptAfterDashClassifier (AC-3): the classifier over the after-`--`
+// token grammar, independent of launch. Pins the boundary logic directly so a
+// regression in flag-set membership or subcommand recognition fails a fast unit
+// test, not only the launch-seam tests.
+func TestStrayPromptAfterDashClassifier(t *testing.T) {
+	cases := []struct {
+		name           string
+		passthrough    []string
+		hasTask        bool
+		host           string
+		wantPositional string
+		wantOK         bool
+	}{
+		{
+			name:           "stray after value-flag pair",
+			passthrough:    []string{"--model", "gpt-x", "@/tmp/handoff.md"},
+			host:           "claude",
+			wantPositional: "@/tmp/handoff.md",
+			wantOK:         true,
+		},
+		{
+			name:        "value of value-taking flag is not stray",
+			passthrough: []string{"-p", "do the thing"},
+			host:        "claude",
+		},
+		{
+			name:        "leading subcommand arg is not stray",
+			passthrough: []string{"exec", "do the thing"},
+			host:        "codex",
+		},
+		{
+			name:           "equals-form successor positional is stray",
+			passthrough:    []string{"--model=gpt-x", "@/tmp/handoff.md"},
+			host:           "claude",
+			wantPositional: "@/tmp/handoff.md",
+			wantOK:         true,
+		},
+		{
+			name:        "hasTask short-circuit suppresses",
+			passthrough: []string{"@/tmp/handoff.md"},
+			hasTask:     true,
+			host:        "claude",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fd := frontDoorArgs{passthrough: tc.passthrough, hasTask: tc.hasTask}
+			pos, ok := strayPromptAfterDash(fd, tc.host)
+			if ok != tc.wantOK || pos != tc.wantPositional {
+				t.Fatalf("strayPromptAfterDash(%v, %q) = (%q, %v), want (%q, %v)",
+					tc.passthrough, tc.host, pos, ok, tc.wantPositional, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/cli/frontdoor_stray_prompt_test.go
+++ b/internal/cli/frontdoor_stray_prompt_test.go
@@ -42,6 +42,37 @@ func TestClaudeStrayPromptAfterDashWarns(t *testing.T) {
 	}
 }
 
+// TestClaudeStrayPromptSession12Shape (AC-1, the captain's actual session-12
+// case): `--plugin-dir "$(pwd)" -- --model gpt-x '@/tmp/handoff.md'`. The
+// spacedock-injected `--plugin-dir <dir>` prefix (re-prepended to fd.passthrough
+// by parseFrontDoorArgs) must NOT shadow the operator's real stray prompt — the
+// warning names `@/tmp/handoff.md`, never the injected dir, and the inner argv is
+// unchanged.
+func TestClaudeStrayPromptSession12Shape(t *testing.T) {
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), []string{"--plugin-dir", "/co", "--", "--model", "gpt-x", "@/tmp/handoff.md"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	warn := stderr.String()
+	if !strings.Contains(warn, strayWarnMarker) {
+		t.Fatalf("stderr missing the stray-positional warning marker %q: %q", strayWarnMarker, warn)
+	}
+	if !strings.Contains(warn, "@/tmp/handoff.md") {
+		t.Fatalf("warning does not name the operator's stray positional: %q", warn)
+	}
+	if strings.Contains(warn, "/co") {
+		t.Fatalf("warning names the spacedock-injected --plugin-dir value (shadows the real prompt): %q", warn)
+	}
+	want := []string{"claude", "--agent", "spacedock:first-officer", "--plugin-dir", "/co", "--model", "gpt-x", "@/tmp/handoff.md", wantBootstrapPrompt}
+	if !equalArgv(fake.launchedArg, want) {
+		t.Fatalf("launch argv = %v, want %v (warn must not change the argv)", fake.launchedArg, want)
+	}
+}
+
 // TestCodexStrayPromptAfterDashWarns (AC-1 positive, codex): the subcommand-less
 // passthrough leading with a value-taking flag still surfaces the stray prompt,
 // and the codex inner argv is unchanged.
@@ -107,6 +138,18 @@ func TestStrayPromptGuardNegatives(t *testing.T) {
 			args: []string{"task before", "--", "@/tmp/handoff.md"},
 			want: []string{"claude", "--agent", "spacedock:first-officer", "@/tmp/handoff.md", wantBootstrapPrompt + " task before"},
 		},
+		{
+			// An unrecognized `-`-prefixed flag's value must NOT get the prescriptive
+			// "put X before --" advice — it is likely that flag's value, so the guard
+			// stays silent rather than mis-advise. The argv is still unchanged.
+			name: "claude value of unrecognized flag — no wrong advice",
+			run: func(args []string, dir string, fake *fakeHost, stderr *bytes.Buffer) int {
+				var stdout bytes.Buffer
+				return runClaude(context.Background(), args, dir, fake, lookFound, &stdout, stderr)
+			},
+			args: []string{"--", "--some-new-flag", "the-value"},
+			want: []string{"claude", "--agent", "spacedock:first-officer", "--some-new-flag", "the-value", wantBootstrapPrompt},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -167,6 +210,22 @@ func TestStrayPromptAfterDashClassifier(t *testing.T) {
 			name:        "hasTask short-circuit suppresses",
 			passthrough: []string{"@/tmp/handoff.md"},
 			hasTask:     true,
+			host:        "claude",
+		},
+		{
+			// The spacedock-injected `--plugin-dir <dir>` prefix is a value-taking
+			// pair: the dir is NOT stray, and the operator's real prompt after it is.
+			name:           "spacedock-injected --plugin-dir prefix does not shadow the real prompt",
+			passthrough:    []string{"--plugin-dir", "/co", "--model", "gpt-x", "@/tmp/handoff.md"},
+			host:           "claude",
+			wantPositional: "@/tmp/handoff.md",
+			wantOK:         true,
+		},
+		{
+			// A value of an UNRECOGNIZED `-`-prefixed flag is ambiguous; the
+			// conservative fallback suppresses rather than prescribe wrong advice.
+			name:        "value of unrecognized flag suppresses (no wrong advice)",
+			passthrough: []string{"--some-new-flag", "the-value"},
 			host:        "claude",
 		},
 	}

--- a/internal/cli/frontdoor_stray_prompt_test.go
+++ b/internal/cli/frontdoor_stray_prompt_test.go
@@ -150,6 +150,31 @@ func TestStrayPromptGuardNegatives(t *testing.T) {
 			args: []string{"--", "--some-new-flag", "the-value"},
 			want: []string{"claude", "--agent", "spacedock:first-officer", "--some-new-flag", "the-value", wantBootstrapPrompt},
 		},
+		{
+			// The spacedock-injected `--plugin-dir <dir>` prefix lands the `exec`
+			// subcommand at index 2; the leading-subcommand exemption must see it
+			// THROUGH the prefix and stay silent. This case REDS if skipInjectedPrefix
+			// is removed (the bare index-0 check then names `exec` as stray), so it
+			// pins the structural skip as the load-bearing mechanism.
+			name: "codex --plugin-dir then exec subcommand behind injected prefix",
+			run: func(args []string, dir string, fake *fakeHost, stderr *bytes.Buffer) int {
+				var stdout bytes.Buffer
+				return runCodex(context.Background(), args, dir, fake, lookFound, &stdout, stderr)
+			},
+			args: []string{"--plugin-dir", "/co", "--", "exec", "do the thing"},
+			want: []string{"codex", "--plugin-dir", "/co", "exec", "do the thing", wantCodexBootstrapPrompt},
+		},
+		{
+			// Same structural skip for the codex `resume` subcommand behind the
+			// injected prefix — no stray warning, argv unchanged.
+			name: "codex --plugin-dir then resume subcommand behind injected prefix",
+			run: func(args []string, dir string, fake *fakeHost, stderr *bytes.Buffer) int {
+				var stdout bytes.Buffer
+				return runCodex(context.Background(), args, dir, fake, lookFound, &stdout, stderr)
+			},
+			args: []string{"--plugin-dir", "/co", "--", "resume", "abc123"},
+			want: []string{"codex", "--plugin-dir", "/co", "resume", "abc123", wantCodexBootstrapPrompt},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -213,13 +238,27 @@ func TestStrayPromptAfterDashClassifier(t *testing.T) {
 			host:        "claude",
 		},
 		{
-			// The spacedock-injected `--plugin-dir <dir>` prefix is a value-taking
-			// pair: the dir is NOT stray, and the operator's real prompt after it is.
+			// skipInjectedPrefix strips the leading `--plugin-dir <dir>` pair so the
+			// dir is NOT named and the operator's real prompt after it IS.
 			name:           "spacedock-injected --plugin-dir prefix does not shadow the real prompt",
 			passthrough:    []string{"--plugin-dir", "/co", "--model", "gpt-x", "@/tmp/handoff.md"},
 			host:           "claude",
 			wantPositional: "@/tmp/handoff.md",
 			wantOK:         true,
+		},
+		{
+			// A leading subcommand BEHIND the injected `--plugin-dir <dir>` prefix must
+			// still be recognized as a subcommand (its args legitimate). This reds if
+			// skipInjectedPrefix is removed — the bare index-0 check then names `exec`.
+			name:        "subcommand behind injected --plugin-dir prefix is not stray",
+			passthrough: []string{"--plugin-dir", "/co", "exec", "do the thing"},
+			host:        "codex",
+		},
+		{
+			// Multiple injected `--plugin-dir <dir>` pairs are all skipped.
+			name:        "multiple injected --plugin-dir pairs all skipped before subcommand",
+			passthrough: []string{"--plugin-dir", "/a", "--plugin-dir", "/b", "exec", "p"},
+			host:        "codex",
 		},
 		{
 			// A value of an UNRECOGNIZED `-`-prefixed flag is ambiguous; the


### PR DESCRIPTION
Make the silent "prompt after `--`" swallow legible: warn (launch unchanged) when an operator places their launch prompt after `--`, so the lost bootstrap is visible instead of silent.

## What changed
- Emit an advisory stderr warning when a stray positional appears after `--` with no task before it, naming the corrected form; the assembled host argv is byte-identical with or without the guard.
- Structurally skip the spacedock-injected `--plugin-dir <dir>` prefix once, so the value-flag scan AND the leading-subcommand exemption see the real after-`--` tokens.
- Boundary covers claude/codex value-taking flags + leading subcommands (`exec`/`resume`); conservative (no prescriptive advice) on unrecognized flags.

## Evidence
- Offline suite: 1022/1022 passed; `gofmt`/`go vet` clean.
- argv-unchanged invariant pinned across all launch-seam paths; the injected-prefix skip is mutation-proven load-bearing (nooping it reds 6 subtests); the captain's session-12 case (`--plugin-dir … -- --model X @file`) now warns on the `@file`, never the dir.

---
[nz](/spacedock-dev/spacedock/blob/06b29c86e376a2b0192cff8e47f85f4deaa78a36/frontdoor-prompt-after-dash-guard/index.md)