### PR TITLE
Deterministic live cycle — absolutize + team-key the dispatch path, re-promote TestLiveEnsignCycle end-state assertions

### DIFF
--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -282,6 +282,19 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 		return buildError(stderr, 1, "entity file not readable at '%s'", entityPath)
 	}
 
+	// Absolutize entityPath against the process cwd, mirroring the workflowDir
+	// absolutization below. The dispatched ensign is a separate agent whose cwd is
+	// not pinned to the workflow root, so a relative entity_path resolves to a
+	// different / nonexistent file there — the "two entity files" divergence. The
+	// FO supplies entity_path itself (status emits no path field) and runs with
+	// cwd = workflow root, so it naturally passes a relative spelling; absolutizing
+	// here makes the entity-read line and the completion signal cwd-independent.
+	// After the readability error message, so that diagnostic shows the original
+	// spelling.
+	if abs, err := filepath.Abs(entityPath); err == nil {
+		entityPath = abs
+	}
+
 	// Absolutize workflowDir against the process cwd once, so every downstream
 	// join — README path, splitRootStateCheckout, the fetch line's --workflow-dir,
 	// and the state-commit guidance — inherits an absolute, cwd-independent base.

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -557,9 +557,21 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 		return 0
 	}
 
-	// v2 file-pointer: write the body to a deterministic path; emit a tiny prompt
-	// the ensign Reads on first action.
-	dispatchFilePath := filepath.Join(dispatchFileDir, derivedName+".md")
+	// v2 file-pointer: write the body to a collision-free path under the shared
+	// dispatch dir; emit a tiny prompt the ensign Reads on first action. A bare
+	// {derivedName}.md is identical across every dispatch of one slug+stage, so two
+	// concurrent FOs — or back-to-back runs of one fixture — alias the same file
+	// and an ensign can Read a STALE prior dispatch's entity pointer. Each real FO
+	// TeamCreate yields a unique team name (`{project}-{dir}-{YYYYMMDD-HHMM}-
+	// {shortuuid}`), so keying the file on the team name disambiguates every team-
+	// mode dispatch. Bare-mode dispatches (no team name) block until the subagent
+	// completes — they cannot alias within a session — so they keep the plain name.
+	// derivedName stays the readable team-member name; only the on-disk path is keyed.
+	dispatchFileName := derivedName
+	if teamName != "" {
+		dispatchFileName = teamName + "-" + derivedName
+	}
+	dispatchFilePath := filepath.Join(dispatchFileDir, dispatchFileName+".md")
 	if err := os.MkdirAll(dispatchFileDir, 0o755); err != nil {
 		fmt.Fprintf(stderr, "dispatch_file_write_failed: %s: %s\n", dispatchFilePath, err)
 		return 1

--- a/internal/dispatch/build_errors_test.go
+++ b/internal/dispatch/build_errors_test.go
@@ -230,10 +230,11 @@ func TestBuildStrEErrors(t *testing.T) {
 		ep := writeFlatEntity(t, wd, "backlog", "")
 		stdin := `{"schema_version":2,"entity_path":"` + ep + `","workflow_dir":"` + wd + `","stage":"backlog","checklist":["- a"],"team_name":"t"}`
 
-		// Force the write to fail: make the deterministic dispatch-file path a
-		// directory so open()/WriteFile cannot write a regular file there. Clear
-		// any leftover regular file other fixtures wrote at this same path first.
-		derived := "spacedock-ensign-thing-backlog"
+		// Force the write to fail: make the dispatch-file path a directory so
+		// open()/WriteFile cannot write a regular file there. Clear any leftover
+		// regular file other fixtures wrote at this same path first. The path is
+		// keyed on the team name ("t" here) to match the collision-free derivation.
+		derived := "t-spacedock-ensign-thing-backlog"
 		target := filepath.Join(dispatchFileDir, derived+".md")
 		if err := os.RemoveAll(target); err != nil {
 			t.Fatal(err)

--- a/internal/dispatch/build_statecommit_test.go
+++ b/internal/dispatch/build_statecommit_test.go
@@ -151,6 +151,71 @@ func TestEntityPathAbsoluteFromRelativeInput(t *testing.T) {
 	}
 }
 
+// TestDispatchFilePathCollisionFreeAcrossTeams pins AC-1(1b): two `dispatch build`
+// invocations that share an entity slug+stage but run under DIFFERENT team names
+// must write to DISTINCT dispatch_file_path locations, and the first file's
+// content must survive the second build (no clobber/alias). The dispatch file was
+// written to a global /tmp path keyed only on {worker_key}-{slug}-{stage}, which
+// is identical across runs of one fixture — so back-to-back runs (or two
+// concurrent FOs) collided on one file and an ensign could Read a STALE prior
+// dispatch's entity pointer (the live cycle's residual flake; a real-world hazard
+// for concurrent FOs too). Each real FO TeamCreate yields a unique team name
+// (`{project}-{dir}-{YYYYMMDD-HHMM}-{shortuuid}`), so keying the filename on the
+// team name disambiguates every run while staying deterministic for a fixed
+// fixture team.
+func TestDispatchFilePathCollisionFreeAcrossTeams(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// build runs one dispatch for the given team name against an isolated workflow
+	// tree (its own root) for the SAME slug+stage, returning the emitted
+	// dispatch_file_path and the on-disk body.
+	build := func(teamName string) (string, string) {
+		root := t.TempDir()
+		workflowDir := filepath.Join(root, "wf")
+		writeFile(t, filepath.Join(workflowDir, "README.md"), readmeWorktree(false))
+		entityPath := filepath.Join(workflowDir, "make-it-work.md")
+		writeFile(t, entityPath, entityFM("Make It Work", "backlog", ""))
+		gitInit(t, root)
+
+		stdin := mergeStdin(map[string]any{
+			"schema_version": 2,
+			"entity_path":    entityPath,
+			"workflow_dir":   workflowDir,
+			"stage":          "backlog",
+			"checklist":      []string{"- a", "- b"},
+			"team_name":      teamName,
+			"bare_mode":      false,
+		}, nil)
+
+		native := runNative(stdin, "build", "--workflow-dir", workflowDir)
+		path := dispatchFilePathFromStdout(t, native.stdout)
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("dispatch file unreadable at %q: %v", path, err)
+		}
+		return path, string(body)
+	}
+
+	path1, body1 := build("proj-wf-20260604-1200-aaaa1111")
+	path2, _ := build("proj-wf-20260604-1201-bbbb2222")
+
+	// Two distinct teams on the same slug+stage must NOT share a dispatch file.
+	if path1 == path2 {
+		t.Errorf("dispatch_file_path collides across two teams for the same slug+stage: %q", path1)
+	}
+
+	// The first file must still hold its OWN body — the second build must not have
+	// clobbered it (the stale-pointer race the live ensign loses).
+	after1, err := os.ReadFile(path1)
+	if err != nil {
+		t.Fatalf("first dispatch file vanished after the second build: %v", err)
+	}
+	if string(after1) != body1 {
+		t.Errorf("first dispatch file body was clobbered by the second build\npath: %s", path1)
+	}
+}
+
 // extractTokenAfter returns the whitespace-delimited token immediately following
 // marker in body, failing the test if the marker is absent.
 func extractTokenAfter(t *testing.T, body, marker, full string) string {

--- a/internal/dispatch/build_statecommit_test.go
+++ b/internal/dispatch/build_statecommit_test.go
@@ -78,6 +78,95 @@ func TestStateCommitPathAbsoluteFromRelativeWorkflowDir(t *testing.T) {
 	}
 }
 
+// TestEntityPathAbsoluteFromRelativeInput pins AC-1: a dispatch built with a
+// RELATIVE entity_path must emit an ABSOLUTE path in BOTH the dispatch-body
+// entity-read line ("Read the entity file at <path>") AND the completion-signal
+// line ("Report written to <path>."). The dispatched ensign is a separate agent
+// whose cwd is not pinned to the workflow root, so a relative entity_path
+// resolves to a different / nonexistent file there — the "two entity files"
+// divergence. runBuild absolutizes entity_path against the process cwd, mirroring
+// the workflow_dir absolutization, so every emitted reference is cwd-independent.
+func TestEntityPathAbsoluteFromRelativeInput(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := t.TempDir()
+
+	// Split-root workflow: the entity lives in the state checkout, which is the
+	// live-cycle shape this fix targets.
+	workflowDir := filepath.Join(root, "wf")
+	stateCheckout := filepath.Join(workflowDir, "state-checkout")
+	writeFile(t, filepath.Join(workflowDir, "README.md"), readmeWorktree(true))
+
+	worktreeRel := ".worktrees/spacedock-ensign-thing"
+	if err := os.MkdirAll(filepath.Join(root, worktreeRel), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	entityPath := filepath.Join(stateCheckout, "thing", "index.md")
+	writeFile(t, entityPath, entityFM("Thing", "implementation", worktreeRel))
+
+	gitInit(t, root)
+
+	// Derive a RELATIVE entity_path spelling from the process cwd, so runBuild's
+	// filepath.Abs resolution is the thing under test. (t.Chdir is go1.24+; this
+	// module targets go1.22, so the relative spelling is derived, not realized via
+	// a cwd change.)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entityRel, err := filepath.Rel(cwd, entityPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.IsAbs(entityRel) {
+		t.Fatalf("derived entity_path spelling is not relative: %q", entityRel)
+	}
+
+	stdin := mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    entityRel,
+		"workflow_dir":   workflowDir,
+		"stage":          "implementation",
+		"checklist":      []string{"- a", "- b"},
+		"team_name":      "fixture-team",
+		"bare_mode":      false,
+	}, nil)
+
+	native := runNative(stdin, "build", "--workflow-dir", workflowDir)
+	body := readDispatchBody(t, dispatchFilePathFromStdout(t, native.stdout))
+
+	// Pull the entity-read line's path and assert it is absolute.
+	readPath := extractTokenAfter(t, body, "Read the entity file at ", body)
+	if !filepath.IsAbs(readPath) {
+		t.Errorf("entity-read line path is not absolute: %q\n--- body ---\n%s", readPath, body)
+	}
+
+	// Pull the completion-signal line's path and assert it is absolute. The
+	// signal renders "Report written to <path>." with a trailing period, so trim
+	// it before the IsAbs check.
+	signalPath := strings.TrimSuffix(extractTokenAfter(t, body, "Report written to ", body), ".")
+	if !filepath.IsAbs(signalPath) {
+		t.Errorf("completion-signal line path is not absolute: %q\n--- body ---\n%s", signalPath, body)
+	}
+}
+
+// extractTokenAfter returns the whitespace-delimited token immediately following
+// marker in body, failing the test if the marker is absent.
+func extractTokenAfter(t *testing.T, body, marker, full string) string {
+	t.Helper()
+	idx := strings.Index(body, marker)
+	if idx < 0 {
+		t.Fatalf("body missing %q\n--- body ---\n%s", marker, full)
+	}
+	rest := body[idx+len(marker):]
+	end := strings.IndexAny(rest, " \n")
+	if end < 0 {
+		end = len(rest)
+	}
+	return rest[:end]
+}
+
 // TestSingleRootNoStateCommitGuidance (AC-3) pins the single-root negative: a
 // workflow with NO state: field must emit NEITHER the "This workflow is
 // split-root" sentence NOR a `git -C` state-commit command — for both a worktree

--- a/internal/dispatch/testdata/golden/build-abs-worktree.txt
+++ b/internal/dispatch/testdata/golden/build-abs-worktree.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-implementation.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-implementation",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage validation"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-validation.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-validation.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-validation",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+bare.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+bare.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
   "model": null
 }
 

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-backlog",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-implementation.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-implementation",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-implementation.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-implementation",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-implementation.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-implementation",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage backlog"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-backlog",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-implementation.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-implementation",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-html-escape.txt
+++ b/internal/dispatch/testdata/golden/build-html-escape.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage validation"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-validation.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-validation.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-validation",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-model-defaults-haiku.txt
+++ b/internal/dispatch/testdata/golden/build-model-defaults-haiku.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage defaultsmodel"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-defaultsmodel.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-defaultsmodel.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-defaultsmodel.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-defaultsmodel.md and treat its content as your assignment.",
   "model": "haiku",
   "name": "spacedock-ensign-thing-defaultsmodel",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-model-null.txt
+++ b/internal/dispatch/testdata/golden/build-model-null.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage nomodel"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-nomodel.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-nomodel.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-nomodel.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-nomodel.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-nomodel",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-model-stage-wins-opus.txt
+++ b/internal/dispatch/testdata/golden/build-model-stage-wins-opus.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage stagemodel"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-stagemodel.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-stagemodel.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-stagemodel.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-stagemodel.md and treat its content as your assignment.",
   "model": "opus",
   "name": "spacedock-ensign-thing-stagemodel",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-mods.txt
+++ b/internal/dispatch/testdata/golden/build-mods.txt
@@ -9,8 +9,8 @@
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog",
     "spacedock dispatch show-standing --workflow-dir <ROOT>"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-backlog",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-nonascii-title.txt
+++ b/internal/dispatch/testdata/golden/build-nonascii-title.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-backlog",
   "team_name": "fixture-team"

--- a/internal/dispatch/testdata/golden/build-schemaversion-float-2.0.txt
+++ b/internal/dispatch/testdata/golden/build-schemaversion-float-2.0.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-backlog",
   "team_name": "t"

--- a/internal/dispatch/testdata/golden/build-schemaversion-int-2.txt
+++ b/internal/dispatch/testdata/golden/build-schemaversion-int-2.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-backlog",
   "team_name": "t"

--- a/internal/dispatch/testdata/golden/build-space-path.txt
+++ b/internal/dispatch/testdata/golden/build-space-path.txt
@@ -8,8 +8,8 @@
   "fetch_commands": [
     "spacedock dispatch show-stage-def --workflow-dir '<ROOT>/work dir' --stage backlog"
   ],
-  "dispatch_file_path": "/tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md",
-  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
+  "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
+  "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
   "model": null,
   "name": "spacedock-ensign-thing-backlog",
   "team_name": "fixture-team"

--- a/internal/ensigncycle/live_test.go
+++ b/internal/ensigncycle/live_test.go
@@ -210,32 +210,27 @@ func TestLiveEnsignCycle(t *testing.T) {
 	t.Logf("located entity at %s", where)
 
 	// The full-lifecycle END-STATE checks below (stage-report shape, terminal
-	// frontmatter, path-scoped commit) are LOGGED, NOT FAILED. They depend on
-	// non-deterministic multi-agent FO+ensign behavior under upstream claude-code
-	// bug #55297 (https://github.com/anthropics/claude-code/issues/55297 — the
-	// per-turn `claude -p` shutdown reminder that panic-shuts-down the team before
-	// the work finishes; the `-p` override above counters it but not always) PLUS
-	// an observed ensign stage-report path divergence (the dispatched ensign
-	// sometimes writes its report to a different `make-it-work.md` than the FO
-	// tracks). A non-deterministic multi-agent lifecycle cannot be a HARD gate, so
-	// these are non-fatal until that determinism is settled — re-promotion is
-	// tracked by entity `live-cycle-end-state-determinism`. The HARD live assertion
-	// (AC-1) is the teardown MARKER grade above; TeamCreate, dispatch-close, and
-	// entity-located stay hard too.
+	// frontmatter, path-scoped commit) are HARD assertions. They verify the REAL
+	// completed-and-archived end-state the multi-agent FO+ensign cycle produces.
+	// They sit AFTER the teardown MARKER grade (the hard AC from `at`/#285), so a
+	// run only reaches them once the FO emitted the terminal-status marker. Each
+	// gates on a PRESENT-and-CORRECT end state: a present-but-wrong end state (e.g.
+	// a malformed stage report, a wrong commit scope) is a real Spacedock
+	// regression and fails immediately — it is NEVER retried or masked.
 
 	// (a) the appended stage-report section has the protocol shape: heading, a
 	// DONE accounting marker, a Summary, and NO checkbox-bullet form.
 	if !liveStageReportHeading.MatchString(entity) {
-		t.Logf("non-fatal (tracked in live-cycle-end-state-determinism #55297): entity missing anchored stage-report heading\n%s", entity)
+		t.Errorf("entity missing anchored stage-report heading\n%s", entity)
 	}
 	if !doneMarker.MatchString(entity) {
-		t.Logf("non-fatal (tracked in live-cycle-end-state-determinism #55297): entity missing anchored - DONE: marker\n%s", entity)
+		t.Errorf("entity missing anchored - DONE: marker\n%s", entity)
 	}
 	if !strings.Contains(entity, "### Summary") {
-		t.Logf("non-fatal (tracked in live-cycle-end-state-determinism #55297): entity missing ### Summary\n%s", entity)
+		t.Errorf("entity missing ### Summary\n%s", entity)
 	}
 	if checkboxBullet.MatchString(entity) {
-		t.Logf("non-fatal (tracked in live-cycle-end-state-determinism #55297): entity contains forbidden checkbox-bullet stage-report markers\n%s", entity)
+		t.Errorf("entity contains forbidden checkbox-bullet stage-report markers\n%s", entity)
 	}
 
 	// (b) the FO finalized the cycle: the entity carries the terminal frontmatter
@@ -244,10 +239,10 @@ func TestLiveEnsignCycle(t *testing.T) {
 	// `verdict: passed`) — both completed the full cycle — so the live test gates
 	// on the verdict being decided, not on a specific word.
 	if !frontmatterField.MatchString(entity) {
-		t.Logf("non-fatal (tracked in live-cycle-end-state-determinism #55297): entity missing terminal `status: done`\n%s", entity)
+		t.Errorf("entity missing terminal `status: done`\n%s", entity)
 	}
 	if !verdictSet.MatchString(entity) {
-		t.Logf("non-fatal (tracked in live-cycle-end-state-determinism #55297): entity missing a finalized (non-empty) `verdict:`\n%s", entity)
+		t.Errorf("entity missing a finalized (non-empty) `verdict:`\n%s", entity)
 	}
 
 	// (c) SOME commit in the history is path-scoped to the entity (names only the
@@ -257,7 +252,7 @@ func TestLiveEnsignCycle(t *testing.T) {
 	// invariant is pinned deterministically by the skeleton's
 	// TestEnsignCycleMechanicalOutputs).
 	if !someCommitNamesOnly(t, root, "make-it-work") {
-		t.Logf("non-fatal (tracked in live-cycle-end-state-determinism #55297): no path-scoped commit named only the entity in the cycle history")
+		t.Errorf("no path-scoped commit named only the entity in the cycle history")
 	}
 }
 


### PR DESCRIPTION
Make the full multi-agent live cycle deterministic enough to re-promote its end-state assertions to hard, and close the dispatch-file collision that caused stale-pointer reads.

## What changed
- Absolutize `entity_path` in `dispatch build` so the dispatched ensign resolves one file regardless of cwd (1a).
- Key the dispatch-file path on `team_name` so concurrent FOs / back-to-back runs never alias a stale dispatch pointer (1b).
- Re-promote `TestLiveEnsignCycle`'s end-state assertions (status/verdict/archived/stage-report-shape) from non-fatal logging back to HARD; the #55297 anti-shutdown override holds (fired 0/5).

## Evidence
- Offline suite: 1004/1004 passed; `go vet` (offline + live) clean.
- Post-fix N=5 genuine `-count=1` `TestLiveEnsignCycle` runs all green with `/tmp/spacedock-dispatch` deliberately uncleared between runs (proving the race is closed, not just winnable); #55297 fired 0/5.
- Detached adversarial audit: refuted nothing material (golden regen froze only the deterministic team-prefix; re-promoted assertions are genuinely hard).

---
[n1a](/spacedock-dev/spacedock/blob/ee38000f7ad43e081c1b389b7bd7f1124e2be2a2/live-cycle-end-state-determinism/index.md)