### PR TITLE
Extract Feedback Rejection Flow into a lazy spacedock-owned skill

### DIFF
--- a/skills/feedback-rejection-flow/SKILL.md
+++ b/skills/feedback-rejection-flow/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: feedback-rejection-flow
+description: "First-officer feedback-rejection routing — read the `feedback-to` target, track `### Feedback Cycles`, escalate on cycle 3, consult the budget probe, route findings back to the target stage in the worktree (else fresh), re-run the reviewer, re-enter the gate flow. Invoke at the rejection-handling point when a feedback gate recommends REJECTED or the captain rejects at a feedback-to stage."
+user-invocable: false
+---
+
+# Feedback Rejection Flow
+
+This skill carries the first-officer's feedback-rejection routing procedure. The rejection DETECTION stays always-on in the FO contract's gate flow; this skill loads at the rejection-handling point to route the findings back to the target stage and re-run the reviewer. The `### Feedback Cycles` write-scope rules, the reuse conditions, and the budget probe stay always-on in the FO contract — this procedure references them by name.
+
+## Feedback Rejection Flow
+
+When a feedback stage recommends REJECTED:
+
+1. Read the rejected stage's `feedback-to` target — the stage that receives the fix request, not the reviewer.
+2. Track cycles in `### Feedback Cycles` in the entity body.
+3. On cycle 3, escalate to the human instead of another round.
+4. Consult the budget probe (reuse condition 0). If the old ensign is over budget or the source is unavailable, shut down and fresh-dispatch; if no probe is declared, proceed to reuse below.
+5. Route findings back to the target stage in the same worktree using the existing handle when addressable and reuse conditions pass (`send_input` on Codex, `SendMessage` on Claude teams); otherwise shut down and fresh-dispatch. The routed message must carry the concrete next-stage assignment and fix work, not just an acknowledgment request. On Codex, do not treat the immediate `send_input` response as the new completion result — if the follow-up is on the entity's critical path, wait for the reused worker's next completion before advancing or shutting it down (entity-scoped wait, not a global scheduling stop).
+6. Re-run the reviewer after fixes.
+7. Re-enter the normal gate flow with the updated result.
+
+The FO owns `### Feedback Cycles`. Routing follows FO Write Scope: worktree-side when `worktree:` is set, main-side otherwise.

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -151,23 +151,9 @@ If the stage is gated:
 - never self-approve
 - present the stage report by invoking `Skill(skill="spacedock:present-gate")` and following its template + assembly rules
 - keep the worker alive while waiting at the gate
-- on a feedback gate recommending `REJECTED`, auto-bounce into the feedback rejection flow instead of waiting for manual review
-- on captain reject at a `feedback-to` stage, enter the Feedback Rejection Flow (priority over generic rejection)
+- on a feedback gate recommending `REJECTED`, invoke `Skill(skill="spacedock:feedback-rejection-flow")` and follow it instead of waiting for manual review
+- on captain reject at a `feedback-to` stage, invoke `Skill(skill="spacedock:feedback-rejection-flow")` and follow it (priority over generic rejection)
 - on captain approve to a non-terminal next stage, apply the reuse conditions. On reuse: keep the agent and SendMessage the next stage. On fresh: shut down the agent and any kept-alive `feedback-to` target the next stage does not need.
-
-## Feedback Rejection Flow
-
-When a feedback stage recommends REJECTED:
-
-1. Read the rejected stage's `feedback-to` target — the stage that receives the fix request, not the reviewer.
-2. Track cycles in `### Feedback Cycles` in the entity body.
-3. On cycle 3, escalate to the human instead of another round.
-4. Consult the budget probe (reuse condition 0). If the old ensign is over budget or the source is unavailable, shut down and fresh-dispatch; if no probe is declared, proceed to reuse below.
-5. Route findings back to the target stage in the same worktree using the existing handle when addressable and reuse conditions pass (`send_input` on Codex, `SendMessage` on Claude teams); otherwise shut down and fresh-dispatch. The routed message must carry the concrete next-stage assignment and fix work, not just an acknowledgment request. On Codex, do not treat the immediate `send_input` response as the new completion result — if the follow-up is on the entity's critical path, wait for the reused worker's next completion before advancing or shutting it down (entity-scoped wait, not a global scheduling stop).
-6. Re-run the reviewer after fixes.
-7. Re-enter the normal gate flow with the updated result.
-
-The FO owns `### Feedback Cycles`. Routing follows FO Write Scope: worktree-side when `worktree:` is set, main-side otherwise.
 
 ## Merge and Cleanup
 

--- a/skills/integration/feedback_rejection_flow_test.go
+++ b/skills/integration/feedback_rejection_flow_test.go
@@ -85,20 +85,28 @@ func TestFeedbackProcedureAbsentFromFOCore(t *testing.T) {
 	}
 }
 
-// feedbackAtToken matches any `@`-prefixed path token in a region — the
-// structural cross-skill @-include ban. The seam must invoke via Skill(...), the
-// proven mechanism; ANY `@`-token in the detection region is the disproven
-// @-include family (`@feedback-rejection-flow`, `@../feedback-rejection-flow`,
-// `@./feedback-rejection-flow/SKILL.md`, …). A whole-region @-ban, not a two-
-// literal enum — the `## Completion and Gates` region carries no legitimate `@`
-// token (ground-truthed), so any `@` there is the disproven include.
-var feedbackAtToken = regexp.MustCompile(`@\S`)
+// feedbackAtInclude matches an `@`-prefixed path token resolving toward the
+// feedback-rejection-flow skill — `@feedback-rejection-flow`,
+// `@../feedback-rejection-flow`, `@./feedback-rejection-flow/SKILL.md`, etc. The
+// leading `@` plus any run of relative-path segments (`./`, `../`, bare) ending
+// in a `feedback-rejection-flow` path component is the disproven cross-skill
+// include the seam must NOT use. Structural (not a two-literal enum), and scanned
+// whole-file: a stale `@feedback-rejection-flow` re-introduced in ANY core
+// section — not just the detection region — is the disproven mechanism. A bare
+// `@\S` whole-file ban would false-fire on a legitimate unrelated
+// `@references/...` include the core may later carry; this name-targeted form
+// only fires on the feedback-rejection-flow include family.
+var feedbackAtInclude = regexp.MustCompile(`@(?:\.{1,2}/)*feedback-rejection-flow\b`)
 
-// TestFOCoreInvokesFeedbackRejectionSkill locks AC-1(c): the FO core's
-// `## Completion and Gates` section invokes the skill via Skill(...) at the
-// rejection-detection point and uses NO cross-skill @-include. Region-scoped to
-// `## Completion and Gates`. The Skill(...) literal is the integration seam; ANY
-// `@`-token in the region is the disproven mechanism.
+// TestFOCoreInvokesFeedbackRejectionSkill locks AC-1(c): the FO core invokes the
+// skill via Skill(...) at the rejection-detection point and uses NO cross-skill
+// @-include toward feedback-rejection-flow ANYWHERE in the file. The positive
+// Skill(...) check is region-scoped to `## Completion and Gates` (the seam lives
+// at the detection point); the @-include ban is WHOLE-FILE so a stale include
+// re-introduced in any other section (e.g. `## Merge and Cleanup`) is caught, not
+// just one in the detection region. The Skill(...) literal is the integration
+// seam; any `@`-token resolving toward feedback-rejection-flow is the disproven
+// mechanism.
 func TestFOCoreInvokesFeedbackRejectionSkill(t *testing.T) {
 	fo := foCore(t)
 	region := sectionAfter(fo, "## Completion and Gates")
@@ -108,8 +116,8 @@ func TestFOCoreInvokesFeedbackRejectionSkill(t *testing.T) {
 	if !strings.Contains(region, `Skill(skill="spacedock:feedback-rejection-flow")`) {
 		t.Errorf("`## Completion and Gates` section does not invoke Skill(skill=\"spacedock:feedback-rejection-flow\")")
 	}
-	if m := feedbackAtToken.FindString(region); m != "" {
-		t.Errorf("`## Completion and Gates` section uses a disproven cross-skill @-include (token %q)", m)
+	if m := feedbackAtInclude.FindString(fo); m != "" {
+		t.Errorf("first-officer-shared-core.md uses a disproven cross-skill @-include toward feedback-rejection-flow (token %q)", m)
 	}
 }
 

--- a/skills/integration/feedback_rejection_flow_test.go
+++ b/skills/integration/feedback_rejection_flow_test.go
@@ -1,0 +1,198 @@
+// ABOUTME: AC-1/AC-2 oracles for the feedback-rejection-flow extraction — the
+// ABOUTME: 7-step rejection procedure lives in the skill, not the FO core, with a Skill() seam; always-on machinery stays.
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// feedbackProcedureFingerprints uniquely identifies the moved feedback-rejection
+// procedure. Each literal is unique-1 in the pre-change first-officer-shared-core.md
+// (ground-truthed 2026-06-04). AC-1(a) asserts presence in the skill; AC-1(b)
+// asserts absence from the FO core. The four cover the load-bearing steps — the
+// 3-cycle escalation, re-run-reviewer, re-enter-gate, and the FO ownership of
+// `### Feedback Cycles`.
+var feedbackProcedureFingerprints = map[string]string{
+	"cycle-3-escalation":     "On cycle 3, escalate to the human instead of another round",
+	"re-run-reviewer":        "Re-run the reviewer after fixes",
+	"re-enter-gate-flow":     "Re-enter the normal gate flow with the updated result",
+	"fo-owns-feedback-cycle": "The FO owns `### Feedback Cycles`",
+}
+
+// feedbackFaithfulnessFingerprints are the AC-2 clauses whose loss would silently
+// mis-route a rejection: the Codex `send_input` non-completion caveat and the
+// `feedback-to` target-read clause. Asserted present in the skill body.
+var feedbackFaithfulnessFingerprints = map[string]string{
+	"send-input-non-completion": "do not treat the immediate `send_input` response as the new completion result",
+	"feedback-to-target-read":   "the stage that receives the fix request, not the reviewer",
+}
+
+// feedbackRejectionFlowSkill reads the new skill body under test.
+func feedbackRejectionFlowSkill(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(skillsRoot(t), "feedback-rejection-flow", "SKILL.md")
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read feedback-rejection-flow SKILL.md: %v", err)
+	}
+	return string(b)
+}
+
+// TestFeedbackProcedurePresentInSkill locks AC-1(a): the moved procedure
+// fingerprints are present in skills/feedback-rejection-flow/SKILL.md.
+func TestFeedbackProcedurePresentInSkill(t *testing.T) {
+	skill := feedbackRejectionFlowSkill(t)
+	for name, fp := range feedbackProcedureFingerprints {
+		if !strings.Contains(skill, fp) {
+			t.Errorf("feedback-rejection-flow SKILL.md missing %s fingerprint %q", name, fp)
+		}
+	}
+}
+
+// TestFeedbackFaithfulnessClausesPresentInSkill locks AC-2 (faithfulness): the
+// two mis-route-on-loss clauses — the Codex `send_input` non-completion caveat
+// and the `feedback-to` target-read clause — are present in the skill body.
+func TestFeedbackFaithfulnessClausesPresentInSkill(t *testing.T) {
+	skill := feedbackRejectionFlowSkill(t)
+	for name, fp := range feedbackFaithfulnessFingerprints {
+		if !strings.Contains(skill, fp) {
+			t.Errorf("feedback-rejection-flow SKILL.md missing %s faithfulness clause %q", name, fp)
+		}
+	}
+}
+
+// TestFeedbackProcedureAbsentFromFOCore locks AC-1(b): the moved procedure
+// fingerprints (and the faithfulness clauses, which moved with the body) are NO
+// LONGER present in first-officer-shared-core.md — moved, not duplicated. Whole-
+// file (NOT region-scoped): region-scoping an absence check would false-pass
+// content that moved elsewhere in the file. Negative-proof: re-inlining the
+// procedure re-introduces a fingerprint and flips this RED.
+func TestFeedbackProcedureAbsentFromFOCore(t *testing.T) {
+	fo := foCore(t)
+	for name, fp := range feedbackProcedureFingerprints {
+		if strings.Contains(fo, fp) {
+			t.Errorf("first-officer-shared-core.md still inlines %s fingerprint %q (moved, not duplicated)", name, fp)
+		}
+	}
+	for name, fp := range feedbackFaithfulnessFingerprints {
+		if strings.Contains(fo, fp) {
+			t.Errorf("first-officer-shared-core.md still inlines %s faithfulness clause %q (moved, not duplicated)", name, fp)
+		}
+	}
+}
+
+// feedbackAtToken matches any `@`-prefixed path token in a region — the
+// structural cross-skill @-include ban. The seam must invoke via Skill(...), the
+// proven mechanism; ANY `@`-token in the detection region is the disproven
+// @-include family (`@feedback-rejection-flow`, `@../feedback-rejection-flow`,
+// `@./feedback-rejection-flow/SKILL.md`, …). A whole-region @-ban, not a two-
+// literal enum — the `## Completion and Gates` region carries no legitimate `@`
+// token (ground-truthed), so any `@` there is the disproven include.
+var feedbackAtToken = regexp.MustCompile(`@\S`)
+
+// TestFOCoreInvokesFeedbackRejectionSkill locks AC-1(c): the FO core's
+// `## Completion and Gates` section invokes the skill via Skill(...) at the
+// rejection-detection point and uses NO cross-skill @-include. Region-scoped to
+// `## Completion and Gates`. The Skill(...) literal is the integration seam; ANY
+// `@`-token in the region is the disproven mechanism.
+func TestFOCoreInvokesFeedbackRejectionSkill(t *testing.T) {
+	fo := foCore(t)
+	region := sectionAfter(fo, "## Completion and Gates")
+	if region == "" {
+		t.Fatal("first-officer-shared-core.md has no `## Completion and Gates` section")
+	}
+	if !strings.Contains(region, `Skill(skill="spacedock:feedback-rejection-flow")`) {
+		t.Errorf("`## Completion and Gates` section does not invoke Skill(skill=\"spacedock:feedback-rejection-flow\")")
+	}
+	if m := feedbackAtToken.FindString(region); m != "" {
+		t.Errorf("`## Completion and Gates` section uses a disproven cross-skill @-include (token %q)", m)
+	}
+}
+
+// TestAlwaysOnMachineryRetainedInFOCore locks AC-1(d): the referenced always-on
+// machinery did NOT move with the procedure. The FO Write Scope `### Feedback
+// Cycles` write-scope bullet and the reuse-conditions/budget-probe block stay in
+// the FO core. Negative-proof: deleting either anchor reds this.
+func TestAlwaysOnMachineryRetainedInFOCore(t *testing.T) {
+	fo := foCore(t)
+	for name, anchor := range map[string]string{
+		"feedback-cycles-write-scope": "**`### Feedback Cycles` section**",
+		"reuse-conditions":            "Reuse conditions",
+	} {
+		if !strings.Contains(fo, anchor) {
+			t.Errorf("first-officer-shared-core.md no longer contains always-on anchor %s %q (must stay — the procedure references it by name)", name, anchor)
+		}
+	}
+}
+
+// TestClaudeBareModeSeamStaysConsistent locks AC-2 (seam): the Claude adapter's
+// `## Feedback Rejection Flow (bare mode)` seam stays — still present, still the
+// sequential-dispatch sentence and the keep-reviewer-alive sentence. The seam is
+// a Claude-runtime execution mode, NOT moved into the runtime-neutral skill.
+// Negative-proof: removing the seam (or either sentence) reds this.
+func TestClaudeBareModeSeamStaysConsistent(t *testing.T) {
+	claude := vendoredSkillFiles(t)["first-officer/references/claude-first-officer-runtime.md"]
+	for name, fp := range map[string]string{
+		"bare-mode-heading":   "## Feedback Rejection Flow (bare mode)",
+		"sequential-dispatch": "the feedback rejection flow is sequential",
+		"keep-reviewer-alive": "Keep the reviewer alive",
+	} {
+		if !strings.Contains(claude, fp) {
+			t.Errorf("claude-first-officer-runtime.md missing bare-mode seam %s fingerprint %q (the adapter seam must stay consistent)", name, fp)
+		}
+	}
+}
+
+// feedbackRejectionFrontmatterValue returns the trimmed scalar value of a
+// top-level `key:` line in the feedback-rejection-flow SKILL.md frontmatter, with
+// surrounding quotes stripped. The bool reports whether the key was found.
+func feedbackRejectionFrontmatterValue(t *testing.T, key string) (string, bool) {
+	t.Helper()
+	fm, ok := frontmatter(feedbackRejectionFlowSkill(t))
+	if !ok {
+		t.Fatal("feedback-rejection-flow SKILL.md has no YAML frontmatter block")
+	}
+	prefix := key + ":"
+	for _, line := range strings.Split(fm, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			v := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+			v = strings.Trim(v, `"'`)
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// TestFeedbackRejectionSkillNameMatchesSeam locks AC-2 (hardened seam): the
+// frontmatter `name:` VALUE equals `feedback-rejection-flow` — the directory name
+// AND the `Skill(skill="spacedock:feedback-rejection-flow")` invocation seam.
+// Token-presence alone (skill_surface_test.go) would pass a renamed skill the
+// seam no longer reaches; binding the value to the seam target catches that
+// drift. Negative-proof: a bogus name value reds this.
+func TestFeedbackRejectionSkillNameMatchesSeam(t *testing.T) {
+	name, ok := feedbackRejectionFrontmatterValue(t, "name")
+	if !ok {
+		t.Fatal("feedback-rejection-flow SKILL.md frontmatter has no name field")
+	}
+	if name != "feedback-rejection-flow" {
+		t.Errorf("feedback-rejection-flow SKILL.md frontmatter name is %q, want %q (the directory name and the Skill(skill=\"spacedock:feedback-rejection-flow\") seam)", name, "feedback-rejection-flow")
+	}
+}
+
+// TestFeedbackRejectionSkillIsFOInternal locks AC-2 (hardened seam): the
+// frontmatter carries `user-invocable: false` — the skill is FO-internal (loaded
+// mid-run via Skill()), not a captain-facing user skill. Negative-proof: flipping
+// to `true` reds this.
+func TestFeedbackRejectionSkillIsFOInternal(t *testing.T) {
+	v, ok := feedbackRejectionFrontmatterValue(t, "user-invocable")
+	if !ok {
+		t.Fatal("feedback-rejection-flow SKILL.md frontmatter has no user-invocable field")
+	}
+	if v != "false" {
+		t.Errorf("feedback-rejection-flow SKILL.md frontmatter user-invocable is %q, want \"false\" (the skill is FO-internal)", v)
+	}
+}

--- a/skills/integration/skill_surface_test.go
+++ b/skills/integration/skill_surface_test.go
@@ -13,7 +13,7 @@ import (
 // userSkills is the published user skill surface: the six skills the host
 // discovers (each owns a SKILL.md). `integration` is deliberately absent — it
 // holds only *_test.go and must not publish.
-var userSkills = []string{"commission", "debrief", "refit", "ensign", "first-officer", "using-claude-team", "present-gate"}
+var userSkills = []string{"commission", "debrief", "refit", "ensign", "first-officer", "using-claude-team", "present-gate", "feedback-rejection-flow"}
 
 // TestUserSkillsPresentWithFrontmatter locks AC-1: each of the five user skills
 // ships a SKILL.md whose YAML frontmatter declares a `name` and a `description`.


### PR DESCRIPTION
The feedback-rejection procedure loaded on every FO boot but fires only when a gate rejects; this lifts it into a lazy skill.

## What changed
- Move the 7-step feedback-rejection procedure into `skills/feedback-rejection-flow/SKILL.md`, byte-identical.
- Rewrite the `## Completion and Gates` detection bullets to invoke `Skill(skill="spacedock:feedback-rejection-flow")`; keep `### Feedback Cycles`, reuse-conditions, and the bare-mode seam always-on.
- Add `feedback_rejection_flow_test.go` oracles: present-in-skill, whole-file absence, Skill()-seam, name-matches-seam, user-invocable, faithfulness clauses, bare-mode-seam-consistent.
- Harden the `@`-include ban to whole-file, name-targeted.

## Evidence
- Offline `go test ./...`: 14/14 packages passed; a live reject→route→re-review drive routed correctly through the lazy skill.
- Moved block byte-identical to `next` (sha `1f24e1eb`); the detached adversarial audit's one Material finding (region-scoped `@`-ban) is closed.

---
[a9](/spacedock-dev/spacedock/blob/4de59e56257b400e777b2a68233de4a3ddfd2ea9/feedback-rejection-flow-skill-extraction/index.md)
