### PR TITLE
Front-door launcher binary path passthrough

### DIFF
--- a/docs/runtime-support.md
+++ b/docs/runtime-support.md
@@ -34,6 +34,10 @@ Add support in small layers. Each layer should have its own proof.
    - Prefer a temp workflow fixture, isolated host config/session dirs, and copied credentials over global host state.
    - Assert process exit, entity content, git log, and clean state. Do not pass by transcript phrasing.
 
+## Launcher binary propagation through wrappers
+
+`spacedock claude` and `spacedock codex` attach `SPACEDOCK_BIN` to the process they exec, including the outer `safehouse -- ...` process when safehouse wrapping is active. Spacedock does not modify safehouse internals or assume a private passthrough mechanism; if a wrapper or runtime strips `SPACEDOCK_BIN` before the agent session observes it, the skill contract's `${SPACEDOCK_BIN:-spacedock}` convention degrades to the existing `$PATH` lookup.
+
 ## Acceptance checklist
 
 A new runtime support slice is not done until the entity or PR records evidence for each applicable item:

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -29,9 +32,9 @@ type hostOps interface {
 	// when no plugin is installed (a distinct, non-error state). A non-nil error
 	// means the host CLI itself failed.
 	ResolveManifest(host string) (string, error)
-	// Launch execs argv, replacing the current process on success (production) or
-	// recording it (test). It returns only on failure to launch.
-	Launch(argv []string) error
+	// Launch execs argv with env, replacing the current process on success
+	// (production) or recording it (test). It returns only on failure to launch.
+	Launch(argv []string, env []string) error
 	// Install issues the host plugin commands to install/update the plugin from
 	// source (optionally pinned to branch), returning combined output.
 	Install(host, source, branch string) (string, error)
@@ -44,6 +47,59 @@ type hostOps interface {
 // is a var (not a const) so the linker can stamp it, mirroring Version, and so
 // `SPACEDOCK_DEV_BRANCH` can override it; tests save/restore it.
 var devBranch = "next"
+
+var executablePath = os.Executable
+
+const spacedockBinEnv = "SPACEDOCK_BIN"
+
+func launchEnv(parent []string) []string {
+	env := withoutEnv(parent, spacedockBinEnv)
+	if bin, ok := resolvedLauncherBin(); ok {
+		env = append(env, spacedockBinEnv+"="+bin)
+	}
+	return env
+}
+
+func withoutEnv(env []string, key string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func resolvedLauncherBin() (string, bool) {
+	p, err := executablePath()
+	if err != nil || p == "" {
+		return "", false
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", false
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil && executableFile(resolved) {
+		return resolved, true
+	}
+	if executableFile(abs) {
+		return abs, true
+	}
+	return "", false
+}
+
+func executableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
 
 // gateHost resolves the installed manifest for host and compares it against
 // CONTRACT_VERSION. It returns whether launch is permitted. Only a Compatible
@@ -136,7 +192,7 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 		argv = safehouse.Wrap(inner, extra)
 	}
 
-	if err := ops.Launch(argv); err != nil {
+	if err := ops.Launch(argv, launchEnv(os.Environ())); err != nil {
 		fmt.Fprintf(stderr, "spacedock claude: launch failed: %v\n", err)
 		return 1
 	}
@@ -258,7 +314,7 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 		argv = safehouse.Wrap(inner, extra)
 	}
 
-	if err := ops.Launch(argv); err != nil {
+	if err := ops.Launch(argv, launchEnv(os.Environ())); err != nil {
 		fmt.Fprintf(stderr, "spacedock codex: launch failed: %v\n", err)
 		return 1
 	}

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,6 +19,7 @@ type fakeHost struct {
 	manifest    string
 	resolveErr  error
 	launchedArg []string // argv captured by Launch
+	launchedEnv []string // env captured by Launch
 	launchErr   error
 	installCmds []string // host commands captured by Install
 	installOut  string
@@ -27,8 +29,9 @@ func (f *fakeHost) ResolveManifest(host string) (string, error) {
 	return f.manifest, f.resolveErr
 }
 
-func (f *fakeHost) Launch(argv []string) error {
+func (f *fakeHost) Launch(argv []string, env []string) error {
 	f.launchedArg = argv
+	f.launchedEnv = env
 	return f.launchErr
 }
 
@@ -57,6 +60,36 @@ func tooOldBinaryManifest(t *testing.T) string {
 	return p
 }
 
+func withExecutablePath(t *testing.T, path string, err error) {
+	t.Helper()
+	orig := executablePath
+	executablePath = func() (string, error) { return path, err }
+	t.Cleanup(func() { executablePath = orig })
+}
+
+func executableFixture(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "spacedock")
+	if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	real, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return real
+}
+
+func envValue(env []string, key string) (string, bool) {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix), true
+		}
+	}
+	return "", false
+}
+
 // TestClaudeFrontDoorLaunchesOnCompatible: on a compatible contract the front
 // door invokes the launch seam with argv beginning `claude --agent
 // spacedock:first-officer` and passes through the operator's trailing args.
@@ -77,6 +110,60 @@ func TestClaudeFrontDoorLaunchesOnCompatible(t *testing.T) {
 
 // TestClaudeFrontDoorFailFastOnMismatch: on a mismatch verdict the launch seam is
 // NOT invoked and the process exits non-zero with the pinned remedy on stderr.
+func TestClaudeFrontDoorInjectsResolvedLauncherBin(t *testing.T) {
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
+	t.Setenv(spacedockBinEnv, "/old/spacedock")
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	got, ok := envValue(fake.launchedEnv, spacedockBinEnv)
+	if !ok || got != bin {
+		t.Fatalf("%s in launch env = %q, %v; want %q, true (env=%v)", spacedockBinEnv, got, ok, bin, fake.launchedEnv)
+	}
+}
+
+func TestClaudeFrontDoorOmitsStaleLauncherBinWhenResolutionFails(t *testing.T) {
+	withExecutablePath(t, "", errors.New("boom"))
+	t.Setenv(spacedockBinEnv, "/old/spacedock")
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if got, ok := envValue(fake.launchedEnv, spacedockBinEnv); ok {
+		t.Fatalf("%s in launch env = %q, want omitted", spacedockBinEnv, got)
+	}
+}
+
+func TestClaudeFrontDoorLaunchEnvResolvesSymlink(t *testing.T) {
+	real := executableFixture(t)
+	link := filepath.Join(t.TempDir(), "spacedock-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	withExecutablePath(t, link, nil)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if got, ok := envValue(fake.launchedEnv, spacedockBinEnv); !ok || got != real {
+		t.Fatalf("%s = %q, %v; want symlink target %q, true", spacedockBinEnv, got, ok, real)
+	}
+}
+
 func TestClaudeFrontDoorFailFastOnMismatch(t *testing.T) {
 	fake := &fakeHost{manifest: tooOldBinaryManifest(t)}
 	var stdout, stderr bytes.Buffer
@@ -226,6 +313,30 @@ func TestCodexFrontDoorLaunchesOnCompatible(t *testing.T) {
 
 // TestCodexFrontDoorFailFastOnMismatch: codex fails fast on a mismatch verdict
 // with the pinned remedy and does NOT launch.
+func TestCodexFrontDoorInjectsLauncherBinThroughSafehouseResume(t *testing.T) {
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
+	t.Setenv(spacedockBinEnv, "/old/spacedock")
+	dir := safehouseFixtureDir(t)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runCodex(context.Background(), []string{"--", "resume", "abc123"}, dir, fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	wantArgv := []string{"safehouse", "--trust-workdir-config", "--",
+		"codex", "--dangerously-bypass-approvals-and-sandbox", "resume", "abc123"}
+	if !equalArgv(fake.launchedArg, wantArgv) {
+		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, wantArgv)
+	}
+	got, ok := envValue(fake.launchedEnv, spacedockBinEnv)
+	if !ok || got != bin {
+		t.Fatalf("%s in launch env = %q, %v; want %q, true (env=%v)", spacedockBinEnv, got, ok, bin, fake.launchedEnv)
+	}
+}
+
 func TestCodexFrontDoorFailFastOnMismatch(t *testing.T) {
 	fake := &fakeHost{manifest: tooOldBinaryManifest(t)}
 	var stdout, stderr bytes.Buffer

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -218,12 +218,12 @@ func marketplaceAddArg(source, branch string) string {
 // Launch replaces the current process with argv via execve, so the host CLI
 // owns the terminal (interactive `claude --agent …`). It returns only when exec
 // itself fails.
-func (execHost) Launch(argv []string) error {
+func (execHost) Launch(argv []string, env []string) error {
 	bin, err := exec.LookPath(argv[0])
 	if err != nil {
 		return err
 	}
-	return syscall.Exec(bin, argv, os.Environ())
+	return syscall.Exec(bin, argv, env)
 }
 
 // installStep is one entry in the install upgrade sequence: an argv to pass to

--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -24,7 +24,7 @@ type execPiRuntimeOps struct{}
 
 func (execPiRuntimeOps) LookPath(name string) (string, error) { return exec.LookPath(name) }
 func (execPiRuntimeOps) Stat(path string) error               { _, err := os.Stat(path); return err }
-func (execPiRuntimeOps) Launch(argv []string) error           { return execHost{}.Launch(argv) }
+func (execPiRuntimeOps) Launch(argv []string) error           { return execHost{}.Launch(argv, os.Environ()) }
 
 type piRuntimeConfig struct {
 	repoRoot        string

--- a/internal/cli/safehouse_env_smoke_test.go
+++ b/internal/cli/safehouse_env_smoke_test.go
@@ -1,0 +1,40 @@
+// ABOUTME: Fixture-backed smoke for safehouse-shaped environment propagation.
+// ABOUTME: Proves SPACEDOCK_BIN can reach an inner child through the wrapper argv shape.
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSafehouseShapePreservesSpacedockBinToInnerChildFixture(t *testing.T) {
+	dir := t.TempDir()
+	safehouse := filepath.Join(dir, "safehouse")
+	if err := os.WriteFile(safehouse, []byte(`#!/bin/sh
+while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done
+if [ "$1" = "--" ]; then shift; fi
+exec "$@"
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	inner := filepath.Join(dir, "inner-env")
+	if err := os.WriteFile(inner, []byte(`#!/bin/sh
+printf '%s\n' "SPACEDOCK_BIN=${SPACEDOCK_BIN:-}"
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bin := filepath.Join(dir, "spacedock")
+	cmd := exec.Command(safehouse, "--trust-workdir-config", "--", inner)
+	cmd.Env = append(os.Environ(), spacedockBinEnv+"="+bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("safehouse-shaped fixture failed: %v\n%s", err, out)
+	}
+	if got, want := strings.TrimSpace(string(out)), spacedockBinEnv+"="+bin; got != want {
+		t.Fatalf("inner child env = %q, want %q", got, want)
+	}
+}

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -462,8 +462,8 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 	// fetch line targets `spacedock dispatch show-stage-def` so the dispatch path
 	// stays Python-free (the one intentional divergence from the oracle).
 	fetchCommands := []string{
-		fmt.Sprintf("spacedock dispatch show-stage-def --workflow-dir %s --stage %s",
-			shlexQuote(workflowDir), shlexQuote(stage)),
+		fmt.Sprintf("%s dispatch show-stage-def --workflow-dir %s --stage %s",
+			launcherCommand(), shlexQuote(workflowDir), shlexQuote(stage)),
 	}
 
 	// 3. Worktree instructions (conditional). Under split root the state-commit
@@ -533,7 +533,7 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 	// claude-team→spacedock dispatch rewrite as the show-stage-def line).
 	if len(EnumerateDeclaredStandingTeammates(workflowDir, teamName)) > 0 {
 		fetchCommands = append(fetchCommands,
-			fmt.Sprintf("spacedock dispatch show-standing --workflow-dir %s", shlexQuote(workflowDir)))
+			fmt.Sprintf("%s dispatch show-standing --workflow-dir %s", launcherCommand(), shlexQuote(workflowDir)))
 	}
 
 	// Emit the `### Fetch commands` block.

--- a/internal/dispatch/build_hazards_test.go
+++ b/internal/dispatch/build_hazards_test.go
@@ -213,8 +213,8 @@ func TestBuildSpaceBearingPath(t *testing.T) {
 	env := goldenEnvelope{res: normRun(native, root, home), body: normPaths(nativeBody, root, home)}
 	assertGolden(t, "build-space-path", env)
 	// Explicit: the space-bearing dir is single-quoted in the native fetch line.
-	wantQuoted := "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir '" + workflowDir + "' --stage backlog"
-	if !strings.Contains(native.stdout, wantQuoted) {
-		t.Errorf("native fetch line not shlex-quoted for space path:\nwant contains: %s\ngot:\n%s", wantQuoted, native.stdout)
+	wantQuoted := launcherCommand() + " dispatch show-stage-def --workflow-dir '" + workflowDir + "' --stage backlog"
+	if !strings.Contains(nativeBody, wantQuoted) {
+		t.Errorf("native fetch line not shlex-quoted for space path:\nwant contains: %s\ngot:\n%s", wantQuoted, nativeBody)
 	}
 }

--- a/internal/dispatch/build_hazards_test.go
+++ b/internal/dispatch/build_hazards_test.go
@@ -213,7 +213,7 @@ func TestBuildSpaceBearingPath(t *testing.T) {
 	env := goldenEnvelope{res: normRun(native, root, home), body: normPaths(nativeBody, root, home)}
 	assertGolden(t, "build-space-path", env)
 	// Explicit: the space-bearing dir is single-quoted in the native fetch line.
-	wantQuoted := "spacedock dispatch show-stage-def --workflow-dir '" + workflowDir + "' --stage backlog"
+	wantQuoted := "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir '" + workflowDir + "' --stage backlog"
 	if !strings.Contains(native.stdout, wantQuoted) {
 		t.Errorf("native fetch line not shlex-quoted for space path:\nwant contains: %s\ngot:\n%s", wantQuoted, native.stdout)
 	}

--- a/internal/dispatch/launcher_command.go
+++ b/internal/dispatch/launcher_command.go
@@ -2,6 +2,6 @@
 // ABOUTME: Keeps launch-provided SPACEDOCK_BIN identity while preserving PATH fallback.
 package dispatch
 
-const launcherCommandExpr = "${SPACEDOCK_BIN:-spacedock}"
+const launcherCommandExpr = `spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher`
 
 func launcherCommand() string { return launcherCommandExpr }

--- a/internal/dispatch/launcher_command.go
+++ b/internal/dispatch/launcher_command.go
@@ -1,0 +1,7 @@
+// ABOUTME: Shared rendering for Spacedock helper invocations emitted into agent prompts.
+// ABOUTME: Keeps launch-provided SPACEDOCK_BIN identity while preserving PATH fallback.
+package dispatch
+
+const launcherCommandExpr = "${SPACEDOCK_BIN:-spacedock}"
+
+func launcherCommand() string { return launcherCommandExpr }

--- a/internal/dispatch/launcher_command_test.go
+++ b/internal/dispatch/launcher_command_test.go
@@ -1,0 +1,11 @@
+// ABOUTME: Locks the env-aware launcher command token generated into dispatch prompts.
+// ABOUTME: Ensures ensign fetch commands prefer SPACEDOCK_BIN with spacedock PATH fallback.
+package dispatch
+
+import "testing"
+
+func TestLauncherCommandUsesSpacedockBinFallbackExpression(t *testing.T) {
+	if got, want := launcherCommand(), "${SPACEDOCK_BIN:-spacedock}"; got != want {
+		t.Fatalf("launcherCommand() = %q, want %q", got, want)
+	}
+}

--- a/internal/dispatch/launcher_command_test.go
+++ b/internal/dispatch/launcher_command_test.go
@@ -1,11 +1,70 @@
 // ABOUTME: Locks the env-aware launcher command token generated into dispatch prompts.
-// ABOUTME: Ensures ensign fetch commands prefer SPACEDOCK_BIN with spacedock PATH fallback.
+// ABOUTME: Ensures ensign fetch commands prefer executable SPACEDOCK_BIN with spacedock PATH fallback.
 package dispatch
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
-func TestLauncherCommandUsesSpacedockBinFallbackExpression(t *testing.T) {
-	if got, want := launcherCommand(), "${SPACEDOCK_BIN:-spacedock}"; got != want {
-		t.Fatalf("launcherCommand() = %q, want %q", got, want)
+func TestLauncherCommandUsesExecutableSpacedockBinWhenAvailable(t *testing.T) {
+	bin := writeExecutable(t, t.TempDir(), "spacedock-bin", "#!/bin/sh\necho env-bin:$1\n")
+	out := runLauncherCommand(t, []string{"SPACEDOCK_BIN=" + bin}, nil, "status")
+
+	if got, want := strings.TrimSpace(out), "env-bin:status"; got != want {
+		t.Fatalf("launcher command output = %q, want %q", got, want)
 	}
+}
+
+func TestLauncherCommandFallsBackToPathWhenSpacedockBinUnsetEmptyOrUnusable(t *testing.T) {
+	pathDir := t.TempDir()
+	writeExecutable(t, pathDir, "spacedock", "#!/bin/sh\necho path-bin:$1\n")
+	nonExecutable := filepath.Join(t.TempDir(), "not-executable")
+	if err := os.WriteFile(nonExecutable, []byte("not executable"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(t.TempDir(), "missing-spacedock")
+
+	for _, tc := range []struct {
+		name string
+		env  []string
+	}{
+		{name: "unset"},
+		{name: "empty", env: []string{"SPACEDOCK_BIN="}},
+		{name: "non-executable", env: []string{"SPACEDOCK_BIN=" + nonExecutable}},
+		{name: "missing", env: []string{"SPACEDOCK_BIN=" + missing}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := runLauncherCommand(t, tc.env, []string{pathDir}, "dispatch")
+			if got, want := strings.TrimSpace(out), "path-bin:dispatch"; got != want {
+				t.Fatalf("launcher command output = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func runLauncherCommand(t *testing.T, env []string, pathDirs []string, arg string) string {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", launcherCommand()+" "+arg)
+	cmd.Env = append(os.Environ(), env...)
+	if pathDirs != nil {
+		cmd.Env = append(cmd.Env, "PATH="+strings.Join(pathDirs, string(os.PathListSeparator)))
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("launcher command failed: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+func writeExecutable(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/internal/dispatch/native_subcommands_routing_test.go
+++ b/internal/dispatch/native_subcommands_routing_test.go
@@ -82,7 +82,7 @@ func TestBuildEmitsStandingFetchLineUnderMods(t *testing.T) {
 	if !strings.Contains(env.FetchCommands[0], "show-stage-def") {
 		t.Errorf("first fetch line is not show-stage-def: %q", env.FetchCommands[0])
 	}
-	if !strings.Contains(env.FetchCommands[1], "${SPACEDOCK_BIN:-spacedock} dispatch show-standing") {
+	if !strings.Contains(env.FetchCommands[1], launcherCommand()+" dispatch show-standing") {
 		t.Errorf("second fetch line is not the native show-standing line: %q", env.FetchCommands[1])
 	}
 }

--- a/internal/dispatch/native_subcommands_routing_test.go
+++ b/internal/dispatch/native_subcommands_routing_test.go
@@ -82,7 +82,7 @@ func TestBuildEmitsStandingFetchLineUnderMods(t *testing.T) {
 	if !strings.Contains(env.FetchCommands[0], "show-stage-def") {
 		t.Errorf("first fetch line is not show-stage-def: %q", env.FetchCommands[0])
 	}
-	if !strings.Contains(env.FetchCommands[1], "spacedock dispatch show-standing") {
+	if !strings.Contains(env.FetchCommands[1], "${SPACEDOCK_BIN:-spacedock} dispatch show-standing") {
 		t.Errorf("second fetch line is not the native show-standing line: %q", env.FetchCommands[1])
 	}
 }

--- a/internal/dispatch/testdata/golden/build-abs-worktree.txt
+++ b/internal/dispatch/testdata/golden/build-abs-worktree.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: implementation",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
@@ -45,7 +45,7 @@ Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for th
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-abs-worktree.txt
+++ b/internal/dispatch/testdata/golden/build-abs-worktree.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: implementation",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
@@ -45,7 +45,7 @@ Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for th
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: validation",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage validation"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage validation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md and treat its content as your assignment.",
@@ -53,7 +53,7 @@ Limit to module X.
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage validation
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage validation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: validation",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage validation"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage validation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md and treat its content as your assignment.",
@@ -53,7 +53,7 @@ Limit to module X.
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage validation
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage validation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+bare.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+bare.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -41,4 +41,4 @@ Read the entity file at <ROOT>/thing.md for the current spec.
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+bare.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+bare.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -41,4 +41,4 @@ Read the entity file at <ROOT>/thing.md for the current spec.
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage backlog

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -42,7 +42,7 @@ Read the entity file at <ROOT>/thing.md for the current spec.
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -42,7 +42,7 @@ Read the entity file at <ROOT>/thing.md for the current spec.
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: implementation",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
@@ -46,7 +46,7 @@ Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for th
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: implementation",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
@@ -46,7 +46,7 @@ Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for th
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: implementation",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
@@ -46,7 +46,7 @@ Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing/index.md 
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: implementation",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage implementation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
@@ -46,7 +46,7 @@ Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing/index.md 
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage implementation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: implementation",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
@@ -47,7 +47,7 @@ Read the entity file at <ROOT>/state-checkout/thing.md for the current spec.
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: implementation",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
@@ -47,7 +47,7 @@ Read the entity file at <ROOT>/state-checkout/thing.md for the current spec.
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage backlog"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -44,7 +44,7 @@ Read the entity file at <ROOT>/state-checkout/thing/index.md for the current spe
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage backlog
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage backlog
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage backlog"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -44,7 +44,7 @@ Read the entity file at <ROOT>/state-checkout/thing/index.md for the current spe
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage backlog
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage backlog
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: implementation",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
@@ -47,7 +47,7 @@ Read the entity file at <ROOT>/state-checkout/thing/index.md for the current spe
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: implementation",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-implementation.md and treat its content as your assignment.",
@@ -47,7 +47,7 @@ Read the entity file at <ROOT>/state-checkout/thing/index.md for the current spe
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT>/state-checkout --stage implementation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-html-escape.txt
+++ b/internal/dispatch/testdata/golden/build-html-escape.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Compare a < b && c > d in <Tag>: validation",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage validation"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage validation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md and treat its content as your assignment.",
@@ -50,7 +50,7 @@ compare a < b && c > d in <Tag> & raw &amp; ampersand
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage validation
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage validation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-html-escape.txt
+++ b/internal/dispatch/testdata/golden/build-html-escape.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Compare a < b && c > d in <Tag>: validation",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage validation"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage validation"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-validation.md and treat its content as your assignment.",
@@ -50,7 +50,7 @@ compare a < b && c > d in <Tag> & raw &amp; ampersand
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage validation
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage validation
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-model-defaults-haiku.txt
+++ b/internal/dispatch/testdata/golden/build-model-defaults-haiku.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: defaultsmodel",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage defaultsmodel"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage defaultsmodel"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-defaultsmodel.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-defaultsmodel.md and treat its content as your assignment.",

--- a/internal/dispatch/testdata/golden/build-model-defaults-haiku.txt
+++ b/internal/dispatch/testdata/golden/build-model-defaults-haiku.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: defaultsmodel",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage defaultsmodel"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage defaultsmodel"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-defaultsmodel.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-defaultsmodel.md and treat its content as your assignment.",

--- a/internal/dispatch/testdata/golden/build-model-null.txt
+++ b/internal/dispatch/testdata/golden/build-model-null.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: nomodel",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage nomodel"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage nomodel"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-nomodel.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-nomodel.md and treat its content as your assignment.",

--- a/internal/dispatch/testdata/golden/build-model-null.txt
+++ b/internal/dispatch/testdata/golden/build-model-null.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: nomodel",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage nomodel"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage nomodel"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-nomodel.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-nomodel.md and treat its content as your assignment.",

--- a/internal/dispatch/testdata/golden/build-model-stage-wins-opus.txt
+++ b/internal/dispatch/testdata/golden/build-model-stage-wins-opus.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: stagemodel",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage stagemodel"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage stagemodel"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-stagemodel.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-stagemodel.md and treat its content as your assignment.",

--- a/internal/dispatch/testdata/golden/build-model-stage-wins-opus.txt
+++ b/internal/dispatch/testdata/golden/build-model-stage-wins-opus.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: stagemodel",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage stagemodel"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage stagemodel"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-stagemodel.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-stagemodel.md and treat its content as your assignment.",

--- a/internal/dispatch/testdata/golden/build-mods.txt
+++ b/internal/dispatch/testdata/golden/build-mods.txt
@@ -6,8 +6,8 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog",
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-standing --workflow-dir <ROOT>"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage backlog",
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-standing --workflow-dir <ROOT>"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -43,8 +43,8 @@ Read the entity file at <ROOT>/thing.md for the current spec.
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-standing --workflow-dir <ROOT>
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-standing --workflow-dir <ROOT>
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-mods.txt
+++ b/internal/dispatch/testdata/golden/build-mods.txt
@@ -6,8 +6,8 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog",
-    "spacedock dispatch show-standing --workflow-dir <ROOT>"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog",
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-standing --workflow-dir <ROOT>"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -43,8 +43,8 @@ Read the entity file at <ROOT>/thing.md for the current spec.
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
-    spacedock dispatch show-standing --workflow-dir <ROOT>
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-standing --workflow-dir <ROOT>
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-nonascii-title.txt
+++ b/internal/dispatch/testdata/golden/build-nonascii-title.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Segregate Claude \u2014 generic split: backlog",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -42,7 +42,7 @@ Read the entity file at <ROOT>/thing.md for the current spec.
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-nonascii-title.txt
+++ b/internal/dispatch/testdata/golden/build-nonascii-title.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Segregate Claude \u2014 generic split: backlog",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -42,7 +42,7 @@ Read the entity file at <ROOT>/thing.md for the current spec.
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage backlog
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-schemaversion-float-2.0.txt
+++ b/internal/dispatch/testdata/golden/build-schemaversion-float-2.0.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",

--- a/internal/dispatch/testdata/golden/build-schemaversion-float-2.0.txt
+++ b/internal/dispatch/testdata/golden/build-schemaversion-float-2.0.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",

--- a/internal/dispatch/testdata/golden/build-schemaversion-int-2.txt
+++ b/internal/dispatch/testdata/golden/build-schemaversion-int-2.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",

--- a/internal/dispatch/testdata/golden/build-schemaversion-int-2.txt
+++ b/internal/dispatch/testdata/golden/build-schemaversion-int-2.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir <ROOT> --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/t-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",

--- a/internal/dispatch/testdata/golden/build-space-path.txt
+++ b/internal/dispatch/testdata/golden/build-space-path.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir '<ROOT>/work dir' --stage backlog"
+    "spacedock_launcher() { if [ -n \"${SPACEDOCK_BIN:-}\" ] && [ -x \"${SPACEDOCK_BIN:-}\" ]; then \"$SPACEDOCK_BIN\" \"$@\"; else spacedock \"$@\"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir '<ROOT>/work dir' --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -41,7 +41,7 @@ Read the entity file at <ROOT>/work dir/thing.md for the current spec.
 
 ### Fetch commands
 
-    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir '<ROOT>/work dir' --stage backlog
+    spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher dispatch show-stage-def --workflow-dir '<ROOT>/work dir' --stage backlog
 
 
 ### Completion Signal

--- a/internal/dispatch/testdata/golden/build-space-path.txt
+++ b/internal/dispatch/testdata/golden/build-space-path.txt
@@ -6,7 +6,7 @@
   "subagent_type": "spacedock:ensign",
   "description": "Thing: backlog",
   "fetch_commands": [
-    "spacedock dispatch show-stage-def --workflow-dir '<ROOT>/work dir' --stage backlog"
+    "${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir '<ROOT>/work dir' --stage backlog"
   ],
   "dispatch_file_path": "/tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md",
   "prompt": "Skill(skill=\"spacedock:ensign\"); then Read /tmp/spacedock-dispatch/fixture-team-spacedock-ensign-thing-backlog.md and treat its content as your assignment.",
@@ -41,7 +41,7 @@ Read the entity file at <ROOT>/work dir/thing.md for the current spec.
 
 ### Fetch commands
 
-    spacedock dispatch show-stage-def --workflow-dir '<ROOT>/work dir' --stage backlog
+    ${SPACEDOCK_BIN:-spacedock} dispatch show-stage-def --workflow-dir '<ROOT>/work dir' --stage backlog
 
 
 ### Completion Signal

--- a/internal/ensigncycle/cycle_test.go
+++ b/internal/ensigncycle/cycle_test.go
@@ -48,8 +48,9 @@ var (
 	// protocol — without grepping the protocol prose itself.
 	skillFirstAction = regexp.MustCompile(`(?m)^    Skill\(skill="spacedock:ensign"\)$`)
 	// fetchStageDef anchors the fetch-on-demand emit line that resolves the stage
-	// definition (the other half of the protocol-loading wiring).
-	fetchStageDef = regexp.MustCompile(`(?m)^    \$\{SPACEDOCK_BIN:-spacedock\} dispatch show-stage-def --workflow-dir `)
+	// definition (the other half of the protocol-loading wiring) through the
+	// executable SPACEDOCK_BIN-or-PATH fallback launcher shim.
+	fetchStageDef = regexp.MustCompile(`(?m)^    spacedock_launcher\(\) \{ .*; \}; spacedock_launcher dispatch show-stage-def --workflow-dir `)
 )
 
 // cycleFixture is a staged dispatch->ensign->stage environment.

--- a/internal/ensigncycle/cycle_test.go
+++ b/internal/ensigncycle/cycle_test.go
@@ -49,7 +49,7 @@ var (
 	skillFirstAction = regexp.MustCompile(`(?m)^    Skill\(skill="spacedock:ensign"\)$`)
 	// fetchStageDef anchors the fetch-on-demand emit line that resolves the stage
 	// definition (the other half of the protocol-loading wiring).
-	fetchStageDef = regexp.MustCompile(`(?m)^    spacedock dispatch show-stage-def --workflow-dir `)
+	fetchStageDef = regexp.MustCompile(`(?m)^    \$\{SPACEDOCK_BIN:-spacedock\} dispatch show-stage-def --workflow-dir `)
 )
 
 // cycleFixture is a staged dispatch->ensign->stage environment.

--- a/skills/debrief/SKILL.md
+++ b/skills/debrief/SKILL.md
@@ -14,11 +14,13 @@ Follow these phases in order. Do not skip or combine phases.
 
 ## Phase 1: Discovery
 
+**Launcher command invariant:** Prefer `${SPACEDOCK_BIN:-spacedock}` for Spacedock helper calls so an explicit front-door launcher remains the command source; when unset, fall back to `spacedock` on `$PATH`. Bare `spacedock` examples are shorthand for that expression.
+
 ### Step 1 — Identify the workflow
 
 The user may provide a workflow directory path as an argument. If they didn't, search for it:
 
-1. Run `spacedock status --discover`. It prints one resolved workflow directory path per line on stdout, scanning from the enclosing git repository root and pruning agent-managed worktrees (`.claude/worktrees/`) and other build/vendor noise.
+1. Run `${SPACEDOCK_BIN:-spacedock} status --discover`. It prints one resolved workflow directory path per line on stdout, scanning from the enclosing git repository root and pruning agent-managed worktrees (`.claude/worktrees/`) and other build/vendor noise.
 2. If exactly one path is returned, use it as `{dir}`. If multiple, ask which one. If none, report "No Spacedock workflow found."
 
 Store the confirmed path as `{dir}`.

--- a/skills/ensign/references/ensign-shared-core.md
+++ b/skills/ensign/references/ensign-shared-core.md
@@ -4,6 +4,8 @@ Shared ensign semantics. Keep aligned with `agents/ensign.md` and the runtime ad
 
 ## Assignment
 
+**Launcher command invariant:** Generated fetch commands and any Spacedock helper calls should prefer `${SPACEDOCK_BIN:-spacedock}` so sessions launched by an explicit binary keep using that binary, while unset environments fall back to `spacedock` on `$PATH`.
+
 Read the assignment context provided by the first officer. It defines:
 - the entity
 - the stage

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -4,9 +4,11 @@ Shared first-officer semantics. Keep aligned with `agents/first-officer.md` and 
 
 ## Startup
 
-1. **Contract version gate.** Before discovery or boot read, run `spacedock --version` and parse `contract <N>`. Confirm `<N>` satisfies this contract's range `>=1,<2`. Abort by class:
-   - **Binary absent or non-executable** — `spacedock --version` is not found or emits no parseable `contract <N>` token. ABORT and tell the operator `spacedock` is not on PATH. Install hint: `brew install spacedock-dev/homebrew-tap/spacedock`, or source build `go build -o spacedock ./cmd/spacedock`. Do NOT run `spacedock doctor` — same missing binary.
-   - **Binary present but contract out of range** — `<N>` below the lower bound (binary too old) or at/above the upper bound (plugin too old). ABORT with the mismatch message and run `spacedock doctor` for the per-class remedy.
+**Launcher command invariant:** When `SPACEDOCK_BIN` is set by `spacedock claude` or `spacedock codex`, prefer that launcher for every Spacedock helper call; when unset, empty, or unusable, fall back to `spacedock` on `$PATH`. Shell examples may use bare `spacedock` as shorthand for `${SPACEDOCK_BIN:-spacedock}`.
+
+1. **Contract version gate.** Before discovery or boot read, run `${SPACEDOCK_BIN:-spacedock} --version` and parse `contract <N>`. Confirm `<N>` satisfies this contract's range `>=1,<2`. Abort by class:
+   - **Binary absent or non-executable** — `${SPACEDOCK_BIN:-spacedock} --version` is not found or emits no parseable `contract <N>` token. If `SPACEDOCK_BIN` is unusable, retry once with bare `spacedock` on `$PATH`; if still absent, ABORT and tell the operator `spacedock` is not on PATH. Install hint: `brew install spacedock-dev/homebrew-tap/spacedock`, or source build `go build -o spacedock ./cmd/spacedock`. Do NOT run `spacedock doctor` — same missing binary.
+   - **Binary present but contract out of range** — `<N>` below the lower bound (binary too old) or at/above the upper bound (plugin too old). ABORT with the mismatch message and run `${SPACEDOCK_BIN:-spacedock} doctor` for the per-class remedy (bare-shorthand: run `spacedock doctor` for the per-class remedy).
 
    In every class, do NOT proceed to discovery or `--boot`.
 2. Discover the project root with `git rev-parse --show-toplevel`.
@@ -26,11 +28,11 @@ Shared first-officer semantics. Keep aligned with `agents/first-officer.md` and 
 
 ## Status Viewer
 
-The `spacedock status` launcher owns path resolution and mutation guards; skill instructions stay declarative and never reference a plugin-private script path.
+The `${SPACEDOCK_BIN:-spacedock} status` launcher owns path resolution and mutation guards; skill instructions stay declarative and never reference a plugin-private script path.
 
 Invoke it as:
 ```
-spacedock status --workflow-dir {workflow_dir} [--next-id|--next|--archived|--where ...|--boot|--validate|--resolve REF]
+${SPACEDOCK_BIN:-spacedock} status --workflow-dir {workflow_dir} [--next-id|--next|--archived|--where ...|--boot|--validate|--resolve REF]
 ```
 
 - `--boot` — startup roll-up (mods, ID style, next-ID candidate, orphans, PR state, dispatchables). Incompatible with `--next`, `--next-id`, `--archived`, `--where`.

--- a/skills/integration/skill_text_test.go
+++ b/skills/integration/skill_text_test.go
@@ -31,6 +31,7 @@ func vendoredSkillFiles(t *testing.T) map[string]string {
 		"first-officer/references/claude-first-officer-runtime.md",
 		"first-officer/references/codex-first-officer-runtime.md",
 		"ensign/references/ensign-shared-core.md",
+		"debrief/SKILL.md",
 	}
 	out := make(map[string]string, len(rel))
 	for _, r := range rel {
@@ -108,6 +109,20 @@ func TestNoPRMergeOrModBehaviorIntroduced(t *testing.T) {
 // TestFirstOfficerDispatchDocsUseFlagFileMode locks the dispatch-build
 // ergonomics contract: the FO runtime docs must teach file-backed dispatch input
 // and runtime-derived host selection, not inline shell JSON.
+func TestSkillSurfaceDocumentsSpacedockBinInvariant(t *testing.T) {
+	files := vendoredSkillFiles(t)
+	for _, name := range []string{
+		"first-officer/references/first-officer-shared-core.md",
+		"ensign/references/ensign-shared-core.md",
+		"debrief/SKILL.md",
+	} {
+		content := files[name]
+		if !strings.Contains(content, "${SPACEDOCK_BIN:-spacedock}") {
+			t.Errorf("%s does not document the env-aware spacedock launcher invariant", name)
+		}
+	}
+}
+
 func TestFirstOfficerDispatchDocsUseFlagFileMode(t *testing.T) {
 	files := vendoredSkillFiles(t)
 	claude := files["first-officer/references/claude-first-officer-runtime.md"]


### PR DESCRIPTION
Explicit launcher paths now carry through Claude/Codex sessions so helpers use the same Spacedock binary.

## What changed

- Injected `SPACEDOCK_BIN` into Claude and Codex launch environments.
- Added fallback shell rendering for unusable launcher paths.
- Updated generated dispatch commands and skill invariants.
- Added safehouse-shaped environment passthrough fixture coverage.

## Evidence

- Go baseline and race suites: 2/2 passed.
- Focused CLI, dispatch, skill, and safehouse-shape fixture tests: passed.

---
[fc](https://github.com/spacedock-dev/spacedock/blob/66ab9669d1a991110802b2ab484f1e027dcbe1d0/launcher-binary-path-passthrough/index.md)
