### PR TITLE
Auto-install Claude plugin on first front-door launch

### DIFF
--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -102,44 +102,50 @@ func executableFile(path string) bool {
 }
 
 // gateHost resolves the installed manifest for host and compares it against
-// CONTRACT_VERSION. It returns whether launch is permitted. Only a Compatible
-// verdict permits launch; everything else (a host-CLI error, no installed
-// plugin, a resolved-but-missing manifest, a mismatch, or a malformed range) is
-// NOT compatible — the front door's fail-fast job — so launch is denied with an
-// actionable message. The gate inspects the VERDICT, not a doctor exit code:
-// RunDoctor maps no-plugin-found to exit 0 (a non-fatal report), so a non-empty
-// installPath to a missing manifest would otherwise slip through as "compatible".
-func gateHost(ops hostOps, host string, stderr io.Writer) (ok bool) {
+// CONTRACT_VERSION, returning the verdict so the caller can distinguish a
+// missing plugin (NoPluginFound — recoverable by installing) from an
+// incompatibility (a mismatch — auto-installing would just fail again). Both
+// no-plugin states (an empty manifestPath AND a resolved-but-missing manifest)
+// collapse to NoPluginFound; a host-CLI resolve error maps to MalformedRange so
+// it stays a hard fail (a broken host CLI is not a missing plugin). The gate
+// inspects the VERDICT, not a doctor exit code: RunDoctor maps no-plugin-found to
+// exit 0 (a non-fatal report), so a non-empty installPath to a missing manifest
+// would otherwise slip through as "compatible". gateHost prints the actionable
+// remedy for every non-Compatible verdict; the caller decides whether to act on
+// it (auto-install) or fail fast.
+func gateHost(ops hostOps, host string, stderr io.Writer) contract.Verdict {
 	manifestPath, err := ops.ResolveManifest(host)
 	if err != nil {
 		fmt.Fprintf(stderr,
 			"Spacedock: could not resolve the installed %s plugin (%v). "+
 				"Run `spacedock doctor` or `spacedock install --host %s`.\n", host, err, host)
-		return false
+		return contract.MalformedRange
 	}
 	if manifestPath == "" {
 		fmt.Fprintf(stderr,
 			"Spacedock: no installed %s plugin found. "+
 				"Run `spacedock install --host %s` (or `spacedock claude --skip-contract-check` to bootstrap).\n", host, host)
-		return false
+		return contract.NoPluginFound
 	}
 	res := contract.ManifestVerdict(manifestPath, host, devBranch)
-	if res.Verdict == contract.Compatible {
-		return true
-	}
 	if res.Verdict == contract.NoPluginFound {
 		fmt.Fprintf(stderr,
 			"Spacedock: the installed %s plugin reported a manifest path that does not exist (%s). "+
 				"Run `spacedock install --host %s` (or `spacedock claude --skip-contract-check` to bootstrap).\n",
 			host, manifestPath, host)
-		return false
+		return contract.NoPluginFound
 	}
-	fmt.Fprintln(stderr, res.Message)
-	return false
+	if res.Verdict != contract.Compatible {
+		fmt.Fprintln(stderr, res.Message)
+	}
+	return res.Verdict
 }
 
-// runClaude is the `spacedock claude` front door: version-gate (fail fast), then
-// launch the first officer. The launch is interposed through
+// runClaude is the `spacedock claude` front door: version-gate, then launch the
+// first officer. The gate fails fast on a contract mismatch, but a missing plugin
+// (NoPluginFound) auto-installs the plugin and proceeds to launch so the single
+// command the user typed yields a working session — `--no-install` opts out,
+// preserving the refuse-and-instruct behavior. The launch is interposed through
 // `safehouse --trust-workdir-config [extra] -- claude --dangerously-skip-permissions …`
 // when ANY of {a `.safehouse` profile in dir, the bare `--safehouse` flag, a
 // `--safehouse-*` knob} is given; otherwise it is plain `claude --agent
@@ -165,7 +171,25 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 	// plugin's contract verdict is irrelevant — it relaxes the gate exactly like
 	// an explicit `--skip-contract-check`.
 	if !fd.skipCheck && !hasPluginDir(fd.passthrough) {
-		if !gateHost(ops, "claude", stderr) {
+		switch gateHost(ops, "claude", stderr) {
+		case contract.Compatible:
+			// proceed to launch
+		case contract.NoPluginFound:
+			// No plugin on disk: the single command the user typed should yield a
+			// working session. Auto-install the plugin then launch, unless the
+			// operator opted out with --no-install (gateHost already printed the
+			// instruct remedy, so just fail fast).
+			if fd.noInstall {
+				return 1
+			}
+			if _, err := ops.Install("claude", marketplaceSource, devBranch); err != nil {
+				fmt.Fprintf(stderr, "spacedock claude: auto-install failed: %v\n", err)
+				return 1
+			}
+		default:
+			// A mismatch / malformed range / host-CLI resolve error: auto-installing
+			// would not fix an incompatibility, so fail fast (gateHost already
+			// printed the message).
 			return 1
 		}
 	}
@@ -287,8 +311,11 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 		fmt.Fprintf(stderr, "spacedock codex: %v\n", err)
 		return 1
 	}
+	// Codex keeps the all-or-nothing gate: any non-Compatible verdict fails fast.
+	// The no-plugin auto-install is Claude-only (Install rejects non-claude hosts),
+	// and codex has no --plugin-dir equivalent, so there is nothing to auto-install.
 	if !fd.skipCheck && !hasPluginDir(fd.passthrough) {
-		if !gateHost(ops, "codex", stderr) {
+		if gateHost(ops, "codex", stderr) != contract.Compatible {
 			return 1
 		}
 	}
@@ -456,6 +483,9 @@ type frontDoorArgs struct {
 	safehouseFlags []string
 	// skipCheck is set by `--skip-contract-check` (bypasses the contract gate).
 	skipCheck bool
+	// noInstall is set by `--no-install` (opt out of the no-plugin auto-install,
+	// preserving the refuse-and-instruct behavior).
+	noInstall bool
 }
 
 // frontDoorFlags binds the spacedock-owned front-door flags onto a pflag.FlagSet
@@ -468,6 +498,7 @@ type frontDoorArgs struct {
 type frontDoorFlags struct {
 	safehouse *bool
 	skipCheck *bool
+	noInstall *bool
 	enable    *[]string
 	addDirs   *[]string
 	addDirsRO *[]string
@@ -480,6 +511,8 @@ func bindFrontDoorFlags(fs *pflag.FlagSet) frontDoorFlags {
 			"Force the safehouse sandbox wrap even without a .safehouse profile in the directory"),
 		skipCheck: fs.Bool("skip-contract-check", false,
 			"Bypass the contract gate and launch without resolving the installed plugin (bootstrap)"),
+		noInstall: fs.Bool("no-install", false,
+			"Do not auto-install the plugin when none is found; refuse and print install instructions instead"),
 		enable: fs.StringArray("safehouse-enable", nil,
 			"Enable a safehouse capability (KEY[,KEY]); repeatable; e.g. --safehouse-enable ssh,docker"),
 		addDirs: fs.StringArray("safehouse-add-dirs", nil,
@@ -512,6 +545,7 @@ func parseFrontDoorArgs(args []string) (fd frontDoorArgs, err error) {
 
 	fd.forceSafehouse = *flags.safehouse
 	fd.skipCheck = *flags.skipCheck
+	fd.noInstall = *flags.noInstall
 	for _, v := range *flags.enable {
 		fd.safehouseFlags = append(fd.safehouseFlags, "enable="+v)
 	}

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/contract"
 )
 
 // fakeHost records every seam interaction and returns canned results so the
@@ -164,6 +166,10 @@ func TestClaudeFrontDoorLaunchEnvResolvesSymlink(t *testing.T) {
 	}
 }
 
+// TestClaudeFrontDoorFailFastOnMismatch (AC-2): a real version mismatch still
+// fails fast even without --no-install — auto-install must NOT paper over an
+// incompatibility. The verdict reaches runClaude's mismatch branch, not the
+// no-plugin branch, so no install is invoked and no launch is reached.
 func TestClaudeFrontDoorFailFastOnMismatch(t *testing.T) {
 	fake := &fakeHost{manifest: tooOldBinaryManifest(t)}
 	var stdout, stderr bytes.Buffer
@@ -173,6 +179,9 @@ func TestClaudeFrontDoorFailFastOnMismatch(t *testing.T) {
 	if code == 0 {
 		t.Fatalf("exit = 0, want non-zero on mismatch")
 	}
+	if len(fake.installCmds) != 0 {
+		t.Fatalf("auto-install invoked over a mismatch: %v", fake.installCmds)
+	}
 	if fake.launchedArg != nil {
 		t.Fatalf("launch seam invoked on mismatch: %v", fake.launchedArg)
 	}
@@ -181,47 +190,92 @@ func TestClaudeFrontDoorFailFastOnMismatch(t *testing.T) {
 	}
 }
 
-// TestClaudeFrontDoorUnresolvableManifestFailsFast: an unresolvable manifest
-// (no installed plugin) is NOT treated as compatible — the front door warns and
-// exits non-zero WITHOUT launching.
-func TestClaudeFrontDoorUnresolvableManifestFailsFast(t *testing.T) {
+// TestClaudeFrontDoorNoPluginAutoInstalls (AC-1a): with no installed plugin and
+// no flags the front door auto-installs the plugin then launches a working
+// session — the single command the user typed yields a working FO session
+// rather than refusing. Install-invocation and launch-reached are observed
+// behaviors recorded by the stub, not a string match.
+func TestClaudeFrontDoorNoPluginAutoInstalls(t *testing.T) {
 	fake := &fakeHost{manifest: ""} // no plugin found
 	var stdout, stderr bytes.Buffer
 
 	code := runClaude(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
 
-	if code == 0 {
-		t.Fatalf("exit = 0, want non-zero when manifest unresolvable")
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 when no plugin → auto-install + launch (stderr=%q)", code, stderr.String())
 	}
-	if fake.launchedArg != nil {
-		t.Fatalf("launch seam invoked with unresolvable manifest: %v", fake.launchedArg)
+	if len(fake.installCmds) == 0 {
+		t.Fatalf("install seam not invoked: auto-install did not run")
 	}
-	if !strings.Contains(stderr.String(), "spacedock doctor") && !strings.Contains(stderr.String(), "spacedock install") {
-		t.Fatalf("stderr missing actionable remedy pointer: %q", stderr.String())
+	if fake.launchedArg == nil {
+		t.Fatalf("launch seam not invoked after auto-install")
 	}
 }
 
-// TestClaudeFrontDoorNonEmptyMissingManifestFailsFast: a host that reports a
-// non-empty installPath to a directory LACKING the plugin manifest must NOT
-// launch. The resolver returned a path, but the file does not exist — the gate
-// must reject the no-plugin-found verdict by inspecting the verdict, not the
-// doctor exit code (which is 0 for a non-fatal no-plugin report).
-func TestClaudeFrontDoorNonEmptyMissingManifestFailsFast(t *testing.T) {
-	missing := filepath.Join(t.TempDir(), "no-such-dir", ".claude-plugin", "plugin.json")
-	fake := &fakeHost{manifest: missing} // non-empty path, but the file is absent
+// TestClaudeFrontDoorNoPluginNoInstallRefuses (AC-1b): --no-install preserves
+// the old refuse-and-instruct behavior — no install, no launch, non-zero exit,
+// with the actionable instruct message on stderr.
+func TestClaudeFrontDoorNoPluginNoInstallRefuses(t *testing.T) {
+	fake := &fakeHost{manifest: ""} // no plugin found
 	var stdout, stderr bytes.Buffer
 
-	code := runClaude(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+	code := runClaude(context.Background(), []string{"--no-install"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
 
 	if code == 0 {
-		t.Fatalf("exit = 0, want non-zero when resolved manifest path is missing")
+		t.Fatalf("exit = 0, want non-zero with --no-install and no plugin")
+	}
+	if len(fake.installCmds) != 0 {
+		t.Fatalf("install seam invoked despite --no-install: %v", fake.installCmds)
 	}
 	if fake.launchedArg != nil {
-		t.Fatalf("launch seam invoked with a missing manifest: %v", fake.launchedArg)
+		t.Fatalf("launch seam invoked despite --no-install: %v", fake.launchedArg)
 	}
-	if !strings.Contains(stderr.String(), "spacedock doctor") && !strings.Contains(stderr.String(), "spacedock install") {
-		t.Fatalf("stderr missing actionable remedy pointer: %q", stderr.String())
+	if !strings.Contains(stderr.String(), "spacedock install") {
+		t.Fatalf("stderr missing actionable instruct message: %q", stderr.String())
 	}
+}
+
+// TestClaudeFrontDoorNonEmptyMissingManifestAutoInstalls: a host that reports a
+// non-empty installPath to a directory LACKING the plugin manifest is the
+// NoPluginFound verdict from a phantom installPath — the plugin genuinely is not
+// on disk, so the default auto-installs (a deliberate behavior change recorded in
+// ideation). --no-install preserves the refuse-and-instruct arm.
+func TestClaudeFrontDoorNonEmptyMissingManifestAutoInstalls(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-dir", ".claude-plugin", "plugin.json")
+
+	t.Run("default auto-installs", func(t *testing.T) {
+		fake := &fakeHost{manifest: missing} // non-empty path, but the file is absent
+		var stdout, stderr bytes.Buffer
+
+		code := runClaude(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+		if code != 0 {
+			t.Fatalf("exit = %d, want 0 when phantom manifest → auto-install + launch (stderr=%q)", code, stderr.String())
+		}
+		if len(fake.installCmds) == 0 {
+			t.Fatalf("install seam not invoked for a phantom (missing) manifest")
+		}
+		if fake.launchedArg == nil {
+			t.Fatalf("launch seam not invoked after auto-install for a phantom manifest")
+		}
+	})
+
+	t.Run("--no-install refuses", func(t *testing.T) {
+		fake := &fakeHost{manifest: missing}
+		var stdout, stderr bytes.Buffer
+
+		code := runClaude(context.Background(), []string{"--no-install"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+		if code == 0 {
+			t.Fatalf("exit = 0, want non-zero with --no-install and a phantom manifest")
+		}
+		if len(fake.installCmds) != 0 {
+			t.Fatalf("install seam invoked despite --no-install: %v", fake.installCmds)
+		}
+		if fake.launchedArg != nil {
+			t.Fatalf("launch seam invoked despite --no-install: %v", fake.launchedArg)
+		}
+	})
 }
 
 // TestGateRemedyNamesLiveInstallCommand: every gateHost remedy must point at a
@@ -244,8 +298,8 @@ func TestGateRemedyNamesLiveInstallCommand(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var stderr bytes.Buffer
-			if ok := gateHost(tc.fake, "claude", &stderr); ok {
-				t.Fatalf("gateHost = ok, want denied for %s", tc.name)
+			if v := gateHost(tc.fake, "claude", &stderr); v == contract.Compatible {
+				t.Fatalf("gateHost = Compatible, want denied for %s", tc.name)
 			}
 			remedy := stderr.String()
 			if !strings.Contains(remedy, "spacedock install") {

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -400,11 +400,46 @@ func TestCodexFrontDoorFailFastOnMismatch(t *testing.T) {
 	if code == 0 {
 		t.Fatalf("exit = 0, want non-zero on mismatch")
 	}
+	if len(fake.installCmds) != 0 {
+		t.Fatalf("install seam invoked on codex mismatch: %v", fake.installCmds)
+	}
 	if fake.launchedArg != nil {
 		t.Fatalf("launch seam invoked on mismatch: %v", fake.launchedArg)
 	}
 	if !strings.Contains(stderr.String(), "too-old-binary") {
 		t.Fatalf("stderr missing pinned remedy: %q", stderr.String())
+	}
+}
+
+func TestCodexFrontDoorNoPluginFailsFastWithoutInstalling(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-dir", ".codex-plugin", "plugin.json")
+	cases := []struct {
+		name     string
+		manifest string
+	}{
+		{name: "empty manifest", manifest: ""},
+		{name: "missing manifest", manifest: missing},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeHost{manifest: tc.manifest}
+			var stdout, stderr bytes.Buffer
+
+			code := runCodex(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+			if code == 0 {
+				t.Fatalf("exit = 0, want non-zero when codex has no plugin")
+			}
+			if len(fake.installCmds) != 0 {
+				t.Fatalf("install seam invoked on codex no-plugin path: %v", fake.installCmds)
+			}
+			if fake.launchedArg != nil {
+				t.Fatalf("launch seam invoked on codex no-plugin path: %v", fake.launchedArg)
+			}
+			if !strings.Contains(stderr.String(), "codex plugin") {
+				t.Fatalf("stderr missing codex no-plugin remedy: %q", stderr.String())
+			}
+		})
 	}
 }
 

--- a/internal/cli/safehouse_frontdoor_test.go
+++ b/internal/cli/safehouse_frontdoor_test.go
@@ -98,18 +98,25 @@ func TestClaudeNoSafehouseLaunchesPlain(t *testing.T) {
 	}
 }
 
-// AC-3: plugin-gate failure SHORT-CIRCUITS before any safehouse logic. Even with
-// .safehouse present AND safehouse binary absent, the missing-plugin gate fires
-// first: plugin remedy on stderr, NO safehouse hint, Launch never called.
+// AC-3: a refused plugin gate SHORT-CIRCUITS before any safehouse logic. With
+// .safehouse present AND safehouse binary absent, --no-install (which refuses the
+// no-plugin case rather than auto-installing) fails at the plugin gate first:
+// plugin remedy on stderr, NO safehouse hint, Launch never called. (Without
+// --no-install the no-plugin case auto-installs and proceeds, so the gate is no
+// longer a fail-fast there — the short-circuit-before-safehouse invariant lives
+// on the refuse path.)
 func TestClaudePluginGateShortCircuitsBeforeSafehouse(t *testing.T) {
 	dir := safehouseFixtureDir(t)
 	fake := &fakeHost{manifest: ""} // no plugin
 	var stdout, stderr bytes.Buffer
 
-	code := runClaude(context.Background(), nil, dir, fake, lookMissing, &stdout, &stderr)
+	code := runClaude(context.Background(), []string{"--no-install"}, dir, fake, lookMissing, &stdout, &stderr)
 
 	if code == 0 {
 		t.Fatalf("exit = 0, want non-zero when plugin gate fails")
+	}
+	if len(fake.installCmds) != 0 {
+		t.Fatalf("install invoked despite --no-install: %v", fake.installCmds)
 	}
 	if fake.launchedArg != nil {
 		t.Fatalf("Launch invoked despite plugin-gate failure: %v", fake.launchedArg)


### PR DESCRIPTION
## Summary
- makes `spacedock claude` treat missing Claude plugin as recoverable: install plugin, then launch
- adds `--no-install` to preserve the old refuse-and-instruct path
- keeps real contract mismatches fail-fast and keeps Codex compatible-or-fail with no auto-install semantics

## Validation
- post-rebase focused front-door run: 13 passed
- post-rebase `go test ./internal/cli -count=1`: 222 passed
- post-rebase `go test ./...`: 1123 passed in 16 packages
- post-rebase `go test ./... -race`: 1123 passed in 16 packages
- `spacedock status --workflow-dir docs/dev --validate`: VALID
- detached adversarial audit: Codex install-on-failure mutation failed 4/4 targeted tests; Claude no-plugin-without-install mutation failed 3 targeted assertions; Claude mismatch-install mutation failed `TestClaudeFrontDoorFailFastOnMismatch`

## Rebase note
Rebased onto `origin/next` after #310. A redundant comment-only status commit conflicted with #310 and was skipped; the rebased branch now contains only front-door changes in `internal/cli/frontdoor.go`, `internal/cli/frontdoor_test.go`, and `internal/cli/safehouse_frontdoor_test.go`.

Workflow state: `docs/dev/.spacedock-state/spacedock-claude-auto-install-plugin/index.md`.