### PR TITLE
Clarify Codex foreground wait interruption behavior

### DIFF
--- a/docs/dev/codex-idle-notification-probe.md
+++ b/docs/dev/codex-idle-notification-probe.md
@@ -23,8 +23,10 @@ must be treated as operator activity, not idle wake evidence.
 1. Dispatch a worker with the exact no-write prompt and record its handle.
 2. When there is no ready workflow work, call `wait_agent(handle)`.
 3. Record whether the call returns a timeout or a final status.
-4. If captain input or another non-stopping interruption occurs, retry the same
-   handle and record the next timeout or final status.
+4. If captain input, Esc, or another operator interruption returns control,
+   record it as a non-terminal foreground-wait return; do not classify it as a
+   worker final status, failure, closure, redispatch, or idle wake-up. Retry the
+   same handle and record the next timeout or final status.
 5. Classify a final status observed through this explicit wait path as
    `foreground_wait`.
 
@@ -54,7 +56,9 @@ must be treated as operator activity, not idle wake evidence.
 ## Interpretation Rules
 
 - `foreground_wait`: `wait_agent(handle)` returned the worker timeout or final
-  status path, and any interruption was followed by a retry of the same handle.
+  status path, and any operator interruption that returned control was recorded
+  as a non-terminal foreground-wait return followed by a retry of the same
+  handle.
 - `queued_flush`: no foreground wait was used, but later captain, tool, or
   shell-out activity caused a queued worker final-status notification to appear.
 - `autonomous_idle_wake`: no foreground wait and no later activity occurred, and

--- a/internal/contractlint/codex_foreground_wait_shape_test.go
+++ b/internal/contractlint/codex_foreground_wait_shape_test.go
@@ -1,0 +1,69 @@
+// ABOUTME: Quarantined structural checks for Codex foreground-wait operator cues.
+// ABOUTME: Keeps instruction-text reads out of behavior/integration tests.
+package contractlint
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCodexForegroundWaitSectionCarriesOperatorInterruptionShape(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "skills", "first-officer", "references", "codex-first-officer-runtime.md")
+	section := markdownSubsection(t, path, "### Foreground wait")
+
+	requireSectionContains(t, path, section, "`wait_agent(handle)`")
+	requireSectionContains(t, path, section, "Before calling `wait_agent`")
+	requireSectionContains(t, path, section, "Esc")
+	requireSectionContains(t, path, section, "operator interruption")
+	requireSectionContains(t, path, section, "returns control")
+	requireSectionContains(t, path, section, "same handle")
+
+	for _, terminalWord := range []string{"fail", "failed", "failure", "close", "redispatch"} {
+		requireSectionContains(t, path, section, terminalWord)
+	}
+}
+
+func TestCodexIdleProbeForegroundWaitInterruptionIsNonTerminal(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "docs", "dev", "codex-idle-notification-probe.md")
+	section := markdownSubsection(t, path, "## Foreground wait comparison")
+
+	requireSectionContains(t, path, section, "`wait_agent(handle)`")
+	requireSectionContains(t, path, section, "operator interruption")
+	requireSectionContains(t, path, section, "returns control")
+	requireSectionContains(t, path, section, "non-terminal")
+	requireSectionContains(t, path, section, "same handle")
+	requireSectionContains(t, path, section, "final status")
+}
+
+func markdownSubsection(t *testing.T, path, heading string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	text := string(data)
+	start := strings.Index(text, heading+"\n")
+	if start < 0 {
+		t.Fatalf("%s: missing heading %q", path, heading)
+	}
+	section := text[start+len(heading)+1:]
+	prefix := "#"
+	if strings.HasPrefix(heading, "### ") {
+		prefix = "### "
+	} else if strings.HasPrefix(heading, "## ") {
+		prefix = "## "
+	}
+	if end := strings.Index(section, "\n"+prefix); end >= 0 {
+		section = section[:end]
+	}
+	return section
+}
+
+func requireSectionContains(t *testing.T, path, section, want string) {
+	t.Helper()
+	if !strings.Contains(section, want) {
+		t.Errorf("%s section is missing %q", path, want)
+	}
+}

--- a/internal/contractlint/codex_foreground_wait_shape_test.go
+++ b/internal/contractlint/codex_foreground_wait_shape_test.go
@@ -3,6 +3,7 @@
 package contractlint
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,8 +21,62 @@ func TestCodexForegroundWaitSectionCarriesOperatorInterruptionShape(t *testing.T
 	requireSectionContains(t, path, section, "returns control")
 	requireSectionContains(t, path, section, "same handle")
 
-	for _, terminalWord := range []string{"fail", "failed", "failure", "close", "redispatch"} {
-		requireSectionContains(t, path, section, terminalWord)
+	requireForegroundWaitLifecycleClaim(t, path, section)
+}
+
+func TestForegroundWaitLifecycleClaimRejectsTerminalMutations(t *testing.T) {
+	tests := []struct {
+		name    string
+		section string
+	}{
+		{
+			name: "worker is terminalized",
+			section: "Before calling `wait_agent`, tell the captain that pressing Esc or otherwise " +
+				"causing an operator interruption only returns control; the worker is failed, " +
+				"closed, or redispatched, and this failure still retries the same handle.",
+		},
+		{
+			name: "interruption marks worker terminal",
+			section: "Before calling `wait_agent`, tell the captain that Esc or operator interruption " +
+				"returns control and marks the worker failed, closes it, or redispatches it before " +
+				"the next foreground wait retries the same handle after the failure.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := foregroundWaitLifecycleClaimError(tt.section); err == nil {
+				t.Fatal("expected a terminal-lifecycle mutation to fail")
+			}
+		})
+	}
+}
+
+func TestForegroundWaitLifecycleClaimAcceptsNegatedClaims(t *testing.T) {
+	tests := []struct {
+		name    string
+		section string
+	}{
+		{
+			name: "worker is not terminalized",
+			section: "Before calling `wait_agent`, tell the captain that pressing Esc or otherwise " +
+				"causing an operator interruption only returns control; the worker is not failed, " +
+				"closed, or redispatched, and the next foreground wait retries the same handle.",
+		},
+		{
+			name: "does not mark worker terminal",
+			section: "Before calling `wait_agent`, tell the captain that Esc or operator interruption " +
+				"returns control and does not mark the worker failed, close it, or redispatch it; " +
+				"the next foreground wait retries the same handle.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := foregroundWaitLifecycleClaimError(tt.section); err != nil {
+				t.Fatalf("expected negated lifecycle claim to pass: %v", err)
+			}
+		})
 	}
 }
 
@@ -66,4 +121,47 @@ func requireSectionContains(t *testing.T, path, section, want string) {
 	if !strings.Contains(section, want) {
 		t.Errorf("%s section is missing %q", path, want)
 	}
+}
+
+func requireForegroundWaitLifecycleClaim(t *testing.T, path, section string) {
+	t.Helper()
+	if err := foregroundWaitLifecycleClaimError(section); err != nil {
+		t.Errorf("%s section has unsafe foreground-wait lifecycle wording: %v", path, err)
+	}
+}
+
+func foregroundWaitLifecycleClaimError(section string) error {
+	normalized := strings.ToLower(strings.Join(strings.Fields(section), " "))
+	for _, phrase := range []string{
+		"worker is failed, closed, or redispatched",
+		"worker is failed, closed, or re-dispatched",
+		"marks the worker failed",
+		"marks the worker as failed",
+		"closes it",
+		"redispatches it",
+		"re-dispatches it",
+	} {
+		if strings.Contains(normalized, phrase) {
+			return fmt.Errorf("contains affirmative terminal lifecycle claim %q", phrase)
+		}
+	}
+
+	for _, phrase := range []string{
+		"worker is not failed, closed, or redispatched",
+		"worker is not failed, closed, or re-dispatched",
+		"does not mark the worker failed, close it, or redispatch it",
+		"does not mark the worker failed, close it, or re-dispatch it",
+		"does not mark the worker as failed, close it, or redispatch it",
+		"does not mark the worker as failed, close it, or re-dispatch it",
+		"does not fail, close, or redispatch the worker",
+		"does not fail, close, or re-dispatch the worker",
+		"does not fail, close, or redispatch it",
+		"does not fail, close, or re-dispatch it",
+	} {
+		if strings.Contains(normalized, phrase) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("missing explicit negated failed/closed/redispatched claim")
 }

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -66,8 +66,11 @@ The FO calls `wait_agent(handle)` as the next useful idle action after the
 scheduling priority above is exhausted. A wait_agent timeout return is normal and
 retryable with the same handle. It means no final-status mailbox update arrived
 before the deadline; it is not a failure, a zombie signal, or a teardown trigger.
-A captain message or shell-out during the wait is operator activity, not idle
-wake evidence.
+Before calling `wait_agent`, tell the captain that pressing Esc or otherwise
+causing an operator interruption only returns control; the worker is not failed,
+closed, or redispatched, and the next foreground wait retries the same handle. A
+captain message or shell-out during the wait is operator activity, not idle wake
+evidence.
 
 ### Queued notification flushed by later activity
 


### PR DESCRIPTION
## Summary
- add the Codex foreground-wait operator hint that Esc/interruption only returns control and does not fail, close, or redispatch the worker
- align the idle-notification probe recipe with the same non-terminal foreground-wait behavior
- add quarantined contractlint coverage, including a mutation guard against terminal-lifecycle wording

## Validation
- go test ./internal/contractlint -run 'TestCodex|TestForegroundWait' -count=1
- go test ./skills/integration -run 'TestCodexIdleNotification|TestCodexForegroundWaitEscapeHint' -count=1
- go test ./...
- go test ./... -race
