### PR TITLE
docs: reader-first README + install/release reconciliation for the 0.20.0 main flip

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,6 @@ spacedock doctor                                          # plugin compatibility
 spacedock --version                                       # print the installed version
 ```
 
-The task goes first. Anything after `--` forwards verbatim to the host, e.g.
-`spacedock claude "task" -- --model opus`.
-
 ## License
 
 Spacedock is released under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,77 +1,91 @@
 # Spacedock
 
-Hand an agent a multi-step job and it drifts, skips steps, or invents its own
-path. Hand it a workflow and it follows the workflow.
+**Spacedock is a multi-agent workflow orchestrator.** It lives inside your agent
+and treats the decision as a first-class citizen. Each stage ends at a gate with
+a bar for done. Some gates you decide, some you delegate, and either way the
+decision gets recorded with its evidence and its reason.
 
-Spacedock runs agent work through stages you define. Each stage gets a fresh
-context, an explicit gate, and a structured report. Reviewers are allowed to
-push back. State lives outside the agent, so work survives the context limit and
-picks up the next session where it left off.
+**Why?**
 
-**You want Spacedock if:**
+- You're the human, and agents from a dozen sessions ping you all day: a design
+  call, a one-line approval, "ship without full coverage?", none of it on a
+  schedule you can plan around. You stopped deciding the work and started just
+  answering the agent.
+- You're the agent, and you stall every few steps waiting on a human who isn't
+  watching, with no clear scope and no clear bar for done, so you ask and then
+  you wait.
+- It's one broken loop on both ends, because generation got cheap and
+  verification didn't. Every task still ends in a decision, and right now nobody
+  owns it. It lands on whoever's awake.
 
-- **You delegate repeatable work to agents** — the same pipeline run over many
-  inputs (code reviews, content drafts, outreach batches) — and you want each
-  run to finish, not stop halfway. Spacedock dispatches a fresh agent per stage,
-  with an approval gate where your judgment actually matters.
-- **You don't trust single-agent output** on its own. Spacedock review stages
-  push back instead of rubber-stamping, with a 3-strikes escalation so you only
-  see what the reviewer couldn't resolve.
-- **Your work spans days or weeks** — a blog draft, a launch plan, a multi-week
-  benchmark. Spacedock holds artifact state outside the agent, so the next
-  session resumes instead of restarts.
+**Start with what you already built.** Point Spacedock at a project you
+vibe-coded into spaghetti and run `/spacedock:survey`. It reads your own agent
+history and shows you three things: the workflow you've been running without
+naming it, how you've been calling work done, and the decisions still open and
+waiting on you.
 
 ## What's different
 
-- **Approval gates with structured evidence.** Every gate comes with a stage
-  report: findings, verdicts, artifacts, anomalies. You approve, redirect, or
-  bounce back without sifting through raw output.
-- **Adversarial review gates.** Review stages can be configured to push back
-  rather than rubber-stamp, targeting thin evidence and work that looks busy
-  without proving its claim.
-- **Plan in batches, decide as work flows back.** Queue many work items at once;
-  agents advance each through its stages while you handle approvals as they
-  surface.
-- **The workflow learns with you.** When a pattern emerges — a stage that never
-  fires, a gate that keeps bouncing the same issue — the first officer helps you
-  adjust the workflow.
-- **Isolation when needed.** Stages that touch shared state run in their own git
-  worktree; lightweight stages run inline.
-- **Work doesn't die at the context limit.** When an agent runs out of context,
-  a successor carries forward what's in flight.
+- **The maker doesn't judge itself.** Review stages are adversarial by default.
+  They push back on thin evidence and work that looks busy without proving its
+  claim. A 3-strikes escalation means you only see what the reviewer couldn't
+  settle.
+- **Every decision leaves a trail.** Each gate carries a stage report: findings,
+  verdicts, artifacts, anomalies. You decide on the evidence, not the
+  transcript. The record outlives the reviewer, so you can walk a bad result
+  back to the call that caused it.
+- **You set the bar, the agent works to it.** Each stage declares what done
+  means. The agent runs to that line on its own. You show up at the gate, not in
+  the loop.
+- **The bar sharpens as you go.** When a pattern shows up, a stage that never
+  fires or a gate that keeps bouncing the same issue, the first officer helps
+  you adjust the workflow. Good is discovered, not declared up front.
+- **Batch the work, decide as it flows back.** Queue many items at once. Agents
+  advance each through its stages. You handle gates as they surface instead of
+  one session at a time.
+- **Isolation when it matters.** Stages that touch shared state run in their own
+  git worktree. Lighter stages run inline.
+- **Work survives the context limit.** When an agent runs out of context, a
+  successor carries forward what's in flight.
 
 ## Install
 
 Spacedock is two pieces: the `spacedock` launcher and a host plugin (the
-first-officer and ensign agents) loaded by Claude Code or Codex.
-
-Install the launcher with Homebrew, then add the plugin:
+first-officer and ensign agents) loaded by your agent. Install the launcher with
+Homebrew:
 
 ```bash
 brew install spacedock-dev/homebrew-tap/spacedock
-spacedock install --host claude
 ```
 
-That installs the launcher, adds the Spacedock plugin to Claude Code, and runs a
-compatibility check. Now launch the first officer with a task:
+Then launch. The first command installs the plugin for you if it's missing, so a
+single line gets you a working session:
 
 ```bash
-spacedock claude -- "your task"
+spacedock claude "your task"
 ```
 
-See [`docs/install-journey.md`](docs/install-journey.md) for the full first-run
-walkthrough, the Codex path, and a from-source build for development.
+Using Codex or Pi instead? Swap the subcommand: `spacedock codex "your task"` or
+`spacedock pi "your task"`.
 
-> [agent-safehouse](https://agent-safehouse.dev) is an optional sandbox for
-> agent runs — install it separately. A `.safehouse` profile in the working
-> directory (or a `--safehouse` flag) wraps the launch through it.
+To keep things current, `brew upgrade spacedock` updates the launcher and
+`spacedock install` refreshes the plugin. Run `spacedock doctor` any time to
+check that the launcher and plugin are compatible. (A plain `claude plugin
+update` will not pick up new releases; the plugin ships through `spacedock`.)
+
+See [`docs/install-journey.md`](docs/install-journey.md) for the full first-run
+walkthrough, the Codex and Pi paths, and a from-source build for development.
+
+> [safehouse](https://agent-safehouse.dev) is an optional sandbox for agent
+> runs. Install it separately. A `.safehouse` profile in the working directory
+> (or a `--safehouse` flag) wraps the launch through it.
 
 ## Quick start
 
 Commission a workflow by describing what you want it to do:
 
 ```bash
-spacedock claude -- "/commission Email triage: fetch, categorize, and act on my
+spacedock claude "/commission Email triage: fetch, categorize, and act on my
 Gmail inbox. Entity: a batch of up to 50 emails. Stages: intake (triage
 in:inbox, categorize, propose an action per email as a table) -> approval
 (Captain reviews the proposal) -> execute (carry out approved actions). Walk me
@@ -85,7 +99,7 @@ before touching anything.
 For a development workflow:
 
 ```bash
-spacedock claude -- "/commission Dev task workflow: design -> plan -> implement
+spacedock claude "/commission Dev task workflow: design -> plan -> implement
 -> review, with the design and implementation plan inlined in each work item,
 implementation on isolated worktrees with strict TDD, design and review gated
 for approval."
@@ -93,51 +107,43 @@ for approval."
 
 ## How it works
 
-A workflow is a directory of markdown work item files plus a README that defines
-the stages, the schema, and the gates. There are three roles:
+A workflow is a directory of plain-text work item files plus a README that
+defines the stages, the schema, and the gates. Everything about a work item, the
+problem, the design notes, the bar for done, the stage reports, lives in the
+file itself, so the state survives a session and the next one picks up where you
+left off. There are three roles:
 
 | Role | Who |
 |------|-----|
-| **Captain** | You. You define the mission and make the calls at approval gates. |
+| **Captain** | You. You define the mission and make the calls at approval gates unless delegated. |
 | **First Officer** | The orchestrator agent that runs the workflow and reports to you at gates. |
 | **Ensign** | The worker agent that moves one item forward through one stage. |
 
 The first officer reads the workflow README, checks which items are ready to
 advance, and dispatches ensigns. Stages that need isolation run in their own git
 worktree; lightweight stages run inline. At a gate the first officer pauses and
-presents the ensign's stage report: approve, redo with feedback, or reject.
+presents the stage report for a decision: approve, redo with feedback, or
+reject. Some gates wait on you; others resolve through a delegated agent review.
 Rejected work bounces back to an earlier stage for revision, with a hard cap so
 you never get stuck in a loop.
 
-A work item carries everything in its body:
-
-```yaml
----
-id: 054
-title: Session debrief command
-status: done
----
-
-Problem statement, design notes, acceptance criteria, and stage reports all
-live in the body of this file as the work moves through its stages.
-```
-
-When you end a session, `/spacedock:debrief` captures what happened — commits,
-state changes, decisions, open issues — into a record the next session picks up.
-When a new Spacedock release is out, `/spacedock:refit` upgrades your workflow
-scaffolding while keeping local modifications.
+When you end a session, `/spacedock:debrief` captures what happened. Commits,
+state changes, decisions, open issues, all into a record the next session picks
+up. When a new Spacedock release is out, `/spacedock:refit` upgrades your
+workflow scaffolding while keeping local modifications.
 
 ## Usage
 
 ```bash
-spacedock claude [host-flags…] [--safehouse…] -- "task"   # launch the first officer in Claude Code
-spacedock codex  [host-flags…] [--safehouse…] -- "task"   # launch the first officer in Codex
+spacedock claude "task" [--safehouse…] [-- host-flags…]   # launch the first officer in Claude Code
+spacedock codex  "task" [--safehouse…] [-- host-flags…]   # launch the first officer in Codex
+spacedock pi     "task" [--safehouse…] [-- host-flags…]   # launch the first officer in Pi
 spacedock doctor                                          # plugin compatibility check
 spacedock --version                                       # print the installed version
 ```
 
-Flags before `--` pass through to the host; the bare text after `--` is the
-launch task.
+The task goes first. Anything after `--` forwards verbatim to the host, e.g.
+`spacedock claude "task" -- --model opus`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ waiting on you.
 - **The agent doesn't get to judge its own work.** Review stages are adversarial
   by default. They push back on thin evidence and work that looks busy without
   proving its claim.
-- **Every decision leaves a trail.** Each gate carries a stage report: findings,
-  verdicts, artifacts, anomalies. You decide on evidence, not the transcript.
+- **Every decision leaves a trail.** Each gate, the decision point at the end of
+  a stage, carries a stage report: findings, verdicts, artifacts, anomalies. You
+  decide on evidence, not the transcript.
   The record outlives the reviewer, so you can trace a bad result back to the
   call that caused it.
 - **The bar sharpens as you use it.** Each stage declares what good means, and

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spacedock
 
-**Spacedock is a workflow orchestrator where nothing ships without a decision.**
+**Spacedock is a multi-agent orchestrator where nothing ships without a decision.**
 It lives inside your agent. Each stage ends at a gate. The work arrives with its
 evidence, measured against a predefined bar for what good looks like. The human
 partner or a delegated agent says yes, sends it back, or escalates. Either way

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Spacedock
 
 **Spacedock is a multi-agent orchestrator where nothing ships without a decision.**
-It lives inside your existing agent: Claude Code or Codex. It breaks work into
-stages and surfaces the decisions each stage needs, batched for you. Each
+It lives within your existing harness: Claude Code, Codex, or Pi. It breaks work
+into stages and surfaces the decisions each stage needs, batched for you. Each
 decision arrives with evidence measured against a predefined bar for what good
 looks like. You approve, send back, or escalate. Or you delegate the call to an
 agent. Either way, the decision is recorded with its evidence and reason.
@@ -37,16 +37,17 @@ waiting on you.
   call that caused it.
 - **The bar sharpens as you use it.** Each stage declares what good means, and
   the agent works to that line on its own. When a standard turns out fuzzy in
-  practice, the agent works it out and proposes an update to the stage. The more
-  you use it, the sharper the bar.
+  practice, the agent proposes an edit to the stage's written criteria for your
+  approval. `/spacedock:debrief` captures each session's learnings so the next
+  one starts from them.
 - **Batch the work; decide as it flows back.** Queue many items at once. Agents
   advance each through its stages. You handle gates as they surface, not one
   session at a time.
 - **Isolation when it matters.** Stages that touch shared state run in their own
   git worktree. Lighter stages run inline.
-- **Native sandbox, zero wrapping.** Drop a `.safehouse` profile in the project
-  and Spacedock runs the agent sandboxed automatically. The `--safehouse` flags
-  tune it per launch.
+- **Native sandbox integration.** Drop a `.safehouse` profile in the project and
+  Spacedock runs the agent sandboxed. safehouse is an optional dependency,
+  installed separately. The `--safehouse` flags tune it per launch.
 - **Work survives the context limit.** When an agent runs out of context, a
   successor carries forward what's in flight.
 
@@ -88,24 +89,24 @@ walkthrough, the Codex and Pi paths, and a from-source build for development.
 Commission a workflow by describing what you want:
 
 ```bash
-spacedock claude "/commission Email triage: fetch, categorize, and act on my
-Gmail inbox. Entity: a batch of up to 50 emails. Stages: intake (triage
+spacedock claude "/spacedock:commission Dev task workflow: design -> plan ->
+implement -> review, with the design and implementation plan inlined in each work
+item, implementation on isolated worktrees with strict TDD, design and review
+gated for approval."
+```
+
+The first officer commissions the workflow and opens a worktree for the
+implementation stage. It pauses at the design and review gates for your call.
+
+The same shape drives non-dev work. This example triages a Gmail inbox. It
+requires a Gmail integration set up before you run it:
+
+```bash
+spacedock claude "/spacedock:commission Email triage: fetch, categorize, and act
+on my Gmail inbox. Entity: a batch of up to 50 emails. Stages: intake (triage
 in:inbox, categorize, propose an action per email as a table) -> approval
 (Captain reviews the proposal) -> execute (carry out approved actions). Walk me
 through Gmail setup if needed."
-```
-
-The first officer commissions the workflow and dispatches an ensign to gather
-your inbox. It then pauses with a categorized proposal and waits for your
-approval before touching anything.
-
-For a development workflow:
-
-```bash
-spacedock claude "/commission Dev task workflow: design -> plan -> implement
--> review, with the design and implementation plan inlined in each work item,
-implementation on isolated worktrees with strict TDD, design and review gated
-for approval."
 ```
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Spacedock v1
 
-Spacedock v1 is the Go launcher and compatibility bridge for the next Spacedock command surface.
+Spacedock runs multi-step agent work through plain-text workflows. You define
+the stages, Spacedock dispatches the right agent for each stage, and the work
+record lives on disk so a long task can survive context limits and resume later.
+
+This repository contains the Go launcher and compatibility bridge for the next
+Spacedock command surface.
 
 The first implementation target is conservative:
 
@@ -16,7 +21,8 @@ The development workflow for this repo lives in `docs/dev/README.md`. Runtime en
 Two lanes — see [`docs/install-journey.md`](docs/install-journey.md) for the
 step-by-step journey with the observable output at each step.
 
-**Released lane (brew)** — available after the first tagged release:
+**Stable lane (`main`)** — starting with `v0.20.0`, tagged releases, Homebrew
+artifacts, and marketplace plugin installs come from `main`:
 
 ```bash
 brew tap spacedock-dev/homebrew-tap
@@ -25,14 +31,15 @@ spacedock install --host claude
 ```
 
 The no-tap one-liner `brew install spacedock-dev/homebrew-tap/spacedock` is
-equivalent.
+equivalent. In the stable lane, `spacedock install` resolves the released
+marketplace plugin from `spacedock-dev/spacedock` on `main`, not from `next`.
 
-**Dev lane (`--plugin-dir`)** — source build from `next`, the primary dev
-workflow (`next` has no release artifact — the pipeline triggers on `v*` tags
-only, so `@next` is a source build, not brew):
+**Dev-only lane (`next` + `--plugin-dir`)** — source build from `next`, the
+primary development workflow. `next` has no Homebrew artifact, and `@next` is a
+source-build or dev-publish path, not the stable install path:
 
 ```bash
-git clone https://github.com/spacedock-dev/spacedock
+git clone --branch next https://github.com/spacedock-dev/spacedock
 cd spacedock
 go build -o spacedock ./cmd/spacedock
 ./spacedock claude --plugin-dir "$PWD" -- "your task"
@@ -48,9 +55,10 @@ plugin is out of date (predates this binary's contract), reinstall it:
 spacedock install --host claude
 ```
 
-`spacedock install` reinstalls from `spacedock-dev/spacedock@next`, replacing a
-stale already-installed plugin (it uninstalls before installing, since a plain
-`plugin install` no-ops when the plugin is already present).
+On the stable lane, `spacedock install` refreshes the released plugin from
+`main`. The old-plugin/no-binary and binary/plugin-skew journeys still need
+their release-gate confirmation before the `0.20.0` flip; this docs update does
+not claim those upgrade paths are automatic yet.
 
 [safehouse](https://agent-safehouse.dev) is a separate runtime dependency for
 sandboxed launches — not installed by either lane. A `.safehouse` profile in the

--- a/README.md
+++ b/README.md
@@ -46,20 +46,18 @@ waiting on you.
   session at a time.
 - **Isolation when it matters.** Stages that touch shared state run in their own
   git worktree. Lighter stages run inline.
-- **Native sandbox integration.** Drop a `.safehouse` profile in the project and
-  Spacedock runs the agent sandboxed. safehouse is an optional dependency,
-  installed separately. The `--safehouse` flags tune it per launch.
+- **Sandboxing built in.** Drop a profile in the project and Spacedock runs the
+  agent sandboxed.
 - **Work survives the context limit.** When an agent runs out of context, a
   successor carries forward what's in flight.
 
 ## Install
 
-Spacedock plugs into a coding agent harness you already run: Claude Code, Codex,
-or Pi. Install one of those first.
+Prerequisite: a coding agent harness. Claude Code, Codex, and Pi are tier-1
+supported; through skill systems it also runs in most other harnesses, including
+Hermes-class agents.
 
-Spacedock itself is two pieces: the `spacedock` launcher and a host plugin (the
-first-officer and ensign agents) that the harness loads. Install the launcher
-with Homebrew:
+Install with Homebrew:
 
 ```bash
 brew tap spacedock-dev/homebrew-tap
@@ -76,17 +74,8 @@ spacedock claude "/spacedock:survey"
 Using Codex or Pi instead? Swap the subcommand: `spacedock codex "/spacedock:survey"`
 or `spacedock pi "/spacedock:survey"`.
 
-To stay current: `brew upgrade spacedock` updates the launcher; `spacedock
-install` refreshes the plugin. Run `spacedock doctor` any time to confirm the
-launcher and plugin are compatible. A plain `claude plugin update` will not pick
-up new releases. The plugin ships through `spacedock`.
-
 See [`docs/install-journey.md`](docs/install-journey.md) for the full first-run
 walkthrough, the Codex and Pi paths, and a from-source build for development.
-
-> [safehouse](https://agent-safehouse.dev) is an optional sandbox for agent
-> runs. Install it separately. A `.safehouse` profile in the working directory
-> (or a `--safehouse` flag) wraps the launch through it.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Spacedock
 
 **Spacedock is a multi-agent orchestrator where nothing ships without a decision.**
-It lives inside your existing agent, like Claude Code or Codex. Each stage ends
-at a gate. The work arrives with its evidence, measured against a predefined bar
-for what good looks like. The human partner or a delegated agent says yes, sends
-it back, or escalates. Either way the decision gets recorded, with its evidence
-and its reason.
+It lives inside your existing agent: Claude Code or Codex. It breaks work into
+stages and surfaces the decisions each stage needs, batched for you. Each
+decision arrives with evidence measured against a predefined bar for what good
+looks like. You approve, send back, or escalate. Or you delegate the call to an
+agent. Either way, the decision is recorded with its evidence and reason.
 
 **Why?**
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Spacedock
 
-**Spacedock is a multi-agent workflow orchestrator.** It lives inside your agent
-and treats the decision as a first-class citizen. Each stage ends at a gate with
-a bar for done. Some gates you decide, some you delegate, and either way the
-decision gets recorded with its evidence and its reason.
+**Spacedock is a workflow orchestrator where nothing ships without a decision.**
+It lives inside your agent. Each stage ends at a gate. The work arrives with its
+evidence, measured against a predefined bar for what good looks like. The human
+partner or a delegated agent says yes, sends it back, or escalates. Either way
+the decision gets recorded, with its evidence and its reason.
 
 **Why?**
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Spacedock
 
 **Spacedock is a multi-agent orchestrator where nothing ships without a decision.**
-It lives inside your agent. Each stage ends at a gate. The work arrives with its
-evidence, measured against a predefined bar for what good looks like. The human
-partner or a delegated agent says yes, sends it back, or escalates. Either way
-the decision gets recorded, with its evidence and its reason.
+It lives inside your existing agent, like Claude Code or Codex. Each stage ends
+at a gate. The work arrives with its evidence, measured against a predefined bar
+for what good looks like. The human partner or a delegated agent says yes, sends
+it back, or escalates. Either way the decision gets recorded, with its evidence
+and its reason.
 
 **Why?**
 
@@ -15,9 +16,9 @@ the decision gets recorded, with its evidence and its reason.
 - You're the agent, and you stall every few steps waiting on a human who isn't
   watching, with no clear scope and no clear bar for done, so you ask and then
   you wait.
-- It's one broken loop on both ends, because generation got cheap and
-  verification didn't. Every task still ends in a decision, and right now nobody
-  owns it. It lands on whoever's awake.
+- Both of you are stuck on the same root cause. Generation got cheap; judgment
+  didn't. Every task still ends in a decision, and no one owns it, so it falls on
+  whoever's around.
 
 **Start with what you already built.** Point Spacedock at a project you
 vibe-coded into spaghetti and run `/spacedock:survey`. It reads your own agent
@@ -27,25 +28,25 @@ waiting on you.
 
 ## What's different
 
-- **The maker doesn't judge itself.** Review stages are adversarial by default.
-  They push back on thin evidence and work that looks busy without proving its
-  claim. A 3-strikes escalation means you only see what the reviewer couldn't
-  settle.
+- **The agent doesn't get to judge its own work.** Review stages are adversarial
+  by default. They push back on thin evidence and work that looks busy without
+  proving its claim.
 - **Every decision leaves a trail.** Each gate carries a stage report: findings,
   verdicts, artifacts, anomalies. You decide on evidence, not the transcript.
   The record outlives the reviewer, so you can trace a bad result back to the
   call that caused it.
-- **You set the bar; the agent works to it.** Each stage declares what done
-  means. The agent runs to that line on its own. You show up at the gate, not in
-  the loop.
-- **The bar sharpens as you go.** When a stage never fires, or a gate keeps
-  bouncing the same issue, the first officer helps you adjust the workflow. Good
-  is discovered, not declared up front.
+- **The bar sharpens as you use it.** Each stage declares what good means, and
+  the agent works to that line on its own. When a standard turns out fuzzy in
+  practice, the agent works it out and proposes an update to the stage. The more
+  you use it, the sharper the bar.
 - **Batch the work; decide as it flows back.** Queue many items at once. Agents
   advance each through its stages. You handle gates as they surface, not one
   session at a time.
 - **Isolation when it matters.** Stages that touch shared state run in their own
   git worktree. Lighter stages run inline.
+- **Native sandbox, zero wrapping.** Drop a `.safehouse` profile in the project
+  and Spacedock runs the agent sandboxed automatically. The `--safehouse` flags
+  tune it per launch.
 - **Work survives the context limit.** When an agent runs out of context, a
   successor carries forward what's in flight.
 
@@ -56,18 +57,19 @@ first-officer and ensign agents) loaded by Claude Code, Codex, or Pi. Install th
 launcher with Homebrew:
 
 ```bash
-brew install spacedock-dev/homebrew-tap/spacedock
+brew tap spacedock-dev/homebrew-tap
+brew install spacedock
 ```
 
-Then launch. The first command installs the plugin if it's missing, so a single
-line gets you a working session:
+Then launch. The first launch sets up the plugin for you, so a single line gets
+you a working session. Point it at a project you already have and let it survey:
 
 ```bash
-spacedock claude "your task"
+spacedock claude "/spacedock:survey"
 ```
 
-Using Codex or Pi instead? Swap the subcommand: `spacedock codex "your task"` or
-`spacedock pi "your task"`.
+Using Codex or Pi instead? Swap the subcommand: `spacedock codex "/spacedock:survey"`
+or `spacedock pi "/spacedock:survey"`.
 
 To stay current: `brew upgrade spacedock` updates the launcher; `spacedock
 install` refreshes the plugin. Run `spacedock doctor` any time to confirm the

--- a/README.md
+++ b/README.md
@@ -1,86 +1,144 @@
-# Spacedock v1
+# Spacedock
 
-Spacedock runs multi-step agent work through plain-text workflows. You define
-the stages, Spacedock dispatches the right agent for each stage, and the work
-record lives on disk so a long task can survive context limits and resume later.
+Hand an agent a multi-step job and it drifts, skips steps, or invents its own
+path. Hand it a workflow and it follows the workflow.
 
-This repository contains the Go launcher and compatibility bridge for the next
-Spacedock command surface.
+Spacedock runs agent work through stages you define. Each stage gets a fresh
+context, an explicit gate, and a structured report. Reviewers are allowed to
+push back. State lives outside the agent, so work survives the context limit and
+picks up the next session where it left off.
 
-The first implementation target is conservative:
+**You want Spacedock if:**
 
-- provide a `spacedock` binary entry point;
-- preserve current `status` behavior through a vendored compatibility path;
-- prove per-workflow `.spacedock-state` state checkouts with the README symlink model;
-- then replace the symlink dependency with native split-root status handling.
+- **You delegate repeatable work to agents** — the same pipeline run over many
+  inputs (code reviews, content drafts, outreach batches) — and you want each
+  run to finish, not stop halfway. Spacedock dispatches a fresh agent per stage,
+  with an approval gate where your judgment actually matters.
+- **You don't trust single-agent output** on its own. Spacedock review stages
+  push back instead of rubber-stamping, with a 3-strikes escalation so you only
+  see what the reviewer couldn't resolve.
+- **Your work spans days or weeks** — a blog draft, a launch plan, a multi-week
+  benchmark. Spacedock holds artifact state outside the agent, so the next
+  session resumes instead of restarts.
 
-The development workflow for this repo lives in `docs/dev/README.md`. Runtime entities for that workflow live in `docs/dev/.spacedock-state/`, which is intended to be a separate git checkout or nested state repo.
+## What's different
+
+- **Approval gates with structured evidence.** Every gate comes with a stage
+  report: findings, verdicts, artifacts, anomalies. You approve, redirect, or
+  bounce back without sifting through raw output.
+- **Adversarial review gates.** Review stages can be configured to push back
+  rather than rubber-stamp, targeting thin evidence and work that looks busy
+  without proving its claim.
+- **Plan in batches, decide as work flows back.** Queue many work items at once;
+  agents advance each through its stages while you handle approvals as they
+  surface.
+- **The workflow learns with you.** When a pattern emerges — a stage that never
+  fires, a gate that keeps bouncing the same issue — the first officer helps you
+  adjust the workflow.
+- **Isolation when needed.** Stages that touch shared state run in their own git
+  worktree; lightweight stages run inline.
+- **Work doesn't die at the context limit.** When an agent runs out of context,
+  a successor carries forward what's in flight.
 
 ## Install
 
-Two lanes — see [`docs/install-journey.md`](docs/install-journey.md) for the
-step-by-step journey with the observable output at each step.
+Spacedock is two pieces: the `spacedock` launcher and a host plugin (the
+first-officer and ensign agents) loaded by Claude Code or Codex.
 
-**Stable lane (`main`)** — starting with `v0.20.0`, tagged releases, Homebrew
-artifacts, and marketplace plugin installs come from `main`:
+Install the launcher with Homebrew, then add the plugin:
 
 ```bash
-brew tap spacedock-dev/homebrew-tap
-brew install spacedock
+brew install spacedock-dev/homebrew-tap/spacedock
 spacedock install --host claude
 ```
 
-The no-tap one-liner `brew install spacedock-dev/homebrew-tap/spacedock` is
-equivalent. In the stable lane, `spacedock install` resolves the released
-marketplace plugin from `spacedock-dev/spacedock` on `main`, not from `next`.
-
-**Dev-only lane (`next` + `--plugin-dir`)** — source build from `next`, the
-primary development workflow. `next` has no Homebrew artifact, and `@next` is a
-source-build or dev-publish path, not the stable install path:
+That installs the launcher, adds the Spacedock plugin to Claude Code, and runs a
+compatibility check. Now launch the first officer with a task:
 
 ```bash
-git clone --branch next https://github.com/spacedock-dev/spacedock
-cd spacedock
-go build -o spacedock ./cmd/spacedock
-./spacedock claude --plugin-dir "$PWD" -- "your task"
+spacedock claude -- "your task"
 ```
 
-`--plugin-dir` loads the repo's own vendored `spacedock:first-officer` /
-`spacedock:ensign` skills and relaxes the contract gate.
+See [`docs/install-journey.md`](docs/install-journey.md) for the full first-run
+walkthrough, the Codex path, and a from-source build for development.
 
-**Upgrade a stale plugin** — when `spacedock doctor` reports your installed
-plugin is out of date (predates this binary's contract), reinstall it:
+> [agent-safehouse](https://agent-safehouse.dev) is an optional sandbox for
+> agent runs — install it separately. A `.safehouse` profile in the working
+> directory (or a `--safehouse` flag) wraps the launch through it.
+
+## Quick start
+
+Commission a workflow by describing what you want it to do:
 
 ```bash
-spacedock install --host claude
+spacedock claude -- "/commission Email triage: fetch, categorize, and act on my
+Gmail inbox. Entity: a batch of up to 50 emails. Stages: intake (triage
+in:inbox, categorize, propose an action per email as a table) -> approval
+(Captain reviews the proposal) -> execute (carry out approved actions). Walk me
+through Gmail setup if needed."
 ```
 
-On the stable lane, `spacedock install` refreshes the released plugin from
-`main`. The old-plugin/no-binary and binary/plugin-skew journeys still need
-their release-gate confirmation before the `0.20.0` flip; this docs update does
-not claim those upgrade paths are automatic yet.
+The first officer commissions the workflow, dispatches an ensign to gather your
+inbox, then pauses with a categorized proposal and waits for your approval
+before touching anything.
 
-[safehouse](https://agent-safehouse.dev) is a separate runtime dependency for
-sandboxed launches — not installed by either lane. A `.safehouse` profile in the
-working directory (or the `--safehouse` / `--safehouse-<key>=…` flags) wraps the
-launch through it.
+For a development workflow:
+
+```bash
+spacedock claude -- "/commission Dev task workflow: design -> plan -> implement
+-> review, with the design and implementation plan inlined in each work item,
+implementation on isolated worktrees with strict TDD, design and review gated
+for approval."
+```
+
+## How it works
+
+A workflow is a directory of markdown work item files plus a README that defines
+the stages, the schema, and the gates. There are three roles:
+
+| Role | Who |
+|------|-----|
+| **Captain** | You. You define the mission and make the calls at approval gates. |
+| **First Officer** | The orchestrator agent that runs the workflow and reports to you at gates. |
+| **Ensign** | The worker agent that moves one item forward through one stage. |
+
+The first officer reads the workflow README, checks which items are ready to
+advance, and dispatches ensigns. Stages that need isolation run in their own git
+worktree; lightweight stages run inline. At a gate the first officer pauses and
+presents the ensign's stage report: approve, redo with feedback, or reject.
+Rejected work bounces back to an earlier stage for revision, with a hard cap so
+you never get stuck in a loop.
+
+A work item carries everything in its body:
+
+```yaml
+---
+id: 054
+title: Session debrief command
+status: done
+---
+
+Problem statement, design notes, acceptance criteria, and stage reports all
+live in the body of this file as the work moves through its stages.
+```
+
+When you end a session, `/spacedock:debrief` captures what happened — commits,
+state changes, decisions, open issues — into a record the next session picks up.
+When a new Spacedock release is out, `/spacedock:refit` upgrades your workflow
+scaffolding while keeping local modifications.
 
 ## Usage
 
 ```bash
-spacedock claude [host-flags…] [--safehouse…] -- "task"   # launch claude --agent spacedock:first-officer
-spacedock codex  [host-flags…] [--safehouse…] -- "task"   # launch codex with the spacedock:first-officer skill
-spacedock --version                                       # spacedock <version> (contract 1)
-spacedock doctor                                          # contract compatibility verdict
+spacedock claude [host-flags…] [--safehouse…] -- "task"   # launch the first officer in Claude Code
+spacedock codex  [host-flags…] [--safehouse…] -- "task"   # launch the first officer in Codex
+spacedock doctor                                          # plugin compatibility check
+spacedock --version                                       # print the installed version
 ```
 
 Flags before `--` pass through to the host; the bare text after `--` is the
-launch task. `--skip-contract-check` bypasses the contract gate (bootstrap
-only); a `--plugin-dir` launch relaxes it without the flag.
+launch task.
 
-## Commands
+## License
 
-```bash
-go test ./...
-go run ./cmd/spacedock --help
-```
+Spacedock is released under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ agent. Either way, the decision is recorded with its evidence and reason.
 - You're the agent, and you stall every few steps waiting on a human who isn't
   watching, with no clear scope and no clear bar for done, so you ask and then
   you wait.
-- Both of you are stuck on the same root cause. Generation got cheap; judgment
-  didn't. Every task still ends in a decision, and no one owns it, so it falls on
+- Generation got cheap. Your attention and judgment are now the bottleneck.
+  Every task still ends in a decision, and no one owns it, so it falls on
   whoever's around.
 
 **Start with what you already built.** Point Spacedock at a project you

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ waiting on you.
 
 ## What's different
 
-- **The agent doesn't get to judge its own work.** Review stages are adversarial
-  by default. They push back on thin evidence and work that looks busy without
-  proving its claim.
+- **The agent doesn't get to judge its own work.** Review runs as a separate
+  stage with fresh context, no access to the maker's reasoning. It pushes back on
+  thin evidence and work that looks busy without proving its claim.
 - **Every decision leaves a trail.** Each gate, the decision point at the end of
   a stage, carries a stage report: findings, verdicts, artifacts, anomalies. You
   decide on evidence, not the transcript.
@@ -54,9 +54,12 @@ waiting on you.
 
 ## Install
 
-Spacedock is two pieces: the `spacedock` launcher and a host plugin (the
-first-officer and ensign agents) loaded by Claude Code, Codex, or Pi. Install the
-launcher with Homebrew:
+Spacedock plugs into a coding agent harness you already run: Claude Code, Codex,
+or Pi. Install one of those first.
+
+Spacedock itself is two pieces: the `spacedock` launcher and a host plugin (the
+first-officer and ensign agents) that the harness loads. Install the launcher
+with Homebrew:
 
 ```bash
 brew tap spacedock-dev/homebrew-tap

--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ waiting on you.
   claim. A 3-strikes escalation means you only see what the reviewer couldn't
   settle.
 - **Every decision leaves a trail.** Each gate carries a stage report: findings,
-  verdicts, artifacts, anomalies. You decide on the evidence, not the
-  transcript. The record outlives the reviewer, so you can walk a bad result
-  back to the call that caused it.
-- **You set the bar, the agent works to it.** Each stage declares what done
+  verdicts, artifacts, anomalies. You decide on evidence, not the transcript.
+  The record outlives the reviewer, so you can trace a bad result back to the
+  call that caused it.
+- **You set the bar; the agent works to it.** Each stage declares what done
   means. The agent runs to that line on its own. You show up at the gate, not in
   the loop.
-- **The bar sharpens as you go.** When a pattern shows up, a stage that never
-  fires or a gate that keeps bouncing the same issue, the first officer helps
-  you adjust the workflow. Good is discovered, not declared up front.
-- **Batch the work, decide as it flows back.** Queue many items at once. Agents
-  advance each through its stages. You handle gates as they surface instead of
-  one session at a time.
+- **The bar sharpens as you go.** When a stage never fires, or a gate keeps
+  bouncing the same issue, the first officer helps you adjust the workflow. Good
+  is discovered, not declared up front.
+- **Batch the work; decide as it flows back.** Queue many items at once. Agents
+  advance each through its stages. You handle gates as they surface, not one
+  session at a time.
 - **Isolation when it matters.** Stages that touch shared state run in their own
   git worktree. Lighter stages run inline.
 - **Work survives the context limit.** When an agent runs out of context, a
@@ -52,15 +52,15 @@ waiting on you.
 ## Install
 
 Spacedock is two pieces: the `spacedock` launcher and a host plugin (the
-first-officer and ensign agents) loaded by your agent. Install the launcher with
-Homebrew:
+first-officer and ensign agents) loaded by Claude Code, Codex, or Pi. Install the
+launcher with Homebrew:
 
 ```bash
 brew install spacedock-dev/homebrew-tap/spacedock
 ```
 
-Then launch. The first command installs the plugin for you if it's missing, so a
-single line gets you a working session:
+Then launch. The first command installs the plugin if it's missing, so a single
+line gets you a working session:
 
 ```bash
 spacedock claude "your task"
@@ -69,10 +69,10 @@ spacedock claude "your task"
 Using Codex or Pi instead? Swap the subcommand: `spacedock codex "your task"` or
 `spacedock pi "your task"`.
 
-To keep things current, `brew upgrade spacedock` updates the launcher and
-`spacedock install` refreshes the plugin. Run `spacedock doctor` any time to
-check that the launcher and plugin are compatible. (A plain `claude plugin
-update` will not pick up new releases; the plugin ships through `spacedock`.)
+To stay current: `brew upgrade spacedock` updates the launcher; `spacedock
+install` refreshes the plugin. Run `spacedock doctor` any time to confirm the
+launcher and plugin are compatible. A plain `claude plugin update` will not pick
+up new releases. The plugin ships through `spacedock`.
 
 See [`docs/install-journey.md`](docs/install-journey.md) for the full first-run
 walkthrough, the Codex and Pi paths, and a from-source build for development.
@@ -83,7 +83,7 @@ walkthrough, the Codex and Pi paths, and a from-source build for development.
 
 ## Quick start
 
-Commission a workflow by describing what you want it to do:
+Commission a workflow by describing what you want:
 
 ```bash
 spacedock claude "/commission Email triage: fetch, categorize, and act on my
@@ -93,9 +93,9 @@ in:inbox, categorize, propose an action per email as a table) -> approval
 through Gmail setup if needed."
 ```
 
-The first officer commissions the workflow, dispatches an ensign to gather your
-inbox, then pauses with a categorized proposal and waits for your approval
-before touching anything.
+The first officer commissions the workflow and dispatches an ensign to gather
+your inbox. It then pauses with a categorized proposal and waits for your
+approval before touching anything.
 
 For a development workflow:
 
@@ -109,10 +109,10 @@ for approval."
 ## How it works
 
 A workflow is a directory of plain-text work item files plus a README that
-defines the stages, the schema, and the gates. Everything about a work item, the
-problem, the design notes, the bar for done, the stage reports, lives in the
-file itself, so the state survives a session and the next one picks up where you
-left off. There are three roles:
+defines the stages, the schema, and the gates. Everything about a work item lives
+in the file itself: the problem, the design notes, the bar for done, the stage
+reports. State survives a session; the next one picks up where you left off.
+Three roles:
 
 | Role | Who |
 |------|-----|
@@ -122,16 +122,16 @@ left off. There are three roles:
 
 The first officer reads the workflow README, checks which items are ready to
 advance, and dispatches ensigns. Stages that need isolation run in their own git
-worktree; lightweight stages run inline. At a gate the first officer pauses and
+worktree; lightweight stages run inline. At a gate, the first officer pauses and
 presents the stage report for a decision: approve, redo with feedback, or
 reject. Some gates wait on you; others resolve through a delegated agent review.
-Rejected work bounces back to an earlier stage for revision, with a hard cap so
-you never get stuck in a loop.
+Rejected work bounces back to an earlier stage for revision. A hard cap prevents
+loops.
 
-When you end a session, `/spacedock:debrief` captures what happened. Commits,
-state changes, decisions, open issues, all into a record the next session picks
-up. When a new Spacedock release is out, `/spacedock:refit` upgrades your
-workflow scaffolding while keeping local modifications.
+When you end a session, `/spacedock:debrief` captures what happened: commits,
+state changes, decisions, open issues, all in a record the next session picks up.
+When a new Spacedock release is out, `/spacedock:refit` upgrades your workflow
+scaffolding while keeping local modifications.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ waiting on you.
   session at a time.
 - **Isolation when it matters.** Stages that touch shared state run in their own
   git worktree. Lighter stages run inline.
-- **Sandboxing built in.** Drop a profile in the project and Spacedock runs the
-  agent sandboxed.
+- **Native sandbox integration.** Drop a profile in the project and Spacedock
+  runs the agent sandboxed.
 - **Work survives the context limit.** When an agent runs out of context, a
   successor carries forward what's in flight.
 

--- a/docs/install-journey.md
+++ b/docs/install-journey.md
@@ -6,12 +6,12 @@ result.
 
 Spacedock is two pieces that install separately:
 
-1. **The `spacedock` launcher** — the command you run to start a session.
-2. **The host plugin** — the first-officer and ensign agents, loaded by Claude
-   Code or Codex.
+1. **The `spacedock` launcher.** The command you run to start a session.
+2. **The host plugin.** The first-officer and ensign agents, loaded by your
+   agent (Claude Code, Codex, or Pi).
 
-The recommended setup installs the launcher with Homebrew and adds the plugin
-with one command. A from-source build is available for development.
+The recommended setup installs the launcher with Homebrew, and the first launch
+adds the plugin for you. A from-source build is available for development.
 
 ## Install with Homebrew (recommended)
 
@@ -41,33 +41,34 @@ with one command. A from-source build is available for development.
 4. **Launch.**
 
    ```bash
-   spacedock claude -- "your task"
+   spacedock claude "your task"
    ```
 
-   Starts the first officer in Claude Code with your task. When a `.safehouse`
-   profile is present in the working directory the launch is wrapped through the
-   sandbox.
+   Starts the first officer in Claude Code with your task. If the plugin isn't
+   installed yet, this first launch installs it for you, then proceeds. When a
+   `.safehouse` profile is present in the working directory the launch is wrapped
+   through the sandbox.
 
-## Use Codex instead
+## Use Codex or Pi instead
 
-Codex support is available but experimental; Claude Code is the primary surface.
+Codex and Pi are supported but experimental. Claude Code is the primary surface.
 
 1. **Install the launcher** (same Homebrew step as above).
 
-2. **Add the plugin.**
+2. **Add the plugin** for your host.
 
    ```bash
-   spacedock install --host codex
+   spacedock install --host codex      # or: --host pi
    ```
 
    Codex installs plugins from your shell rather than programmatically, so this
-   prints the two `codex plugin` commands to run. Run them, then use the
+   prints the `codex plugin` commands to run. Run them, then use the
    first-officer skill in your Codex session.
 
-3. **Launch.**
+3. **Launch** with the matching subcommand.
 
    ```bash
-   spacedock codex -- "your task"
+   spacedock codex "your task"         # or: spacedock pi "your task"
    ```
 
 ## Build from source (for development)
@@ -95,13 +96,14 @@ local changes take effect immediately.
 3. **Launch with the local plugin.**
 
    ```bash
-   ./spacedock claude --plugin-dir "$PWD" -- "your task"
+   ./spacedock claude "your task" -- --plugin-dir "$PWD"
    ```
 
-   `--plugin-dir` loads the first-officer and ensign agents from your checkout
-   instead of the installed plugin, so edits to the repo are live.
+   `--plugin-dir` is a host flag, so it rides after `--`. It loads the
+   first-officer and ensign agents from your checkout instead of the installed
+   plugin, so edits to the repo are live.
 
-The `next` branch is the development channel — it has no Homebrew release, so
+The `next` branch is the development channel. It has no Homebrew release, so
 there is no `brew install` for it. Use the Homebrew path above for a stable
 install.
 
@@ -119,11 +121,11 @@ first, then run `spacedock install --host claude`.
 
 ## Command grammar
 
-The front door is `spacedock claude [host-flags…] [--safehouse…] -- "task"`
-(and the same shape for `spacedock codex`):
+The front door is `spacedock claude "task" [--safehouse…] [-- host-flags…]`
+(and the same shape for `spacedock codex` and `spacedock pi`):
 
-- Flags before `--` pass through to the host (`claude` / `codex`), including
-  `--plugin-dir`, `--resume`, `--model`, and the like.
-- The bare text after `--` is the launch task, handed to the first officer.
+- The task comes first. It's handed to the first officer as the launch prompt.
+- Anything after `--` forwards verbatim to the host (`claude` / `codex` / `pi`),
+  including `--plugin-dir`, `--resume`, `--model`, and the like.
 - `--safehouse` forces the launch through the sandbox; a `.safehouse` profile in
   the working directory does the same automatically.

--- a/docs/install-journey.md
+++ b/docs/install-journey.md
@@ -10,15 +10,16 @@ Spacedock is two pieces that install separately:
 2. **The host plugin.** The first-officer and ensign agents, loaded by your
    agent (Claude Code, Codex, or Pi).
 
-The recommended setup installs the launcher with Homebrew, and the first launch
-adds the plugin for you. A from-source build is available for development.
+The recommended setup installs the launcher with Homebrew, then adds the plugin.
+A from-source build is available for development.
 
 ## Install with Homebrew (recommended)
 
 1. **Install the launcher.**
 
    ```bash
-   brew install spacedock-dev/homebrew-tap/spacedock
+   brew tap spacedock-dev/homebrew-tap
+   brew install spacedock
    ```
 
 2. **Confirm it.**
@@ -38,16 +39,15 @@ adds the plugin for you. A from-source build is available for development.
    Adds the Spacedock plugin to Claude Code and runs a compatibility check that
    reports `OK` when the launcher and plugin match.
 
-4. **Launch.**
+4. **Launch.** Point it at a project you already have and let it survey.
 
    ```bash
-   spacedock claude "your task"
+   spacedock claude "/spacedock:survey"
    ```
 
-   Starts the first officer in Claude Code with your task. If the plugin isn't
-   installed yet, this first launch installs it for you, then proceeds. When a
-   `.safehouse` profile is present in the working directory the launch is wrapped
-   through the sandbox.
+   Starts the first officer in Claude Code and runs the survey. When a
+   `.safehouse` profile is present in the working directory, the launch runs
+   sandboxed.
 
 ## Use Codex or Pi instead
 

--- a/docs/install-journey.md
+++ b/docs/install-journey.md
@@ -1,13 +1,13 @@
 # Fresh-install journey
 
 This walks a fresh install of Spacedock end to end on a clean Mac, naming the
-observable command at each step and the output you should see. There are two
-install lanes:
+observable command at each step and the output you should see. After the
+`v0.20.0` main flip, there are two install lanes:
 
-- **Released lane (brew)** — the published, tagged release. Available only after
-  the first tagged release is cut.
-- **Dev lane (`--plugin-dir`)** — a source build from `next`. The captain's
-  primary development workflow today.
+- **Stable lane (`main`)** — the published, tagged release. Homebrew artifacts
+  and marketplace plugin installs resolve from `main`.
+- **Dev-only lane (`next` + `--plugin-dir`)** — a source build from `next`, used
+  for development and pre-stable publishing tests.
 
 Each documented command is one you can run and observe the stated output.
 
@@ -17,19 +17,19 @@ Spacedock is two pieces that install separately:
 
 1. **The `spacedock` binary** — the launcher and contract gate.
 2. **The host plugin** (`spacedock:first-officer` / `spacedock:ensign` skills and
-   named agents) — loaded by Claude Code / Codex. The released lane installs it
-   through the host's marketplace; the dev lane loads it from your checkout with
-   `--plugin-dir`.
+   named agents) — loaded by Claude Code / Codex. The stable lane installs it
+   through the host's marketplace from `main`; the dev lane loads it from your
+   checkout with `--plugin-dir`.
 
 [safehouse](https://agent-safehouse.dev) is a separate runtime dependency used
 to sandbox launches. It is NOT installed by either lane — install it yourself
 when you want sandboxed runs.
 
-## Released lane (brew)
+## Stable lane (`main` + brew)
 
-> The brew lane is available only after the first tagged release. Until then the
-> formula ships a placeholder url + sha256 and `brew install` will not fetch a
-> real binary — use the dev lane below.
+> The stable lane is available after `v0.20.0` is cut from `main`. Before that
+> flip, the formula may still carry placeholder release data — use the dev-only
+> lane below.
 
 1. **Install the binary.**
 
@@ -61,9 +61,9 @@ when you want sandboxed runs.
    spacedock install --host claude
    ```
 
-   Adds the `spacedock-dev/spacedock` marketplace plugin for Claude Code, then
-   runs the contract doctor. The published plugin carries
-   `requires-contract: ">=1,<2"` so the doctor reports
+   Adds the `spacedock-dev/spacedock` marketplace plugin for Claude Code from
+   the stable `main` lane, then runs the contract doctor. The published plugin
+   carries `requires-contract: ">=1,<2"` so the doctor reports
    `OK: binary contract 1 satisfies plugin range >=1,<2.`
 
 4. **Launch.**
@@ -77,19 +77,37 @@ when you want sandboxed runs.
    spacedock:first-officer`. When a `.safehouse` profile is present in the
    working directory the launch is wrapped through safehouse.
 
-## Dev lane (`--plugin-dir`)
+## Upgrade and skew checks
+
+`spacedock doctor` is the compatibility source of truth. When it reports a
+stale installed plugin on the stable lane, rerun:
+
+```bash
+spacedock install --host claude
+```
+
+That refreshes the released plugin from `main` once the `0.20.0` lane exists. If
+the `spacedock` binary itself is missing, install the binary first with Homebrew,
+then run `spacedock install --host claude`.
+
+The `0.20.0` release still owes isolated upgrade-path confirmation for old
+`0.12.x` plugins with no usable binary and for `0.19.x` binary/plugin skew.
+Until that gate lands, docs should not promise automatic recovery for those
+cases.
+
+## Dev-only lane (`next` + `--plugin-dir`)
 
 This lane builds from source and loads the repo's own vendored plugin straight
 from disk — no marketplace install, and `--plugin-dir` relaxes the contract gate
 because the local checkout supersedes any installed plugin.
 
-`next` has no release artifact — the release pipeline triggers on `v*` tags
-only, so there is no `brew install …@next`. The `@next` lane is a source build.
-Three source routes, each with different version-stamp behavior:
+`next` has no stable release artifact, so there is no `brew install ...@next`.
+The `@next` lane is a source-build or dev-publish path. Three source routes,
+each with different version-stamp behavior:
 
 | Route | Command | `spacedock --version` reports |
 |---|---|---|
-| Local checkout (recommended) | `git clone … && go build -o spacedock ./cmd/spacedock` | the default `Version` (unstamped), `(contract 1)` correct |
+| Local checkout (recommended) | `git clone --branch next https://github.com/spacedock-dev/spacedock && cd spacedock && go build -o spacedock ./cmd/spacedock` | the default `Version` (unstamped), `(contract 1)` correct |
 | Toolchain fallback | `go install github.com/spacedock-dev/spacedock/cmd/spacedock@next` | the default `Version` (unstamped — `go install` does not pass release ldflags), NOT a git-describe pre-release identifier |
 | Dev snapshot | `goreleaser release --snapshot --clean` | a snapshot-stamped tarball, not published |
 
@@ -99,7 +117,7 @@ yield a stamped version.
 1. **Clone and build.**
 
    ```bash
-   git clone https://github.com/spacedock-dev/spacedock
+   git clone --branch next https://github.com/spacedock-dev/spacedock
    cd spacedock
    go build -o spacedock ./cmd/spacedock
    ```

--- a/docs/install-journey.md
+++ b/docs/install-journey.md
@@ -1,70 +1,42 @@
-# Fresh-install journey
+# Install Spacedock
 
-This walks a fresh install of Spacedock end to end on a clean Mac, naming the
-observable command at each step and the output you should see. After the
-`v0.20.0` main flip, there are two install lanes:
-
-- **Stable lane (`main`)** — the published, tagged release. Homebrew artifacts
-  and marketplace plugin installs resolve from `main`.
-- **Dev-only lane (`next` + `--plugin-dir`)** — a source build from `next`, used
-  for development and pre-stable publishing tests.
-
-Each documented command is one you can run and observe the stated output.
-
-## What gets installed
+This guide walks a fresh install end to end and names the output you should see
+at each step. Every command here is one you can run and check against the stated
+result.
 
 Spacedock is two pieces that install separately:
 
-1. **The `spacedock` binary** — the launcher and contract gate.
-2. **The host plugin** (`spacedock:first-officer` / `spacedock:ensign` skills and
-   named agents) — loaded by Claude Code / Codex. The stable lane installs it
-   through the host's marketplace from `main`; the dev lane loads it from your
-   checkout with `--plugin-dir`.
+1. **The `spacedock` launcher** — the command you run to start a session.
+2. **The host plugin** — the first-officer and ensign agents, loaded by Claude
+   Code or Codex.
 
-[safehouse](https://agent-safehouse.dev) is a separate runtime dependency used
-to sandbox launches. It is NOT installed by either lane — install it yourself
-when you want sandboxed runs.
+The recommended setup installs the launcher with Homebrew and adds the plugin
+with one command. A from-source build is available for development.
 
-## Stable lane (`main` + brew)
+## Install with Homebrew (recommended)
 
-> The stable lane is available after `v0.20.0` is cut from `main`. Before that
-> flip, the formula may still carry placeholder release data — use the dev-only
-> lane below.
-
-1. **Install the binary.**
-
-   ```bash
-   brew tap spacedock-dev/homebrew-tap
-   brew install spacedock
-   ```
-
-   The no-tap one-liner is equivalent (the bare formula name is safe — no
-   homebrew-core `spacedock` exists to disambiguate):
+1. **Install the launcher.**
 
    ```bash
    brew install spacedock-dev/homebrew-tap/spacedock
    ```
 
-2. **Confirm the binary.**
+2. **Confirm it.**
 
    ```bash
    spacedock --version
    ```
 
-   Prints `spacedock <version> (contract 1)`. The `(contract 1)` token is the
-   binary's compiled-in contract version; it is always correct regardless of how
-   the binary was built.
+   Prints the installed version, e.g. `spacedock 0.20.0`.
 
-3. **Install the host plugin.**
+3. **Add the plugin to Claude Code.**
 
    ```bash
    spacedock install --host claude
    ```
 
-   Adds the `spacedock-dev/spacedock` marketplace plugin for Claude Code from
-   the stable `main` lane, then runs the contract doctor. The published plugin
-   carries `requires-contract: ">=1,<2"` so the doctor reports
-   `OK: binary contract 1 satisfies plugin range >=1,<2.`
+   Adds the Spacedock plugin to Claude Code and runs a compatibility check that
+   reports `OK` when the launcher and plugin match.
 
 4. **Launch.**
 
@@ -72,47 +44,37 @@ when you want sandboxed runs.
    spacedock claude -- "your task"
    ```
 
-   Version-gates against the installed plugin's `requires-contract` (GREEN, no
-   `--skip-contract-check` needed) and launches `claude --agent
-   spacedock:first-officer`. When a `.safehouse` profile is present in the
-   working directory the launch is wrapped through safehouse.
+   Starts the first officer in Claude Code with your task. When a `.safehouse`
+   profile is present in the working directory the launch is wrapped through the
+   sandbox.
 
-## Upgrade and skew checks
+## Use Codex instead
 
-`spacedock doctor` is the compatibility source of truth. When it reports a
-stale installed plugin on the stable lane, rerun:
+Codex support is available but experimental; Claude Code is the primary surface.
 
-```bash
-spacedock install --host claude
-```
+1. **Install the launcher** (same Homebrew step as above).
 
-That refreshes the released plugin from `main` once the `0.20.0` lane exists. If
-the `spacedock` binary itself is missing, install the binary first with Homebrew,
-then run `spacedock install --host claude`.
+2. **Add the plugin.**
 
-The `0.20.0` release still owes isolated upgrade-path confirmation for old
-`0.12.x` plugins with no usable binary and for `0.19.x` binary/plugin skew.
-Until that gate lands, docs should not promise automatic recovery for those
-cases.
+   ```bash
+   spacedock install --host codex
+   ```
 
-## Dev-only lane (`next` + `--plugin-dir`)
+   Codex installs plugins from your shell rather than programmatically, so this
+   prints the two `codex plugin` commands to run. Run them, then use the
+   first-officer skill in your Codex session.
 
-This lane builds from source and loads the repo's own vendored plugin straight
-from disk — no marketplace install, and `--plugin-dir` relaxes the contract gate
-because the local checkout supersedes any installed plugin.
+3. **Launch.**
 
-`next` has no stable release artifact, so there is no `brew install ...@next`.
-The `@next` lane is a source-build or dev-publish path. Three source routes,
-each with different version-stamp behavior:
+   ```bash
+   spacedock codex -- "your task"
+   ```
 
-| Route | Command | `spacedock --version` reports |
-|---|---|---|
-| Local checkout (recommended) | `git clone --branch next https://github.com/spacedock-dev/spacedock && cd spacedock && go build -o spacedock ./cmd/spacedock` | the default `Version` (unstamped), `(contract 1)` correct |
-| Toolchain fallback | `go install github.com/spacedock-dev/spacedock/cmd/spacedock@next` | the default `Version` (unstamped — `go install` does not pass release ldflags), NOT a git-describe pre-release identifier |
-| Dev snapshot | `goreleaser release --snapshot --clean` | a snapshot-stamped tarball, not published |
+## Build from source (for development)
 
-Only a `v*` tag produces a git-describe-stamped binary. Do not expect `@next` to
-yield a stamped version.
+Use this when you're working on Spacedock itself. It builds the launcher from
+the development branch and loads the plugin straight from your checkout, so your
+local changes take effect immediately.
 
 1. **Clone and build.**
 
@@ -128,53 +90,40 @@ yield a stamped version.
    ./spacedock --version
    ```
 
-   Prints `spacedock <version> (contract 1)` — the unstamped default `Version`
-   on a local build, with the correct `(contract 1)` token.
+   Prints `spacedock <version>` for your local build.
 
-3. **Confirm the repo loads as a plugin** (optional, observe-don't-grep). In an
-   isolated config so no installed plugin masks the result:
-
-   ```bash
-   CLAUDE_CONFIG_DIR=$(mktemp -d) claude --plugin-dir "$PWD" plugin details spacedock
-   ```
-
-   Reports `Source: spacedock@inline` and an inventory naming `first-officer`
-   and `ensign` under Skills and Agents, exit 0.
-
-4. **Confirm the contract gate** (optional). The binary reads the vendored
-   manifest's `requires-contract` directly:
-
-   ```bash
-   ./spacedock doctor --plugin-manifest .claude-plugin/plugin.json
-   ```
-
-   Prints `OK: binary contract 1 satisfies plugin range >=1,<2.` followed by a
-   `Note: hosts emit a load-time warning for the 'requires-contract' field; this
-   is expected — the host ignores the field and spacedock reads it itself.` line,
-   exit 0.
-
-5. **Launch.**
+3. **Launch with the local plugin.**
 
    ```bash
    ./spacedock claude --plugin-dir "$PWD" -- "your task"
    ```
 
-   Loads the repo's own vendored `spacedock:first-officer` / `spacedock:ensign`
-   skills, relaxes the contract gate (the `--plugin-dir` checkout supersedes the
-   installed plugin), and launches `claude --agent spacedock:first-officer` with
-   your task appended.
+   `--plugin-dir` loads the first-officer and ensign agents from your checkout
+   instead of the installed plugin, so edits to the repo are live.
+
+The `next` branch is the development channel — it has no Homebrew release, so
+there is no `brew install` for it. Use the Homebrew path above for a stable
+install.
+
+## Keep things in sync
+
+`spacedock doctor` is the compatibility check. If it reports your installed
+plugin is out of date, refresh it:
+
+```bash
+spacedock install --host claude
+```
+
+If the `spacedock` command itself is missing, install the launcher with Homebrew
+first, then run `spacedock install --host claude`.
 
 ## Command grammar
 
 The front door is `spacedock claude [host-flags…] [--safehouse…] -- "task"`
 (and the same shape for `spacedock codex`):
 
-- Flags before `--` are passed through to the host (`claude` / `codex`),
-  including `--plugin-dir`, `--resume`, `--model`, etc.
-- The bare text after the `--` fence is the launch task, appended to the
-  first-officer bootstrap prompt.
-- `--safehouse` (or any `--safehouse-<key>=…` knob) forces the launch through
-  safehouse; a `.safehouse` profile in the working directory does the same
-  automatically.
-- `--skip-contract-check` bypasses the contract gate (bootstrap only); a
-  `--plugin-dir` launch relaxes the gate without it.
+- Flags before `--` pass through to the host (`claude` / `codex`), including
+  `--plugin-dir`, `--resume`, `--model`, and the like.
+- The bare text after `--` is the launch task, handed to the first officer.
+- `--safehouse` forces the launch through the sandbox; a `.safehouse` profile in
+  the working directory does the same automatically.

--- a/docs/install-journey.md
+++ b/docs/install-journey.md
@@ -30,24 +30,19 @@ A from-source build is available for development.
 
    Prints the installed version, e.g. `spacedock 0.20.0`.
 
-3. **Add the plugin to Claude Code.**
-
-   ```bash
-   spacedock install --host claude
-   ```
-
-   Adds the Spacedock plugin to Claude Code and runs a compatibility check. It
-   reports `OK` when the launcher and plugin match.
-
-4. **Launch.** Point it at a project you already have and let it survey.
+3. **Launch.** Point it at a project you already have and let it survey.
 
    ```bash
    spacedock claude "/spacedock:survey"
    ```
 
-   Starts the first officer in Claude Code and runs the survey. When a
+   Starts the first officer in Claude Code and runs the survey. The first launch
+   sets up the plugin for you, so this single command is enough. When a
    `.safehouse` profile is present in the working directory, the launch runs
    sandboxed.
+
+   To set up the plugin ahead of time, or to refresh it later, run
+   `spacedock install --host claude`.
 
 ## Use Codex or Pi instead
 

--- a/docs/install-journey.md
+++ b/docs/install-journey.md
@@ -36,7 +36,7 @@ A from-source build is available for development.
    spacedock install --host claude
    ```
 
-   Adds the Spacedock plugin to Claude Code and runs a compatibility check that
+   Adds the Spacedock plugin to Claude Code and runs a compatibility check. It
    reports `OK` when the launcher and plugin match.
 
 4. **Launch.** Point it at a project you already have and let it survey.
@@ -74,8 +74,8 @@ Codex and Pi are supported but experimental. Claude Code is the primary surface.
 ## Build from source (for development)
 
 Use this when you're working on Spacedock itself. It builds the launcher from
-the development branch and loads the plugin straight from your checkout, so your
-local changes take effect immediately.
+the development branch and loads the plugin from your checkout, so local changes
+take effect immediately.
 
 1. **Clone and build.**
 
@@ -101,11 +101,10 @@ local changes take effect immediately.
 
    `--plugin-dir` is a host flag, so it rides after `--`. It loads the
    first-officer and ensign agents from your checkout instead of the installed
-   plugin, so edits to the repo are live.
+   plugin. Edits to the repo are live.
 
-The `next` branch is the development channel. It has no Homebrew release, so
-there is no `brew install` for it. Use the Homebrew path above for a stable
-install.
+The `next` branch is the development channel. It has no Homebrew release. Use the
+Homebrew path above for a stable install.
 
 ## Keep things in sync
 
@@ -127,5 +126,5 @@ The front door is `spacedock claude "task" [--safehouse…] [-- host-flags…]`
 - The task comes first. It's handed to the first officer as the launch prompt.
 - Anything after `--` forwards verbatim to the host (`claude` / `codex` / `pi`),
   including `--plugin-dir`, `--resume`, `--model`, and the like.
-- `--safehouse` forces the launch through the sandbox; a `.safehouse` profile in
+- `--safehouse` forces the launch through the sandbox. A `.safehouse` profile in
   the working directory does the same automatically.

--- a/docs/install-journey.md
+++ b/docs/install-journey.md
@@ -4,11 +4,14 @@ This guide walks a fresh install end to end and names the output you should see
 at each step. Every command here is one you can run and check against the stated
 result.
 
-Spacedock is two pieces that install separately:
+Spacedock plugs into a coding agent harness you already run: Claude Code, Codex,
+or Pi. Install one of those first.
+
+Spacedock itself is two pieces that install separately:
 
 1. **The `spacedock` launcher.** The command you run to start a session.
 2. **The host plugin.** The first-officer and ensign agents, loaded by your
-   agent (Claude Code, Codex, or Pi).
+   harness (Claude Code, Codex, or Pi).
 
 The recommended setup installs the launcher with Homebrew, then adds the plugin.
 A from-source build is available for development.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,41 +1,89 @@
 # Releasing Spacedock
 
-Releases are cut from `next` (the source of truth). `origin/main` is vestigial —
-do not push or merge to it. A release is a `vX.Y.Z` annotated-tag push, which
-triggers `.github/workflows/release.yml`.
+This document describes the post-main-flip release lane. Starting with
+`v0.20.0`, stable releases are cut from `main`; `next` remains a dev-only branch
+for source builds and pre-stable publishing tests. Do not present `next` as the
+stable marketplace source after the flip.
 
-## What the tag push does
+## 0.20.0 Main Flip
 
-`release.yml` runs one goreleaser job on `macos-latest` that:
+The `0.20.0` release is the branch transition. It must not ship until the release
+gate fixes, runtime-live checks, README/install reconciliation, and upgrade-path
+confirmation have passed.
 
-- cross-builds the darwin arm64 + amd64 tarballs and `checksums.txt`, stamping
-  `git describe --tags` into `internal/cli.Version` (so the binary reports the
-  release version);
-- publishes the GitHub Release with those assets;
-- bumps the `spacedock-dev/homebrew-tap` cask (via the `HOMEBREW_TAP_TOKEN`
-  secret — a PAT, since the default `GITHUB_TOKEN` can't write cross-repo);
-- stamps the plugin manifests' `version` on `next`
-  (`spacedock-release stamp-version`, idempotent).
-
-Pushing the tag is therefore by itself sufficient to stamp `next` — the manual
-bump in the steps below just pre-stamps (release.yml then finds it already done
-and no-ops). Its real value is producing a reviewable annotated-tag changelog
-before publishing.
-
-## Cutting a release
-
-1. Ensure all release content is merged to `next`. Choose the version `X.Y.Z`.
-
-2. Create a release worktree off `next`:
+1. Record the current pre-v1 `origin/main` SHA, then archive it:
 
    ```bash
-   git worktree add .worktrees/release-X.Y.Z -b release/X.Y.Z origin/next
+   git fetch origin main next
+   preflip_main="$(git rev-parse origin/main)"
+   git tag -a v0-archived "$preflip_main" -m "archive pre-v1 main before 0.20.0 flip"
+   git push origin v0-archived
+   ```
+
+2. Prepare the release line from `origin/next`. The release-prep commit must
+   stamp `0.20.0`, move stable marketplace references to `main`, and remove the
+   released-binary install pin to `next`. Keep any dev-only `next` publish path
+   separate.
+
+   ```bash
+   git worktree add .worktrees/release-0.20.0 -b release/0.20.0 origin/next
+   ```
+
+3. Replace `origin/main` with the prepared line using a guarded update. The
+   lease must name the pre-flip `main` SHA recorded in step 1:
+
+   ```bash
+   git push origin --force-with-lease=main:"$preflip_main" release/0.20.0:main
+   ```
+
+   Do not delete `next`. After the flip, `main` is the stable branch and `next`
+   is the dev-only branch.
+
+4. Cut and push the annotated `v0.20.0` tag from the `main` release line:
+
+   ```bash
+   git fetch origin main
+   git switch release/0.20.0
+   git reset --hard origin/main
+   git tag -a v0.20.0 -F <changelog-file>
+   git push origin v0.20.0
+   ```
+
+Before pushing the tag, verify `.github/workflows/release.yml` and
+`.goreleaser.yaml` no longer stamp or pin the stable release to `next`. Those
+release-mechanics changes are part of the main-flip release work, not this docs
+reconciliation.
+
+## What the Tag Push Does
+
+Once the main-flip release mechanics are in place, `release.yml` runs one
+goreleaser job on `macos-latest` that:
+
+- cross-builds the darwin arm64 and amd64 tarballs plus `checksums.txt`,
+  stamping `git describe --tags` into `internal/cli.Version`;
+- publishes the GitHub Release with those assets;
+- bumps the `spacedock-dev/homebrew-tap` cask via `HOMEBREW_TAP_TOKEN`;
+- stamps the plugin manifests' `version` on `main`;
+- keeps the marketplace entry serving the stable plugin from `main`.
+
+The tag push is therefore enough to publish the stable release once the release
+config targets `main`. A manual release-prep commit is still useful because it
+produces a reviewable annotated-tag changelog and manifest diff before the tag
+is pushed.
+
+## Cutting a Stable Release After 0.20.0
+
+1. Ensure all release content is merged to `main`. Choose the version `X.Y.Z`.
+
+2. Create a release worktree off `main`:
+
+   ```bash
+   git worktree add .worktrees/release-X.Y.Z -b release/X.Y.Z origin/main
    ```
 
 3. Bump the version stamps with the release tool, then commit. `stamp-version`
    writes the release `X.Y.Z` into the plugin manifests; `bump-calendar` advances
-   the marketplace entry's separate `0.0.YYYYMMDDNN` calendar key (the
-   `claude plugin update` re-pull key) — they stamp different files, so both run:
+   the marketplace entry's separate `0.0.YYYYMMDDNN` calendar key:
 
    ```bash
    go run ./cmd/spacedock-release stamp-version X.Y.Z .claude-plugin/plugin.json .codex-plugin/plugin.json
@@ -46,14 +94,14 @@ before publishing.
 4. Write a changelog. Summarize the commits since the last tag into plain text:
 
    ```bash
-   git log $(git describe --tags --abbrev=0 origin/next)..HEAD --oneline
+   git log $(git describe --tags --abbrev=0 origin/main)..HEAD --oneline
    ```
 
-   One sentence naming the release theme, then user-value-led `- ` bullets (lead
-   with what upgrading gives you). Ignore workflow-state churn
+   One sentence names the release theme, then user-value-led `- ` bullets name
+   what upgrading gives users. Ignore workflow-state churn
    (dispatch/advance/archive/mod-block/pr/report commits).
 
-5. Create the annotated tag (local, nothing pushed):
+5. Create the annotated tag locally:
 
    ```bash
    git tag -a vX.Y.Z -F <changelog-file>
@@ -63,19 +111,17 @@ before publishing.
 
    ```bash
    git show vX.Y.Z
-   git diff origin/next..release/X.Y.Z
+   git diff origin/main..release/X.Y.Z
    ```
 
    To amend the changelog: `git tag -d vX.Y.Z` then re-tag.
 
-7. Publish (after confirmation):
+7. Publish after confirmation:
 
    ```bash
-   git push origin release/X.Y.Z:next   # fast-forwards next with the stamp
-   git push origin vX.Y.Z               # triggers release.yml
+   git push origin release/X.Y.Z:main
+   git push origin vX.Y.Z
    ```
-
-   NEVER push `origin/main`.
 
 8. Clean up:
 
@@ -84,10 +130,20 @@ before publishing.
    git branch -d release/X.Y.Z
    ```
 
+## Dev-Only `next` Publishing
+
+Keep `next` for development. Source builds may use
+`go install github.com/spacedock-dev/spacedock/cmd/spacedock@next`, local
+checkouts may use `--plugin-dir`, and the deliberate `next-publish` workflow may
+bump the marketplace calendar key for dev testers.
+
+Do not send stable users to `next`. If a command or manifest uses `@next`, it is
+a dev-only path.
+
 ## Notes
 
-- Don't stamp the version via a pull request; the release branch + annotated tag
-  IS the mechanism.
+- Do not stamp the version via a pull request; the release branch and annotated
+  tag are the release mechanism.
 - macOS binaries are adhoc-signed, not yet notarized; the Homebrew cask's
   postflight strips the `com.apple.quarantine` xattr as the interim Gatekeeper
   fix until Developer-ID notarization lands.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,63 +1,12 @@
 # Releasing Spacedock
 
-This document describes the post-main-flip release lane. Starting with
-`v0.20.0`, stable releases are cut from `main`; `next` remains a dev-only branch
-for source builds and pre-stable publishing tests. Do not present `next` as the
-stable marketplace source after the flip.
-
-## 0.20.0 Main Flip
-
-The `0.20.0` release is the branch transition. It must not ship until the release
-gate fixes, runtime-live checks, README/install reconciliation, and upgrade-path
-confirmation have passed.
-
-1. Record the current pre-v1 `origin/main` SHA, then archive it:
-
-   ```bash
-   git fetch origin main next
-   preflip_main="$(git rev-parse origin/main)"
-   git tag -a v0-archived "$preflip_main" -m "archive pre-v1 main before 0.20.0 flip"
-   git push origin v0-archived
-   ```
-
-2. Prepare the release line from `origin/next`. The release-prep commit must
-   stamp `0.20.0`, move stable marketplace references to `main`, and remove the
-   released-binary install pin to `next`. Keep any dev-only `next` publish path
-   separate.
-
-   ```bash
-   git worktree add .worktrees/release-0.20.0 -b release/0.20.0 origin/next
-   ```
-
-3. Replace `origin/main` with the prepared line using a guarded update. The
-   lease must name the pre-flip `main` SHA recorded in step 1:
-
-   ```bash
-   git push origin --force-with-lease=main:"$preflip_main" release/0.20.0:main
-   ```
-
-   Do not delete `next`. After the flip, `main` is the stable branch and `next`
-   is the dev-only branch.
-
-4. Cut and push the annotated `v0.20.0` tag from the `main` release line:
-
-   ```bash
-   git fetch origin main
-   git switch release/0.20.0
-   git reset --hard origin/main
-   git tag -a v0.20.0 -F <changelog-file>
-   git push origin v0.20.0
-   ```
-
-Before pushing the tag, verify `.github/workflows/release.yml` and
-`.goreleaser.yaml` no longer stamp or pin the stable release to `next`. Those
-release-mechanics changes are part of the main-flip release work, not this docs
-reconciliation.
+Stable releases are cut from `main`. `next` remains a dev-only branch for source
+builds and pre-stable publishing tests. Do not present `next` as the stable
+marketplace source.
 
 ## What the Tag Push Does
 
-Once the main-flip release mechanics are in place, `release.yml` runs one
-goreleaser job on `macos-latest` that:
+`release.yml` runs one goreleaser job on `macos-latest` that:
 
 - cross-builds the darwin arm64 and amd64 tarballs plus `checksums.txt`,
   stamping `git describe --tags` into `internal/cli.Version`;
@@ -66,12 +15,11 @@ goreleaser job on `macos-latest` that:
 - stamps the plugin manifests' `version` on `main`;
 - keeps the marketplace entry serving the stable plugin from `main`.
 
-The tag push is therefore enough to publish the stable release once the release
-config targets `main`. A manual release-prep commit is still useful because it
-produces a reviewable annotated-tag changelog and manifest diff before the tag
-is pushed.
+The tag push is therefore enough to publish the stable release. A manual
+release-prep commit is still useful because it produces a reviewable
+annotated-tag changelog and manifest diff before the tag is pushed.
 
-## Cutting a Stable Release After 0.20.0
+## Cutting a Stable Release
 
 1. Ensure all release content is merged to `main`. Choose the version `X.Y.Z`.
 


### PR DESCRIPTION
## What

Reworks the user-facing docs for the 0.20.0 main flip — reader-first and honest:

- **README.md** — decision-first rewrite. Leads with the problem and "nothing ships without a decision"; claims grounded in real mechanism (review runs as a fresh-context `validation` stage; native sandbox integration via the optional safehouse; "harness" not "agent"; Captain/First Officer/Ensign defined). One clean install path, namespaced commands, present-tense.
- **docs/install-journey.md** — clean install guide: Homebrew launcher + Claude plugin auto-install on first launch; Codex/Pi manual; from-source dev path. No contract-token / ldflags / goreleaser internals.
- **docs/releasing.md** — de-flipped to steady-state release docs. The one-time 0.20.0 flip runbook is owned by the `main-flip-0200-marketplace` track, not this doc.

## Why

Pre-flip the docs were maintainer-voiced, jargon-heavy, and written in future-conditional "after the flip" tense. This makes them reader-first and honest for the post-flip world, and reconciles the install/release facts (stable from `main`, `next` dev-only). No source-resolution behavior is claimed that the binary doesn't yet ship.

## Provenance

Validated against the entity acceptance criteria (AC-1..AC-9), then hardened by a 3-reviewer ICP bounty (30-second skeptic / hands-on installer / positioning critic) + captain triage:

- README↔install-journey install-path contradiction reconciled (Claude single-line auto-install; Codex/Pi manual).
- "native sandbox, zero wrapping" overclaim fixed → honest "native sandbox integration".
- flagship claims grounded in real mechanism, verified against `internal/cli/frontdoor.go` + the workflow's `fresh:true` validation stage.
- launch grammar corrected (task before `--`), verified against the front-door parser.
- command namespacing fixed (`/spacedock:commission`).

## Supersedes

Closes #213, Closes #220, Closes #315 — this work absorbs their correct install facts and the reader-first framing they each partially carried, reconciled against current `next` and the flip.

## Notes

Docs-only — no code changed. `go test ./...` 1141/16 green; `gofmt -l` / `git diff --check` / content lints clean. Live-e2e lanes not exercised (the runtime scenarios don't touch these docs); merges on the offline gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
