### PR TITLE
Clean up the Homebrew cask caveats — drop the xattr note, shrink the safehouse wall

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,17 +73,9 @@ homebrew_casks:
     description: Workflow launcher and first-officer dispatch for agentic dev
     license: Apache-2.0
     caveats: |
-      spacedock launches host agent tooling (Claude Code / Codex) inside a
-      sandbox called "safehouse". safehouse is a runtime dependency and is NOT
-      installed by brew; install it through the host tooling before first launch.
-      See the safehouse install docs:
-        https://agent-safehouse.dev
-
-      The spacedock binary is not yet notarized, so the cask download is tagged
-      with the com.apple.quarantine attribute and macOS Gatekeeper blocks the
-      first launch. This cask clears the attribute automatically on install. If
-      Gatekeeper still blocks spacedock, clear it manually before first launch:
-        xattr -dr com.apple.quarantine "$(brew --prefix)/bin/spacedock"
+      Recommended companions (not installed by brew):
+        safehouse  — sandboxes agent runs (https://agent-safehouse.dev)
+        agentsview — powers /spacedock:survey
     hooks:
       # The binary is adhoc/linker-signed only (not notarized), so the cask
       # download carries com.apple.quarantine and Gatekeeper kills the first


### PR DESCRIPTION
Slim the Homebrew cask install message so it recommends the optional companions instead of explaining a quarantine step the install already handles.

## What changed
- Drop the notarization/quarantine explanation and the manual `xattr` fallback from the cask caveats.
- Keep the `post.install` hook that auto-clears `com.apple.quarantine`.
- Replace the multi-line safehouse block with a brief safehouse + agentsview companions note.

## Evidence
- `goreleaser check` passes; `go test ./...` 1141/1141 passed.

---
[78](/spacedock-dev/spacedock/blob/2230aa9bb876625bdc3786a4812e2b508f7e5da5/brew-cask-message-cleanup.md)
