### PR TITLE
Validate/sanitize team_name in the dispatch-file path + fix the bare-mode comment (n1a audit polish)

### DIFF
--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -21,6 +21,10 @@ const (
 	nameMaxLen      = 200
 	modelEnumList   = "must be one of: sonnet, opus, haiku"
 	dispatchFileDir = "/tmp/spacedock-dispatch"
+	// dispatchFileNameMaxLen caps the dispatch filename stem (team_name +
+	// derived name) so the on-disk file with its .md suffix stays under the
+	// common 255-byte filesystem name limit.
+	dispatchFileNameMaxLen = 251
 )
 
 // buildRequiredFields are the stdin keys that must be present and non-null.
@@ -28,6 +32,13 @@ var buildRequiredFields = []string{"schema_version", "entity_path", "workflow_di
 
 // namePattern is the dispatch-name regex derived worker names must match.
 var namePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
+
+// teamNamePattern is the path-safety regex for a team_name prepended to the
+// dispatch filename. It enforces namePattern's kebab character class and
+// no-leading/trailing-hyphen rule, but also admits a single character — a
+// degenerate yet path-safe name namePattern's two-anchor shape rejects. Derived
+// names are always multi-char, so namePattern never needed the single-char case.
+var teamNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
 // modelEnum is the Agent-schema model enum declared values are validated against.
 var modelEnum = map[string]bool{"sonnet": true, "opus": true, "haiku": true}
@@ -564,12 +575,29 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 	// and an ensign can Read a STALE prior dispatch's entity pointer. Each real FO
 	// TeamCreate yields a unique team name (`{project}-{dir}-{YYYYMMDD-HHMM}-
 	// {shortuuid}`), so keying the file on the team name disambiguates every team-
-	// mode dispatch. Bare-mode dispatches (no team name) block until the subagent
-	// completes — they cannot alias within a session — so they keep the plain name.
+	// mode dispatch. Dispatches with no team_name keep the plain derived name.
 	// derivedName stays the readable team-member name; only the on-disk path is keyed.
 	dispatchFileName := derivedName
 	if teamName != "" {
+		// team_name is prepended to a filesystem path, so it gets the same
+		// path-safety the derived name already gets (kebab-only char class,
+		// capped). Team names are harness-generated and kebab-safe today; this is
+		// defense-in-depth against an odd or path-bearing name building an
+		// unsanitized /tmp path.
+		if len(teamName) > nameMaxLen {
+			return buildError(stderr, 1, "team name '%s' exceeds %d characters", teamName, nameMaxLen)
+		}
+		if !teamNamePattern.MatchString(teamName) {
+			return buildError(stderr, 1,
+				"team name '%s' contains invalid characters: must match %s "+
+					"(kebab-case lowercase letters, digits, and hyphens only)",
+				teamName, teamNamePattern.String())
+		}
 		dispatchFileName = teamName + "-" + derivedName
+	}
+	if len(dispatchFileName) > dispatchFileNameMaxLen {
+		return buildError(stderr, 1,
+			"dispatch filename '%s' exceeds %d characters", dispatchFileName, dispatchFileNameMaxLen)
 	}
 	dispatchFilePath := filepath.Join(dispatchFileDir, dispatchFileName+".md")
 	if err := os.MkdirAll(dispatchFileDir, 0o755); err != nil {

--- a/internal/dispatch/build_teamname_path_test.go
+++ b/internal/dispatch/build_teamname_path_test.go
@@ -1,0 +1,116 @@
+// ABOUTME: team_name path-safety — a path-unsafe or over-long team_name fails
+// ABOUTME: with a clean error before the dispatch-file path is constructed.
+package dispatch
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// teamNameStdin builds a well-formed build request for the good README's backlog
+// stage with the given team_name, leaving every other guard satisfied so the
+// team_name path-safety check is the one under test.
+func teamNameStdin(t *testing.T, root, teamName string) (workflowDir, stdin string) {
+	t.Helper()
+	wd := writeGood(t, root)
+	ep := writeFlatEntity(t, wd, "backlog", "")
+	return wd, mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    ep,
+		"workflow_dir":   wd,
+		"stage":          "backlog",
+		"checklist":      []string{"- a"},
+		"team_name":      teamName,
+		"bare_mode":      false,
+	}, nil)
+}
+
+// TestBuildTeamNamePathSafety asserts a path-unsafe team_name (path separator,
+// dot-dot traversal, or odd characters) fails with a clean exit-1 error rather
+// than building an unsanitized /tmp path. The derived name beside it is already
+// validated this way; team_name gets the same treatment before path construction.
+func TestBuildTeamNamePathSafety(t *testing.T) {
+	cases := []struct {
+		name     string
+		teamName string
+	}{
+		{"dot-dot-traversal", "../escape"},
+		{"path-separator", "a/b"},
+		{"leading-slash", "/abs"},
+		{"uppercase", "BadTeam"},
+		{"space", "bad team"},
+		{"trailing-hyphen", "team-"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			root := t.TempDir()
+			wd, stdin := teamNameStdin(t, root, tc.teamName)
+
+			native := runNative(stdin, "build", "--workflow-dir", wd)
+
+			if native.exit != 1 {
+				t.Errorf("exit native=%d, want 1 for team_name %q\nstdout:\n%s\nstderr:\n%s",
+					native.exit, tc.teamName, native.stdout, native.stderr)
+			}
+			if !strings.HasPrefix(native.stderr, "error: ") {
+				t.Errorf("stderr lacks clean error prefix for team_name %q:\n%q", tc.teamName, native.stderr)
+			}
+		})
+	}
+}
+
+// TestBuildTeamNameCombinedLengthCap asserts that a team_name and a derived name
+// each short enough to pass their per-name length cap still fail when their
+// combination pushes the on-disk filename past the filesystem name limit. The
+// derived name is lengthened via a long entity slug.
+func TestBuildTeamNameCombinedLengthCap(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := t.TempDir()
+	wd := writeGood(t, root)
+	// A long (but per-name-valid) entity slug stretches the derived name so the
+	// combined filename overshoots dispatchFileNameMaxLen.
+	ep := filepath.Join(wd, strings.Repeat("a", 100)+".md")
+	writeFile(t, ep, entityFM("Thing", "backlog", ""))
+	teamName := strings.Repeat("b", nameMaxLen) // valid in isolation (== nameMaxLen)
+	stdin := mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    ep,
+		"workflow_dir":   wd,
+		"stage":          "backlog",
+		"checklist":      []string{"- a"},
+		"team_name":      teamName,
+		"bare_mode":      false,
+	}, nil)
+
+	native := runNative(stdin, "build", "--workflow-dir", wd)
+
+	if native.exit != 1 {
+		t.Errorf("exit native=%d, want 1 for combined-length overflow\nstderr:\n%s", native.exit, native.stderr)
+	}
+	if !strings.HasPrefix(native.stderr, "error: ") {
+		t.Errorf("stderr lacks clean error prefix:\n%q", native.stderr)
+	}
+}
+
+// TestBuildTeamNameValidPath asserts a path-safe team_name still keys the
+// dispatch filename as {teamName}-{derivedName}.md — the happy path is unchanged.
+func TestBuildTeamNameValidPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := t.TempDir()
+	wd, stdin := teamNameStdin(t, root, "fixture-team")
+
+	native := runNative(stdin, "build", "--workflow-dir", wd)
+	if native.exit != 0 {
+		t.Fatalf("exit native=%d, want 0\nstderr:\n%s", native.exit, native.stderr)
+	}
+	got := dispatchFilePathFromStdout(t, native.stdout)
+	want := filepath.Join(dispatchFileDir, "fixture-team-spacedock-ensign-thing-backlog.md")
+	if got != want {
+		t.Errorf("dispatch_file_path = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Harden the dispatch-file path against an unsafe `team_name`, and correct a misleading bare-mode comment.

## What changed
- Validate `team_name` for path-safety (kebab pattern + length cap) before it is prepended to the `/tmp` dispatch filename.
- Add a combined-filename length cap below the OS name limit.
- Correct the bare-mode comment to key on `team_name` presence, not `bare_mode`.

## Evidence
- `go test ./...` 1150/1150; CLI-verified `../`/`a/b`/`/abs` rejected with no traversal; a guards-removed edit turns the new tests RED.

---
[e30](/spacedock-dev/spacedock/blob/121078d6410d188a4e41f649ddb4a209b094395b/dispatch-path-teamname-sanitize/index.md)
