### PR TITLE
Test-hygiene: make `go test ./...` pass from the repo root (migration-check + contractlint sweep skips)

### DIFF
--- a/internal/contractlint/boundary_guard_control_test.go
+++ b/internal/contractlint/boundary_guard_control_test.go
@@ -7,6 +7,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -124,6 +125,53 @@ func TestLeak(t *T) {
 	for _, o := range offenders {
 		if filepath.Dir(o) == quarantinePkg {
 			t.Fatalf("sweep wrongly flagged the quarantine package's own read %q; the quarantine is the legal read path", o)
+		}
+	}
+}
+
+// TestBoundaryGuardSweepSkipsAgentWorktrees pins that the sweep prunes the
+// untracked agent-team worktree trees — both the Spacedock `.worktrees` and the
+// Claude-Code `.claude` scratch. Those checkouts hold copies of instruction
+// files that are not the repo's shipped surface, so an instruction read living
+// inside one must NOT be reported as an offender. A real out-of-quarantine
+// offender alongside them proves the sweep is still live, not skipping wholesale.
+func TestBoundaryGuardSweepSkipsAgentWorktrees(t *testing.T) {
+	root := t.TempDir()
+
+	instructionRead := `package fixture
+func TestReadsInstruction(t *T) {
+	data, _ := os.ReadFile("skills/integration/SKILL.md")
+	_ = data
+}
+`
+	// A real offender outside the quarantine -> must be flagged.
+	policedDir := filepath.Join(root, "internal", "hostneutrality")
+	if err := os.MkdirAll(policedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixture(t, filepath.Join(policedDir, "leak_test.go"), instructionRead)
+
+	// The same instruction read planted inside each agent-worktree scratch tree
+	// -> must NOT be flagged.
+	scratchDirs := []string{
+		filepath.Join(root, ".worktrees", "agent-spacedock", "skills", "integration"),
+		filepath.Join(root, ".claude", "worktrees", "agent-claude", "skills", "integration"),
+	}
+	for _, dir := range scratchDirs {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFixture(t, filepath.Join(dir, "skill_surface_test.go"), instructionRead)
+	}
+
+	offenders := sweepInstructionReadsOutsideQuarantine(t, root)
+	if !contains(offenders, filepath.Join("internal", "hostneutrality", "leak_test.go")) {
+		t.Fatalf("sweep failed to flag the real out-of-quarantine read; offenders=%v", offenders)
+	}
+	for _, o := range offenders {
+		if strings.HasPrefix(o, ".worktrees"+string(filepath.Separator)) ||
+			strings.HasPrefix(o, ".claude"+string(filepath.Separator)) {
+			t.Fatalf("sweep flagged an agent-worktree scratch read %q; those trees are untracked agent checkouts, not the shipped surface", o)
 		}
 	}
 }

--- a/internal/contractlint/boundary_guard_test.go
+++ b/internal/contractlint/boundary_guard_test.go
@@ -85,7 +85,7 @@ func sweepInstructionReadsOutsideQuarantine(t *testing.T, repoRootDir string) []
 		}
 		if d.IsDir() {
 			switch rel {
-			case ".git", ".worktrees", "docs/dev/.spacedock-state", "vendor", quarantinePkg:
+			case ".git", ".worktrees", ".claude", "docs/dev/.spacedock-state", "vendor", quarantinePkg:
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/status/migration_check_test.go
+++ b/internal/status/migration_check_test.go
@@ -66,6 +66,15 @@ func TestMigrationCheckFixturesParseConsistently(t *testing.T) {
 			return walkErr
 		}
 		if info.IsDir() {
+			// Debriefs are session records with their own frontmatter shape
+			// (session-date, sequence, first-commit) — not entity fixtures the
+			// migration check governs. Their bare-YAML date scalars parse as
+			// time.Time in a direct yaml.v3 decode but as strings through the
+			// reader, which is expected for non-entity frontmatter and outside
+			// this check's scope.
+			if info.Name() == "_debriefs" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if !strings.HasSuffix(path, ".md") {


### PR DESCRIPTION
Make `go test ./...` pass from the repo root for developers — the migration-check and contractlint sweeps were tripping on untracked agent scratch.

## What changed
- Exclude `_debriefs/` from the migration-check fixture walk (debriefs aren't entity fixtures).
- Skip `.claude` in the contractlint boundary sweep, alongside the existing `.worktrees` skip.
- Add a regression that plants instruction-read scratch in both `.worktrees` and `.claude` and asserts neither is flagged.

## Evidence
- `go test ./...` from the repo root = 1142 passed with `.spacedock-state` + live `.claude/worktrees` present; the regression REDs if either skip is removed.

---
[qy](/spacedock-dev/spacedock/blob/286235c337b055216430bca6c6a04b75310d629a/internal-status-test-hygiene/index.md)
