### PR TITLE
Codex plugin auto-install on `spacedock codex` (mirror #311; codex 0.137.0 marketplace + plugin add)

### DIFF
--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -288,8 +288,11 @@ func containsResume(args []string) bool {
 // `spacedock:first-officer` skill explicitly.
 const codexBootstrapPrompt = "You totally got this. Take your time. I love you. And tell all subagents and team members you love them too. Engage. Assume $spacedock:first-officer for the entire session."
 
-// runCodex is the `spacedock codex` front door: version-gate (fail fast), then
-// launch the first officer. The launch is interposed through
+// runCodex is the `spacedock codex` front door: version-gate, then launch the
+// first officer. The gate fails fast on a contract mismatch, but a missing plugin
+// (NoPluginFound) auto-installs the plugin and proceeds to launch so the single
+// command the user typed yields a working session — `--no-install` opts out,
+// preserving the refuse-and-instruct behavior. The launch is interposed through
 // `safehouse --trust-workdir-config [extra] -- codex --dangerously-bypass-approvals-and-sandbox …`
 // when ANY of {a `.safehouse` profile in dir, the bare `--safehouse` flag, a
 // `--safehouse-*` knob} is given — safehouse is the sandbox, so codex's own
@@ -311,11 +314,29 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 		fmt.Fprintf(stderr, "spacedock codex: %v\n", err)
 		return 1
 	}
-	// Codex keeps the all-or-nothing gate: any non-Compatible verdict fails fast.
-	// The no-plugin auto-install is Claude-only (Install rejects non-claude hosts),
-	// and codex has no --plugin-dir equivalent, so there is nothing to auto-install.
+	// The gate fails fast on a contract mismatch, but a missing plugin
+	// (NoPluginFound) auto-installs the codex plugin and proceeds to launch so the
+	// single command the user typed yields a working session — `--no-install` opts
+	// out, preserving the refuse-and-instruct behavior. This mirrors runClaude.
 	if !fd.skipCheck && !hasPluginDir(fd.passthrough) {
-		if gateHost(ops, "codex", stderr) != contract.Compatible {
+		switch gateHost(ops, "codex", stderr) {
+		case contract.Compatible:
+			// proceed to launch
+		case contract.NoPluginFound:
+			// No plugin on disk: auto-install then launch, unless the operator opted
+			// out with --no-install (gateHost already printed the instruct remedy, so
+			// just fail fast).
+			if fd.noInstall {
+				return 1
+			}
+			if _, err := ops.Install("codex", marketplaceSource, devBranch); err != nil {
+				fmt.Fprintf(stderr, "spacedock codex: auto-install failed: %v\n", err)
+				return 1
+			}
+		default:
+			// A mismatch / malformed range / host-CLI resolve error: auto-installing
+			// would not fix an incompatibility, so fail fast (gateHost already
+			// printed the message).
 			return 1
 		}
 	}

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -426,7 +426,14 @@ func TestCodexFrontDoorFailFastOnMismatch(t *testing.T) {
 	assertGateMismatchMessage(t, stderr.String())
 }
 
-func TestCodexFrontDoorNoPluginFailsFastWithoutInstalling(t *testing.T) {
+// TestCodexFrontDoorNoPluginAutoInstalls (AC-2): with no installed codex plugin
+// and no flags the front door auto-installs the plugin then launches a working
+// session — the single command the user typed yields a working FO session rather
+// than refusing. Both no-plugin verdicts (an empty manifest AND a phantom
+// installPath to an absent manifest) auto-install, matching the claude branch.
+// The recorded install seam ({host, source, branch}) and the captured launch argv
+// are the independent sources of truth.
+func TestCodexFrontDoorNoPluginAutoInstalls(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "no-such-dir", ".codex-plugin", "plugin.json")
 	cases := []struct {
 		name     string
@@ -442,14 +449,48 @@ func TestCodexFrontDoorNoPluginFailsFastWithoutInstalling(t *testing.T) {
 
 			code := runCodex(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
 
+			if code != 0 {
+				t.Fatalf("exit = %d, want 0 when codex has no plugin → auto-install + launch (stderr=%q)", code, stderr.String())
+			}
+			wantInstall := []string{"codex", marketplaceSource, devBranch}
+			if !equalArgv(fake.installCmds, wantInstall) {
+				t.Fatalf("install seam = %v, want %v (the {host, source, branch} seam)", fake.installCmds, wantInstall)
+			}
+			if fake.launchedArg == nil {
+				t.Fatalf("launch seam not invoked after codex auto-install")
+			}
+		})
+	}
+}
+
+// TestCodexFrontDoorNoPluginNoInstallRefuses (AC-3): --no-install preserves the
+// refuse-and-instruct behavior — no install, no launch, non-zero exit, with the
+// codex no-plugin remedy on stderr. This is the migrated assertion from the old
+// fail-fast test, now gated behind --no-install. Both no-plugin verdicts refuse.
+func TestCodexFrontDoorNoPluginNoInstallRefuses(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-dir", ".codex-plugin", "plugin.json")
+	cases := []struct {
+		name     string
+		manifest string
+	}{
+		{name: "empty manifest", manifest: ""},
+		{name: "missing manifest", manifest: missing},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeHost{manifest: tc.manifest}
+			var stdout, stderr bytes.Buffer
+
+			code := runCodex(context.Background(), []string{"--no-install"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
 			if code == 0 {
-				t.Fatalf("exit = 0, want non-zero when codex has no plugin")
+				t.Fatalf("exit = 0, want non-zero with --no-install and no codex plugin")
 			}
 			if len(fake.installCmds) != 0 {
-				t.Fatalf("install seam invoked on codex no-plugin path: %v", fake.installCmds)
+				t.Fatalf("install seam invoked despite --no-install: %v", fake.installCmds)
 			}
 			if fake.launchedArg != nil {
-				t.Fatalf("launch seam invoked on codex no-plugin path: %v", fake.launchedArg)
+				t.Fatalf("launch seam invoked despite --no-install: %v", fake.launchedArg)
 			}
 			if !strings.Contains(stderr.String(), "codex plugin") {
 				t.Fatalf("stderr missing codex no-plugin remedy: %q", stderr.String())

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -63,11 +63,11 @@ func (execHost) resolveClaudeManifest(host string) (string, error) {
 }
 
 // resolveCodexManifest confirms spacedock@spacedock is installed via the text
-// `codex plugin list` and resolves the manifest under the Codex plugin cache
-// (codex's `--json` carries no install path, so the text listing + cache layout
-// is the resolver). Codex installs land at
-// <CODEX_HOME>/plugins/cache/<marketplace>/<plugin>/<version>/.codex-plugin/plugin.json;
-// the listing carries no install path, so the cache layout is the resolver.
+// `codex plugin list` and resolves the manifest under the Codex plugin cache.
+// Codex's listing carries no install path (its `--json` form has one only for
+// the marketplace root, not the cached plugin), so the deterministic cache
+// layout is the resolver. Codex installs land at
+// <CODEX_HOME>/plugins/cache/<marketplace>/<plugin>/<version>/.codex-plugin/plugin.json.
 // Returns "" (no error) when the plugin is not installed or no cached manifest
 // exists for it yet.
 func (execHost) resolveCodexManifest() (string, error) {

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -29,9 +29,9 @@ type pluginListEntry struct {
 // ResolveManifest returns the installed spacedock@spacedock plugin manifest path
 // for host, or "" (no error) when no plugin is installed. The two hosts resolve
 // differently: Claude reports an installPath in `claude plugin list --json`;
-// Codex 0.136.0 has no --json (it rejects the flag, exit 2) and its text listing
-// carries no install path, so the Codex path confirms the install via the text
-// listing and resolves the manifest under the deterministic Codex plugin cache.
+// Codex's `plugin list --json` carries no install path (only an installed flag,
+// different schema), so the Codex path confirms the install via the text listing
+// and resolves the manifest under the deterministic Codex plugin cache.
 func (e execHost) ResolveManifest(host string) (string, error) {
 	if host == "codex" {
 		return e.resolveCodexManifest()
@@ -63,8 +63,9 @@ func (execHost) resolveClaudeManifest(host string) (string, error) {
 }
 
 // resolveCodexManifest confirms spacedock@spacedock is installed via the text
-// `codex plugin list` (no --json — 0.136.0 rejects it) and resolves the manifest
-// under the Codex plugin cache. Codex installs land at
+// `codex plugin list` and resolves the manifest under the Codex plugin cache
+// (codex's `--json` carries no install path, so the text listing + cache layout
+// is the resolver). Codex installs land at
 // <CODEX_HOME>/plugins/cache/<marketplace>/<plugin>/<version>/.codex-plugin/plugin.json;
 // the listing carries no install path, so the cache layout is the resolver.
 // Returns "" (no error) when the plugin is not installed or no cached manifest
@@ -260,20 +261,50 @@ func installArgvSequence(source, branch string) []installStep {
 	}
 }
 
-// Install shells the host plugin upgrade sequence (uninstall + marketplace
-// remove + add + install). The marketplace source is pinned to branch via @ref
-// (Claude) when set. The two cleanup steps (uninstall, marketplace remove) are
-// tolerated — their non-zero exits on a fresh-box ("not installed" / "not
-// found") are appended to combined output and the loop continues. The two
-// pinning steps (marketplace add, plugin install) are fail-fast and surface
-// real install failures. Codex installs are not shelled here — runInit emits
-// the documented prose for that host.
+// codexInstallArgvSequence is the codex analog of installArgvSequence: the same
+// 4-command cleanup-then-pin shape, but in codex's verb vocabulary (`plugin
+// remove` / `plugin add`, not claude's `uninstall` / `install`) and pinning the
+// branch via codex's own `--ref <branch>` flag (a separate argv token), NOT the
+// claude `source@branch` shorthand. `--ref` and its value are OMITTED when branch
+// is empty (the default-branch install). The tolerance asymmetry matches claude:
+// BOTH cleanup steps (plugin remove + marketplace remove) are tolerated — on a
+// fresh box `plugin remove` exits 0 (idempotent) but `marketplace remove` exits 1
+// ("marketplace `spacedock` is not configured or installed"), and neither is a
+// real failure. BOTH pinning steps (marketplace add + plugin add) stay fail-fast
+// — they are the real-failure backstops.
+func codexInstallArgvSequence(source, branch string) []installStep {
+	addArgv := []string{"plugin", "marketplace", "add", source}
+	if branch != "" {
+		addArgv = append(addArgv, "--ref", branch)
+	}
+	return []installStep{
+		{argv: []string{"plugin", "remove", "spacedock@spacedock"}, tolerateExit: true},
+		{argv: []string{"plugin", "marketplace", "remove", "spacedock"}, tolerateExit: true},
+		{argv: addArgv},
+		{argv: []string{"plugin", "add", "spacedock@spacedock"}},
+	}
+}
+
+// Install shells the host plugin upgrade sequence (cleanup-then-pin) for claude
+// or codex, returning combined output. Each host uses its own verb vocabulary and
+// branch-pinning form (claude `source@branch` shorthand; codex `--ref <branch>`),
+// supplied by installArgvSequence / codexInstallArgvSequence. The two cleanup
+// steps are tolerated — their non-zero exits on a fresh-box ("not installed" /
+// "not found") are appended to combined output and the loop continues. The two
+// pinning steps (marketplace add, plugin install/add) are fail-fast and surface
+// real install failures.
 func (execHost) Install(host, source, branch string) (string, error) {
-	if host != "claude" {
-		return "", fmt.Errorf("programmatic install is only supported for claude; codex install is documented prose")
+	var steps []installStep
+	switch host {
+	case "claude":
+		steps = installArgvSequence(source, branch)
+	case "codex":
+		steps = codexInstallArgvSequence(source, branch)
+	default:
+		return "", fmt.Errorf("programmatic install is supported for claude and codex, not %q", host)
 	}
 	var sb strings.Builder
-	for _, step := range installArgvSequence(source, branch) {
+	for _, step := range steps {
 		cmd := exec.Command(host, step.argv...)
 		out, err := cmd.CombinedOutput()
 		sb.Write(out)

--- a/internal/cli/install_behavior_codex_test.go
+++ b/internal/cli/install_behavior_codex_test.go
@@ -1,0 +1,115 @@
+// ABOUTME: AC-5 behavioral codex install — a real isolated-CODEX_HOME run of
+// ABOUTME: execHost.Install against a local-path marketplace, observing on-disk state.
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestCodexPluginInstallIsHostNative runs the REAL execHost{}.Install("codex", …)
+// against an isolated CODEX_HOME + a local-path marketplace, then observes that
+// (a) `codex plugin list --json` reports spacedock@spacedock with installed:true,
+// and (b) the cache manifest the resolver looks for exists on disk. The source is
+// the local marketplace path with an empty branch, so the install carries no
+// --ref and stays hermetic/offline. This proves the real codex CLI accepts the
+// 4-step Install sequence (the two cleanup steps run first against a fresh
+// CODEX_HOME — plugin remove exits 0, marketplace remove exits 1 tolerated — then
+// the two pin steps install) unattended, not just the stub. Skips when `codex` is
+// not on PATH; kept hermetic by env isolation, not a mock.
+func TestCodexPluginInstallIsHostNative(t *testing.T) {
+	if _, err := exec.LookPath("codex"); err != nil {
+		t.Skip("codex not on PATH; behavioral install test requires the host CLI")
+	}
+
+	tmp := t.TempDir()
+	marketplace := buildLocalCodexMarketplace(t, tmp)
+	codexHomeDir := filepath.Join(tmp, "codexhome")
+	mustMkdir(t, codexHomeDir)
+	t.Setenv("CODEX_HOME", codexHomeDir)
+
+	// The real Install runs in-process through the production seam: the codex arm
+	// shells the 4-step sequence against the isolated CODEX_HOME (CODEX_HOME is read
+	// from the env by the codex CLI). Empty branch → no --ref → fully offline.
+	out, err := execHost{}.Install("codex", marketplace, "")
+	if err != nil {
+		t.Fatalf("execHost.Install(codex) failed: %v\nout=%q", err, out)
+	}
+
+	// (a) The real codex CLI reports the plugin installed. The --json schema is
+	// {"installed":[{"pluginId":…,"installed":true}]}; the installed flag is the
+	// independent source of truth, not a substring of our source.
+	listOut := runHost(t, mustLookPath(t, "codex"), os.Environ(), "plugin", "list", "--json")
+	var listing struct {
+		Installed []struct {
+			PluginID  string `json:"pluginId"`
+			Installed bool   `json:"installed"`
+		} `json:"installed"`
+	}
+	if err := json.Unmarshal([]byte(listOut), &listing); err != nil {
+		t.Fatalf("parse codex plugin list --json: %v\n%s", err, listOut)
+	}
+	found := false
+	for _, e := range listing.Installed {
+		if e.PluginID == "spacedock@spacedock" && e.Installed {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("codex plugin list --json did not report spacedock@spacedock installed:true:\n%s", listOut)
+	}
+
+	// (b) The cache manifest exists at exactly the resolver's path
+	// (<CODEX_HOME>/plugins/cache/spacedock/spacedock/<version>/.codex-plugin/plugin.json).
+	// resolveCodexManifest must therefore resolve a non-empty manifest path.
+	manifest, err := execHost{}.resolveCodexManifest()
+	if err != nil {
+		t.Fatalf("resolveCodexManifest after install: %v", err)
+	}
+	if manifest == "" {
+		t.Fatalf("resolveCodexManifest returned empty after a real install")
+	}
+	if _, statErr := os.Stat(manifest); statErr != nil {
+		t.Fatalf("resolved manifest %s does not exist: %v", manifest, statErr)
+	}
+}
+
+// buildLocalCodexMarketplace writes a minimal valid local-path marketplace under
+// root and returns the marketplace directory. Codex reads the marketplace
+// manifest from .claude-plugin/marketplace.json (it reuses the claude manifest
+// layout) and the plugin manifest from the plugin's .codex-plugin/plugin.json.
+// The plugin manifest carries a requires-contract bracketing CONTRACT_VERSION.
+func buildLocalCodexMarketplace(t *testing.T, root string) string {
+	t.Helper()
+	marketplace := filepath.Join(root, "marketplace")
+	plugin := filepath.Join(marketplace, "spacedock")
+	mustMkdir(t, filepath.Join(marketplace, ".claude-plugin"))
+	mustMkdir(t, filepath.Join(plugin, ".codex-plugin"))
+	mustMkdir(t, filepath.Join(plugin, "skills", "demo"))
+
+	mustWrite(t, filepath.Join(marketplace, ".claude-plugin", "marketplace.json"), `{
+  "name": "spacedock",
+  "owner": { "name": "CL Kao" },
+  "plugins": [
+    { "name": "spacedock", "source": "./spacedock", "description": "test", "category": "workflow" }
+  ]
+}
+`)
+	mustWrite(t, filepath.Join(plugin, ".codex-plugin", "plugin.json"), `{ "name": "spacedock", "version": "0.0.0", "requires-contract": ">=1,<2", "skills": "./skills/" }
+`)
+	mustWrite(t, filepath.Join(plugin, "skills", "demo", "SKILL.md"), "---\nname: demo\ndescription: demo skill\n---\ndemo\n")
+	return marketplace
+}
+
+// mustLookPath resolves bin on PATH or fails the test.
+func mustLookPath(t *testing.T, bin string) string {
+	t.Helper()
+	p, err := exec.LookPath(bin)
+	if err != nil {
+		t.Fatalf("look path %s: %v", bin, err)
+	}
+	return p
+}

--- a/internal/cli/install_tolerance_codex_test.go
+++ b/internal/cli/install_tolerance_codex_test.go
@@ -1,0 +1,168 @@
+// ABOUTME: AC-1 codex install-tolerance — drives execHost.Install against a per-PATH
+// ABOUTME: stub codex, asserting the codex install sequence's order + tolerance asymmetry.
+package cli
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestCodexInstallIssuesSequenceInOrder locks AC-1a: a stub codex that exits 0 on
+// every step → Install("codex", "spacedock-dev/spacedock", "next") returns nil and
+// the combined output carries all four step markers, including the codex-specific
+// `plugin marketplace add spacedock-dev/spacedock --ref next` and `plugin add
+// spacedock@spacedock`. The stub's echoed argv is the independent source of truth.
+func TestCodexInstallIssuesSequenceInOrder(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub script uses /bin/sh; not portable to Windows")
+	}
+	dir := writeHostStub(t, "codex", "")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := execHost{}.Install("codex", "spacedock-dev/spacedock", "next")
+	if err != nil {
+		t.Fatalf("Install returned error on all-zero codex stub: %v\nout=%q", err, out)
+	}
+	wantOrder := []string{
+		"stub:plugin remove spacedock@spacedock:exit=0",
+		"stub:plugin marketplace remove spacedock:exit=0",
+		"stub:plugin marketplace add spacedock-dev/spacedock --ref next:exit=0",
+		"stub:plugin add spacedock@spacedock:exit=0",
+	}
+	last := -1
+	for _, want := range wantOrder {
+		idx := strings.Index(out, want)
+		if idx < 0 {
+			t.Errorf("combined output missing %q\nout=%q", want, out)
+			continue
+		}
+		if idx <= last {
+			t.Errorf("step %q out of order (idx=%d, prev=%d)\nout=%q", want, idx, last, out)
+		}
+		last = idx
+	}
+}
+
+// TestCodexInstallToleratesMarketplaceRemoveFailure locks AC-1b: the fresh-box
+// path where `codex plugin marketplace remove spacedock` exits 1 ("is not
+// configured or installed") and every other step exits 0. Install MUST return a
+// nil error and the combined output MUST carry all four step markers — the
+// marketplace remove is a tolerated cleanup step.
+func TestCodexInstallToleratesMarketplaceRemoveFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub script uses /bin/sh; not portable to Windows")
+	}
+	dir := writeHostStub(t, "codex", "plugin marketplace remove")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := execHost{}.Install("codex", "spacedock-dev/spacedock", "next")
+	if err != nil {
+		t.Fatalf("Install returned error on tolerated marketplace-remove failure: %v\nout=%q", err, out)
+	}
+	for _, want := range []string{
+		"stub:plugin remove spacedock@spacedock:exit=0",
+		"stub:plugin marketplace remove spacedock:exit=1",
+		"stub:plugin marketplace add spacedock-dev/spacedock --ref next:exit=0",
+		"stub:plugin add spacedock@spacedock:exit=0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("combined output missing %q\nout=%q", want, out)
+		}
+	}
+}
+
+// TestCodexInstallToleratesPluginRemoveFailure locks the cleanup half of AC-1b:
+// when `codex plugin remove spacedock@spacedock` exits 1 and every other step
+// exits 0, Install MUST still return nil — the plugin remove is a tolerated
+// cleanup step (idempotent on a fresh box per the spike, exit 0; tolerated here
+// so a future codex that exits 1 on a fresh box does not break the install).
+func TestCodexInstallToleratesPluginRemoveFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub script uses /bin/sh; not portable to Windows")
+	}
+	dir := writeHostStub(t, "codex", "plugin remove")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := execHost{}.Install("codex", "spacedock-dev/spacedock", "next")
+	if err != nil {
+		t.Fatalf("Install returned error on tolerated plugin-remove failure: %v\nout=%q", err, out)
+	}
+	for _, want := range []string{
+		"stub:plugin remove spacedock@spacedock:exit=1",
+		"stub:plugin marketplace add spacedock-dev/spacedock --ref next:exit=0",
+		"stub:plugin add spacedock@spacedock:exit=0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("combined output missing %q\nout=%q", want, out)
+		}
+	}
+}
+
+// TestCodexInstallFailsFastOnMarketplaceAdd locks AC-1c: tolerance is asymmetric.
+// The marketplace add is NOT tolerated, so a stub exiting 1 on add must surface a
+// non-nil error wrapping that subcommand argv (the real-failure backstop).
+func TestCodexInstallFailsFastOnMarketplaceAdd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub script uses /bin/sh; not portable to Windows")
+	}
+	dir := writeHostStub(t, "codex", "plugin marketplace add")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := execHost{}.Install("codex", "spacedock-dev/spacedock", "next")
+	if err == nil {
+		t.Fatalf("Install returned nil error; want marketplace-add fail-fast\nout=%q", out)
+	}
+	if !strings.Contains(err.Error(), "plugin marketplace add spacedock-dev/spacedock --ref next") {
+		t.Errorf("error %q does not wrap the codex add subcommand argv", err)
+	}
+	if !strings.Contains(out, "stub:plugin marketplace add spacedock-dev/spacedock --ref next:exit=1") {
+		t.Errorf("combined output missing add-step stub marker; out=%q", out)
+	}
+}
+
+// TestCodexInstallFailsFastOnPluginAdd locks the other fail-fast arm of AC-1c: the
+// final `plugin add` step is not tolerated either. A stub exiting 1 on it must
+// surface a non-nil error wrapping that subcommand argv.
+func TestCodexInstallFailsFastOnPluginAdd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub script uses /bin/sh; not portable to Windows")
+	}
+	dir := writeHostStub(t, "codex", "plugin add")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := execHost{}.Install("codex", "spacedock-dev/spacedock", "next")
+	if err == nil {
+		t.Fatalf("Install returned nil error; want plugin-add fail-fast\nout=%q", out)
+	}
+	if !strings.Contains(err.Error(), "plugin add spacedock@spacedock") {
+		t.Errorf("error %q does not wrap the codex plugin add subcommand argv", err)
+	}
+	if !strings.Contains(out, "stub:plugin add spacedock@spacedock:exit=1") {
+		t.Errorf("combined output missing plugin-add stub marker; out=%q", out)
+	}
+}
+
+// TestCodexInstallOmitsRefWhenBranchEmpty locks the empty-branch arm of AC-1: with
+// branch=="" the marketplace add carries the bare source and NO `--ref` token. A
+// stub recording the exact argv is the source of truth — a leaked `--ref` would
+// pin against a non-existent ref on the default-branch install path.
+func TestCodexInstallOmitsRefWhenBranchEmpty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub script uses /bin/sh; not portable to Windows")
+	}
+	dir := writeHostStub(t, "codex", "")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := execHost{}.Install("codex", "spacedock-dev/spacedock", "")
+	if err != nil {
+		t.Fatalf("Install returned error on empty-branch codex stub: %v\nout=%q", err, out)
+	}
+	if !strings.Contains(out, "stub:plugin marketplace add spacedock-dev/spacedock:exit=0") {
+		t.Errorf("combined output missing bare-source add marker; out=%q", out)
+	}
+	if strings.Contains(out, "--ref") {
+		t.Errorf("combined output carries a --ref token with empty branch; out=%q", out)
+	}
+}

--- a/internal/cli/install_tolerance_test.go
+++ b/internal/cli/install_tolerance_test.go
@@ -91,25 +91,36 @@ func TestInstallFailsFastOnAddStep(t *testing.T) {
 	}
 }
 
-// writeClaudeStub writes a `claude` shell script under a temp dir and returns
-// the dir (suitable for PATH prepend). The stub echoes
+// writeClaudeStub writes a `claude` host stub (see writeHostStub).
+func writeClaudeStub(t *testing.T, failOn string) string {
+	t.Helper()
+	return writeHostStub(t, "claude", failOn)
+}
+
+// writeHostStub writes a host CLI shell script named binName under a temp dir and
+// returns the dir (suitable for PATH prepend). The stub echoes
 // `stub:<joined args>:exit=<code>` to stdout, then exits with code 1 if the
 // argv joined with single spaces starts with failOn, else exit 0. failOn is
 // quoted into the case pattern so it can contain spaces (e.g. "plugin
-// marketplace remove"). This lets a single helper drive both "fail on remove"
-// and "fail on add" tests.
-func writeClaudeStub(t *testing.T, failOn string) string {
+// marketplace remove"). An empty failOn never matches, so every step exits 0.
+// This lets a single helper drive both "fail on <step>" and all-zero tests for
+// either host binary.
+func writeHostStub(t *testing.T, binName, failOn string) string {
 	t.Helper()
 	dir := t.TempDir()
-	path := filepath.Join(dir, "claude")
-	body := `#!/bin/sh
-args="$*"
-case "$args" in
-"` + failOn + `"*)
+	path := filepath.Join(dir, binName)
+	matchArm := ""
+	if failOn != "" {
+		matchArm = `"` + failOn + `"*)
   echo "stub:$args:exit=1"
   exit 1
   ;;
-*)
+`
+	}
+	body := `#!/bin/sh
+args="$*"
+case "$args" in
+` + matchArm + `*)
   echo "stub:$args:exit=0"
   exit 0
   ;;

--- a/internal/cli/safehouse_frontdoor_test.go
+++ b/internal/cli/safehouse_frontdoor_test.go
@@ -227,19 +227,25 @@ func TestCodexNoSafehouseLaunchesPlainNoBypass(t *testing.T) {
 	}
 }
 
-// codex AC-3 analog: plugin-gate failure SHORT-CIRCUITS before any safehouse
-// logic. Even with .safehouse present AND the safehouse binary absent, the
-// missing-plugin gate fires first: plugin remedy on stderr, NO safehouse hint,
-// Launch never called.
+// codex AC-3 analog: a refused plugin gate SHORT-CIRCUITS before any safehouse
+// logic. With .safehouse present AND the safehouse binary absent, --no-install
+// (which refuses the no-plugin case rather than auto-installing) fails at the
+// plugin gate first: plugin remedy on stderr, NO safehouse hint, Launch never
+// called. (Without --no-install the no-plugin case auto-installs and proceeds, so
+// the gate is no longer a fail-fast there — the short-circuit-before-safehouse
+// invariant lives on the refuse path, mirroring runClaude.)
 func TestCodexPluginGateShortCircuitsBeforeSafehouse(t *testing.T) {
 	dir := safehouseFixtureDir(t)
 	fake := &fakeHost{manifest: ""} // no plugin
 	var stdout, stderr bytes.Buffer
 
-	code := runCodex(context.Background(), nil, dir, fake, lookMissing, &stdout, &stderr)
+	code := runCodex(context.Background(), []string{"--no-install"}, dir, fake, lookMissing, &stdout, &stderr)
 
 	if code == 0 {
 		t.Fatalf("exit = 0, want non-zero when plugin gate fails")
+	}
+	if len(fake.installCmds) != 0 {
+		t.Fatalf("install invoked despite --no-install: %v", fake.installCmds)
 	}
 	if fake.launchedArg != nil {
 		t.Fatalf("Launch invoked despite plugin-gate failure: %v", fake.launchedArg)


### PR DESCRIPTION
`spacedock codex` now auto-installs a missing plugin and launches, so the single command
the user typed yields a working first-officer session — the codex analog of #311.

## What changed
- Add a codex arm to `execHost.Install` with a host-native install sequence (tolerant cleanup, fail-fast pins, `--ref <devBranch>`).
- Wire `runCodex` to auto-install on a missing plugin then launch, mirroring `runClaude`.
- Honor `--no-install` (refuse-and-instruct) and still fail fast on a contract mismatch.
- Rewrite three now-false codex comments/error-strings to describe the new behavior.

## Evidence
- `go test ./...`: green (1166+ tests; vet clean); the host-native install ran against real codex-cli 0.137.0.
- Detached adversarial audit: 5 mandated + 2 bonus breaking edits each turned the suite red — no material findings.

---
[z9](/spacedock-dev/spacedock/blob/a9a58faf2fc4189b16967758b9700a0cac8fff71/codex-plugin-auto-install.md)
