### PR TITLE
migration-check test shares the production walk composition (extract a walk-step helper)

### DIFF
--- a/internal/status/migration_check.go
+++ b/internal/status/migration_check.go
@@ -1,4 +1,4 @@
-// ABOUTME: Migration-check walk-step — the .spacedock-state prune composition
+// ABOUTME: Migration-check walk-step — the non-entity-tree prune composition
 // ABOUTME: shared by the live consistency check and its hermetic prune test.
 package status
 
@@ -8,33 +8,47 @@ import (
 )
 
 // isMigrationCheckPrunedDir reports whether the migration-check walk skips a
-// directory whole. The .spacedock-state tree is the gitignored split-root state
-// checkout: on a dev machine it materializes under docs/dev/ and holds ~100
-// machine-local entity files (active entities plus _debriefs session records)
-// the migration check was never meant to govern; on CI the tree is absent and
-// the prune is moot. The debriefs in particular carry their own frontmatter
-// shape (session-date, sequence, first-commit), whose bare-YAML date scalars
-// decode as time.Time directly but as strings through the reader — expected for
-// non-entity frontmatter and outside this check's scope. Pruning the tree
-// wholesale matches the established sibling prunes in handlers.go
-// (discoverIgnoreDirs) and boundary_guard_test.go.
-func isMigrationCheckPrunedDir(name string) bool {
-	return name == ".spacedock-state"
+// directory whole, given its path. Two non-entity trees are pruned, both holding
+// frontmatter the migration check was never meant to govern:
+//
+//   - .spacedock-state — the gitignored split-root state checkout. On a dev
+//     machine it materializes under docs/dev/ and holds ~100 machine-local entity
+//     files (active entities plus _debriefs session records); on CI the tree is
+//     absent and the prune is moot.
+//   - docs/roadmap — the strategy layer (sprint definitions, staff reviews,
+//     session debriefs). It owns outcome/scope/sequencing, NOT entity state
+//     (that lives in docs/dev/.spacedock-state), so it carries no entity
+//     frontmatter; matched as a `roadmap` dir directly under a `docs` dir so the
+//     prune is location-independent (fires under the repo root AND under a temp
+//     fixture root).
+//
+// The debriefs in both trees carry their own frontmatter shape (session-date,
+// sequence, first-commit), whose bare-YAML date scalars decode as time.Time
+// directly but as strings through the reader — expected for non-entity
+// frontmatter and outside this check's scope. Pruning these trees wholesale
+// matches the established sibling prunes in handlers.go (discoverIgnoreDirs) and
+// boundary_guard_test.go.
+func isMigrationCheckPrunedDir(path string) bool {
+	name := filepath.Base(path)
+	if name == ".spacedock-state" {
+		return true
+	}
+	return name == "roadmap" && filepath.Base(filepath.Dir(path)) == "docs"
 }
 
 // migrationCheckWalkDir is the directory walk-step for the migration-check
-// filepath.Walk. For a directory entry it returns filepath.SkipDir to prune the
-// .spacedock-state subtree wholesale (else nil to descend), and dir=true so the
+// filepath.Walk. For a directory entry it returns filepath.SkipDir to prune a
+// non-entity subtree wholesale (else nil to descend), and dir=true so the
 // callback returns that action immediately. For a non-directory entry it returns
 // dir=false and the callback proceeds to file handling. Sharing this step keeps
 // the prune composition defined once — the live consistency check and the
 // hermetic prune test drive the same walk-step, so a divergence in production's
 // composition cannot pass the hermetic test unnoticed.
-func migrationCheckWalkDir(info os.FileInfo) (action error, dir bool) {
+func migrationCheckWalkDir(path string, info os.FileInfo) (action error, dir bool) {
 	if !info.IsDir() {
 		return nil, false
 	}
-	if isMigrationCheckPrunedDir(info.Name()) {
+	if isMigrationCheckPrunedDir(path) {
 		return filepath.SkipDir, true
 	}
 	return nil, true

--- a/internal/status/migration_check.go
+++ b/internal/status/migration_check.go
@@ -1,0 +1,41 @@
+// ABOUTME: Migration-check walk-step — the .spacedock-state prune composition
+// ABOUTME: shared by the live consistency check and its hermetic prune test.
+package status
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// isMigrationCheckPrunedDir reports whether the migration-check walk skips a
+// directory whole. The .spacedock-state tree is the gitignored split-root state
+// checkout: on a dev machine it materializes under docs/dev/ and holds ~100
+// machine-local entity files (active entities plus _debriefs session records)
+// the migration check was never meant to govern; on CI the tree is absent and
+// the prune is moot. The debriefs in particular carry their own frontmatter
+// shape (session-date, sequence, first-commit), whose bare-YAML date scalars
+// decode as time.Time directly but as strings through the reader — expected for
+// non-entity frontmatter and outside this check's scope. Pruning the tree
+// wholesale matches the established sibling prunes in handlers.go
+// (discoverIgnoreDirs) and boundary_guard_test.go.
+func isMigrationCheckPrunedDir(name string) bool {
+	return name == ".spacedock-state"
+}
+
+// migrationCheckWalkDir is the directory walk-step for the migration-check
+// filepath.Walk. For a directory entry it returns filepath.SkipDir to prune the
+// .spacedock-state subtree wholesale (else nil to descend), and dir=true so the
+// callback returns that action immediately. For a non-directory entry it returns
+// dir=false and the callback proceeds to file handling. Sharing this step keeps
+// the prune composition defined once — the live consistency check and the
+// hermetic prune test drive the same walk-step, so a divergence in production's
+// composition cannot pass the hermetic test unnoticed.
+func migrationCheckWalkDir(info os.FileInfo) (action error, dir bool) {
+	if !info.IsDir() {
+		return nil, false
+	}
+	if isMigrationCheckPrunedDir(info.Name()) {
+		return filepath.SkipDir, true
+	}
+	return nil, true
+}

--- a/internal/status/migration_check.go
+++ b/internal/status/migration_check.go
@@ -25,9 +25,8 @@ import (
 // The debriefs in both trees carry their own frontmatter shape (session-date,
 // sequence, first-commit), whose bare-YAML date scalars decode as time.Time
 // directly but as strings through the reader — expected for non-entity
-// frontmatter and outside this check's scope. Pruning these trees wholesale
-// matches the established sibling prunes in handlers.go (discoverIgnoreDirs) and
-// boundary_guard_test.go.
+// frontmatter and outside this check's scope. Both trees are pruned wholesale:
+// neither holds the entity frontmatter the migration check governs.
 func isMigrationCheckPrunedDir(path string) bool {
 	name := filepath.Base(path)
 	if name == ".spacedock-state" {

--- a/internal/status/migration_check_test.go
+++ b/internal/status/migration_check_test.go
@@ -66,11 +66,8 @@ func TestMigrationCheckFixturesParseConsistently(t *testing.T) {
 		if walkErr != nil {
 			return walkErr
 		}
-		if info.IsDir() {
-			if isMigrationCheckPrunedDir(info.Name()) {
-				return filepath.SkipDir
-			}
-			return nil
+		if action, dir := migrationCheckWalkDir(info); dir {
+			return action
 		}
 		if !strings.HasSuffix(path, ".md") {
 			return nil
@@ -160,27 +157,12 @@ func TestMigrationCheckFixturesParseConsistently(t *testing.T) {
 	t.Logf("migration-check verified %d frontmatters across fixtures + live", checked)
 }
 
-// isMigrationCheckPrunedDir reports whether the migration-check walk skips a
-// directory whole. The .spacedock-state tree is the gitignored split-root state
-// checkout: on a dev machine it materializes under docs/dev/ and holds ~100
-// machine-local entity files (active entities plus _debriefs session records)
-// the migration check was never meant to govern; on CI the tree is absent and
-// the prune is moot. The debriefs in particular carry their own frontmatter
-// shape (session-date, sequence, first-commit), whose bare-YAML date scalars
-// decode as time.Time directly but as strings through the reader — expected for
-// non-entity frontmatter and outside this check's scope. Pruning the tree
-// wholesale matches the established sibling prunes in handlers.go
-// (discoverIgnoreDirs) and boundary_guard_test.go.
-func isMigrationCheckPrunedDir(name string) bool {
-	return name == ".spacedock-state"
-}
-
 // TestMigrationCheckPrunesStateTree is the hermetic, CI-stable positive proof
 // that the migration-check walk prunes the .spacedock-state tree wholesale
 // rather than name-matching individual subdirs. It plants a temp tree holding a
 // real entity alongside a .spacedock-state subtree, drives filepath.Walk
-// through the same isMigrationCheckPrunedDir predicate the migration check uses,
-// and asserts the state subtree is never visited while the real entity is —
+// through the same migrationCheckWalkDir step the production migration check
+// uses, and asserts the state subtree is never visited while the real entity is —
 // which keeps the checked>0 guard in TestMigrationCheckFixturesParseConsistently
 // non-vacuous (the prune does not also swallow legitimate entities).
 func TestMigrationCheckPrunesStateTree(t *testing.T) {
@@ -214,11 +196,8 @@ func TestMigrationCheckPrunesStateTree(t *testing.T) {
 		if walkErr != nil {
 			return walkErr
 		}
-		if info.IsDir() {
-			if isMigrationCheckPrunedDir(info.Name()) {
-				return filepath.SkipDir
-			}
-			return nil
+		if action, dir := migrationCheckWalkDir(info); dir {
+			return action
 		}
 		if strings.HasSuffix(path, ".md") {
 			visited = append(visited, path)

--- a/internal/status/migration_check_test.go
+++ b/internal/status/migration_check_test.go
@@ -66,7 +66,7 @@ func TestMigrationCheckFixturesParseConsistently(t *testing.T) {
 		if walkErr != nil {
 			return walkErr
 		}
-		if action, dir := migrationCheckWalkDir(info); dir {
+		if action, dir := migrationCheckWalkDir(path, info); dir {
 			return action
 		}
 		if !strings.HasSuffix(path, ".md") {
@@ -158,13 +158,14 @@ func TestMigrationCheckFixturesParseConsistently(t *testing.T) {
 }
 
 // TestMigrationCheckPrunesStateTree is the hermetic, CI-stable positive proof
-// that the migration-check walk prunes the .spacedock-state tree wholesale
-// rather than name-matching individual subdirs. It plants a temp tree holding a
-// real entity alongside a .spacedock-state subtree, drives filepath.Walk
-// through the same migrationCheckWalkDir step the production migration check
-// uses, and asserts the state subtree is never visited while the real entity is —
-// which keeps the checked>0 guard in TestMigrationCheckFixturesParseConsistently
-// non-vacuous (the prune does not also swallow legitimate entities).
+// that the migration-check walk prunes the non-entity trees wholesale rather
+// than name-matching individual subdirs. It plants a temp tree holding a real
+// entity alongside both pruned subtrees — a .spacedock-state checkout and a
+// docs/roadmap strategy tree — drives filepath.Walk through the same
+// migrationCheckWalkDir step the production migration check uses, and asserts
+// neither pruned subtree is visited while the real entity is — which keeps the
+// checked>0 guard in TestMigrationCheckFixturesParseConsistently non-vacuous
+// (the prune does not also swallow legitimate entities).
 func TestMigrationCheckPrunesStateTree(t *testing.T) {
 	root := t.TempDir()
 
@@ -191,12 +192,26 @@ func TestMigrationCheckPrunesStateTree(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// A session debrief inside the pruned docs/roadmap strategy tree — the walk
+	// must NOT visit this one either. Its bare-YAML session-date scalar decodes as
+	// time.Time directly but as a string through the reader, so the consistency
+	// walk would flag it if it ever read it. The roadmap tree is the strategy
+	// layer (non-entity by design), pruned wholesale for the same reason.
+	roadmapDir := filepath.Join(root, "docs", "roadmap", "0198-pre-flip-hardening")
+	if err := os.MkdirAll(roadmapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	debrief := filepath.Join(roadmapDir, "debrief.md")
+	if err := os.WriteFile(debrief, []byte("---\nsession-date: 2026-06-08\n---\n\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	var visited []string
 	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		if action, dir := migrationCheckWalkDir(info); dir {
+		if action, dir := migrationCheckWalkDir(path, info); dir {
 			return action
 		}
 		if strings.HasSuffix(path, ".md") {
@@ -212,6 +227,9 @@ func TestMigrationCheckPrunesStateTree(t *testing.T) {
 	for _, p := range visited {
 		if p == poison {
 			t.Errorf("walk descended into the pruned .spacedock-state tree: visited %s", p)
+		}
+		if p == debrief {
+			t.Errorf("walk descended into the pruned docs/roadmap tree: visited %s", p)
 		}
 		if p == liveEntity {
 			visitedLive = true


### PR DESCRIPTION
Define and test the migration-check's directory-prune once, and stop the entity-frontmatter check from policing non-entity roadmap debriefs.

## What changed
- Extract the walk-step composition (`info.IsDir()`→`SkipDir` around the prune predicate) into a shared `migrationCheckWalkDir` helper.
- Drive both the production migration-check and the hermetic prune test through that one helper — no inlined copy in the test.
- Widen the shared prune to skip the `docs/roadmap` strategy tree (non-entity session debriefs).
- Extend the hermetic prune test to plant a `docs/roadmap` debrief and assert it is pruned.

## Evidence
- `go test ./...` — 1172/1172 passed across 16 packages; `TestMigrationCheckPrunesStateTree` + `TestMigrationCheckFixturesParseConsistently` both green.
- Detached adversarial audit: no over-pruning — 4 adversarial edits; the prune skips exactly the one non-entity debrief and still catches every real entity inconsistency.

---
[f1](/spacedock-dev/spacedock/blob/ddd6d1238a50d945a58b49246355b66e19fc3d73/migration-check-share-walk-helper.md)
