### PR TITLE
Ship Linux binaries + a Linux install path (release is darwin-only)

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -1,0 +1,97 @@
+# Proves install.sh installs a runnable `spacedock` on BOTH Linux and macOS from
+# a checksum-verified release tarball, and that its checksum gate is fail-closed.
+#
+# Each matrix leg snapshots the release tarballs locally (goreleaser
+# --snapshot), then runs install.sh against the runner's NATIVE-OS tarball via
+# the SPACEDOCK_INSTALL_FROM local-dist override (real binary, no publish, no
+# mocks): the ubuntu leg installs+runs the linux binary, the macos leg the
+# darwin binary. A tamper case (corrupted tarball) asserts install.sh exits
+# non-zero and installs nothing, keeping the checksum gate load-bearing.
+name: install-e2e
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [next]
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      # Build the release tarballs + checksums.txt locally without publishing.
+      # The runner's native-OS tarball is what install.sh below consumes.
+      - name: Snapshot release tarballs
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean --skip=publish,homebrew
+
+      # Happy path: install the native-OS tarball via the local-dist override and
+      # assert the installed binary runs and reports a non-empty stamped version.
+      # The SAME extract/verify/install path runs here as in production; only the
+      # source (local dist vs. GitHub Release) differs.
+      - name: Install from local snapshot and run
+        run: |
+          set -euo pipefail
+          export SPACEDOCK_INSTALL_FROM="$PWD/dist"
+          export SPACEDOCK_INSTALL_DIR="$RUNNER_TEMP/sd-bin"
+          sh ./install.sh
+          "$SPACEDOCK_INSTALL_DIR/spacedock" --version
+          ver="$("$SPACEDOCK_INSTALL_DIR/spacedock" --version)"
+          case "$ver" in
+            spacedock\ ?*) echo "installed and ran: $ver" ;;
+            *) echo "::error::unexpected --version output: $ver"; exit 1 ;;
+          esac
+
+      # Tamper case: corrupt the native-OS tarball so its sha256 no longer matches
+      # checksums.txt, then assert install.sh exits NON-ZERO and installs nothing.
+      # This keeps the checksum gate load-bearing — without it a swapped tarball
+      # would install silently.
+      - name: Reject a tampered tarball (checksum gate)
+        run: |
+          set -euo pipefail
+          tdir="$RUNNER_TEMP/sd-tamper"
+          rm -rf "$tdir"
+          mkdir -p "$tdir/dist"
+          os="$(uname -s | tr 'A-Z' 'a-z')"
+          case "$(uname -m)" in
+            x86_64|amd64) arch=amd64 ;;
+            arm64|aarch64) arch=arm64 ;;
+            *) echo "::error::unexpected arch $(uname -m)"; exit 1 ;;
+          esac
+          cp dist/spacedock_*_"${os}"_"${arch}".tar.gz "$tdir/dist/"
+          cp dist/checksums.txt "$tdir/dist/"
+          # Append bytes to the (single) native-OS tarball: its sha256 changes, the
+          # checksums.txt expected hash does not — the gate must catch the mismatch.
+          tarball="$(ls "$tdir"/dist/spacedock_*_"${os}"_"${arch}".tar.gz)"
+          printf '\xde\xad\xbe\xef' >> "$tarball"
+          export SPACEDOCK_INSTALL_FROM="$tdir/dist"
+          export SPACEDOCK_INSTALL_DIR="$tdir/bin"
+          set +e
+          sh ./install.sh
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::install.sh accepted a tampered tarball (exit 0); checksum gate is NOT load-bearing"
+            exit 1
+          fi
+          if [ -e "$tdir/bin/spacedock" ]; then
+            echo "::error::install.sh installed a binary despite the checksum mismatch"
+            exit 1
+          fi
+          echo "tamper rejected as expected (exit $rc, nothing installed)"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
-# Release build for the spacedock launcher: darwin arm64 + amd64 tarballs,
-# a checksums file, a GitHub Release, and a Homebrew formula bump on the own-tap.
+# Release build for the spacedock launcher: darwin + linux arm64 + amd64
+# tarballs, a checksums file, a GitHub Release, and a Homebrew formula bump on
+# the own-tap (cask is darwin-only; linux installs via install.sh).
 version: 2
 
 project_name: spacedock
@@ -16,6 +17,7 @@ builds:
       - CGO_ENABLED=0
     goos:
       - darwin
+      - linux
     goarch:
       - arm64
       - amd64
@@ -36,10 +38,10 @@ builds:
       - -X github.com/spacedock-dev/spacedock/internal/cli.devBranch=next
 
 archives:
-  # Asset name template is the B<->C contract with the homebrew-tap formula:
-  # spacedock_{version}_darwin_{arm64|amd64}.tar.gz, with the bare `spacedock`
-  # binary at the archive root (no wrapping directory) so `bin.install
-  # "spacedock"` resolves.
+  # Asset name template is the B<->C contract with the homebrew-tap formula and
+  # install.sh: spacedock_{version}_{darwin|linux}_{arm64|amd64}.tar.gz, with the
+  # bare `spacedock` binary at the archive root (no wrapping directory) so
+  # `bin.install "spacedock"` (cask) and install.sh's tar-extract both resolve.
   - id: spacedock
     formats:
       - tar.gz

--- a/docs/install-journey.md
+++ b/docs/install-journey.md
@@ -80,12 +80,12 @@ Release, verifies it against the release `checksums.txt`, and installs the
 **Sandboxing on Linux.** Spacedock's safehouse integration behaves the same on
 Linux as on macOS: when a `.safehouse` profile is present in the working
 directory, Spacedock wraps the launch through the `safehouse` command. Spacedock
-itself does not ship a sandbox — it detects the profile and delegates. So a run
-is actually sandboxed only when a Linux-capable `safehouse` binary is installed
-on your `PATH`. When the binary is absent, Spacedock prints an install hint and
-the launch proceeds **unsandboxed**. Install safehouse separately if you need
-the sandbox on Linux; the macOS-only Gatekeeper/quarantine handling does not
-apply on Linux and is not needed there.
+does not ship a sandbox — it detects the profile and delegates. A run is
+sandboxed only when a Linux-capable `safehouse` binary is on your `PATH`. When
+the binary is absent, Spacedock prints an install hint and the launch proceeds
+**unsandboxed**. Install safehouse separately if you need the sandbox on Linux;
+the macOS-only Gatekeeper/quarantine handling does not apply on Linux and is not
+needed there.
 
 ## Use Codex or Pi instead
 

--- a/docs/install-journey.md
+++ b/docs/install-journey.md
@@ -47,6 +47,46 @@ A from-source build is available for development.
    To set up the plugin ahead of time, or to refresh it later, run
    `spacedock install --host claude`.
 
+## Install on Linux (or macOS without Homebrew)
+
+The Homebrew cask is macOS-only. On Linux — and on macOS if you'd rather not use
+Homebrew — install the launcher with the `curl | sh` script. It detects your
+OS and architecture, downloads the matching tarball from the latest GitHub
+Release, verifies it against the release `checksums.txt`, and installs the
+`spacedock` binary to `~/.local/bin`.
+
+1. **Install the launcher.**
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/next/install.sh | sh
+   ```
+
+   Installs `spacedock` to `~/.local/bin`. If that directory is not on your
+   `PATH`, the script prints a note; add it (`export PATH="$HOME/.local/bin:$PATH"`)
+   so the `spacedock` command resolves. Set `SPACEDOCK_INSTALL_DIR` to install
+   elsewhere (e.g. `SPACEDOCK_INSTALL_DIR=/usr/local/bin`, which may need `sudo`).
+
+2. **Confirm it.**
+
+   ```bash
+   spacedock --version
+   ```
+
+   Prints the installed version, e.g. `spacedock 0.20.0`.
+
+3. **Add the plugin and launch** exactly as in the Homebrew steps above
+   (`spacedock claude "/spacedock:survey"`).
+
+**Sandboxing on Linux.** Spacedock's safehouse integration behaves the same on
+Linux as on macOS: when a `.safehouse` profile is present in the working
+directory, Spacedock wraps the launch through the `safehouse` command. Spacedock
+itself does not ship a sandbox — it detects the profile and delegates. So a run
+is actually sandboxed only when a Linux-capable `safehouse` binary is installed
+on your `PATH`. When the binary is absent, Spacedock prints an install hint and
+the launch proceeds **unsandboxed**. Install safehouse separately if you need
+the sandbox on Linux; the macOS-only Gatekeeper/quarantine handling does not
+apply on Linux and is not needed there.
+
 ## Use Codex or Pi instead
 
 Codex and Pi are supported but experimental. Claude Code is the primary surface.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,185 @@
+#!/bin/sh
+# ABOUTME: Universal curl|sh installer — fetch the checksum-verified spacedock
+# ABOUTME: release tarball for this host's OS/arch and install the bare binary.
+#
+# Usage (Linux or macOS):
+#   curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/next/install.sh | sh
+#
+# Behavior:
+#   * Detects OS (darwin|linux) and arch (amd64|arm64) from uname.
+#   * Resolves the asset to fetch from one of two sources, same extract/verify/
+#     install path for both:
+#       - SPACEDOCK_INSTALL_FROM unset (production): the latest GitHub Release.
+#       - SPACEDOCK_INSTALL_FROM=<dir|url-base> (tests / pinned mirror): a local
+#         goreleaser `dist/` directory or a URL prefix holding the same
+#         `spacedock_<ver>_<os>_<arch>.tar.gz` + `checksums.txt` layout.
+#   * Verifies the tarball sha256 against the matching `checksums.txt` line and
+#     ABORTS (installs nothing) on any mismatch — the gate is fail-closed.
+#   * Extracts the bare `spacedock` binary and installs it to SPACEDOCK_INSTALL_DIR
+#     (default ~/.local/bin).
+#
+# SPACEDOCK_PRINT_TARGET=1 runs the detection + URL-construction path and prints
+# the resolved os/arch/asset/tarball/checksums, then exits before any download —
+# the inspection seam the AC-3 live-URL test asserts against.
+#
+# The macOS Homebrew cask remains the preferred mac path; this script is the
+# universal fallback and the only Linux install path.
+set -eu
+
+REPO="spacedock-dev/spacedock"
+INSTALL_DIR="${SPACEDOCK_INSTALL_DIR:-$HOME/.local/bin}"
+
+err() { printf 'install.sh: %s\n' "$*" >&2; }
+die() { err "$*"; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
+
+# detect_os maps `uname -s` to the goreleaser goos token. Only darwin and linux
+# ship release tarballs; anything else is unsupported here (use Homebrew on mac,
+# or build from source).
+detect_os() {
+	case "$(uname -s)" in
+		Darwin) echo darwin ;;
+		Linux) echo linux ;;
+		*) die "unsupported OS $(uname -s); see docs/install-journey.md for source build" ;;
+	esac
+}
+
+# detect_arch maps `uname -m` to the goreleaser goarch token. The release builds
+# amd64 + arm64; uname reports several spellings for each.
+detect_arch() {
+	case "$(uname -m)" in
+		x86_64 | amd64) echo amd64 ;;
+		arm64 | aarch64) echo arm64 ;;
+		*) die "unsupported arch $(uname -m); release ships amd64 + arm64 only" ;;
+	esac
+}
+
+# sha256_of prints the lowercase hex sha256 of a file, using whichever tool the
+# host carries: sha256sum (Linux), or `shasum -a 256` (macOS).
+sha256_of() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | awk '{print $1}'
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$1" | awk '{print $1}'
+	else
+		die "no sha256 tool found (need sha256sum or shasum)"
+	fi
+}
+
+# fetch copies a source ref (local file path or http(s) URL) to a destination
+# file. A missing local file or a non-2xx HTTP status is a hard failure so the
+# caller never proceeds on a partial download.
+fetch() {
+	src="$1"
+	dst="$2"
+	case "$src" in
+		http://* | https://*)
+			curl -fsSL -o "$dst" "$src" || die "download failed: $src"
+			;;
+		*)
+			[ -f "$src" ] || die "file not found: $src"
+			cp "$src" "$dst"
+			;;
+	esac
+}
+
+# resolve_latest_tag asks the GitHub API for the repo's latest release tag (e.g.
+# v0.20.0). Unauthenticated; the public releases endpoint needs no token.
+resolve_latest_tag() {
+	api="https://api.github.com/repos/$REPO/releases/latest"
+	curl -fsSL "$api" \
+		| grep '"tag_name"' \
+		| head -n 1 \
+		| sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+}
+
+# asset_name builds the goreleaser archive name for a version/os/arch. The
+# version carries no leading `v` (goreleaser stamps the bare semver into the
+# `{{ .Version }}` template); the tag does, so callers strip it.
+asset_name() {
+	printf 'spacedock_%s_%s_%s.tar.gz' "$1" "$2" "$3"
+}
+
+main() {
+	need uname
+	need curl
+	need tar
+	need mktemp
+
+	os="$(detect_os)"
+	arch="$(detect_arch)"
+
+	# Resolve the asset name + the source refs (tarball + checksums) for either
+	# source. The SAME verify/extract/install path runs below for both.
+	if [ -n "${SPACEDOCK_INSTALL_FROM:-}" ]; then
+		from="${SPACEDOCK_INSTALL_FROM%/}"
+		# A local dist directory embeds the snapshot version in the filename, not
+		# known a priori, so glob for the os/arch tarball. A URL base must carry a
+		# resolvable version, so SPACEDOCK_INSTALL_VERSION pins it.
+		case "$from" in
+			http://* | https://*)
+				ver="${SPACEDOCK_INSTALL_VERSION:?SPACEDOCK_INSTALL_VERSION required when SPACEDOCK_INSTALL_FROM is a URL}"
+				asset="$(asset_name "$ver" "$os" "$arch")"
+				tarball_src="$from/$asset"
+				checksums_src="$from/checksums.txt"
+				;;
+			*)
+				[ -d "$from" ] || die "SPACEDOCK_INSTALL_FROM is not a directory or URL: $from"
+				asset="$(cd "$from" && ls spacedock_*_"${os}"_"${arch}".tar.gz 2>/dev/null | head -n 1)"
+				[ -n "$asset" ] || die "no spacedock_*_${os}_${arch}.tar.gz in $from"
+				tarball_src="$from/$asset"
+				checksums_src="$from/checksums.txt"
+				;;
+		esac
+	else
+		tag="$(resolve_latest_tag)"
+		[ -n "$tag" ] || die "could not resolve the latest release tag for $REPO"
+		ver="${tag#v}"
+		asset="$(asset_name "$ver" "$os" "$arch")"
+		base="https://github.com/$REPO/releases/download/$tag"
+		tarball_src="$base/$asset"
+		checksums_src="$base/checksums.txt"
+	fi
+
+	# Inspection mode: print the resolved target and stop before any download or
+	# install. This runs the EXACT production detection + URL-construction path
+	# above (no divergent branch) so a test can assert the asset name + URL the
+	# real installer would fetch against the live release.
+	if [ -n "${SPACEDOCK_PRINT_TARGET:-}" ]; then
+		printf 'os=%s\narch=%s\nasset=%s\ntarball=%s\nchecksums=%s\n' \
+			"$os" "$arch" "$asset" "$tarball_src" "$checksums_src"
+		return 0
+	fi
+
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "$tmp"' EXIT
+
+	fetch "$tarball_src" "$tmp/$asset"
+	fetch "$checksums_src" "$tmp/checksums.txt"
+
+	# Checksum gate (fail-closed). Pull THIS asset's expected hash from
+	# checksums.txt by exact filename, compute the downloaded tarball's hash, and
+	# abort installing anything on any mismatch or a missing checksum line.
+	expected="$(awk -v f="$asset" '$2 == f {print $1}' "$tmp/checksums.txt" | head -n 1)"
+	[ -n "$expected" ] || die "no checksum line for $asset in checksums.txt — refusing to install"
+	actual="$(sha256_of "$tmp/$asset")"
+	if [ "$expected" != "$actual" ]; then
+		die "checksum mismatch for $asset (expected $expected, got $actual) — refusing to install"
+	fi
+
+	# Extract the bare `spacedock` binary (archive root, no wrapping dir) and
+	# install it. Only after the checksum passes do we touch the install dir.
+	tar -xzf "$tmp/$asset" -C "$tmp" spacedock || die "tarball did not contain a spacedock binary"
+	mkdir -p "$INSTALL_DIR"
+	install -m 0755 "$tmp/spacedock" "$INSTALL_DIR/spacedock" 2>/dev/null \
+		|| { cp "$tmp/spacedock" "$INSTALL_DIR/spacedock" && chmod 0755 "$INSTALL_DIR/spacedock"; }
+
+	printf 'install.sh: installed spacedock %s to %s/spacedock\n' "$asset" "$INSTALL_DIR" >&2
+	case ":$PATH:" in
+		*":$INSTALL_DIR:"*) ;;
+		*) err "note: $INSTALL_DIR is not on PATH; add it to run 'spacedock' directly" ;;
+	esac
+}
+
+main "$@"

--- a/internal/release/goreleaser_guard_test.go
+++ b/internal/release/goreleaser_guard_test.go
@@ -1,0 +1,110 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// buildTarget is a single goos/goarch build pair, the cross-product element a
+// `v*` release tarball is published for.
+type buildTarget struct {
+	os   string
+	arch string
+}
+
+func (t buildTarget) String() string { return t.os + "/" + t.arch }
+
+// parseGoreleaserBuildTargets expands the goreleaser config's `builds[].goos` ×
+// `builds[].goarch` cross-product into the flat set of build targets goreleaser
+// produces — the same expansion goreleaser does when it emits one tarball per
+// goos/goarch pair. A config that does not parse yields a nil set (the guard's
+// superset assertion then fails loudly).
+func parseGoreleaserBuildTargets(config string) map[buildTarget]bool {
+	var doc struct {
+		Builds []struct {
+			Goos   []string `yaml:"goos"`
+			Goarch []string `yaml:"goarch"`
+		} `yaml:"builds"`
+	}
+	if err := yaml.Unmarshal([]byte(config), &doc); err != nil {
+		return nil
+	}
+	targets := map[buildTarget]bool{}
+	for _, b := range doc.Builds {
+		for _, o := range b.Goos {
+			for _, a := range b.Goarch {
+				targets[buildTarget{os: o, arch: a}] = true
+			}
+		}
+	}
+	return targets
+}
+
+// TestGoreleaserBuildsLinuxAndDarwin locks AC-1: the release config's build
+// target set is a superset of {linux,darwin}×{amd64,arm64}, so a `v*` release
+// publishes the two linux tarballs alongside the two darwin ones. The expected
+// set is written here independently of the YAML it checks — a future edit that
+// drops `linux` from `builds.goos` reds this test, exactly as the AC requires.
+func TestGoreleaserBuildsLinuxAndDarwin(t *testing.T) {
+	got := parseGoreleaserBuildTargets(readGoreleaserConfig(t))
+
+	want := []buildTarget{
+		{os: "linux", arch: "amd64"},
+		{os: "linux", arch: "arm64"},
+		{os: "darwin", arch: "amd64"},
+		{os: "darwin", arch: "arm64"},
+	}
+	var missing []string
+	for _, target := range want {
+		if !got[target] {
+			missing = append(missing, target.String())
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf(".goreleaser.yaml build target set is missing %s; got %s",
+			strings.Join(missing, ", "), targetSetString(got))
+	}
+}
+
+// TestGoreleaserBuildGuardRejectsDroppedLinux proves the guard is load-bearing:
+// a config with `linux` removed from `builds.goos` must fail the superset check.
+// The check parses the YAML rather than grepping its text, so the guard tracks
+// what goreleaser actually builds, not what the file happens to mention.
+func TestGoreleaserBuildGuardRejectsDroppedLinux(t *testing.T) {
+	config := readGoreleaserConfig(t)
+	// Drop the linux goos line the production config carries. The remaining
+	// darwin-only config is the pre-task shape this task replaces.
+	adversarial := strings.Replace(config, "      - linux\n", "", 1)
+	if adversarial == config {
+		t.Fatal("fixture .goreleaser.yaml has no `      - linux` goos line to drop")
+	}
+
+	got := parseGoreleaserBuildTargets(adversarial)
+	if got[buildTarget{os: "linux", arch: "amd64"}] || got[buildTarget{os: "linux", arch: "arm64"}] {
+		t.Fatalf("dropping the linux goos line still left a linux target in the set: %s", targetSetString(got))
+	}
+}
+
+func targetSetString(targets map[buildTarget]bool) string {
+	var names []string
+	for target := range targets {
+		names = append(names, target.String())
+	}
+	sort.Strings(names)
+	return "{" + strings.Join(names, ", ") + "}"
+}
+
+func readGoreleaserConfig(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", ".goreleaser.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/internal/release/install_doc_test.go
+++ b/internal/release/install_doc_test.go
@@ -1,0 +1,72 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInstallJourneyDocumentsLinuxPath locks AC-4's positive half: the install
+// guide carries a runnable `curl … install.sh | sh` invocation so a Linux user
+// has a concrete install path (the cask is darwin-only). The check requires the
+// raw.githubusercontent install.sh URL piped to a shell — the exact line a user
+// copy-pastes — not merely a mention of "install.sh".
+func TestInstallJourneyDocumentsLinuxPath(t *testing.T) {
+	doc := readInstallJourney(t)
+	commands := executableShellCommands(doc)
+
+	found := false
+	for _, c := range commands {
+		if strings.Contains(c, "install.sh") &&
+			strings.Contains(c, "curl ") &&
+			strings.Contains(c, "raw.githubusercontent.com/spacedock-dev/spacedock") &&
+			(strings.Contains(c, "| sh") || strings.HasSuffix(c, "sh")) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("docs/install-journey.md has no runnable `curl … install.sh | sh` Linux install line")
+	}
+}
+
+// TestInstallJourneyDoesNotOverclaimLinuxSandbox locks AC-4's honesty half:
+// spacedock ships no sandbox — internal/safehouse only detects a profile, checks
+// for a `safehouse` binary on PATH, and wraps argv. So the doc must NOT assert an
+// unqualified "sandboxed on Linux" claim. We scan for sandbox-claim phrasings
+// near "Linux" and reject any that promise sandboxing without the
+// requires-a-safehouse-binary qualifier.
+func TestInstallJourneyDoesNotOverclaimLinuxSandbox(t *testing.T) {
+	// Strip markdown code backticks so `safehouse` binary reads as the plain
+	// phrase the qualifier check looks for.
+	doc := strings.ToLower(strings.ReplaceAll(readInstallJourney(t), "`", ""))
+
+	// Phrasings that would over-claim a Linux sandbox if stated unqualified.
+	for _, claim := range []string{
+		"sandboxed on linux",
+		"runs sandboxed on linux",
+		"sandboxing on linux works",
+	} {
+		if strings.Contains(doc, claim) {
+			t.Errorf("install-journey over-claims a Linux sandbox with %q; spacedock ships no sandbox — sandboxing requires a Linux-capable safehouse binary", claim)
+		}
+	}
+
+	// If the doc discusses safehouse on Linux at all, it must name the binary
+	// dependency so the claim is qualified, not an unconditional promise.
+	if strings.Contains(doc, "safehouse") && strings.Contains(doc, "linux") {
+		if !strings.Contains(doc, "safehouse binary") {
+			t.Errorf("install-journey mentions safehouse + Linux but never names the required `safehouse binary` — the qualifier that keeps the claim honest")
+		}
+	}
+}
+
+func readInstallJourney(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "install-journey.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/internal/release/install_url_test.go
+++ b/internal/release/install_url_test.go
@@ -1,0 +1,170 @@
+package release
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestInstallScriptResolvesLiveReleaseAsset locks AC-3: install.sh's production
+// path (OS/arch detection + GitHub latest-release resolution + asset-URL
+// construction) is exercised against the LIVE GitHub API, and the URL it would
+// fetch is asserted against the release's actually-published asset for this host.
+//
+// This is the installer's ONLY network path; AC-2's local-dist override isolates
+// the extract/verify/install logic from network flakiness, and this test isolates
+// the network URL construction here. The test drives install.sh itself (via its
+// SPACEDOCK_PRINT_TARGET inspection mode) rather than re-deriving the mapping in
+// Go, so it proves the real installer's logic — no duplicate-and-drift.
+//
+// When this host's os/arch tarball is not yet published in the live release
+// (the linux gap this task closes ships before linux assets exist), the test
+// still asserts the construction is correct against goreleaser's naming for the
+// resolved tag, and confirms the constructed URL points at that tag's asset
+// namespace. When the asset IS published (darwin today), it asserts an exact
+// match against the live browser_download_url. The test skips when the GitHub
+// API is unreachable so transient network failure does not red the suite.
+func TestInstallScriptResolvesLiveReleaseAsset(t *testing.T) {
+	rel, ok := fetchLatestRelease(t)
+	if !ok {
+		t.Skip("github releases API unreachable; skipping live AC-3 URL check")
+	}
+
+	got := runInstallPrintTarget(t)
+
+	wantOS, wantArch := goosArch(t)
+	if got["os"] != wantOS {
+		t.Errorf("install.sh detected os=%q, want %q for this host", got["os"], wantOS)
+	}
+	if got["arch"] != wantArch {
+		t.Errorf("install.sh detected arch=%q, want %q for this host", got["arch"], wantArch)
+	}
+
+	ver := strings.TrimPrefix(rel.TagName, "v")
+	wantAsset := "spacedock_" + ver + "_" + wantOS + "_" + wantArch + ".tar.gz"
+	if got["asset"] != wantAsset {
+		t.Errorf("constructed asset name = %q, want %q (goreleaser template for live tag %s)",
+			got["asset"], wantAsset, rel.TagName)
+	}
+	wantURL := "https://github.com/spacedock-dev/spacedock/releases/download/" + rel.TagName + "/" + wantAsset
+	if got["tarball"] != wantURL {
+		t.Errorf("constructed tarball URL = %q, want %q", got["tarball"], wantURL)
+	}
+
+	// When the live release publishes this host's asset, the constructed URL must
+	// match its browser_download_url byte-for-byte. (Pre-ship, a linux host's
+	// asset is absent; the construction assertions above still bind it.)
+	for _, a := range rel.Assets {
+		if a.Name == wantAsset {
+			if a.BrowserDownloadURL != got["tarball"] {
+				t.Errorf("constructed URL %q != live published browser_download_url %q",
+					got["tarball"], a.BrowserDownloadURL)
+			}
+			return
+		}
+	}
+	t.Logf("note: %s is not yet published in live release %s (expected pre-ship for this host's os/arch); construction asserted against goreleaser naming",
+		wantAsset, rel.TagName)
+}
+
+// goosArch maps the Go runtime's GOOS/GOARCH to the goreleaser goos/goarch
+// tokens install.sh derives from uname — the independent oracle the test checks
+// install.sh's own detection against.
+func goosArch(t *testing.T) (string, string) {
+	t.Helper()
+	os := runtime.GOOS
+	switch os {
+	case "darwin", "linux":
+	default:
+		t.Skipf("unsupported host OS %q for install.sh", os)
+	}
+	var arch string
+	switch runtime.GOARCH {
+	case "amd64":
+		arch = "amd64"
+	case "arm64":
+		arch = "arm64"
+	default:
+		t.Skipf("unsupported host arch %q for install.sh", runtime.GOARCH)
+	}
+	return os, arch
+}
+
+// runInstallPrintTarget runs install.sh in its inspection mode (no download, no
+// install) and parses the `key=value` lines it prints into a map.
+func runInstallPrintTarget(t *testing.T) map[string]string {
+	t.Helper()
+	script := filepath.Join("..", "..", "install.sh")
+	cmd := exec.Command("sh", script)
+	cmd.Env = append([]string{"SPACEDOCK_PRINT_TARGET=1"}, scrubInstallEnv()...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install.sh SPACEDOCK_PRINT_TARGET=1 failed: %v\n%s", err, out)
+	}
+	fields := map[string]string{}
+	for _, line := range strings.Split(string(out), "\n") {
+		if k, v, ok := strings.Cut(line, "="); ok {
+			fields[k] = v
+		}
+	}
+	for _, k := range []string{"os", "arch", "asset", "tarball"} {
+		if fields[k] == "" {
+			t.Fatalf("install.sh print-target output missing %q:\n%s", k, out)
+		}
+	}
+	return fields
+}
+
+// scrubInstallEnv returns the process env with the install overrides removed so
+// the print-target run takes the PRODUCTION GitHub-resolution path, not a
+// local-dist override that a parent test or shell might have set.
+func scrubInstallEnv() []string {
+	var env []string
+	for _, kv := range os.Environ() {
+		switch {
+		case strings.HasPrefix(kv, "SPACEDOCK_INSTALL_FROM="),
+			strings.HasPrefix(kv, "SPACEDOCK_INSTALL_VERSION="),
+			strings.HasPrefix(kv, "SPACEDOCK_PRINT_TARGET="):
+			continue
+		}
+		env = append(env, kv)
+	}
+	return env
+}
+
+type ghRelease struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+// fetchLatestRelease pulls the live latest-release JSON. ok=false on any network
+// or decode failure so the caller skips rather than reds on transient flakiness.
+func fetchLatestRelease(t *testing.T) (ghRelease, bool) {
+	t.Helper()
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get("https://api.github.com/repos/spacedock-dev/spacedock/releases/latest")
+	if err != nil {
+		return ghRelease{}, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ghRelease{}, false
+	}
+	var rel ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return ghRelease{}, false
+	}
+	if rel.TagName == "" {
+		return ghRelease{}, false
+	}
+	return rel, true
+}

--- a/internal/release/install_url_test.go
+++ b/internal/release/install_url_test.go
@@ -97,7 +97,10 @@ func goosArch(t *testing.T) (string, string) {
 }
 
 // runInstallPrintTarget runs install.sh in its inspection mode (no download, no
-// install) and parses the `key=value` lines it prints into a map.
+// install) and parses the `key=value` lines it prints into a map. The script's
+// production path makes its OWN live GitHub call to resolve the latest tag; a
+// network/transport failure there SKIPS (the live network is this test's one
+// flaky dependency), while a logic failure (malformed output) hard-fails.
 func runInstallPrintTarget(t *testing.T) map[string]string {
 	t.Helper()
 	script := filepath.Join("..", "..", "install.sh")
@@ -105,6 +108,9 @@ func runInstallPrintTarget(t *testing.T) map[string]string {
 	cmd.Env = append([]string{"SPACEDOCK_PRINT_TARGET=1"}, scrubInstallEnv()...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if strings.Contains(string(out), "could not resolve the latest release tag") {
+			t.Skipf("install.sh could not reach the GitHub releases API; skipping live AC-3 URL check:\n%s", out)
+		}
 		t.Fatalf("install.sh SPACEDOCK_PRINT_TARGET=1 failed: %v\n%s", err, out)
 	}
 	fields := map[string]string{}


### PR DESCRIPTION
Ship Linux binaries and a universal install path, so Linux users can install spacedock (the release was darwin-only).

## What changed
- Add `linux` (amd64+arm64) to the goreleaser `builds.goos` so a release publishes Linux tarballs alongside darwin.
- Add a universal `install.sh` — OS/arch detect → fetch the latest Release tarball → checksum-verify → install to `~/.local/bin`, on Linux and macOS.
- Add a `[ubuntu, macos]` CI job that installs from a snapshot tarball and asserts a runnable `spacedock --version`, plus checksum-tamper cases.
- Document the Linux `curl … | sh` path and the honest safehouse-on-Linux story in `docs/install-journey.md`.

## Evidence
- `go test ./internal/release/...` green; offline `goreleaser --snapshot` builds both linux tarballs + `checksums.txt`; `install.sh` installs a real binary on each OS and 4 tamper variants fail closed.
- Detached adversarial audit: no material findings — the config guard reds when linux is dropped, the CI tamper step reds the lane when the checksum gate is gutted.

---
[v3](/spacedock-dev/spacedock/blob/b6b21782f7bdcd190f3c1f59f0f44858b7d302f5/ship-linux-binaries.md)
Closes spacedock-dev/spacedock#321
