### PR TITLE
safehouse-wrapped spacedock claude/codex preserves launcher-injected SPACEDOCK_BIN (via --env-pass)

### DIFF
--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -60,22 +60,18 @@ func launchEnv(parent []string) []string {
 	return env
 }
 
-// envBinary is the absolute path to env used in the inner-argv re-assert prefix.
-// A bare `env` would depend on env being on the sandbox PATH — if it is not, the
-// launch itself fails; the absolute path is PATH-independent (the ideation spike
-// confirmed /usr/bin/env is present and portable in the sandbox).
-const envBinary = "/usr/bin/env"
-
-// launcherBinArgvPrefix returns the `/usr/bin/env SPACEDOCK_BIN=<bin>` argv token
-// pair that re-asserts the launching binary inside the inner host argv, so the
-// value survives a wrapper that scrubs SPACEDOCK_BIN from the environment
-// (safehouse does). It reads the same resolvedLauncherBin() source as launchEnv,
-// and mirrors its omit-on-failure: when no binary resolves it returns nil — never
-// a blank value. Callers prepend it to the inner argv on the wrap path only; the
-// unwrapped launch inherits SPACEDOCK_BIN directly through launchEnv.
-func launcherBinArgvPrefix() []string {
-	if bin, ok := resolvedLauncherBin(); ok {
-		return []string{envBinary, spacedockBinEnv + "=" + bin}
+// launcherBinEnvPassFlags returns the `--env-pass SPACEDOCK_BIN` safehouse flags
+// that tell safehouse to forward SPACEDOCK_BIN from its (the launching process's)
+// environment into the otherwise-sanitized sandbox, so the launcher binary the
+// helper calls resolve survives the boundary. launchEnv already sets SPACEDOCK_BIN
+// on the safehouse process; this flag carries it through. It is gated on the same
+// resolvedLauncherBin() source as launchEnv and mirrors its omit-on-failure: when
+// no binary resolves, no flag — never a stale pass-through. Returned as safehouse
+// wrap flags (before `--`) so the inner program safehouse sees stays the real host
+// (claude/codex), keeping its program-keyed profile auto-detection intact.
+func launcherBinEnvPassFlags() []string {
+	if _, ok := resolvedLauncherBin(); ok {
+		return []string{"--env-pass", spacedockBinEnv}
 	}
 	return nil
 }
@@ -233,11 +229,12 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 			fmt.Fprintln(stderr, hint)
 			return 1
 		}
-		// Re-assert SPACEDOCK_BIN inside the inner argv: safehouse scrubs it from
-		// the environment, so the env-only propagation through launchEnv does not
-		// survive the boundary. The prefix rides argv, which safehouse hands to the
-		// inner host verbatim past `--`. Omitted when the bin cannot be resolved.
-		argv = safehouse.Wrap(append(launcherBinArgvPrefix(), inner...), extra)
+		// Forward SPACEDOCK_BIN through safehouse's env sanitization with
+		// `--env-pass`: launchEnv sets it on the safehouse process, this flag carries
+		// it into the sandbox. It rides the safehouse flags (before `--`), so the
+		// inner program stays `claude` and safehouse's program-keyed profile
+		// auto-detection still fires. Omitted when the bin cannot be resolved.
+		argv = safehouse.Wrap(inner, append(launcherBinEnvPassFlags(), extra...))
 	}
 
 	if err := ops.Launch(argv, launchEnv(os.Environ())); err != nil {
@@ -383,11 +380,12 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 			fmt.Fprintln(stderr, hint)
 			return 1
 		}
-		// Re-assert SPACEDOCK_BIN inside the inner argv: safehouse scrubs it from
-		// the environment, so the env-only propagation through launchEnv does not
-		// survive the boundary. The prefix rides argv, which safehouse hands to the
-		// inner host verbatim past `--`. Omitted when the bin cannot be resolved.
-		argv = safehouse.Wrap(append(launcherBinArgvPrefix(), inner...), extra)
+		// Forward SPACEDOCK_BIN through safehouse's env sanitization with
+		// `--env-pass`: launchEnv sets it on the safehouse process, this flag carries
+		// it into the sandbox. It rides the safehouse flags (before `--`), so the
+		// inner program stays `codex` and safehouse's program-keyed profile
+		// auto-detection still fires. Omitted when the bin cannot be resolved.
+		argv = safehouse.Wrap(inner, append(launcherBinEnvPassFlags(), extra...))
 	}
 
 	if err := ops.Launch(argv, launchEnv(os.Environ())); err != nil {

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -60,16 +60,22 @@ func launchEnv(parent []string) []string {
 	return env
 }
 
-// launcherBinArgvPrefix returns the `env SPACEDOCK_BIN=<bin>` argv token pair that
-// re-asserts the launching binary inside the inner host argv, so the value
-// survives a wrapper that scrubs SPACEDOCK_BIN from the environment (safehouse
-// does). It reads the same resolvedLauncherBin() source as launchEnv, and mirrors
-// its omit-on-failure: when no binary resolves it returns nil — never a blank
-// value. Callers prepend it to the inner argv on the wrap path only; the
+// envBinary is the absolute path to env used in the inner-argv re-assert prefix.
+// A bare `env` would depend on env being on the sandbox PATH — if it is not, the
+// launch itself fails; the absolute path is PATH-independent (the ideation spike
+// confirmed /usr/bin/env is present and portable in the sandbox).
+const envBinary = "/usr/bin/env"
+
+// launcherBinArgvPrefix returns the `/usr/bin/env SPACEDOCK_BIN=<bin>` argv token
+// pair that re-asserts the launching binary inside the inner host argv, so the
+// value survives a wrapper that scrubs SPACEDOCK_BIN from the environment
+// (safehouse does). It reads the same resolvedLauncherBin() source as launchEnv,
+// and mirrors its omit-on-failure: when no binary resolves it returns nil — never
+// a blank value. Callers prepend it to the inner argv on the wrap path only; the
 // unwrapped launch inherits SPACEDOCK_BIN directly through launchEnv.
 func launcherBinArgvPrefix() []string {
 	if bin, ok := resolvedLauncherBin(); ok {
-		return []string{"env", spacedockBinEnv + "=" + bin}
+		return []string{envBinary, spacedockBinEnv + "=" + bin}
 	}
 	return nil
 }

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -60,6 +60,20 @@ func launchEnv(parent []string) []string {
 	return env
 }
 
+// launcherBinArgvPrefix returns the `env SPACEDOCK_BIN=<bin>` argv token pair that
+// re-asserts the launching binary inside the inner host argv, so the value
+// survives a wrapper that scrubs SPACEDOCK_BIN from the environment (safehouse
+// does). It reads the same resolvedLauncherBin() source as launchEnv, and mirrors
+// its omit-on-failure: when no binary resolves it returns nil — never a blank
+// value. Callers prepend it to the inner argv on the wrap path only; the
+// unwrapped launch inherits SPACEDOCK_BIN directly through launchEnv.
+func launcherBinArgvPrefix() []string {
+	if bin, ok := resolvedLauncherBin(); ok {
+		return []string{"env", spacedockBinEnv + "=" + bin}
+	}
+	return nil
+}
+
 func withoutEnv(env []string, key string) []string {
 	prefix := key + "="
 	out := make([]string, 0, len(env))
@@ -213,7 +227,11 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 			fmt.Fprintln(stderr, hint)
 			return 1
 		}
-		argv = safehouse.Wrap(inner, extra)
+		// Re-assert SPACEDOCK_BIN inside the inner argv: safehouse scrubs it from
+		// the environment, so the env-only propagation through launchEnv does not
+		// survive the boundary. The prefix rides argv, which safehouse hands to the
+		// inner host verbatim past `--`. Omitted when the bin cannot be resolved.
+		argv = safehouse.Wrap(append(launcherBinArgvPrefix(), inner...), extra)
 	}
 
 	if err := ops.Launch(argv, launchEnv(os.Environ())); err != nil {
@@ -359,7 +377,11 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 			fmt.Fprintln(stderr, hint)
 			return 1
 		}
-		argv = safehouse.Wrap(inner, extra)
+		// Re-assert SPACEDOCK_BIN inside the inner argv: safehouse scrubs it from
+		// the environment, so the env-only propagation through launchEnv does not
+		// survive the boundary. The prefix rides argv, which safehouse hands to the
+		// inner host verbatim past `--`. Omitted when the bin cannot be resolved.
+		argv = safehouse.Wrap(append(launcherBinArgvPrefix(), inner...), extra)
 	}
 
 	if err := ops.Launch(argv, launchEnv(os.Environ())); err != nil {

--- a/internal/cli/frontdoor_stray_prompt_test.go
+++ b/internal/cli/frontdoor_stray_prompt_test.go
@@ -96,7 +96,7 @@ func TestCodexStrayPromptAfterDashWarns(t *testing.T) {
 		t.Fatalf("warning does not name the stray positional: %q", warn)
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"env", spacedockBinEnv + "=" + bin,
+		"/usr/bin/env", spacedockBinEnv + "=" + bin,
 		"codex", "--dangerously-bypass-approvals-and-sandbox", "-m", "gpt-x", "@/tmp/handoff.md", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v (warn must not change the argv)", fake.launchedArg, want)

--- a/internal/cli/frontdoor_stray_prompt_test.go
+++ b/internal/cli/frontdoor_stray_prompt_test.go
@@ -95,8 +95,7 @@ func TestCodexStrayPromptAfterDashWarns(t *testing.T) {
 	if !strings.Contains(warn, "@/tmp/handoff.md") {
 		t.Fatalf("warning does not name the stray positional: %q", warn)
 	}
-	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"/usr/bin/env", spacedockBinEnv + "=" + bin,
+	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
 		"codex", "--dangerously-bypass-approvals-and-sandbox", "-m", "gpt-x", "@/tmp/handoff.md", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v (warn must not change the argv)", fake.launchedArg, want)

--- a/internal/cli/frontdoor_stray_prompt_test.go
+++ b/internal/cli/frontdoor_stray_prompt_test.go
@@ -78,6 +78,8 @@ func TestClaudeStrayPromptSession12Shape(t *testing.T) {
 // and the codex inner argv is unchanged.
 func TestCodexStrayPromptAfterDashWarns(t *testing.T) {
 	dir := safehouseFixtureDir(t)
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
@@ -94,6 +96,7 @@ func TestCodexStrayPromptAfterDashWarns(t *testing.T) {
 		t.Fatalf("warning does not name the stray positional: %q", warn)
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--",
+		"env", spacedockBinEnv + "=" + bin,
 		"codex", "--dangerously-bypass-approvals-and-sandbox", "-m", "gpt-x", "@/tmp/handoff.md", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v (warn must not change the argv)", fake.launchedArg, want)

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -377,8 +377,7 @@ func TestCodexFrontDoorLaunchesOnCompatible(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"/usr/bin/env", spacedockBinEnv + "=" + bin,
+	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
 		"codex", "--dangerously-bypass-approvals-and-sandbox", "-m", "gpt-x", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -400,8 +399,7 @@ func TestCodexFrontDoorInjectsLauncherBinThroughSafehouseResume(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	wantArgv := []string{"safehouse", "--trust-workdir-config", "--",
-		"/usr/bin/env", spacedockBinEnv + "=" + bin,
+	wantArgv := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
 		"codex", "--dangerously-bypass-approvals-and-sandbox", "resume", "abc123"}
 	if !equalArgv(fake.launchedArg, wantArgv) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, wantArgv)

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -378,7 +378,7 @@ func TestCodexFrontDoorLaunchesOnCompatible(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"env", spacedockBinEnv + "=" + bin,
+		"/usr/bin/env", spacedockBinEnv + "=" + bin,
 		"codex", "--dangerously-bypass-approvals-and-sandbox", "-m", "gpt-x", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -401,7 +401,7 @@ func TestCodexFrontDoorInjectsLauncherBinThroughSafehouseResume(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	wantArgv := []string{"safehouse", "--trust-workdir-config", "--",
-		"env", spacedockBinEnv + "=" + bin,
+		"/usr/bin/env", spacedockBinEnv + "=" + bin,
 		"codex", "--dangerously-bypass-approvals-and-sandbox", "resume", "abc123"}
 	if !equalArgv(fake.launchedArg, wantArgv) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, wantArgv)

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -367,6 +367,8 @@ func TestClaudeFrontDoorSkipContractCheckBootstrap(t *testing.T) {
 // through the operator's trailing args before the FO-skill prompt.
 func TestCodexFrontDoorLaunchesOnCompatible(t *testing.T) {
 	dir := safehouseFixtureDir(t)
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
@@ -376,6 +378,7 @@ func TestCodexFrontDoorLaunchesOnCompatible(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--",
+		"env", spacedockBinEnv + "=" + bin,
 		"codex", "--dangerously-bypass-approvals-and-sandbox", "-m", "gpt-x", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -398,6 +401,7 @@ func TestCodexFrontDoorInjectsLauncherBinThroughSafehouseResume(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	wantArgv := []string{"safehouse", "--trust-workdir-config", "--",
+		"env", spacedockBinEnv + "=" + bin,
 		"codex", "--dangerously-bypass-approvals-and-sandbox", "resume", "abc123"}
 	if !equalArgv(fake.launchedArg, wantArgv) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, wantArgv)

--- a/internal/cli/launch_parity_test.go
+++ b/internal/cli/launch_parity_test.go
@@ -23,7 +23,7 @@ func TestSafehouseEnableForwardsRepeatedFlags(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--enable=ssh", "--enable=docker", "--",
-		"env", spacedockBinEnv + "=" + bin,
+		"/usr/bin/env", spacedockBinEnv + "=" + bin,
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -45,7 +45,7 @@ func TestSafehouseAddDirsForwardsPathGrants(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--add-dirs=/a", "--add-dirs-ro=/b", "--",
-		"env", spacedockBinEnv + "=" + bin,
+		"/usr/bin/env", spacedockBinEnv + "=" + bin,
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -87,7 +87,7 @@ func TestClaudeForceSafehouseWrapsNoProfile(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"env", spacedockBinEnv + "=" + bin,
+		"/usr/bin/env", spacedockBinEnv + "=" + bin,
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -110,7 +110,7 @@ func TestCodexForceSafehouseWrapsNoProfile(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"env", spacedockBinEnv + "=" + bin,
+		"/usr/bin/env", spacedockBinEnv + "=" + bin,
 		"codex", "--dangerously-bypass-approvals-and-sandbox", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -132,7 +132,7 @@ func TestKnobImpliesSandboxOnNoProfile(t *testing.T) {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
 		want := []string{"safehouse", "--trust-workdir-config", "--enable=docker", "--",
-			"env", spacedockBinEnv + "=" + bin,
+			"/usr/bin/env", spacedockBinEnv + "=" + bin,
 			"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 		if !equalArgv(fake.launchedArg, want) {
 			t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -149,7 +149,7 @@ func TestKnobImpliesSandboxOnNoProfile(t *testing.T) {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
 		want := []string{"safehouse", "--trust-workdir-config", "--enable=docker", "--",
-			"env", spacedockBinEnv + "=" + bin,
+			"/usr/bin/env", spacedockBinEnv + "=" + bin,
 			"codex", "--dangerously-bypass-approvals-and-sandbox", wantCodexBootstrapPrompt}
 		if !equalArgv(fake.launchedArg, want) {
 			t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)

--- a/internal/cli/launch_parity_test.go
+++ b/internal/cli/launch_parity_test.go
@@ -12,6 +12,8 @@ import (
 // the pre-`--` extra slot, after --trust-workdir-config.
 func TestSafehouseEnableForwardsRepeatedFlags(t *testing.T) {
 	dir := safehouseFixtureDir(t)
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
@@ -21,6 +23,7 @@ func TestSafehouseEnableForwardsRepeatedFlags(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--enable=ssh", "--enable=docker", "--",
+		"env", spacedockBinEnv + "=" + bin,
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -31,6 +34,8 @@ func TestSafehouseEnableForwardsRepeatedFlags(t *testing.T) {
 // the pre-`--` extra slot, in operator order.
 func TestSafehouseAddDirsForwardsPathGrants(t *testing.T) {
 	dir := safehouseFixtureDir(t)
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
@@ -40,6 +45,7 @@ func TestSafehouseAddDirsForwardsPathGrants(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--add-dirs=/a", "--add-dirs-ro=/b", "--",
+		"env", spacedockBinEnv + "=" + bin,
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -70,6 +76,8 @@ func TestSafehousePrefixStrippedByDispatcher(t *testing.T) {
 // bare token is consumed and never reaches claude.
 func TestClaudeForceSafehouseWrapsNoProfile(t *testing.T) {
 	dir := t.TempDir() // no .safehouse
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
@@ -79,6 +87,7 @@ func TestClaudeForceSafehouseWrapsNoProfile(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--",
+		"env", spacedockBinEnv + "=" + bin,
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -90,6 +99,8 @@ func TestClaudeForceSafehouseWrapsNoProfile(t *testing.T) {
 // codex.
 func TestCodexForceSafehouseWrapsNoProfile(t *testing.T) {
 	dir := t.TempDir() // no .safehouse
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
@@ -99,6 +110,7 @@ func TestCodexForceSafehouseWrapsNoProfile(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--",
+		"env", spacedockBinEnv + "=" + bin,
 		"codex", "--dangerously-bypass-approvals-and-sandbox", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -111,6 +123,8 @@ func TestCodexForceSafehouseWrapsNoProfile(t *testing.T) {
 func TestKnobImpliesSandboxOnNoProfile(t *testing.T) {
 	t.Run("claude", func(t *testing.T) {
 		dir := t.TempDir()
+		bin := executableFixture(t)
+		withExecutablePath(t, bin, nil)
 		fake := &fakeHost{manifest: compatibleManifest(t)}
 		var stdout, stderr bytes.Buffer
 		code := runClaude(context.Background(), []string{"--safehouse-enable=docker"}, dir, fake, lookFound, &stdout, &stderr)
@@ -118,6 +132,7 @@ func TestKnobImpliesSandboxOnNoProfile(t *testing.T) {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
 		want := []string{"safehouse", "--trust-workdir-config", "--enable=docker", "--",
+			"env", spacedockBinEnv + "=" + bin,
 			"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 		if !equalArgv(fake.launchedArg, want) {
 			t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -125,6 +140,8 @@ func TestKnobImpliesSandboxOnNoProfile(t *testing.T) {
 	})
 	t.Run("codex", func(t *testing.T) {
 		dir := t.TempDir()
+		bin := executableFixture(t)
+		withExecutablePath(t, bin, nil)
 		fake := &fakeHost{manifest: compatibleManifest(t)}
 		var stdout, stderr bytes.Buffer
 		code := runCodex(context.Background(), []string{"--safehouse-enable=docker"}, dir, fake, lookFound, &stdout, &stderr)
@@ -132,6 +149,7 @@ func TestKnobImpliesSandboxOnNoProfile(t *testing.T) {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
 		want := []string{"safehouse", "--trust-workdir-config", "--enable=docker", "--",
+			"env", spacedockBinEnv + "=" + bin,
 			"codex", "--dangerously-bypass-approvals-and-sandbox", wantCodexBootstrapPrompt}
 		if !equalArgv(fake.launchedArg, want) {
 			t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)

--- a/internal/cli/launch_parity_test.go
+++ b/internal/cli/launch_parity_test.go
@@ -22,8 +22,7 @@ func TestSafehouseEnableForwardsRepeatedFlags(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	want := []string{"safehouse", "--trust-workdir-config", "--enable=ssh", "--enable=docker", "--",
-		"/usr/bin/env", spacedockBinEnv + "=" + bin,
+	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--enable=ssh", "--enable=docker", "--",
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -44,8 +43,7 @@ func TestSafehouseAddDirsForwardsPathGrants(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	want := []string{"safehouse", "--trust-workdir-config", "--add-dirs=/a", "--add-dirs-ro=/b", "--",
-		"/usr/bin/env", spacedockBinEnv + "=" + bin,
+	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--add-dirs=/a", "--add-dirs-ro=/b", "--",
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -86,8 +84,7 @@ func TestClaudeForceSafehouseWrapsNoProfile(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"/usr/bin/env", spacedockBinEnv + "=" + bin,
+	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -109,8 +106,7 @@ func TestCodexForceSafehouseWrapsNoProfile(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"/usr/bin/env", spacedockBinEnv + "=" + bin,
+	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
 		"codex", "--dangerously-bypass-approvals-and-sandbox", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -131,8 +127,7 @@ func TestKnobImpliesSandboxOnNoProfile(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
-		want := []string{"safehouse", "--trust-workdir-config", "--enable=docker", "--",
-			"/usr/bin/env", spacedockBinEnv + "=" + bin,
+		want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--enable=docker", "--",
 			"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 		if !equalArgv(fake.launchedArg, want) {
 			t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
@@ -148,8 +143,7 @@ func TestKnobImpliesSandboxOnNoProfile(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
-		want := []string{"safehouse", "--trust-workdir-config", "--enable=docker", "--",
-			"/usr/bin/env", spacedockBinEnv + "=" + bin,
+		want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--enable=docker", "--",
 			"codex", "--dangerously-bypass-approvals-and-sandbox", wantCodexBootstrapPrompt}
 		if !equalArgv(fake.launchedArg, want) {
 			t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)

--- a/internal/cli/safehouse_env_smoke_test.go
+++ b/internal/cli/safehouse_env_smoke_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: End-to-end env-scrub smoke: through a safehouse that STRIPS SPACEDOCK_BIN,
-// ABOUTME: the argv re-assert lets the real spacedock_launcher resolve the launched binary.
+// ABOUTME: End-to-end env-pass smoke: through a safehouse that scrubs SPACEDOCK_BIN
+// ABOUTME: by default, --env-pass SPACEDOCK_BIN forwards it so the real launcher resolves the launched binary.
 package cli
 
 import (
@@ -13,18 +13,27 @@ import (
 	"github.com/spacedock-dev/spacedock/internal/safehouse"
 )
 
-// scrubbingSafehouse writes a fake `safehouse` that UNSETS SPACEDOCK_BIN before
-// exec'ing the inner argv past `--` — the env-scrubbing behavior the real
-// safehouse exhibits across its sandbox boundary. The env-only propagation
-// (launchEnv setting SPACEDOCK_BIN on the outer process) cannot survive this, so
-// the value must ride the inner argv to reach the host.
-func scrubbingSafehouse(t *testing.T, dir string) string {
+// envPassSafehouse writes a fake `safehouse` that SCRUBS SPACEDOCK_BIN by default
+// (the env-sanitization the real safehouse does across its boundary) BUT honors
+// `--env-pass NAMES` (comma-separated): each named var is forwarded from the host
+// env it inherited, on top of the sanitized defaults. This models the real
+// `--env-pass` flag the front door now passes. The inner program after `--` runs
+// with SPACEDOCK_BIN present only when `--env-pass SPACEDOCK_BIN` was given.
+func envPassSafehouse(t *testing.T, dir string) string {
 	t.Helper()
 	path := filepath.Join(dir, "safehouse")
 	body := `#!/bin/sh
+# Capture the inherited value before scrubbing (the host env safehouse sees).
+saved_bin="${SPACEDOCK_BIN:-}"
 unset SPACEDOCK_BIN
-while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done
+pass=""
+while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
+  if [ "$1" = "--env-pass" ]; then shift; pass="$1"; fi
+  shift
+done
 if [ "$1" = "--" ]; then shift; fi
+# Honor --env-pass SPACEDOCK_BIN: forward the named var from the saved host env.
+case ",$pass," in *,SPACEDOCK_BIN,*) export SPACEDOCK_BIN="$saved_bin" ;; esac
 exec "$@"
 `
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
@@ -57,16 +66,17 @@ func markerBinary(t *testing.T, path, marker string) {
 	}
 }
 
-// TestSafehouseScrubPreservedThroughArgvReassert is the AC-5 regression oracle.
-// Through a safehouse that STRIPS SPACEDOCK_BIN, the inner argv re-assert
-// (`env SPACEDOCK_BIN=<bin> …`, the prefix runClaude/runCodex prepend on the wrap
-// path) lets the real spacedock_launcher resolve the LAUNCHED binary. The control
-// case — the SAME wrap WITHOUT the argv prefix (env-only propagation) — falls back
-// to the PATH `spacedock`, proving the test fails for the right reason absent the
-// fix rather than passing trivially.
-func TestSafehouseScrubPreservedThroughArgvReassert(t *testing.T) {
+// TestSafehouseEnvPassForwardsSpacedockBin is the AC-5 regression oracle. Through
+// a safehouse that SCRUBS SPACEDOCK_BIN by default, the `--env-pass SPACEDOCK_BIN`
+// wrap flag the front door adds forwards the launching binary so the real
+// spacedock_launcher resolves it. The control case — the SAME wrap WITHOUT
+// `--env-pass` (env-only propagation) — falls back to the PATH `spacedock`,
+// proving the test fails for the right reason absent the flag rather than passing
+// trivially. The inner program after `--` is the host probe directly (no wrapper),
+// matching the production argv shape.
+func TestSafehouseEnvPassForwardsSpacedockBin(t *testing.T) {
 	dir := t.TempDir()
-	safehousePath := scrubbingSafehouse(t, dir)
+	safehousePath := envPassSafehouse(t, dir)
 	probe := launcherProbe(t, dir)
 
 	// The launched binary (what SPACEDOCK_BIN points at) and a DIFFERENT spacedock
@@ -80,41 +90,40 @@ func TestSafehouseScrubPreservedThroughArgvReassert(t *testing.T) {
 	markerBinary(t, filepath.Join(pathDir, "spacedock"), "PATH-FALLBACK")
 	// Build a clean env (no inherited PATH or SPACEDOCK_BIN to collide): pathDir
 	// holds the ONLY `spacedock` on PATH; the system dirs follow so `sh` and the
-	// coreutils the probe/wrapper need still resolve (the re-assert itself uses the
-	// absolute /usr/bin/env, so it needs no PATH entry).
+	// coreutils the probe/wrapper need still resolve. SPACEDOCK_BIN is set on the
+	// safehouse process, exactly as launchEnv sets it on the launched process.
 	base := withoutEnv(withoutEnv(os.Environ(), "PATH"), spacedockBinEnv)
-	scrubEnv := append(base,
+	env := append(base,
 		"PATH="+pathDir+":/usr/bin:/bin",
 		spacedockBinEnv+"="+launchedBin)
 
-	t.Run("argv re-assert survives the scrub", func(t *testing.T) {
-		// The inner argv as runClaude composes it on the wrap path: the production
-		// launcherBinArgvPrefix (driven by executablePath → launchedBin) ahead of the
-		// inner host (here the probe). Exercising the real prefix builder, not a copy.
+	t.Run("--env-pass forwards SPACEDOCK_BIN through the scrub", func(t *testing.T) {
+		// The wrap as runClaude composes it: the production launcherBinEnvPassFlags
+		// (driven by executablePath → launchedBin) in the safehouse extra slot. The
+		// inner program after `--` is the probe directly (no /usr/bin/env wrapper).
 		withExecutablePath(t, launchedBin, nil)
-		inner := append(launcherBinArgvPrefix(), probe)
-		argv := safehouse.Wrap(inner, nil)
-		out := runWrapped(t, safehousePath, argv[1:], scrubEnv)
+		argv := safehouse.Wrap([]string{probe}, launcherBinEnvPassFlags())
+		out := runWrapped(t, safehousePath, argv[1:], env)
 		if out != "LAUNCHED" {
-			t.Fatalf("probe resolved %q, want LAUNCHED (the launched binary survived the scrub via argv)", out)
+			t.Fatalf("probe resolved %q, want LAUNCHED (--env-pass must forward SPACEDOCK_BIN through the scrub)", out)
 		}
 	})
 
-	t.Run("without the re-assert it falls back to PATH (regression control)", func(t *testing.T) {
-		// The SAME wrap WITHOUT the argv prefix — env-only propagation. The scrub
-		// drops SPACEDOCK_BIN, so the probe falls back to the PATH spacedock. This is
-		// the bug the argv re-assert fixes; it proves the oracle is not trivial.
+	t.Run("without --env-pass it falls back to PATH (regression control)", func(t *testing.T) {
+		// The SAME wrap WITHOUT --env-pass — env-only propagation. The scrub drops
+		// SPACEDOCK_BIN, so the probe falls back to the PATH spacedock. This is the bug
+		// the --env-pass flag fixes; it proves the oracle is not trivial.
 		argv := safehouse.Wrap([]string{probe}, nil)
-		out := runWrapped(t, safehousePath, argv[1:], scrubEnv)
+		out := runWrapped(t, safehousePath, argv[1:], env)
 		if out != "PATH-FALLBACK" {
-			t.Fatalf("env-only probe resolved %q, want PATH-FALLBACK (the scrub must drop SPACEDOCK_BIN)", out)
+			t.Fatalf("env-only probe resolved %q, want PATH-FALLBACK (the scrub must drop SPACEDOCK_BIN absent --env-pass)", out)
 		}
 	})
 }
 
 // runWrapped execs the fake safehouse with the wrapped argv (everything after the
-// `safehouse` token) under the scrubbing env, returning the probe's single
-// trimmed output line.
+// `safehouse` token) under the env, returning the probe's single trimmed output
+// line.
 func runWrapped(t *testing.T, safehousePath string, args []string, env []string) string {
 	t.Helper()
 	cmd := exec.Command(safehousePath, args...)

--- a/internal/cli/safehouse_env_smoke_test.go
+++ b/internal/cli/safehouse_env_smoke_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: Fixture-backed smoke for safehouse-shaped environment propagation.
-// ABOUTME: Proves SPACEDOCK_BIN can reach an inner child through the wrapper argv shape.
+// ABOUTME: End-to-end env-scrub smoke: through a safehouse that STRIPS SPACEDOCK_BIN,
+// ABOUTME: the argv re-assert lets the real spacedock_launcher resolve the launched binary.
 package cli
 
 import (
@@ -8,33 +8,119 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/dispatch"
+	"github.com/spacedock-dev/spacedock/internal/safehouse"
 )
 
-func TestSafehouseShapePreservesSpacedockBinToInnerChildFixture(t *testing.T) {
-	dir := t.TempDir()
-	safehouse := filepath.Join(dir, "safehouse")
-	if err := os.WriteFile(safehouse, []byte(`#!/bin/sh
+// scrubbingSafehouse writes a fake `safehouse` that UNSETS SPACEDOCK_BIN before
+// exec'ing the inner argv past `--` — the env-scrubbing behavior the real
+// safehouse exhibits across its sandbox boundary. The env-only propagation
+// (launchEnv setting SPACEDOCK_BIN on the outer process) cannot survive this, so
+// the value must ride the inner argv to reach the host.
+func scrubbingSafehouse(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "safehouse")
+	body := `#!/bin/sh
+unset SPACEDOCK_BIN
 while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done
 if [ "$1" = "--" ]; then shift; fi
 exec "$@"
-`), 0o755); err != nil {
+`
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	inner := filepath.Join(dir, "inner-env")
-	if err := os.WriteFile(inner, []byte(`#!/bin/sh
-printf '%s\n' "SPACEDOCK_BIN=${SPACEDOCK_BIN:-}"
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	return path
+}
 
-	bin := filepath.Join(dir, "spacedock")
-	cmd := exec.Command(safehouse, "--trust-workdir-config", "--", inner)
-	cmd.Env = append(os.Environ(), spacedockBinEnv+"="+bin)
+// launcherProbe writes a fake host whose only job is to resolve a spacedock
+// helper through the REAL spacedock_launcher expression (dispatch.LauncherCommand)
+// and print whatever that resolution runs. It is the in-session helper call:
+// prefer an executable SPACEDOCK_BIN, else fall back to `spacedock` on PATH.
+func launcherProbe(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "probe")
+	body := "#!/bin/sh\n" + dispatch.LauncherCommand() + " status\n"
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// markerBinary writes an executable that prints a single marker line and ignores
+// its args — stands in for a spacedock binary so the probe's resolution is
+// observable (which binary ran), not just present.
+func markerBinary(t *testing.T, path, marker string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf '%s\\n' "+marker+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSafehouseScrubPreservedThroughArgvReassert is the AC-5 regression oracle.
+// Through a safehouse that STRIPS SPACEDOCK_BIN, the inner argv re-assert
+// (`env SPACEDOCK_BIN=<bin> …`, the prefix runClaude/runCodex prepend on the wrap
+// path) lets the real spacedock_launcher resolve the LAUNCHED binary. The control
+// case — the SAME wrap WITHOUT the argv prefix (env-only propagation) — falls back
+// to the PATH `spacedock`, proving the test fails for the right reason absent the
+// fix rather than passing trivially.
+func TestSafehouseScrubPreservedThroughArgvReassert(t *testing.T) {
+	dir := t.TempDir()
+	safehousePath := scrubbingSafehouse(t, dir)
+	probe := launcherProbe(t, dir)
+
+	// The launched binary (what SPACEDOCK_BIN points at) and a DIFFERENT spacedock
+	// on PATH, each printing a distinct marker so the resolution is observable.
+	launchedBin := filepath.Join(dir, "spacedock-launched")
+	markerBinary(t, launchedBin, "LAUNCHED")
+	pathDir := filepath.Join(dir, "pathbin")
+	if err := os.Mkdir(pathDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	markerBinary(t, filepath.Join(pathDir, "spacedock"), "PATH-FALLBACK")
+	// Build a clean env (no inherited PATH or SPACEDOCK_BIN to collide): pathDir
+	// holds the ONLY `spacedock` on PATH; the system dirs follow so `env`, `sh`, and
+	// coreutils the probe/wrapper need still resolve.
+	base := withoutEnv(withoutEnv(os.Environ(), "PATH"), spacedockBinEnv)
+	scrubEnv := append(base,
+		"PATH="+pathDir+":/usr/bin:/bin",
+		spacedockBinEnv+"="+launchedBin)
+
+	t.Run("argv re-assert survives the scrub", func(t *testing.T) {
+		// The inner argv as runClaude composes it on the wrap path: the production
+		// launcherBinArgvPrefix (driven by executablePath → launchedBin) ahead of the
+		// inner host (here the probe). Exercising the real prefix builder, not a copy.
+		withExecutablePath(t, launchedBin, nil)
+		inner := append(launcherBinArgvPrefix(), probe)
+		argv := safehouse.Wrap(inner, nil)
+		out := runWrapped(t, safehousePath, argv[1:], scrubEnv)
+		if out != "LAUNCHED" {
+			t.Fatalf("probe resolved %q, want LAUNCHED (the launched binary survived the scrub via argv)", out)
+		}
+	})
+
+	t.Run("without the re-assert it falls back to PATH (regression control)", func(t *testing.T) {
+		// The SAME wrap WITHOUT the argv prefix — env-only propagation. The scrub
+		// drops SPACEDOCK_BIN, so the probe falls back to the PATH spacedock. This is
+		// the bug the argv re-assert fixes; it proves the oracle is not trivial.
+		argv := safehouse.Wrap([]string{probe}, nil)
+		out := runWrapped(t, safehousePath, argv[1:], scrubEnv)
+		if out != "PATH-FALLBACK" {
+			t.Fatalf("env-only probe resolved %q, want PATH-FALLBACK (the scrub must drop SPACEDOCK_BIN)", out)
+		}
+	})
+}
+
+// runWrapped execs the fake safehouse with the wrapped argv (everything after the
+// `safehouse` token) under the scrubbing env, returning the probe's single
+// trimmed output line.
+func runWrapped(t *testing.T, safehousePath string, args []string, env []string) string {
+	t.Helper()
+	cmd := exec.Command(safehousePath, args...)
+	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("safehouse-shaped fixture failed: %v\n%s", err, out)
+		t.Fatalf("wrapped exec failed: %v\n%s", err, out)
 	}
-	if got, want := strings.TrimSpace(string(out)), spacedockBinEnv+"="+bin; got != want {
-		t.Fatalf("inner child env = %q, want %q", got, want)
-	}
+	return strings.TrimSpace(string(out))
 }

--- a/internal/cli/safehouse_env_smoke_test.go
+++ b/internal/cli/safehouse_env_smoke_test.go
@@ -79,8 +79,9 @@ func TestSafehouseScrubPreservedThroughArgvReassert(t *testing.T) {
 	}
 	markerBinary(t, filepath.Join(pathDir, "spacedock"), "PATH-FALLBACK")
 	// Build a clean env (no inherited PATH or SPACEDOCK_BIN to collide): pathDir
-	// holds the ONLY `spacedock` on PATH; the system dirs follow so `env`, `sh`, and
-	// coreutils the probe/wrapper need still resolve.
+	// holds the ONLY `spacedock` on PATH; the system dirs follow so `sh` and the
+	// coreutils the probe/wrapper need still resolve (the re-assert itself uses the
+	// absolute /usr/bin/env, so it needs no PATH entry).
 	base := withoutEnv(withoutEnv(os.Environ(), "PATH"), spacedockBinEnv)
 	scrubEnv := append(base,
 		"PATH="+pathDir+":/usr/bin:/bin",

--- a/internal/cli/safehouse_frontdoor_test.go
+++ b/internal/cli/safehouse_frontdoor_test.go
@@ -50,7 +50,7 @@ func TestClaudeSafehousePresentWrapsArgv(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"env", spacedockBinEnv + "=" + bin,
+		"/usr/bin/env", spacedockBinEnv + "=" + bin,
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer",
 		"--foo", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
@@ -131,7 +131,7 @@ func TestClaudeNoSafehouseLaunchesPlain(t *testing.T) {
 		// AC-3: the argv re-assert is wrap-path-only; an unwrapped launch carries no
 		// `env`/`SPACEDOCK_BIN=` prefix (SPACEDOCK_BIN still reaches the host through
 		// launchEnv, asserted by TestClaudeFrontDoorInjectsResolvedLauncherBin).
-		if tok == "env" || strings.HasPrefix(tok, spacedockBinEnv+"=") {
+		if tok == envBinary || strings.HasPrefix(tok, spacedockBinEnv+"=") {
 			t.Fatalf("unsandboxed launch carried the argv re-assert prefix %q: %v", tok, fake.launchedArg)
 		}
 	}
@@ -212,7 +212,7 @@ func TestCodexSafehousePresentWrapsArgv(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"env", spacedockBinEnv + "=" + bin,
+		"/usr/bin/env", spacedockBinEnv + "=" + bin,
 		"codex", "--dangerously-bypass-approvals-and-sandbox",
 		"--foo", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
@@ -271,7 +271,7 @@ func TestCodexNoSafehouseLaunchesPlainNoBypass(t *testing.T) {
 		// AC-3: the argv re-assert is wrap-path-only; an unwrapped launch carries no
 		// `env`/`SPACEDOCK_BIN=` prefix (SPACEDOCK_BIN still reaches the host through
 		// launchEnv).
-		if tok == "env" || strings.HasPrefix(tok, spacedockBinEnv+"=") {
+		if tok == envBinary || strings.HasPrefix(tok, spacedockBinEnv+"=") {
 			t.Fatalf("unsandboxed codex launch carried the argv re-assert prefix %q: %v", tok, fake.launchedArg)
 		}
 	}
@@ -356,7 +356,7 @@ func TestClaudeResumeFamilySuppressesBootstrapPrompt(t *testing.T) {
 				t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 			}
 			want := []string{"safehouse", "--trust-workdir-config", "--",
-				"env", spacedockBinEnv + "=" + bin,
+				"/usr/bin/env", spacedockBinEnv + "=" + bin,
 				"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", tc.arg}
 			if !equalArgv(fake.launchedArg, want) {
 				t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)

--- a/internal/cli/safehouse_frontdoor_test.go
+++ b/internal/cli/safehouse_frontdoor_test.go
@@ -34,9 +34,37 @@ func safehouseFixtureDir(t *testing.T) string {
 }
 
 // AC-1: .safehouse present → canonical safehouse-wrapped argv with the bootstrap
-// prompt appended LAST, after the operator passthrough.
+// prompt appended LAST, after the operator passthrough. The wrapped argv
+// re-asserts `env SPACEDOCK_BIN=<resolvedLauncherBin>` between `--` and `claude`
+// so the launcher binary survives any env-scrubbing safehouse wrapper.
 func TestClaudeSafehousePresentWrapsArgv(t *testing.T) {
 	dir := safehouseFixtureDir(t)
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), []string{"--", "--foo"}, dir, fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	want := []string{"safehouse", "--trust-workdir-config", "--",
+		"env", spacedockBinEnv + "=" + bin,
+		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer",
+		"--foo", wantBootstrapPrompt}
+	if !equalArgv(fake.launchedArg, want) {
+		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
+	}
+}
+
+// AC-4: when resolvedLauncherBin() cannot resolve a binary (executablePath
+// errors), the wrapped argv carries NO `env SPACEDOCK_BIN=` prefix — never a
+// blank value — exactly as launchEnv omits the env entry. The wrap is otherwise
+// the canonical shape (no prefix tokens between `--` and `claude`).
+func TestClaudeSafehouseWrapsWithoutPrefixWhenBinUnresolved(t *testing.T) {
+	dir := safehouseFixtureDir(t)
+	withExecutablePath(t, "", errors.New("boom"))
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
@@ -50,6 +78,11 @@ func TestClaudeSafehousePresentWrapsArgv(t *testing.T) {
 		"--foo", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
+	}
+	for _, tok := range fake.launchedArg {
+		if strings.HasPrefix(tok, spacedockBinEnv+"=") {
+			t.Fatalf("wrapped argv carried a SPACEDOCK_BIN= token despite unresolved bin: %v", fake.launchedArg)
+		}
 	}
 }
 
@@ -94,6 +127,12 @@ func TestClaudeNoSafehouseLaunchesPlain(t *testing.T) {
 		}
 		if tok == "--dangerously-skip-permissions" {
 			t.Fatalf("unsandboxed launch carried --dangerously-skip-permissions: %v", fake.launchedArg)
+		}
+		// AC-3: the argv re-assert is wrap-path-only; an unwrapped launch carries no
+		// `env`/`SPACEDOCK_BIN=` prefix (SPACEDOCK_BIN still reaches the host through
+		// launchEnv, asserted by TestClaudeFrontDoorInjectsResolvedLauncherBin).
+		if tok == "env" || strings.HasPrefix(tok, spacedockBinEnv+"=") {
+			t.Fatalf("unsandboxed launch carried the argv re-assert prefix %q: %v", tok, fake.launchedArg)
 		}
 	}
 }
@@ -157,9 +196,13 @@ const wantCodexBootstrapPrompt = "You totally got this. Take your time. I love y
 
 // codex AC-1: .safehouse present → canonical safehouse-wrapped codex argv with
 // codex's own sandbox bypassed and the FO-skill prompt appended LAST, after the
-// operator passthrough. Mirrors runClaude's dir+lookPath threading.
+// operator passthrough. Mirrors runClaude's dir+lookPath threading. The wrapped
+// argv re-asserts `env SPACEDOCK_BIN=<resolvedLauncherBin>` between `--` and
+// `codex` so the launcher binary survives any env-scrubbing safehouse wrapper.
 func TestCodexSafehousePresentWrapsArgv(t *testing.T) {
 	dir := safehouseFixtureDir(t)
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
@@ -169,6 +212,7 @@ func TestCodexSafehousePresentWrapsArgv(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--",
+		"env", spacedockBinEnv + "=" + bin,
 		"codex", "--dangerously-bypass-approvals-and-sandbox",
 		"--foo", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
@@ -223,6 +267,12 @@ func TestCodexNoSafehouseLaunchesPlainNoBypass(t *testing.T) {
 		}
 		if tok == "--dangerously-bypass-approvals-and-sandbox" {
 			t.Fatalf("unsandboxed codex launch carried the bypass flag: %v", fake.launchedArg)
+		}
+		// AC-3: the argv re-assert is wrap-path-only; an unwrapped launch carries no
+		// `env`/`SPACEDOCK_BIN=` prefix (SPACEDOCK_BIN still reaches the host through
+		// launchEnv).
+		if tok == "env" || strings.HasPrefix(tok, spacedockBinEnv+"=") {
+			t.Fatalf("unsandboxed codex launch carried the argv re-assert prefix %q: %v", tok, fake.launchedArg)
 		}
 	}
 }
@@ -295,6 +345,8 @@ func TestClaudeResumeFamilySuppressesBootstrapPrompt(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := safehouseFixtureDir(t)
+			bin := executableFixture(t)
+			withExecutablePath(t, bin, nil)
 			fake := &fakeHost{manifest: compatibleManifest(t)}
 			var stdout, stderr bytes.Buffer
 
@@ -304,6 +356,7 @@ func TestClaudeResumeFamilySuppressesBootstrapPrompt(t *testing.T) {
 				t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 			}
 			want := []string{"safehouse", "--trust-workdir-config", "--",
+				"env", spacedockBinEnv + "=" + bin,
 				"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", tc.arg}
 			if !equalArgv(fake.launchedArg, want) {
 				t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)

--- a/internal/cli/safehouse_frontdoor_test.go
+++ b/internal/cli/safehouse_frontdoor_test.go
@@ -34,9 +34,10 @@ func safehouseFixtureDir(t *testing.T) string {
 }
 
 // AC-1: .safehouse present → canonical safehouse-wrapped argv with the bootstrap
-// prompt appended LAST, after the operator passthrough. The wrapped argv
-// re-asserts `env SPACEDOCK_BIN=<resolvedLauncherBin>` between `--` and `claude`
-// so the launcher binary survives any env-scrubbing safehouse wrapper.
+// prompt appended LAST, after the operator passthrough. The wrap carries
+// `--env-pass SPACEDOCK_BIN` among the safehouse flags (before `--`) so safehouse
+// forwards the launcher binary through its env sanitization; the inner program is
+// `claude` directly after `--` (NO /usr/bin/env, NO SPACEDOCK_BIN= argv token).
 func TestClaudeSafehousePresentWrapsArgv(t *testing.T) {
 	dir := safehouseFixtureDir(t)
 	bin := executableFixture(t)
@@ -49,8 +50,7 @@ func TestClaudeSafehousePresentWrapsArgv(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"/usr/bin/env", spacedockBinEnv + "=" + bin,
+	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer",
 		"--foo", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
@@ -59,10 +59,10 @@ func TestClaudeSafehousePresentWrapsArgv(t *testing.T) {
 }
 
 // AC-4: when resolvedLauncherBin() cannot resolve a binary (executablePath
-// errors), the wrapped argv carries NO `env SPACEDOCK_BIN=` prefix — never a
-// blank value — exactly as launchEnv omits the env entry. The wrap is otherwise
-// the canonical shape (no prefix tokens between `--` and `claude`).
-func TestClaudeSafehouseWrapsWithoutPrefixWhenBinUnresolved(t *testing.T) {
+// errors), the wrap carries NO `--env-pass SPACEDOCK_BIN` flag — never a stale
+// pass-through — exactly as launchEnv omits the env entry. The wrap is otherwise
+// the canonical shape.
+func TestClaudeSafehouseWrapsWithoutEnvPassWhenBinUnresolved(t *testing.T) {
 	dir := safehouseFixtureDir(t)
 	withExecutablePath(t, "", errors.New("boom"))
 	fake := &fakeHost{manifest: compatibleManifest(t)}
@@ -80,10 +80,49 @@ func TestClaudeSafehouseWrapsWithoutPrefixWhenBinUnresolved(t *testing.T) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
 	}
 	for _, tok := range fake.launchedArg {
-		if strings.HasPrefix(tok, spacedockBinEnv+"=") {
-			t.Fatalf("wrapped argv carried a SPACEDOCK_BIN= token despite unresolved bin: %v", fake.launchedArg)
+		if tok == "--env-pass" {
+			t.Fatalf("wrapped argv carried --env-pass despite unresolved bin: %v", fake.launchedArg)
 		}
 	}
+}
+
+// AC-6 (regression guard for the profile-detection ship-blocker): the wrapped
+// inner argv's FIRST token after the safehouse `--` is the host program name
+// (`claude`), NOT a wrapper like `/usr/bin/env` — so safehouse's program-keyed
+// profile auto-detection sees the real program. This is the oracle that would
+// have caught the argv-prefix mechanism breaking the default claude profile.
+func TestClaudeSafehouseWrapInnerProgramIsHost(t *testing.T) {
+	dir := safehouseFixtureDir(t)
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), nil, dir, fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	assertInnerProgramIsHost(t, fake.launchedArg, "claude")
+}
+
+// assertInnerProgramIsHost asserts the token immediately after the safehouse `--`
+// separator is the host program name — never a wrapper (`/usr/bin/env`, `env`)
+// that would mask the program from safehouse's profile auto-detection.
+func assertInnerProgramIsHost(t *testing.T, argv []string, host string) {
+	t.Helper()
+	for i, tok := range argv {
+		if tok == "--" {
+			if i+1 >= len(argv) {
+				t.Fatalf("no inner program after the safehouse `--`: %v", argv)
+			}
+			if got := argv[i+1]; got != host {
+				t.Fatalf("inner program after `--` = %q, want host %q (a wrapper here breaks safehouse profile auto-detection): %v", got, host, argv)
+			}
+			return
+		}
+	}
+	t.Fatalf("no safehouse `--` separator in wrapped argv: %v", argv)
 }
 
 // AC-1 companion: a `.safehouse` DIRECTORY is detected identically to a file.
@@ -128,11 +167,11 @@ func TestClaudeNoSafehouseLaunchesPlain(t *testing.T) {
 		if tok == "--dangerously-skip-permissions" {
 			t.Fatalf("unsandboxed launch carried --dangerously-skip-permissions: %v", fake.launchedArg)
 		}
-		// AC-3: the argv re-assert is wrap-path-only; an unwrapped launch carries no
-		// `env`/`SPACEDOCK_BIN=` prefix (SPACEDOCK_BIN still reaches the host through
-		// launchEnv, asserted by TestClaudeFrontDoorInjectsResolvedLauncherBin).
-		if tok == envBinary || strings.HasPrefix(tok, spacedockBinEnv+"=") {
-			t.Fatalf("unsandboxed launch carried the argv re-assert prefix %q: %v", tok, fake.launchedArg)
+		// AC-3: `--env-pass` is wrap-path-only; an unwrapped launch carries no
+		// `--env-pass` flag (SPACEDOCK_BIN still reaches the host through launchEnv,
+		// asserted by TestClaudeFrontDoorInjectsResolvedLauncherBin).
+		if tok == "--env-pass" {
+			t.Fatalf("unsandboxed launch carried --env-pass: %v", fake.launchedArg)
 		}
 	}
 }
@@ -194,11 +233,12 @@ func TestClaudeSafehousePresentButBinaryMissing(t *testing.T) {
 // literal `spacedock:first-officer` skill-name token (codex has no --agent).
 const wantCodexBootstrapPrompt = "You totally got this. Take your time. I love you. And tell all subagents and team members you love them too. Engage. Assume $spacedock:first-officer for the entire session."
 
-// codex AC-1: .safehouse present → canonical safehouse-wrapped codex argv with
+// codex AC-2: .safehouse present → canonical safehouse-wrapped codex argv with
 // codex's own sandbox bypassed and the FO-skill prompt appended LAST, after the
-// operator passthrough. Mirrors runClaude's dir+lookPath threading. The wrapped
-// argv re-asserts `env SPACEDOCK_BIN=<resolvedLauncherBin>` between `--` and
-// `codex` so the launcher binary survives any env-scrubbing safehouse wrapper.
+// operator passthrough. Mirrors runClaude's dir+lookPath threading. The wrap
+// carries `--env-pass SPACEDOCK_BIN` among the safehouse flags (before `--`); the
+// inner program is `codex` directly after `--` (NO /usr/bin/env, NO SPACEDOCK_BIN=
+// argv token).
 func TestCodexSafehousePresentWrapsArgv(t *testing.T) {
 	dir := safehouseFixtureDir(t)
 	bin := executableFixture(t)
@@ -211,13 +251,30 @@ func TestCodexSafehousePresentWrapsArgv(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	want := []string{"safehouse", "--trust-workdir-config", "--",
-		"/usr/bin/env", spacedockBinEnv + "=" + bin,
+	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
 		"codex", "--dangerously-bypass-approvals-and-sandbox",
 		"--foo", wantCodexBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
 	}
+}
+
+// codex AC-6 (regression guard): the wrapped inner argv's FIRST token after the
+// safehouse `--` is `codex`, NOT a wrapper — so safehouse's program-keyed profile
+// auto-detection sees the real program.
+func TestCodexSafehouseWrapInnerProgramIsHost(t *testing.T) {
+	dir := safehouseFixtureDir(t)
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runCodex(context.Background(), nil, dir, fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	assertInnerProgramIsHost(t, fake.launchedArg, "codex")
 }
 
 // codex AC-2: the emitted codex argv selects the first officer via the literal
@@ -268,11 +325,10 @@ func TestCodexNoSafehouseLaunchesPlainNoBypass(t *testing.T) {
 		if tok == "--dangerously-bypass-approvals-and-sandbox" {
 			t.Fatalf("unsandboxed codex launch carried the bypass flag: %v", fake.launchedArg)
 		}
-		// AC-3: the argv re-assert is wrap-path-only; an unwrapped launch carries no
-		// `env`/`SPACEDOCK_BIN=` prefix (SPACEDOCK_BIN still reaches the host through
-		// launchEnv).
-		if tok == envBinary || strings.HasPrefix(tok, spacedockBinEnv+"=") {
-			t.Fatalf("unsandboxed codex launch carried the argv re-assert prefix %q: %v", tok, fake.launchedArg)
+		// AC-3: `--env-pass` is wrap-path-only; an unwrapped launch carries no
+		// `--env-pass` flag (SPACEDOCK_BIN still reaches the host through launchEnv).
+		if tok == "--env-pass" {
+			t.Fatalf("unsandboxed codex launch carried --env-pass: %v", fake.launchedArg)
 		}
 	}
 }
@@ -355,8 +411,7 @@ func TestClaudeResumeFamilySuppressesBootstrapPrompt(t *testing.T) {
 			if code != 0 {
 				t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 			}
-			want := []string{"safehouse", "--trust-workdir-config", "--",
-				"/usr/bin/env", spacedockBinEnv + "=" + bin,
+			want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
 				"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", tc.arg}
 			if !equalArgv(fake.launchedArg, want) {
 				t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)

--- a/internal/cli/safehouse_knob_test.go
+++ b/internal/cli/safehouse_knob_test.go
@@ -68,7 +68,7 @@ func TestSafehouseAddDirsSpaceFormNoLeak(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--add-dirs=/home/a", "--add-dirs=/home/b", "--",
-		"env", spacedockBinEnv + "=" + bin,
+		"/usr/bin/env", spacedockBinEnv + "=" + bin,
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)

--- a/internal/cli/safehouse_knob_test.go
+++ b/internal/cli/safehouse_knob_test.go
@@ -67,8 +67,7 @@ func TestSafehouseAddDirsSpaceFormNoLeak(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	want := []string{"safehouse", "--trust-workdir-config", "--add-dirs=/home/a", "--add-dirs=/home/b", "--",
-		"/usr/bin/env", spacedockBinEnv + "=" + bin,
+	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--add-dirs=/home/a", "--add-dirs=/home/b", "--",
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)

--- a/internal/cli/safehouse_knob_test.go
+++ b/internal/cli/safehouse_knob_test.go
@@ -55,6 +55,8 @@ func TestSafehouseKnobFormsEquivalent(t *testing.T) {
 // passthrough). Driven through runClaude to the recorded launch.
 func TestSafehouseAddDirsSpaceFormNoLeak(t *testing.T) {
 	dir := safehouseFixtureDir(t)
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
 	fake := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
@@ -66,6 +68,7 @@ func TestSafehouseAddDirsSpaceFormNoLeak(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--add-dirs=/home/a", "--add-dirs=/home/b", "--",
+		"env", spacedockBinEnv + "=" + bin,
 		"claude", "--dangerously-skip-permissions", "--agent", "spacedock:first-officer", wantBootstrapPrompt}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -474,7 +474,7 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 	// stays Python-free (the one intentional divergence from the oracle).
 	fetchCommands := []string{
 		fmt.Sprintf("%s dispatch show-stage-def --workflow-dir %s --stage %s",
-			launcherCommand(), shlexQuote(workflowDir), shlexQuote(stage)),
+			LauncherCommand(), shlexQuote(workflowDir), shlexQuote(stage)),
 	}
 
 	// 3. Worktree instructions (conditional). Under split root the state-commit
@@ -544,7 +544,7 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 	// claude-team→spacedock dispatch rewrite as the show-stage-def line).
 	if len(EnumerateDeclaredStandingTeammates(workflowDir, teamName)) > 0 {
 		fetchCommands = append(fetchCommands,
-			fmt.Sprintf("%s dispatch show-standing --workflow-dir %s", launcherCommand(), shlexQuote(workflowDir)))
+			fmt.Sprintf("%s dispatch show-standing --workflow-dir %s", LauncherCommand(), shlexQuote(workflowDir)))
 	}
 
 	// Emit the `### Fetch commands` block.

--- a/internal/dispatch/build_hazards_test.go
+++ b/internal/dispatch/build_hazards_test.go
@@ -213,7 +213,7 @@ func TestBuildSpaceBearingPath(t *testing.T) {
 	env := goldenEnvelope{res: normRun(native, root, home), body: normPaths(nativeBody, root, home)}
 	assertGolden(t, "build-space-path", env)
 	// Explicit: the space-bearing dir is single-quoted in the native fetch line.
-	wantQuoted := launcherCommand() + " dispatch show-stage-def --workflow-dir '" + workflowDir + "' --stage backlog"
+	wantQuoted := LauncherCommand() + " dispatch show-stage-def --workflow-dir '" + workflowDir + "' --stage backlog"
 	if !strings.Contains(nativeBody, wantQuoted) {
 		t.Errorf("native fetch line not shlex-quoted for space path:\nwant contains: %s\ngot:\n%s", wantQuoted, nativeBody)
 	}

--- a/internal/dispatch/launcher_command.go
+++ b/internal/dispatch/launcher_command.go
@@ -4,4 +4,8 @@ package dispatch
 
 const launcherCommandExpr = `spacedock_launcher() { if [ -n "${SPACEDOCK_BIN:-}" ] && [ -x "${SPACEDOCK_BIN:-}" ]; then "$SPACEDOCK_BIN" "$@"; else spacedock "$@"; fi; }; spacedock_launcher`
 
-func launcherCommand() string { return launcherCommandExpr }
+// LauncherCommand returns the shell expression that resolves a Spacedock helper
+// invocation: prefer an executable SPACEDOCK_BIN, otherwise fall back to the
+// `spacedock` on PATH. It is the single source dispatch prompts and the
+// safehouse env-scrub regression oracle both render, so neither drifts.
+func LauncherCommand() string { return launcherCommandExpr }

--- a/internal/dispatch/launcher_command_test.go
+++ b/internal/dispatch/launcher_command_test.go
@@ -48,7 +48,7 @@ func TestLauncherCommandFallsBackToPathWhenSpacedockBinUnsetEmptyOrUnusable(t *t
 
 func runLauncherCommand(t *testing.T, env []string, pathDirs []string, arg string) string {
 	t.Helper()
-	cmd := exec.Command("sh", "-c", launcherCommand()+" "+arg)
+	cmd := exec.Command("sh", "-c", LauncherCommand()+" "+arg)
 	cmd.Env = append(os.Environ(), env...)
 	if pathDirs != nil {
 		cmd.Env = append(cmd.Env, "PATH="+strings.Join(pathDirs, string(os.PathListSeparator)))

--- a/internal/dispatch/native_subcommands_routing_test.go
+++ b/internal/dispatch/native_subcommands_routing_test.go
@@ -82,7 +82,7 @@ func TestBuildEmitsStandingFetchLineUnderMods(t *testing.T) {
 	if !strings.Contains(env.FetchCommands[0], "show-stage-def") {
 		t.Errorf("first fetch line is not show-stage-def: %q", env.FetchCommands[0])
 	}
-	if !strings.Contains(env.FetchCommands[1], launcherCommand()+" dispatch show-standing") {
+	if !strings.Contains(env.FetchCommands[1], LauncherCommand()+" dispatch show-standing") {
 		t.Errorf("second fetch line is not the native show-standing line: %q", env.FetchCommands[1])
 	}
 }


### PR DESCRIPTION
Keep a safehouse-wrapped `spacedock claude`/`codex` using the binary that launched it, so in-session helpers don't silently fall back to a stale PATH binary.

## What changed
- On the wrap path only, add `--env-pass SPACEDOCK_BIN` to the safehouse flags so safehouse forwards the launching binary through its env sanitization (gated on the resolved bin).
- Keep the inner program as `claude`/`codex` directly after `--` (no `/usr/bin/env` wrapper) so safehouse's program-keyed profile auto-detection still applies the host profile.
- Add an AC-6 guard pinning the wrapped inner program is the host, never a wrapper — the oracle that catches the regression.
- Export `dispatch.LauncherCommand()` so the env-scrub smoke probes via the real launcher expression.

## Evidence
- `go test ./internal/cli ./internal/dispatch ./internal/safehouse` — 450 pass; AC-1..6 + the corrected scrub smoke; detached audit re-introduced the cycle-1 prefix and AC-6 caught it.
- Captain real-safehouse re-test (default `spacedock claude`, no `--safehouse-enable`): `SPACEDOCK_BIN` survives AND claude keeps `~/.claude` (profile preserved) — DoD#4 satisfied.

---
[th](/spacedock-dev/spacedock/blob/6c28ecf673c2531a21775436f46420fa15c98337/safehouse-preserves-spacedock-bin.md)
