### PR TITLE
Launch-banner UX — first-officer framing, status-command overload, multi-workflow limbo

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -23,9 +23,11 @@ import (
 // the release pipeline via -ldflags "-X
 // github.com/spacedock-dev/spacedock/internal/cli.Version=$(git describe --tags --always)".
 // It is a var (not a const) because the linker can only write package-level vars;
-// a const is silently ignored by -X. The default is the current release version,
-// overwritten by the git-describe tag on a stamped release build.
-var Version = "0.19.0"
+// a const is silently ignored by -X. The default is the `dev` sentinel so an
+// unstamped `go build`/`go install` binary reads honestly as a dev build rather
+// than impersonating a stale release; the git-describe tag overwrites it on a
+// stamped release build.
+var Version = "dev"
 
 // tagline is the one-line product description rendered as the first help line.
 const tagline = "spacedock — agentic workflow launcher"

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -136,40 +136,47 @@ func noPluginRemedy(host string) string {
 // one-line orientation pointer. Callers suppress it on a resume (the operator is
 // continuing a session, not starting one).
 func launchBanner(host, dir string, w io.Writer) {
-	fmt.Fprintf(w, "spacedock %s · first officer launching %s\n", Version, host)
-	fmt.Fprintf(w, "Workflow: %s\n", detectedWorkflow(dir))
-	fmt.Fprintf(w, "%s is starting as your first officer; run `spacedock status` inside the session for the queue.\n", host)
+	label, value := detectedWorkflow(dir)
+	fmt.Fprintf(w, "spacedock %s · launching %s as your first officer\n", Version, host)
+	fmt.Fprintf(w, "%s: %s\n", label, value)
+	fmt.Fprintf(w, "%s is your first officer — ask it for the queue and next steps.\n", host)
 }
 
 // detectedWorkflow names the workflow the launch belongs to, found from ANY
-// launch dir. When dir is inside a git repo, the whole repo is scanned downward
-// (status.DiscoverWorkflows, which prunes the linked/agent-worktree + VCS noise),
-// so launching from the repo root resolves the repo's real workflow rather than
-// missing it. A single workflow is named by its path relative to the repo root
-// (e.g. `docs/dev`); two or more report the count plus a pointer to `spacedock
-// status`. With no enclosing git repo, a bounded walk-up names a workflow at or
-// above dir. The result is never the cwd-relative `.`/`..`; "none detected
-// (launching anyway)" is shown when no workflow is found.
-func detectedWorkflow(dir string) string {
-	const noneDetected = "none detected (launching anyway)"
+// launch dir, returning the banner's line-2 label ("Workflow"/"Workflows") and its
+// value so the label agrees with the content. When dir is inside a git repo, the
+// whole repo is scanned downward (status.DiscoverWorkflows, which prunes the
+// linked/agent-worktree + VCS noise), so launching from the repo root resolves the
+// repo's real workflow rather than missing it. A single workflow is named by its
+// path relative to the repo root (e.g. `docs/dev`); two or more list the detected
+// paths space-separated in discovery order (`Workflows: docs/dev docs/user-testing`),
+// the first officer disambiguating in-session. With no enclosing git repo, a
+// bounded walk-up names a workflow at or above dir. The value is never the
+// cwd-relative `.`/`..`; "none detected" is shown when no workflow is found.
+func detectedWorkflow(dir string) (label, value string) {
+	const noneDetected = "none detected"
 	repoRoot := status.FindGitRoot(dir)
 	gitEntry := filepath.Join(repoRoot, ".git")
 	if dirExists(gitEntry) || fileExists(gitEntry) { // .git is a dir (repo) or a file (worktree gitlink)
 		workflows := status.DiscoverWorkflows(repoRoot)
 		switch len(workflows) {
 		case 0:
-			return noneDetected
+			return "Workflow", noneDetected
 		case 1:
-			return workflowLabel(repoRoot, workflows[0])
+			return "Workflow", workflowLabel(repoRoot, workflows[0])
 		default:
-			return fmt.Sprintf("%d workflows detected (run `spacedock status` to pick)", len(workflows))
+			labels := make([]string, len(workflows))
+			for i, wf := range workflows {
+				labels[i] = workflowLabel(repoRoot, wf)
+			}
+			return "Workflows", strings.Join(labels, " ")
 		}
 	}
 	// No enclosing git repo: a bounded walk-up names a workflow at or above dir.
 	if workflowDir, ok := status.DiscoverWorkflowDir(dir); ok {
-		return workflowLabel(repoRoot, workflowDir)
+		return "Workflow", workflowLabel(repoRoot, workflowDir)
 	}
-	return noneDetected
+	return "Workflow", noneDetected
 }
 
 // workflowLabel renders a workflow dir as a recognizable path relative to base

--- a/internal/cli/launch_banner_test.go
+++ b/internal/cli/launch_banner_test.go
@@ -42,9 +42,9 @@ func gitRepoFixture(t *testing.T) string {
 // to the repo root (e.g. `docs/dev`). From the repo root, from inside the
 // workflow, and from a deep subdir it names the same workflow. A noise copy under
 // `.claude/worktrees/...` (a real concern: agent worktrees are full repo checkouts
-// each carrying a `docs/dev`) is NOT named and does NOT inflate the count. Outside
+// each carrying a `docs/dev`) is NOT named and does NOT inflate the list. Outside
 // any workflow it reads "none detected"; with more than one top-level workflow it
-// reads the count + a pointer to `spacedock status`. The fixture layout is the
+// lists the detected workflow paths space-separated. The fixture layout is the
 // independent expected value.
 func TestLaunchBannerNamesDetectedWorkflow(t *testing.T) {
 	// repoWithRealWorkflowAndNoise builds a temp git repo with the single real
@@ -113,7 +113,7 @@ func TestLaunchBannerNamesDetectedWorkflow(t *testing.T) {
 		}
 	})
 
-	t.Run("more than one real top-level workflow reports the count + status pointer", func(t *testing.T) {
+	t.Run("more than one real top-level workflow lists the detected paths", func(t *testing.T) {
 		repo := gitRepoFixture(t)
 		commissionWorkflowAt(t, filepath.Join(repo, "docs", "dev"))
 		commissionWorkflowAt(t, filepath.Join(repo, "ops", "release"))
@@ -121,8 +121,9 @@ func TestLaunchBannerNamesDetectedWorkflow(t *testing.T) {
 		launchBanner("claude", repo, &buf)
 
 		out := buf.String()
-		if !strings.Contains(out, "2 workflows detected (run `spacedock status` to pick)") {
-			t.Fatalf("banner does not report the 2-workflow count + pointer: %q", out)
+		wantLine := "Workflows: " + filepath.Join("docs", "dev") + " " + filepath.Join("ops", "release") + "\n"
+		if !strings.Contains(out, wantLine) {
+			t.Fatalf("banner does not list the two workflow paths %q: %q", wantLine, out)
 		}
 		if strings.Contains(out, "none detected") {
 			t.Fatalf("banner reads none detected with two real workflows: %q", out)

--- a/internal/cli/launch_banner_wording_test.go
+++ b/internal/cli/launch_banner_wording_test.go
@@ -1,0 +1,199 @@
+// ABOUTME: AC-1..AC-7 oracles for the rewritten pre-launch banner — consistent
+// ABOUTME: first-officer framing, no self-serve status, multi-workflow path list.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// renderBanner exercises the real launchBanner for host from dir and returns the
+// rendered stderr bytes — the proof surface for AC-1/2/3/4/5 (the bytes the
+// operator actually sees), never a source-grep of the constant.
+func renderBanner(host, dir string) string {
+	var buf bytes.Buffer
+	launchBanner(host, dir, &buf)
+	return buf.String()
+}
+
+// twoWorkflowRepo builds a git repo holding exactly two top-level commissioned
+// workflows, docs/dev and docs/user-testing. DiscoverWorkflows sorts the resolved
+// absolute paths, so docs/dev precedes docs/user-testing; the relative-path order
+// in the banner is therefore deterministic and is the independent expected value.
+func twoWorkflowRepo(t *testing.T) string {
+	t.Helper()
+	repo := gitRepoFixture(t)
+	commissionWorkflowAt(t, filepath.Join(repo, "docs", "dev"))
+	commissionWorkflowAt(t, filepath.Join(repo, "docs", "user-testing"))
+	return repo
+}
+
+// TestLaunchBannerConsistentFirstOfficerMetaphor (AC-1): line 1 frames the host as
+// the first officer the launcher starts (`launching {host} as your first officer`),
+// never the flipped `first officer launching` that read as spacedock-is-FO. The
+// expected/forbidden phrases are written independently of the source constant, so a
+// reverted-wording edit fails this assertion.
+func TestLaunchBannerConsistentFirstOfficerMetaphor(t *testing.T) {
+	for _, host := range []string{"claude", "codex"} {
+		t.Run(host, func(t *testing.T) {
+			out := renderBanner(host, t.TempDir())
+			want := "launching " + host + " as your first officer"
+			if !strings.Contains(out, want) {
+				t.Fatalf("banner missing consistent line-1 framing %q: %q", want, out)
+			}
+			if strings.Contains(out, "first officer launching") {
+				t.Fatalf("banner still carries the flipped line-1 framing %q: %q", "first officer launching", out)
+			}
+		})
+	}
+}
+
+// TestLaunchBannerNoSelfServeStatus (AC-2): the banner tells the operator to ask
+// the first officer (which runs status for them) rather than printing a self-serve
+// `spacedock status` instruction, on all three workflow shapes (single / multi /
+// none). The pitch is "the host is your first officer," so a `spacedock status`
+// instruction would contradict it.
+func TestLaunchBannerNoSelfServeStatus(t *testing.T) {
+	single := gitRepoFixture(t)
+	commissionWorkflowAt(t, filepath.Join(single, "docs", "dev"))
+	cases := map[string]string{
+		"single": single,
+		"multi":  twoWorkflowRepo(t),
+		"none":   gitRepoFixture(t),
+	}
+	for name, dir := range cases {
+		t.Run(name, func(t *testing.T) {
+			out := renderBanner("claude", dir)
+			if strings.Contains(out, "spacedock status") {
+				t.Fatalf("%s banner carries a self-serve `spacedock status` instruction: %q", name, out)
+			}
+			if !strings.Contains(out, "ask it for the queue") {
+				t.Fatalf("%s banner does not point the operator to ask the first officer: %q", name, out)
+			}
+		})
+	}
+}
+
+// TestLaunchBannerMultiWorkflowListsPaths (AC-3): on the multi-workflow path, line 2
+// is exactly `Workflows: docs/dev docs/user-testing` — the detected paths, space
+// separated, in discovery order — with no count, no "will help you pick", no
+// "to pick)", and no `spacedock status`. The fixture's two relative paths are the
+// independent expected value.
+func TestLaunchBannerMultiWorkflowListsPaths(t *testing.T) {
+	out := renderBanner("claude", twoWorkflowRepo(t))
+	wantLine := "Workflows: " + filepath.Join("docs", "dev") + " " + filepath.Join("docs", "user-testing")
+	if !lineEquals(out, wantLine) {
+		t.Fatalf("multi-workflow line 2 is not the space-joined path list %q: %q", wantLine, out)
+	}
+	for _, forbidden := range []string{"found", "will help you pick", "to pick)", "spacedock status"} {
+		if strings.Contains(out, forbidden) {
+			t.Fatalf("multi-workflow banner contains forbidden token %q: %q", forbidden, out)
+		}
+	}
+}
+
+// TestLaunchBannerLabelAgreement (AC-4): the singular label `Workflow:` is used for
+// the single and none shapes; the plural `Workflows:` only for the multi shape, so
+// the label agrees with its content.
+func TestLaunchBannerLabelAgreement(t *testing.T) {
+	single := gitRepoFixture(t)
+	commissionWorkflowAt(t, filepath.Join(single, "docs", "dev"))
+
+	if got := bannerLine2(renderBanner("claude", single)); got != "Workflow: "+filepath.Join("docs", "dev") {
+		t.Fatalf("single line 2 = %q, want singular Workflow: docs/dev", got)
+	}
+	if got := bannerLine2(renderBanner("claude", gitRepoFixture(t))); got != "Workflow: none detected" {
+		t.Fatalf("none line 2 = %q, want %q", got, "Workflow: none detected")
+	}
+	multi := bannerLine2(renderBanner("claude", twoWorkflowRepo(t)))
+	if !strings.HasPrefix(multi, "Workflows: ") {
+		t.Fatalf("multi line 2 = %q, want plural Workflows: prefix", multi)
+	}
+}
+
+// TestLaunchBannerSingleWorkflowGolden (AC-5): the single-workflow happy path is the
+// exact three lines, in order, with no extra lines — a byte-exact golden, the
+// strongest assertion, so any drift (an added line, a reworded line, a separator
+// change) fails. The three expected lines are written independently of the source.
+func TestLaunchBannerSingleWorkflowGolden(t *testing.T) {
+	repo := gitRepoFixture(t)
+	commissionWorkflowAt(t, filepath.Join(repo, "docs", "dev"))
+
+	want := "spacedock " + Version + " · launching claude as your first officer\n" +
+		"Workflow: " + filepath.Join("docs", "dev") + "\n" +
+		"claude is your first officer — ask it for the queue and next steps.\n"
+	if got := renderBanner("claude", repo); got != want {
+		t.Fatalf("single-workflow banner golden mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+// TestUnstampedVersionIsNotARelease (AC-6): the package default Version (the value
+// before any ldflags stamp) is the `dev` sentinel and is NOT a release-shaped
+// semver, so an unstamped `go build`/`go install` binary does not impersonate a
+// release. A stamped release still overwrites Version via the ldflags path
+// exercised by the release pipeline.
+func TestUnstampedVersionIsNotARelease(t *testing.T) {
+	if Version != "dev" {
+		t.Fatalf("unstamped package Version = %q, want the dev sentinel %q", Version, "dev")
+	}
+	releaseShaped := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	if releaseShaped.MatchString(Version) {
+		t.Fatalf("unstamped Version %q matches the release semver pattern; it must read as a dev build", Version)
+	}
+}
+
+// lineEquals reports whether out has a line equal (whole-line) to want.
+func lineEquals(out, want string) bool {
+	for _, line := range strings.Split(out, "\n") {
+		if line == want {
+			return true
+		}
+	}
+	return false
+}
+
+// bannerLine2 returns the banner's second line (the Workflow/Workflows line).
+func bannerLine2(out string) string {
+	lines := strings.Split(out, "\n")
+	if len(lines) < 2 {
+		return ""
+	}
+	return lines[1]
+}
+
+// TestPiBannerEmittedBeforeLaunch (AC-7): `spacedock pi` renders the same 3-line
+// banner before launch — closing the pi no-orientation gap — and still reaches the
+// launch seam. Driven through runPi with a ready stub runtime (no live host, no
+// network) via the existing pi fixtures.
+func TestPiBannerEmittedBeforeLaunch(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	ops := &fakePiRuntimeOps{
+		lookPath: piHealthyPathFixtures(),
+		statOK:   statOKForPiResources(repo, pkg),
+	}
+	var stdout, stderr bytes.Buffer
+
+	code := runPi(context.Background(), []string{"--plugin-dir", repo}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	out := stderr.String()
+	for _, want := range []string{
+		"launching pi as your first officer",
+		"pi is your first officer — ask it for the queue",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("pi banner missing %q: %q", want, out)
+		}
+	}
+	if len(ops.launched) == 0 {
+		t.Fatalf("launch seam not reached after pi banner")
+	}
+}

--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -77,6 +77,8 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 		return 1
 	}
 
+	launchBanner("pi", dir, stderr)
+
 	argv := []string{
 		"pi",
 		"--extension", cfg.extensionPath,


### PR DESCRIPTION
The pre-launch banner flipped the first-officer metaphor and overloaded `spacedock status`; now it reads with one stable framing across every host and workflow shape.

## What changed
- Reword banner line 1 to `launching {host} as your first officer` (no metaphor flip).
- Reword line 3 to `ask it for the queue and next steps` (drop self-serve `spacedock status`).
- List discovered workflow paths on the multi-workflow line; agree singular/plural label.
- Emit the banner from `runPi`, closing pi's no-orientation gap.
- Default unstamped `Version` to `dev` so a dev build cannot impersonate a release.

## Evidence
- `go test ./internal/cli/` → 272/272 passed; AC-5 byte-exact golden and AC-6 `Version` regex hold.
- Detached adversarial audit: 5 reverted-wording edits (line 1/3, multi count, `Version`, dropped pi banner) each caught RED; no material findings.

---
[cm](/spacedock-dev/spacedock/blob/a5ca5604d04c96238594bb5096acc04ff95649de/frontdoor-launch-banner-ux.md)
