### PR TITLE
Two-channel release (stable→main / edge spacedock@next→next) + per-channel devBranch stamp + next-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,17 +186,22 @@ jobs:
 
       # AC-4: stamp the plugin manifests' `version` to the release so the host
       # plugin panel (`claude plugin list --json`) displays a version that tracks
-      # the binary instead of the frozen placeholder. The displayed version is
-      # pulled from plugin.json on the `next` ref (the marketplace source), so the
-      # stamp must commit to `next` — not goreleaser's transient working tree. The
-      # marketplace-entry calendar key is a DIFFERENT file (marketplace.json) and
-      # is left untouched here; it is the moving-branch re-pull key (AC-2d).
+      # the binary instead of the frozen placeholder. release.yml triggers ONLY on
+      # a `push: tags: ['v*']` cut, which carries no channel signal and has no edge
+      # `v*`-tag scheme — so exactly ONE thing reaches this step: a STABLE release.
+      # The stable channel's plugin lives on `main` (the stable binary stamps
+      # devBranch=main), so the displayed version must be stamped+pushed to `main`,
+      # not the edge `next` branch. This is a single-target stamp, not a
+      # per-channel branch; the edge channel's version-display rides the unchanged
+      # next-publish.yml, with no involvement here. The marketplace-entry calendar
+      # key is a DIFFERENT file (marketplace.json) and is left untouched here; it is
+      # the moving-branch re-pull key (AC-2d), pj's surface.
       - name: Stamp plugin manifests to the release version
         run: |
           set -euo pipefail
           RELEASE_VERSION="${GITHUB_REF_NAME#v}"
-          git fetch origin next
-          git switch next
+          git fetch origin main
+          git switch main
           go run ./cmd/spacedock-release stamp-version "$RELEASE_VERSION" \
             .claude-plugin/plugin.json .codex-plugin/plugin.json
           if git diff --quiet -- .claude-plugin/plugin.json .codex-plugin/plugin.json; then
@@ -207,4 +212,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "release: stamp plugin manifests to $RELEASE_VERSION" \
             -- .claude-plugin/plugin.json .codex-plugin/plugin.json
-          git push origin next
+          git push origin main

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,16 +9,23 @@ before:
   hooks:
     - go mod tidy
 
+# One `goreleaser release` on a `v*` tag produces BOTH distribution channels from
+# the same source tree: a STABLE binary stamped devBranch=main (installs the
+# `main` plugin) and an EDGE binary stamped devBranch=next (installs the `next`
+# plugin). The two channels differ ONLY in the devBranch ldflag; everything else
+# (goos/goarch matrix, Version stamp, binary name) is identical. The shared fields
+# live in a YAML anchor so a future matrix/flag change cannot drift the channels
+# apart.
 builds:
-  - id: spacedock
+  - id: spacedock-stable
     main: ./cmd/spacedock
     binary: spacedock
     env:
       - CGO_ENABLED=0
-    goos:
+    goos: &channel-goos
       - darwin
       - linux
-    goarch:
+    goarch: &channel-goarch
       - arm64
       - amd64
     # The version stamp the formula's `test do` asserts. Target is the
@@ -27,11 +34,26 @@ builds:
     # const, for the linker to write it. {{.Version}} is goreleaser's
     # git-describe-derived version (the tag on a release, a snapshot string on
     # --snapshot).
-    # devBranch pins the marketplace @ref the released binary installs from. Until
-    # `next` is the repository's default branch, the root marketplace.json lives on
-    # `next`, so `spacedock init` must target `spacedock-dev/spacedock@next`. The
-    # source default is already `next`; the stamp makes the pin explicit at build
-    # time, mirroring the Version stamp (var, not const, for -X to write it).
+    # devBranch pins the marketplace @ref the released binary installs from. The
+    # STABLE channel binds to `main`: a stable release published on `main` must
+    # install the `main` plugin. The source default stays `next` (frontdoor.go) so
+    # a `go install …@next` / `--plugin-dir` dev build is unaffected; only this
+    # released stable artifact carries the `main` stamp (var, not const, for -X to
+    # write it).
+    ldflags:
+      - -s -w
+      - -X github.com/spacedock-dev/spacedock/internal/cli.Version={{ .Version }}
+      - -X github.com/spacedock-dev/spacedock/internal/cli.devBranch=main
+  - id: spacedock-edge
+    main: ./cmd/spacedock
+    binary: spacedock
+    env:
+      - CGO_ENABLED=0
+    goos: *channel-goos
+    goarch: *channel-goarch
+    # The EDGE channel binds to `next`: the `spacedock@next` cask installs the
+    # `next` plugin. Same Version stamp as stable; only the devBranch ldflag
+    # differs (the sole per-channel knob).
     ldflags:
       - -s -w
       - -X github.com/spacedock-dev/spacedock/internal/cli.Version={{ .Version }}
@@ -42,10 +64,21 @@ archives:
   # install.sh: spacedock_{version}_{darwin|linux}_{arm64|amd64}.tar.gz, with the
   # bare `spacedock` binary at the archive root (no wrapping directory) so
   # `bin.install "spacedock"` (cask) and install.sh's tar-extract both resolve.
-  - id: spacedock
+  # One archive per channel build; the edge archive carries an `-edge` suffix so
+  # the two channels' assets never collide in the release.
+  - id: spacedock-stable
+    ids:
+      - spacedock-stable
     formats:
       - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    wrap_in_directory: false
+  - id: spacedock-edge
+    ids:
+      - spacedock-edge
+    formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}_edge"
     wrap_in_directory: false
 
 checksum:
@@ -63,8 +96,14 @@ homebrew_casks:
   # release, pinning the per-arch url + sha256 from the release assets +
   # checksums.txt — the seam the homebrew-tap entity consumes. `brews:` is
   # hard-deprecated at goreleaser v2.16; casks auto-detect the bare `spacedock`
-  # binary from the archive root, so no install/test stanza is given.
+  # binary from the archive root, so no install/test stanza is given. Two casks
+  # ship per release: the STABLE `spacedock` cask (from the stable archive,
+  # installs the `main` plugin) and the EDGE `spacedock@next` cask (from the edge
+  # archive, installs the `next` plugin). Each pins ONLY its own channel's archive
+  # via `ids: [<archive-id>]` so the two casks never cross-pin.
   - name: spacedock
+    ids:
+      - spacedock-stable
     repository:
       owner: spacedock-dev
       name: homebrew-tap
@@ -83,6 +122,28 @@ homebrew_casks:
       # download carries com.apple.quarantine and Gatekeeper kills the first
       # launch. Strip the attribute from the staged binary so the user needs no
       # manual step. Interim until a Developer ID notarized build lands.
+      post:
+        install: |
+          system_command "/usr/bin/xattr",
+                         args: ["-dr", "com.apple.quarantine", "#{staged_path}/spacedock"]
+  # The EDGE cask: `brew install spacedock-dev/tap/spacedock@next` ships the
+  # devBranch=next binary that installs the `next` plugin. Its on-demand re-pull
+  # cadence rides the unchanged next-publish.yml; goreleaser only emits the cask.
+  - name: spacedock@next
+    ids:
+      - spacedock-edge
+    repository:
+      owner: spacedock-dev
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/spacedock-dev/spacedock
+    description: Workflow launcher and first-officer dispatch for agentic dev (edge channel)
+    license: Apache-2.0
+    caveats: |
+      Recommended companions (not installed by brew):
+        safehouse  — sandboxes agent runs (https://agent-safehouse.dev)
+        agentsview — powers /spacedock:survey
+    hooks:
       post:
         install: |
           system_command "/usr/bin/xattr",

--- a/internal/cli/codex_channel_smoke_test.go
+++ b/internal/cli/codex_channel_smoke_test.go
@@ -1,0 +1,133 @@
+// ABOUTME: AC-a/AC-d — per-channel devBranch drives the claude/codex no-plugin
+// ABOUTME: auto-install to @main/@next (claude) and --ref main/next (codex) in argv.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// TestClaudeNoPluginAutoInstallChannelRef is AC-a's hermetic half: the claude
+// front door, with devBranch set per channel, drives the no-plugin auto-install
+// to the channel-correct marketplace `@ref`. It mirrors the codex test but in
+// claude's `source@branch` shorthand: a stable binary (devBranch=main) resolves
+// `spacedock-dev/spacedock@main`; an edge binary (devBranch=next) resolves
+// `…@next`. The branch is observed off the recorded install seam, and
+// marketplaceAddArg is confirmed to compose `source@branch` from it — so the
+// observed value IS the production marketplace-add argv, never a constant grep.
+// (The live built-binary smoke proves the BUILD stamp end-to-end; this test pins
+// the channel→argv contract hermetically.)
+func TestClaudeNoPluginAutoInstallChannelRef(t *testing.T) {
+	saved := devBranch
+	defer func() { devBranch = saved }()
+
+	cases := []struct {
+		channel string
+		branch  string
+	}{
+		{channel: "stable", branch: "main"},
+		{channel: "edge", branch: "next"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.channel, func(t *testing.T) {
+			devBranch = tc.branch
+
+			fake := &fakeHost{manifest: ""} // fresh HOME: no claude plugin installed
+			var stdout, stderr bytes.Buffer
+			code := runClaude(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit = %d, want 0 (no plugin → auto-install + launch) (stderr=%q)", code, stderr.String())
+			}
+
+			if len(fake.installCmds) < 3 {
+				t.Fatalf("install seam recorded %v, want {host, source, branch}", fake.installCmds)
+			}
+			if got := fake.installCmds[0]; got != "claude" {
+				t.Fatalf("install host = %q, want claude", got)
+			}
+			if got := fake.installCmds[2]; got != tc.branch {
+				t.Fatalf("%s channel install branch = %q, want %q", tc.channel, got, tc.branch)
+			}
+
+			wantRef := marketplaceSource + "@" + tc.branch
+			if got := marketplaceAddArg(marketplaceSource, fake.installCmds[2]); got != wantRef {
+				t.Fatalf("%s channel marketplace add arg = %q, want %q", tc.channel, got, wantRef)
+			}
+		})
+	}
+}
+
+// TestCodexNoPluginAutoInstallChannelRef is AC-d's hermetic proof: the codex
+// front door is the SOLE-knob host (no .codex-plugin/marketplace.json calendar
+// key acts as a secondary channel signal — claude has one, codex does not), so
+// the `devBranch` ldflag is the only determinant of the codex `--ref`. The test
+// drives the real runCodex no-plugin auto-install with devBranch set per channel
+// and OBSERVES the branch the install seam records — exactly the value
+// codexInstallArgvSequence threads into codex's `--ref <branch>` flag (asserted
+// below). A stable binary (devBranch=main) must resolve `--ref main`; an edge
+// binary (devBranch=next) must resolve `--ref next`. The branch is read off the
+// recorded seam interaction, never grepped from the constant.
+func TestCodexNoPluginAutoInstallChannelRef(t *testing.T) {
+	saved := devBranch
+	defer func() { devBranch = saved }()
+
+	cases := []struct {
+		channel string
+		branch  string
+	}{
+		{channel: "stable", branch: "main"},
+		{channel: "edge", branch: "next"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.channel, func(t *testing.T) {
+			devBranch = tc.branch // the per-channel ldflag the released binary carries
+
+			fake := &fakeHost{manifest: ""} // fresh HOME: no codex plugin installed
+			var stdout, stderr bytes.Buffer
+			code := runCodex(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit = %d, want 0 (no plugin → auto-install + launch) (stderr=%q)", code, stderr.String())
+			}
+
+			// The seam records {host, source, branch}; branch is the channel ref.
+			if len(fake.installCmds) < 3 {
+				t.Fatalf("install seam recorded %v, want {host, source, branch}", fake.installCmds)
+			}
+			if got := fake.installCmds[0]; got != "codex" {
+				t.Fatalf("install host = %q, want codex", got)
+			}
+			if got := fake.installCmds[2]; got != tc.branch {
+				t.Fatalf("%s channel install branch = %q, want %q (devBranch is the sole codex channel knob)", tc.channel, got, tc.branch)
+			}
+
+			// The recorded branch is exactly what codex's `--ref` carries: confirm the
+			// argv composition threads it through `--ref <branch>` on the marketplace
+			// add step, so the observed seam value IS the production install argv.
+			seq := codexInstallArgvSequence(marketplaceSource, fake.installCmds[2])
+			if !codexMarketplaceAddHasRef(seq, tc.branch) {
+				t.Fatalf("%s channel codexInstallArgvSequence has no `marketplace add … --ref %s`; steps=%v", tc.channel, tc.branch, seq)
+			}
+		})
+	}
+}
+
+// codexMarketplaceAddHasRef reports whether the install sequence's marketplace
+// add step carries `--ref <branch>` as adjacent argv tokens — the codex
+// branch-pinning form (a separate flag, not the claude `source@branch`
+// shorthand). It reads the argv structurally so a reordering or a dropped `--ref`
+// reds AC-d rather than passing on a substring coincidence.
+func codexMarketplaceAddHasRef(steps []installStep, branch string) bool {
+	for _, step := range steps {
+		argv := step.argv
+		if len(argv) < 4 || argv[0] != "plugin" || argv[1] != "marketplace" || argv[2] != "add" {
+			continue
+		}
+		for i := 3; i+1 < len(argv); i++ {
+			if argv[i] == "--ref" && argv[i+1] == branch {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/release/channel_agreement_guard_test.go
+++ b/internal/release/channel_agreement_guard_test.go
@@ -1,0 +1,233 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The post-flip agreement invariant: the released stable channel's plugin source
+// must settle on `main` across three INDEPENDENTLY-authored surfaces —
+//   (1) release.yml's "Stamp plugin manifests" step git switch/push target,
+//   (2) .goreleaser.yaml's stable-build cli.devBranch ldflag,
+//   (3) .claude-plugin/marketplace.json source.ref.
+// Surfaces (1) and (2) are the BINARY side (k6d); surface (3) is the
+// marketplace side (pj), flipped next→main at the 0.20.0 flip. k6d lands
+// pre-flip, so the k6d-green half is the binary-side PAIR (1)==(2)==main. The
+// full tri-surface ==main check (channelAgreementSurfaces including the
+// marketplace ref) goes green only when pj flips surface (3); it is RED by
+// construction between k6d's merge and pj's flip, exactly like pj's paired
+// marketplace_manifest_test.go edit. The surfaces are parsed out of three real
+// artifacts authored by three different changes, so a drift in any one fails the
+// check — an independent source of truth, not a re-read of the value the
+// implementer wrote.
+const stableChannelBranch = "main"
+
+// releaseStampTarget extracts the branch the release.yml "Stamp plugin manifests
+// to the release version" step switches to and pushes — the surface (1) value.
+// It reads the step's run block, finds the `git switch <branch>` and `git push
+// origin <branch>` commands, and returns the branch only when BOTH name the same
+// branch (a switch/push split would itself be a drift). Returns "" when the step,
+// or either command, is absent.
+func releaseStampTarget(workflow string) string {
+	for _, step := range parseWorkflowSteps(workflow) {
+		if step.name != "Stamp plugin manifests to the release version" {
+			continue
+		}
+		var switchTo, pushTo string
+		for _, command := range executableShellCommands(step.run) {
+			fields := strings.Fields(command)
+			if len(fields) == 3 && fields[0] == "git" && fields[1] == "switch" {
+				switchTo = fields[2]
+			}
+			if len(fields) == 4 && fields[0] == "git" && fields[1] == "push" && fields[2] == "origin" {
+				pushTo = fields[3]
+			}
+		}
+		if switchTo != "" && switchTo == pushTo {
+			return switchTo
+		}
+		return ""
+	}
+	return ""
+}
+
+// goreleaserStableDevBranch extracts the cli.devBranch value the goreleaser
+// STABLE build stamps — the surface (2) value. The stable build is the one whose
+// id is spacedock-stable (it ldflags devBranch=main); the edge build
+// (spacedock-edge) ldflags devBranch=next. The parse reads the build's ldflags
+// for `-X …cli.devBranch=<value>` rather than grepping the file, so an edge-only
+// or single-build config yields "" and reds the agreement check loudly.
+func goreleaserStableDevBranch(config string) string {
+	var doc struct {
+		Builds []struct {
+			ID      string   `yaml:"id"`
+			Ldflags []string `yaml:"ldflags"`
+		} `yaml:"builds"`
+	}
+	if err := yaml.Unmarshal([]byte(config), &doc); err != nil {
+		return ""
+	}
+	for _, b := range doc.Builds {
+		if b.ID != "spacedock-stable" {
+			continue
+		}
+		return devBranchLdflag(b.Ldflags)
+	}
+	return ""
+}
+
+// goreleaserEdgeDevBranch extracts the cli.devBranch value the goreleaser EDGE
+// build (spacedock-edge) stamps. The edge channel is the sole consumer of `next`
+// post-flip, so the edge build must keep stamping `next` even after the stable
+// build moves to `main` — a guard that the channels do not collapse to one value.
+func goreleaserEdgeDevBranch(config string) string {
+	var doc struct {
+		Builds []struct {
+			ID      string   `yaml:"id"`
+			Ldflags []string `yaml:"ldflags"`
+		} `yaml:"builds"`
+	}
+	if err := yaml.Unmarshal([]byte(config), &doc); err != nil {
+		return ""
+	}
+	for _, b := range doc.Builds {
+		if b.ID != "spacedock-edge" {
+			continue
+		}
+		return devBranchLdflag(b.Ldflags)
+	}
+	return ""
+}
+
+// devBranchLdflag returns the value of the `-X …cli.devBranch=<value>` entry in
+// ldflags, or "" when none is present.
+func devBranchLdflag(ldflags []string) string {
+	const marker = "cli.devBranch="
+	for _, f := range ldflags {
+		if i := strings.Index(f, marker); i >= 0 {
+			return strings.TrimSpace(f[i+len(marker):])
+		}
+	}
+	return ""
+}
+
+// marketplaceSourceRef extracts .claude-plugin/marketplace.json's first plugin
+// entry's source.ref — surface (3), pj's. Parsed from the real file so a pj flip
+// (next→main) is observed here, not asserted from a value k6d wrote.
+func marketplaceSourceRef(manifest string) string {
+	var doc struct {
+		Plugins []struct {
+			Source struct {
+				Ref string `json:"ref"`
+			} `json:"source"`
+		} `json:"plugins"`
+	}
+	if err := yamlJSON([]byte(manifest), &doc); err != nil {
+		return ""
+	}
+	if len(doc.Plugins) == 0 {
+		return ""
+	}
+	return doc.Plugins[0].Source.Ref
+}
+
+// yamlJSON decodes JSON via the yaml.v3 codec (a JSON document is valid YAML), so
+// the agreement guard needs no extra import beyond the one the sibling goreleaser
+// guard already carries.
+func yamlJSON(blob []byte, out any) error {
+	return yaml.Unmarshal(blob, out)
+}
+
+func readReleaseWorkflow(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func readMarketplaceManifest(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", ".claude-plugin", "marketplace.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+// TestStableChannelBinaryPairAgreesOnMain locks AC-b's k6d-landable half: the two
+// BINARY-side surfaces — release.yml's stamp target (1) and .goreleaser.yaml's
+// stable-build devBranch (2) — must both be `main`. Each is parsed out of its own
+// real artifact, authored by a different part of this change; a drift in either
+// (a stamp step left on `next`, a stable build stamping `next`) reds this test.
+// This is the half k6d makes green now, pre-flip, on `next`.
+func TestStableChannelBinaryPairAgreesOnMain(t *testing.T) {
+	stampTarget := releaseStampTarget(readReleaseWorkflow(t))
+	if stampTarget == "" {
+		t.Fatal("release.yml has no 'Stamp plugin manifests' step with matching git switch/push branch targets")
+	}
+	stableDevBranch := goreleaserStableDevBranch(readGoreleaserConfig(t))
+	if stableDevBranch == "" {
+		t.Fatal(".goreleaser.yaml has no spacedock-stable build with a cli.devBranch ldflag")
+	}
+
+	if stampTarget != stableChannelBranch {
+		t.Errorf("release.yml stamp target = %q, want %q (stable channel binds the plugin version to main)", stampTarget, stableChannelBranch)
+	}
+	if stableDevBranch != stableChannelBranch {
+		t.Errorf(".goreleaser.yaml stable-build cli.devBranch = %q, want %q", stableDevBranch, stableChannelBranch)
+	}
+	if stampTarget != stableDevBranch {
+		t.Errorf("binary-side pair disagrees: release.yml stamp target %q != .goreleaser.yaml stable devBranch %q", stampTarget, stableDevBranch)
+	}
+}
+
+// TestEdgeChannelStampsNext locks the channel-separation half: the edge build
+// must keep stamping `next` even as the stable build moves to `main`, so the two
+// channels resolve distinct plugin sources rather than collapsing to one branch.
+func TestEdgeChannelStampsNext(t *testing.T) {
+	edgeDevBranch := goreleaserEdgeDevBranch(readGoreleaserConfig(t))
+	if edgeDevBranch == "" {
+		t.Fatal(".goreleaser.yaml has no spacedock-edge build with a cli.devBranch ldflag")
+	}
+	if edgeDevBranch != "next" {
+		t.Errorf(".goreleaser.yaml edge-build cli.devBranch = %q, want next (the edge channel stays on next)", edgeDevBranch)
+	}
+	stableDevBranch := goreleaserStableDevBranch(readGoreleaserConfig(t))
+	if edgeDevBranch == stableDevBranch {
+		t.Errorf("stable and edge builds both stamp devBranch=%q; the two channels collapsed to one source", edgeDevBranch)
+	}
+}
+
+// TestTriSurfaceChannelAgreement is the FULL agreement invariant: all three
+// independently-authored surfaces — release.yml stamp target (1, k6d),
+// .goreleaser.yaml stable devBranch (2, k6d), and .claude-plugin/marketplace.json
+// source.ref (3, pj) — must agree on `main`. It is RED by construction between
+// k6d's merge and pj's flip: surface (3) is still `next` until pj flips it in the
+// SAME commit it extends this guard. pj co-gates the flip on this test going
+// green. It is skipped (not failed) while surface (3) is still `next`, so k6d's
+// pre-flip merge is green; the binary-side pair is asserted unconditionally by
+// TestStableChannelBinaryPairAgreesOnMain above. pj removes this skip when it
+// flips the ref.
+func TestTriSurfaceChannelAgreement(t *testing.T) {
+	marketplaceRef := marketplaceSourceRef(readMarketplaceManifest(t))
+	if marketplaceRef != stableChannelBranch {
+		t.Skipf("marketplace source.ref = %q, not yet flipped to %q (pj owns surface 3); binary-side pair is covered by TestStableChannelBinaryPairAgreesOnMain", marketplaceRef, stableChannelBranch)
+	}
+
+	surfaces := map[string]string{
+		"release.yml stamp target":           releaseStampTarget(readReleaseWorkflow(t)),
+		".goreleaser.yaml stable devBranch":  goreleaserStableDevBranch(readGoreleaserConfig(t)),
+		".claude-plugin/marketplace.json ref": marketplaceRef,
+	}
+	for name, got := range surfaces {
+		if got != stableChannelBranch {
+			t.Errorf("channel surface %q = %q, want %q", name, got, stableChannelBranch)
+		}
+	}
+}


### PR DESCRIPTION
Ahead of the 0.20.0 flip, each released channel's binary must install its own channel's plugin — this stamps `devBranch` per channel and emits both casks.

## What changed
- Stamp `devBranch` per channel via two goreleaser builds (stable→`main`, edge→`next`).
- Emit two casks: stable `spacedock` and edge `spacedock@next`, each pinning its own archive.
- Swap the `release.yml` plugin-manifest stamp step to `main` (single-target, tag-only trigger).
- Add an `internal/release` guard pinning the binary-side pair agreement on `main`.
- Add a codex sole-knob smoke asserting per-channel `--ref main`/`--ref next` install argv.

## Evidence
- `goreleaser release --snapshot` emits both casks (distinct archives/shas); built binaries install `@main`/`@next` (claude) and `--ref main`/`next` (codex), observed in argv.
- `go test ./internal/release/ ./internal/cli/` → 75 + 341 passed; detached adversarial audit caught every weakening, no material findings.

## Review guidance
- The tri-surface guard intentionally SKIPs until pj flips the marketplace ref; the binary-side pair is green now and pj un-skips it green-by-construction at the flip.

---
[k6d](/spacedock-dev/spacedock/blob/68d2df2780cd4acf5610d001fc2147a4c6edb807/two-channel-release-devbranch-stamp.md)
