### PR TITLE
docs: load webfonts from Bunny Fonts instead of Google

### DIFF
--- a/docs/site/stylesheets/brand.css
+++ b/docs/site/stylesheets/brand.css
@@ -1,6 +1,14 @@
 /* ABOUTME: C2 brand layer for Material docs. */
 /* ABOUTME: Maps C2 tokens to Material surfaces; loaded after tokens.css. No hardcoded values. */
 
+/* Font-family slots. theme.font is false (webfonts load from Bunny, not Google),
+   so Material no longer defines these; restore them to the same families so the
+   body text and code resolve to Hanken Grotesk / JetBrains Mono. */
+:root {
+  --md-text-font: "Hanken Grotesk";
+  --md-code-font: "JetBrains Mono";
+}
+
 /* Header/footer chrome -- matches landing nav bg + border. Text colour must
    travel with the repainted background: Material defaults header/tabs text
    to the primary-bg alias (ink-on-gold), which is dark-on-dark over the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,9 +18,9 @@ theme:
   custom_dir: overrides
   logo: brand/logo.svg
   favicon: brand/favicon.svg
-  font:
-    text: Hanken Grotesk
-    code: JetBrains Mono
+  # Webfonts load from Bunny Fonts (GDPR-clean, no IP logging) via overrides/main.html,
+  # not Material's built-in Google Fonts. brand.css restores --md-text-font/--md-code-font.
+  font: false
   palette:
     - scheme: slate
       primary: custom

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+<!--
+  Webfonts load from Bunny Fonts (fonts.bunny.net) instead of Material's
+  built-in Google Fonts. theme.font is false in mkdocs.yml, which suppresses
+  Material's Google Fonts <link> and its --md-text-font/--md-code-font
+  definitions; brand.css restores those two variables. Same families and
+  weights as before (Hanken Grotesk text, JetBrains Mono code) — only the CDN
+  changes, so no IP transfer to Google.
+-->
+{% block extrahead %}
+  {{ super() }}
+  <link rel="preconnect" href="https://fonts.bunny.net" crossorigin>
+  <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=hanken-grotesk:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&family=jetbrains-mono:ital,wght@0,400;0,700;1,400;1,700&display=fallback">
+{% endblock %}


### PR DESCRIPTION
## What

Material auto-loads webfonts from Google Fonts via `theme.font`, which transfers every docs visitor's IP to Google (the GDPR / IP-logging exposure flagged on the landing side). This moves docs webfont loading to **Bunny Fonts** (`fonts.bunny.net`) — GDPR-clean, no IP logging, same families and weights, same CSS-link API. No type change.

## How

- `mkdocs.yml`: `theme.font: false` — suppresses Material's built-in Google Fonts `<link>` and its `--md-text-font` / `--md-code-font` definitions.
- `overrides/main.html`: inject Bunny `<link>`s for Hanken Grotesk (text) + JetBrains Mono (code) in `{% block extrahead %}`, same weights Material requested (`300/400/700` + italics for text, `400/700` + italics for code).
- `docs/site/stylesheets/brand.css`: restore `--md-text-font` / `--md-code-font` so body text and code still resolve to Hanken Grotesk / JetBrains Mono.

## Evidence

Built with `mkdocs build --strict` (green), then network capture on the built site:

- Requests to `fonts.googleapis.com` / `fonts.gstatic.com`: **0**
- Webfonts download from `fonts.bunny.net` (Hanken + JBM `.woff2`)
- `document.fonts.check("16px 'Hanken Grotesk'")` → `true`
- `document.fonts.check("16px 'JetBrains Mono'")` → `true`
- Desktop + mobile stills show type unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)