### PR TITLE
CI PR gating on main (post-flip trunk)

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -12,7 +12,7 @@ name: install-e2e
 on:
   workflow_dispatch:
   pull_request:
-    branches: [next]
+    branches: [next, main]
 
 permissions:
   contents: read

--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -1,7 +1,7 @@
 # SECURITY MODEL — read before editing.
 #
 # Triggers: workflow_dispatch (a maintainer triggers it manually) and
-# pull_request on `next`. It uses pull_request, NOT pull_request_target, so it
+# pull_request on `next` and `main`. It uses pull_request, NOT pull_request_target, so it
 # runs the PR-head version of the workflow and GitHub withholds repo secrets from
 # FORK PRs — untrusted fork code cannot exfiltrate live API keys because the
 # secrets are simply absent for forks. Workflow-level permissions are read-only.
@@ -43,7 +43,7 @@ on:
   # cannot exfiltrate live API keys because the secrets are simply absent.
   # Same-repo PRs get the secret; the live job stays per-variant environment-gated.
   pull_request:
-    branches: [next]
+    branches: [next, main]
 
 permissions:
   contents: read


### PR DESCRIPTION
Gate main-PRs on the Go test suite and install smoke, so code cannot reach the post-flip release trunk untested.

## What changed
- Add `main` to the `pull_request` branch filter of `install-e2e.yml` and `runtime-live-e2e.yml`.
- The offline `go build ./...` + `go test ./...` gate and the install matrix now run on main-PRs.
- The three live e2e lanes stay environment-gated — they queue `waiting`, never auto-spend API credits.
- Refresh the runtime-live-e2e SECURITY-MODEL header to name `next` and `main`.

## Evidence
- `go test ./...` 1249/1249; `internal/release` workflow_exec_guard green (no structural guard reds on the edit).
- Main-PR trigger proven live: PR #347's docs `build` already runs on a main-PR.

## Review guidance
On `main`'s branch protection, mark only `offline` / `install` / `docs` as required checks — never the live lanes (they wait on environment approval by design).

---
[ea](/spacedock-dev/spacedock/blob/03fe82449847c0ba681904c69a51a9ec449da52a/ci-pr-gating-on-main.md)
