### PR TITLE
fix(0201): restore marketplace.json bridge on main + add LICENSE (pre-cut hardening)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "spacedock",
+  "owner": {
+    "name": "CL Kao"
+  },
+  "plugins": [
+    {
+      "name": "spacedock",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/spacedock-dev/spacedock.git",
+        "ref": "main"
+      },
+      "description": "Turn directories of markdown files into structured workflows operated by AI agents",
+      "version": "0.0.2026060901",
+      "category": "workflow"
+    }
+  ]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,200 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an
+      information on the current year for the copyright statement.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/internal/release/channel_agreement_guard_test.go
+++ b/internal/release/channel_agreement_guard_test.go
@@ -13,12 +13,13 @@ import (
 // must settle on `main` across the two BINARY-side surfaces —
 //   (1) release.yml's "Stamp plugin manifests" step git switch/push target,
 //   (2) .goreleaser.yaml's stable-build cli.devBranch ldflag.
-// Under Model B the marketplace manifest moved OUT of the plugin branch into a
-// separate marketplace repo, so the former third surface — an in-branch
-// .claude-plugin/marketplace.json source.ref that had to be re-settled per release
-// — no longer exists. That removal is the AC-2 invariant guarded by
-// TestPluginBranchCarriesNoMarketplaceManifest below; the channel pin now lives in
-// the marketplace repo's manifest, not the plugin branch. The two binary surfaces
+// Under Model B the marketplace manifest will move OUT of the plugin branch into a
+// separate marketplace repo, retiring the former third surface — an in-branch
+// .claude-plugin/marketplace.json source.ref re-settled per release. That removal is
+// deferred until after the v0.20.1 cutover (the released v0.20.0 binary still resolves
+// its install from main's marketplace.json), so a transitional bridge manifest stays on
+// main meanwhile, guarded by TestMainCarriesMarketplaceBridgeManifest below; the channel
+// pin for the new binary lives in the marketplace repo's manifest. The two binary surfaces
 // are parsed out of two real artifacts authored by different changes, so a drift in
 // either fails the check — an independent source of truth, not a re-read of the
 // value the implementer wrote.
@@ -166,30 +167,24 @@ func TestEdgeChannelStampsNext(t *testing.T) {
 	}
 }
 
-// TestPluginBranchCarriesNoMarketplaceManifest is the AC-2 git-state guard: the
-// Model B decouple moves the marketplace manifest OUT of the plugin branch into a
-// separate marketplace repo, so the plugin branch carries NO
-// .claude-plugin/marketplace.json. With no in-branch manifest there is no
-// per-release source.ref surface to re-settle — the field that used to be `main`
-// on the stable branch and `next` on the edge branch, forcing a re-settle every
-// release, is simply absent. The check is git state — the file's presence on disk,
-// an independent fact, not a re-read of a value the implementer wrote. (The
-// plugin's own .claude-plugin/plugin.json stays; only the marketplace.json moved.)
-// This guards the main-bound branch; the next-branch manifest removal + full
-// main/next alignment is the separate trunk reconcile.
-func TestPluginBranchCarriesNoMarketplaceManifest(t *testing.T) {
+// TestMainCarriesMarketplaceBridgeManifest guards the transitional bridge that keeps
+// the released v0.20.0 binary's install path working. That binary resolves its
+// install from main's .claude-plugin/marketplace.json (`claude plugin marketplace
+// add spacedock-dev/spacedock@main`). Model B's removal of this manifest — it moves
+// to the standalone marketplace repo, retiring the per-release source.ref re-settle —
+// is deferred until the v0.20.1 cutover ships the binary that points at that repo and
+// existing v0.20.0 installs have migrated. Until then the bridge MUST stay on main, or
+// v0.20.0 installs break, so this guards its PRESENCE (git state — the file on disk,
+// an independent fact). The plugin's own .claude-plugin/plugin.json stays alongside it.
+func TestMainCarriesMarketplaceBridgeManifest(t *testing.T) {
 	manifest := filepath.Join("..", "..", ".claude-plugin", "marketplace.json")
-	if _, err := os.Stat(manifest); err == nil {
-		t.Fatalf("%s is present on the plugin branch; Model B moves the marketplace manifest to the separate marketplace repo, so the plugin branch must carry no marketplace.json (and thus no per-release source.ref to re-settle)", manifest)
-	} else if !os.IsNotExist(err) {
-		t.Fatalf("stat %s: %v", manifest, err)
+	if _, err := os.Stat(manifest); err != nil {
+		t.Fatalf("bridge marketplace manifest %s missing: %v — the released v0.20.0 binary resolves its install from main's marketplace.json; removing it before the v0.20.1 cutover breaks v0.20.0 installs", manifest, err)
 	}
 
-	// The plugin manifest itself stays on the plugin branch — only the marketplace
-	// manifest moved out.
 	plugin := filepath.Join("..", "..", ".claude-plugin", "plugin.json")
 	if _, err := os.Stat(plugin); err != nil {
-		t.Fatalf("plugin manifest %s missing: %v (only marketplace.json should move out of the plugin branch)", plugin, err)
+		t.Fatalf("plugin manifest %s missing: %v", plugin, err)
 	}
 }
 
@@ -198,7 +193,8 @@ func TestPluginBranchCarriesNoMarketplaceManifest(t *testing.T) {
 // served had THREE surfaces that had to agree (release.yml stamp target,
 // goreleaser stable devBranch, and an in-branch marketplace.json source.ref), and
 // a drift on the manifest ref was a real per-release re-settle hazard. The decouple
-// removes the in-branch ref surface entirely (guarded above), so the channel is now
+// will retire the in-branch ref surface (deferred post-cutover; a transitional bridge
+// manifest stays on main meanwhile, guarded above), so the new binary's channel is
 // determined SOLELY by the binary's devBranch stamp selecting a marketplace ENTRY
 // NAME (stable=main→spacedock, edge=next→spacedock-edge). The surviving invariant —
 // independent values that CAN disagree, so not a tautology — is that the two

--- a/skills/integration/marketplace_manifest_test.go
+++ b/skills/integration/marketplace_manifest_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: AC-2 manifest tests — the plugin branch carries no marketplace.json
-// ABOUTME: (Model B), and .codex-plugin/plugin.json requires-contract brackets binary.
+// ABOUTME: Manifest tests — main carries a transitional bridge marketplace.json
+// ABOUTME: (Model B removal deferred), and .codex-plugin/plugin.json brackets binary.
 package integration
 
 import (
@@ -11,24 +11,23 @@ import (
 	"github.com/spacedock-dev/spacedock/internal/contract"
 )
 
-// TestPluginBranchCarriesNoMarketplaceManifest locks AC-2: under Model B the
-// marketplace manifest moved OUT of the plugin branch into a separate marketplace
-// repo (the two channels — stable pinned to a release tag, edge tracking next HEAD
-// — are entries of one source in THAT repo's manifest). So the plugin branch
-// carries NO .claude-plugin/marketplace.json; with it gone, there is no in-branch
-// source.ref for a release to re-settle. The plugin's own
-// .claude-plugin/plugin.json stays — only the marketplace manifest moved.
-func TestPluginBranchCarriesNoMarketplaceManifest(t *testing.T) {
+// TestMainCarriesMarketplaceBridgeManifest guards the transitional bridge: the
+// released v0.20.0 binary resolves its install from main's
+// .claude-plugin/marketplace.json (`claude plugin marketplace add
+// spacedock-dev/spacedock@main`). Model B's removal of this manifest — it moves to the
+// standalone marketplace repo, retiring the in-branch source.ref re-settle — is
+// deferred until the v0.20.1 cutover ships the binary that points at that repo and
+// existing v0.20.0 installs have migrated; until then the bridge MUST stay on main, or
+// v0.20.0 installs break. The plugin's own .claude-plugin/plugin.json stays alongside it.
+func TestMainCarriesMarketplaceBridgeManifest(t *testing.T) {
 	marketplace := filepath.Join(repoRoot(t), ".claude-plugin", "marketplace.json")
-	if _, err := os.Stat(marketplace); err == nil {
-		t.Fatalf("%s is present; Model B moves the marketplace manifest to the separate marketplace repo, so the plugin branch must carry no marketplace.json", marketplace)
-	} else if !os.IsNotExist(err) {
-		t.Fatalf("stat %s: %v", marketplace, err)
+	if _, err := os.Stat(marketplace); err != nil {
+		t.Fatalf("bridge marketplace manifest %s missing: %v — the released v0.20.0 binary resolves its install from main's marketplace.json; removing it before the v0.20.1 cutover breaks v0.20.0 installs", marketplace, err)
 	}
 
 	plugin := filepath.Join(repoRoot(t), ".claude-plugin", "plugin.json")
 	if _, err := os.Stat(plugin); err != nil {
-		t.Fatalf("plugin manifest %s missing: %v (only marketplace.json should move out)", plugin, err)
+		t.Fatalf("plugin manifest %s missing: %v", plugin, err)
 	}
 }
 


### PR DESCRIPTION
Pre-cut hardening for v0.20.1.

gp (#352) removed .claude-plugin/marketplace.json from main, but the released v0.20.0 binary and the manual install docs resolve their install from main's manifest (claude plugin marketplace add spacedock-dev/spacedock@main; the repo default branch is main) — so the removal broke v0.20.0 installs. Model B's manifest removal must be cutover-last, not decouple-first.

## Changes
- Restore the bridge marketplace.json on main (single spacedock entry, ref main) so v0.20.0 installs resolve again. Removal is deferred to a post-cutover follow-up (after v0.20.1 ships the binary pointing at the standalone spacedock-dev/marketplace repo and v0.20.0 installs migrate).
- Re-express the two AC-2 absence guards (now TestMainCarriesMarketplaceBridgeManifest) to guard the bridge PRESENCE — a regression guard against premature re-removal.
- Add the Apache-2.0 LICENSE to main (the release-prep blob never merged) so the README front-door license link resolves.

gp binary repoint + entry-name channel selection untouched (correct for v0.20.1). Whole-repo go test ./... green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)