### PR TITLE
docs(0201): repoint manual marketplace-add to canonical spacedock-dev/marketplace

### DIFF
--- a/docs/site/get-started/install.md
+++ b/docs/site/get-started/install.md
@@ -43,7 +43,7 @@ Replace `claude` with `codex` or `pi` for the respective coding agents.
 Spacedock installs the relevant skills on launch. To install them manually:
 
 ```bash
-claude plugin marketplace add spacedock-dev/spacedock
+claude plugin marketplace add spacedock-dev/marketplace
 claude plugin install spacedock@spacedock
 ```
 


### PR DESCRIPTION
Pre-cut fold (captain-approved).

install.md's manual Skills-install block pointed at `spacedock-dev/spacedock` (the plugin repo carrying the transitional bridge manifest from #353), not the canonical standalone `spacedock-dev/marketplace` repo the v0.20.1 binary uses. It resolves today only via the bridge and would break when the bridge is retired post-cutover. Repointed now; the `plugin install spacedock@spacedock` id is unchanged (both manifests use marketplace name `spacedock`). Docs-only, whole-repo go test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)