### PR TITLE
dispatch build emits Agent name >64 chars for long slugs — Agent() dispatch fails

### DIFF
--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -26,6 +26,20 @@ const (
 	// derived name) so the on-disk file with its .md suffix stays under the
 	// common 255-byte filesystem name limit.
 	dispatchFileNameMaxLen = 251
+	// nameAgentMaxLen is the Agent-tool name ceiling (^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$
+	// — 64 chars). A derived name longer than this is rejected by Agent() with
+	// InputValidationError, so the worker name is capped to fit.
+	nameAgentMaxLen = 64
+	// nameCapTarget is the budget the cap fits the worker name into. It reserves
+	// nameAgentMaxLen − len("-cycle9") so any single-digit FO cycle suffix the
+	// roster appends downstream of dispatch build keeps the name ≤ nameAgentMaxLen.
+	nameCapTarget = nameAgentMaxLen - len("-cycle9")
+	// sdB32NameIDPrefixLen is the fixed-length id-prefix substituted for the slug
+	// component when an id-style: sd-b32 name overflows. A fixed length keeps the
+	// embedded token stable across the workflow's lifetime (unlike the shortest-
+	// unique display prefix, which lengthens as entities are added). 10 chars
+	// leaves ample collision headroom while the resulting name stays ≤ nameCapTarget.
+	sdB32NameIDPrefixLen = 10
 )
 
 // buildRequiredFields are the stdin keys that must be present and non-null.
@@ -435,10 +449,15 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 		subagentType = agent
 	}
 
-	// Derive worker_key, slug, and name (slug-not-stem via EntitySlug).
+	// Derive worker_key, slug, and name (slug-not-stem via EntitySlug). When the
+	// readable {workerKey}-{slug}-{stage} form overflows the Agent-tool 64-char
+	// ceiling, capWorkerName substitutes the entity id (id-first) or truncates the
+	// slug head, preserving the workerKey prefix and -{stage} suffix so the name
+	// still decomposes; short names pass through byte-identical.
 	workerKey := strings.ReplaceAll(subagentType, ":", "-")
 	slug := status.EntitySlug(entityPath)
-	derivedName := fmt.Sprintf("%s-%s-%s", workerKey, slug, stage)
+	idStyle := status.ParseFrontmatter(readmePath)["id-style"]
+	derivedName := capWorkerName(workerKey, slug, stage, entityFields["id"], idStyle)
 
 	// Rule 7: Name length and safety.
 	if len(derivedName) > nameMaxLen {
@@ -634,6 +653,57 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 	}
 
 	return emitBuildJSON(stdout, out)
+}
+
+// capWorkerName builds the worker name {workerKey}-{slug}-{stage}, capping it to
+// the Agent-tool 64-char ceiling when the readable form overflows. The cap is
+// id-first: an id-style: sd-b32 entity substitutes a fixed-length prefix of its
+// stored id for the slug component (a stable, decomposition-safe token); a
+// sequential id substitutes the whole numeric id (short, never overflows); an
+// id-less slug workflow truncates the slug head to fit. The workerKey prefix and
+// -{stage} suffix are preserved verbatim in every form so reconcile's decompose()
+// still peels the stage and strips the worker prefix. Short names (≤64) return
+// unchanged — no id substitution, no truncation — so existing readable names and
+// golden fixtures are byte-identical.
+func capWorkerName(workerKey, slug, stage, id, idStyle string) string {
+	full := fmt.Sprintf("%s-%s-%s", workerKey, slug, stage)
+	if len(full) <= nameAgentMaxLen {
+		return full
+	}
+
+	// id-first: replace the slug component with a stable id-derived token. sd-b32
+	// ids are 24-char tokens from the namePattern-safe alphabet, so a fixed-length
+	// prefix is hyphen-free and decomposition-safe; sequential ids are short
+	// integers used whole. Either keeps the prefix + suffix intact.
+	idToken := ""
+	switch idStyle {
+	case "sd-b32":
+		if status.IsValidSDB32ID(id) {
+			idToken = id[:sdB32NameIDPrefixLen]
+		}
+	case "sequential":
+		if status.IsDigits(id) {
+			idToken = id
+		}
+	}
+	if idToken != "" {
+		return fmt.Sprintf("%s-%s-%s", workerKey, idToken, stage)
+	}
+
+	// id-less (id-style: slug) fallback: truncate the slug head so the whole name
+	// fits nameCapTarget (reserving cycle headroom), trimming any trailing hyphen
+	// so the result matches namePattern and carries no `--`.
+	fixed := len(workerKey) + 2 + len(stage) // "-{slug}-" framing minus the slug
+	budget := nameCapTarget - fixed
+	if budget < 1 {
+		budget = 1
+	}
+	truncated := slug
+	if len(truncated) > budget {
+		truncated = truncated[:budget]
+	}
+	truncated = strings.TrimRight(truncated, "-")
+	return fmt.Sprintf("%s-%s-%s", workerKey, truncated, stage)
 }
 
 func firstActionBlock(host string) string {

--- a/internal/dispatch/build_namecap_test.go
+++ b/internal/dispatch/build_namecap_test.go
@@ -1,0 +1,243 @@
+// ABOUTME: name-cap tests — dispatch build caps the worker name at 64 chars for
+// ABOUTME: long slugs via an sd-b32 id-prefix, keeping short names byte-identical.
+package dispatch
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readmeIDStyle builds a worktree README declaring the given id-style. The stage
+// set mirrors readmeWorktree so the same long-slug entity exercises both id-style
+// fixtures; the only difference is the id-style frontmatter line.
+func readmeIDStyle(idStyle string, splitRoot bool) string {
+	state := ""
+	if splitRoot {
+		state = "state: state-checkout\n"
+	}
+	return "---\n" +
+		"entity-type: task\n" +
+		"id-style: " + idStyle + "\n" +
+		state +
+		"stages:\n" +
+		"  defaults:\n" +
+		"    worktree: false\n" +
+		"    concurrency: 1\n" +
+		"  states:\n" +
+		"    - name: backlog\n" +
+		"      initial: true\n" +
+		"    - name: implementation\n" +
+		"      worktree: true\n" +
+		"    - name: validation\n" +
+		"      worktree: true\n" +
+		"      feedback-to: implementation\n" +
+		"    - name: done\n" +
+		"      terminal: true\n" +
+		"---\n" +
+		"# Fixture Workflow\n" +
+		"\n" +
+		"### backlog\n\nseed.\n\n- **Outputs:** x.\n\n" +
+		"### implementation\n\nwork.\n\n- **Outputs:** y.\n\n" +
+		"### validation\n\nverify.\n\n- **Outputs:** z.\n\n" +
+		"### done\n\nterm.\n"
+}
+
+// entityFMID builds an entity file carrying an explicit id frontmatter value (a
+// real 24-char sd-b32 id for the id-first fixtures), the given title/status, and
+// no worktree (the name-cap fixtures dispatch the non-worktree backlog stage so
+// no on-disk worktree dir is needed).
+func entityFMID(id, title, status string) string {
+	return "---\n" +
+		"id: " + id + "\n" +
+		"title: " + title + "\n" +
+		"status: " + status + "\n" +
+		"worktree: \n" +
+		"---\n" +
+		"# " + title + "\n\nBody.\n"
+}
+
+// nameFromStdout pulls the emitted name out of a build stdout JSON.
+func nameFromStdout(t *testing.T, stdout string) string {
+	t.Helper()
+	var out struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("stdout is not build JSON: %v\n%s", err, stdout)
+	}
+	if out.Name == "" {
+		t.Fatalf("no name in stdout:\n%s", stdout)
+	}
+	return out.Name
+}
+
+// buildNameCapStdin writes an id-style: sd-b32 workflow with an entity carrying
+// the given sd-b32 id and a (possibly long) slug, then returns the workflow dir
+// and a well-formed build request for the backlog stage. The slug is the flat
+// entity filename stem, so a long slug name overflows the 64-char budget.
+func buildNameCapStdin(t *testing.T, root, idStyle, slug, id string) (workflowDir, stdin string) {
+	t.Helper()
+	wd := root
+	writeFile(t, filepath.Join(wd, "README.md"), readmeIDStyle(idStyle, false))
+	ep := filepath.Join(wd, slug+".md")
+	writeFile(t, ep, entityFMID(id, "Thing", "backlog"))
+	gitInit(t, root)
+	return wd, mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    ep,
+		"workflow_dir":   wd,
+		"stage":          "backlog",
+		"checklist":      []string{"- a"},
+		"team_name":      "fixture-team",
+		"bare_mode":      false,
+	}, nil)
+}
+
+// A real 24-char sd-b32 id (alphabet 0123456789abcdefghjkmnpqrstvwxyz) used by
+// the id-first fixtures. Distinct from idBravo so the no-collision AC holds.
+const (
+	idAlpha = "367s2zrbkm4fcwfff5ac62zz"
+	idBravo = "0qv3kaqs062fp3p01tz6re99"
+	// A 57-char slug: spacedock-ensign-{slug}-backlog overflows 64 well past the
+	// ceiling (17 + 57 + 9 = 83 chars), reproducing the github#366 hazard.
+	longSlug      = "dispatch-reconcile-deconflate-repo-hygiene-and-name-overflow"
+	longSlugShare = "dispatch-reconcile-deconflate-repo-hygiene-and-name-sibling"
+)
+
+// TestBuildNameCapSDB32LongSlug — AC1: a sd-b32 entity whose uncapped name would
+// exceed 64 chars emits a name ≤64 that matches namePattern. Fails today (the
+// uncapped form is 80+ chars).
+func TestBuildNameCapSDB32LongSlug(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := t.TempDir()
+	wd, stdin := buildNameCapStdin(t, root, "sd-b32", longSlug, idAlpha)
+
+	native := runNative(stdin, "build", "--workflow-dir", wd)
+	if native.exit != 0 {
+		t.Fatalf("exit native=%d, want 0\nstderr:\n%s", native.exit, native.stderr)
+	}
+	name := nameFromStdout(t, native.stdout)
+	if len(name) > 64 {
+		t.Errorf("name %q is %d chars, want ≤64", name, len(name))
+	}
+	if !namePattern.MatchString(name) {
+		t.Errorf("name %q does not match namePattern %s", name, namePattern.String())
+	}
+	// The capped name carries the id-prefix in place of the slug, keeping the
+	// worker-key prefix and -{stage} suffix verbatim.
+	if !strings.HasPrefix(name, "spacedock-ensign-") {
+		t.Errorf("name %q lost worker-key prefix", name)
+	}
+	if !strings.HasSuffix(name, "-backlog") {
+		t.Errorf("name %q lost -{stage} suffix", name)
+	}
+	if !strings.Contains(name, idAlpha[:sdB32NameIDPrefixLen]) {
+		t.Errorf("name %q does not embed the id-prefix %q", name, idAlpha[:sdB32NameIDPrefixLen])
+	}
+}
+
+// TestBuildNameCapDistinctIDs — AC2: two sd-b32 entities whose slugs share a long
+// common prefix produce two different names (distinct because their ids differ).
+func TestBuildNameCapDistinctIDs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rootA := t.TempDir()
+	wdA, stdinA := buildNameCapStdin(t, rootA, "sd-b32", longSlug, idAlpha)
+	nativeA := runNative(stdinA, "build", "--workflow-dir", wdA)
+	if nativeA.exit != 0 {
+		t.Fatalf("alpha exit=%d\nstderr:\n%s", nativeA.exit, nativeA.stderr)
+	}
+	nameA := nameFromStdout(t, nativeA.stdout)
+
+	rootB := t.TempDir()
+	wdB, stdinB := buildNameCapStdin(t, rootB, "sd-b32", longSlugShare, idBravo)
+	nativeB := runNative(stdinB, "build", "--workflow-dir", wdB)
+	if nativeB.exit != 0 {
+		t.Fatalf("bravo exit=%d\nstderr:\n%s", nativeB.exit, nativeB.stderr)
+	}
+	nameB := nameFromStdout(t, nativeB.stdout)
+
+	if nameA == nameB {
+		t.Errorf("distinct entities produced identical name %q (cohort collision)", nameA)
+	}
+}
+
+// TestBuildNameCapShortUnchanged — AC5: a short slug emits the uncapped
+// {workerKey}-{slug}-{stage} byte-for-byte, with no id substitution. Runs for
+// every id-style so the cap fires only on overflow regardless of id-style.
+func TestBuildNameCapShortUnchanged(t *testing.T) {
+	for _, idStyle := range []string{"sd-b32", "slug", "sequential"} {
+		t.Run(idStyle, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			root := t.TempDir()
+			id := idAlpha
+			if idStyle == "sequential" {
+				id = "001"
+			} else if idStyle == "slug" {
+				id = ""
+			}
+			wd, stdin := buildNameCapStdin(t, root, idStyle, "thing", id)
+
+			native := runNative(stdin, "build", "--workflow-dir", wd)
+			if native.exit != 0 {
+				t.Fatalf("exit native=%d, want 0\nstderr:\n%s", native.exit, native.stderr)
+			}
+			name := nameFromStdout(t, native.stdout)
+			want := "spacedock-ensign-thing-backlog"
+			if name != want {
+				t.Errorf("short name = %q, want %q (no cap should fire)", name, want)
+			}
+		})
+	}
+}
+
+// TestBuildNameCapCycleHeadroom — AC6: a capped base name plus a realistic FO
+// cycle suffix stays ≤64.
+func TestBuildNameCapCycleHeadroom(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := t.TempDir()
+	wd, stdin := buildNameCapStdin(t, root, "sd-b32", longSlug, idAlpha)
+
+	native := runNative(stdin, "build", "--workflow-dir", wd)
+	if native.exit != 0 {
+		t.Fatalf("exit native=%d, want 0\nstderr:\n%s", native.exit, native.stderr)
+	}
+	name := nameFromStdout(t, native.stdout)
+	if len(name+"-cycle3") > 64 {
+		t.Errorf("name+cycle3 %q is %d chars, want ≤64 (no cycle headroom)", name+"-cycle3", len(name+"-cycle3"))
+	}
+}
+
+// TestBuildNameCapSlugFallback — id-less slug-truncation path: an id-style: slug
+// long-slug entity (no stored id) still emits a ≤64 namePattern-valid name by
+// truncating the slug head. This is the only path that truncates a slug.
+func TestBuildNameCapSlugFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := t.TempDir()
+	wd, stdin := buildNameCapStdin(t, root, "slug", longSlug, "")
+
+	native := runNative(stdin, "build", "--workflow-dir", wd)
+	if native.exit != 0 {
+		t.Fatalf("exit native=%d, want 0\nstderr:\n%s", native.exit, native.stderr)
+	}
+	name := nameFromStdout(t, native.stdout)
+	if len(name) > 64 {
+		t.Errorf("slug-fallback name %q is %d chars, want ≤64", name, len(name))
+	}
+	if !namePattern.MatchString(name) {
+		t.Errorf("slug-fallback name %q does not match namePattern (trailing hyphen / -- not trimmed?)", name)
+	}
+	if len(name+"-cycle3") > 64 {
+		t.Errorf("slug-fallback name+cycle3 %q is %d chars, want ≤64", name+"-cycle3", len(name+"-cycle3"))
+	}
+	if !strings.HasPrefix(name, "spacedock-ensign-") || !strings.HasSuffix(name, "-backlog") {
+		t.Errorf("slug-fallback name %q lost prefix/suffix", name)
+	}
+}

--- a/internal/dispatch/reconcile.go
+++ b/internal/dispatch/reconcile.go
@@ -255,9 +255,12 @@ func filterEnsigns(members []claudeteam.ReconcileMember) []claudeteam.ReconcileM
 }
 
 // entityRecord is the minimal frontmatter the sweep reads — every field is a
-// frontmatter top-level key (no body parsing).
+// frontmatter top-level key (no body parsing). id carries the entity's stored id
+// so a capped worker name (whose slug component was replaced by an id-prefix at
+// dispatch build) resolves back to its entity by id-prefix, not string-split.
 type entityRecord struct {
 	slug     string
+	id       string
 	status   string
 	worktree string
 	pr       string
@@ -296,6 +299,7 @@ func loadEntityFrontmatter(dir string) map[string]entityRecord {
 		fm := status.ParseFrontmatter(entityPath)
 		out[slug] = entityRecord{
 			slug:     slug,
+			id:       fm["id"],
 			status:   fm["status"],
 			worktree: fm["worktree"],
 			pr:       fm["pr"],
@@ -421,6 +425,42 @@ func isAllDigits(s string) bool {
 	return true
 }
 
+// resolveSlugToken maps a decomposed name token to its entity slug. For an
+// uncapped name the token IS the slug, so an exact match against the active or
+// archived maps wins immediately (the common case). For a capped sd-b32 name the
+// token is a fixed-length id-prefix; when no slug matches exactly, the token is
+// resolved by HasPrefix against the active+archived id set — the same resolution
+// `status --resolve prefix:` performs. A unique id-prefix match yields the real
+// slug; an ambiguous (≥2) or absent match leaves the token unresolved (ok=false),
+// the conservative outcome that avoids a false Class-A against a live sibling.
+func resolveSlugToken(token string, active, archived map[string]entityRecord) (string, bool) {
+	if _, ok := active[token]; ok {
+		return token, true
+	}
+	if _, ok := archived[token]; ok {
+		return token, true
+	}
+	// id-prefix resolution: the token must be a non-trivial prefix of exactly one
+	// stored id. sdB32MinPrefix guards against a too-short token matching many ids.
+	if len(token) < status.SDB32MinPrefix {
+		return "", false
+	}
+	matched := ""
+	count := 0
+	for _, m := range []map[string]entityRecord{active, archived} {
+		for slug, rec := range m {
+			if rec.id != "" && strings.HasPrefix(rec.id, token) {
+				matched = slug
+				count++
+			}
+		}
+	}
+	if count != 1 {
+		return "", false
+	}
+	return matched, true
+}
+
 // classA flags ensigns whose entity is archived OR whose entity status is
 // terminal ("done" or empty next-stage equivalent). Lingering = the entity is
 // past terminal but the agent is still in the team roster.
@@ -431,22 +471,28 @@ func classA(ensigns []claudeteam.ReconcileMember, stages []string, active, archi
 		if !d.ok {
 			continue
 		}
+		// Resolve the decomposed token to a real slug (exact-slug-first, then
+		// sd-b32 id-prefix). An unresolved token leaves the member unclassified.
+		slug, ok := resolveSlugToken(d.slug, active, archived)
+		if !ok {
+			continue
+		}
 		// Archived: definitive terminal.
-		if _, ok := archived[d.slug]; ok {
+		if _, ok := archived[slug]; ok {
 			out = append(out, driftItem{
 				Class:  "A",
 				Name:   m.Name,
-				Slug:   d.slug,
+				Slug:   slug,
 				Reason: "entity archived",
 			})
 			continue
 		}
-		if rec, ok := active[d.slug]; ok {
+		if rec, ok := active[slug]; ok {
 			if rec.status == "done" {
 				out = append(out, driftItem{
 					Class:  "A",
 					Name:   m.Name,
-					Slug:   d.slug,
+					Slug:   slug,
 					Reason: "entity status=done",
 				})
 			}

--- a/internal/dispatch/reconcile_namecap_test.go
+++ b/internal/dispatch/reconcile_namecap_test.go
@@ -1,0 +1,220 @@
+// ABOUTME: name-cap reconcile round-trip — a capped (id-prefix) worker name
+// ABOUTME: resolves to the correct entity by id, no false Class-A against a sibling.
+package dispatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/claudeteam"
+)
+
+// nameCapReconcileFixture seeds an active dir + _archive dir with two sd-b32
+// entities whose slugs share a long common prefix but whose ids differ, emits the
+// capped name for each via real dispatch build, and runs real Reconcile over a
+// stub roster carrying those capped names. The expectation (which slug each
+// capped name resolves to, and which is Class-A) is bound to the seeded on-disk
+// id set — an independent source from the resolution under test.
+type nameCapReconcileFixture struct {
+	t            *testing.T
+	home         string
+	repoRoot     string
+	workflowDir  string
+	stateRoot    string
+	teamName     string
+	archivedName string // capped name of the archived long-slug entity
+	activeName   string // capped name of the active long-slug sibling
+}
+
+// sdb32NameReadme is a split-root README declaring id-style: sd-b32 (so the build
+// cap takes the id-first path) and a state checkout reconcile reads entities from.
+const sdb32NameReadme = `---
+entity-type: task
+id-style: sd-b32
+state: .spacedock-state
+stages:
+  defaults:
+    worktree: false
+    concurrency: 1
+  states:
+    - name: backlog
+      initial: true
+    - name: implementation
+      worktree: true
+    - name: validation
+      worktree: true
+      feedback-to: implementation
+    - name: done
+      terminal: true
+---
+# Fixture Workflow
+
+### backlog
+
+seed.
+
+- **Outputs:** x.
+
+### implementation
+
+work.
+
+- **Outputs:** y.
+
+### validation
+
+verify.
+
+- **Outputs:** z.
+
+### done
+
+term.
+`
+
+// buildCappedName drives real dispatch build over a sd-b32 entity at the state
+// checkout carrying the given slug + id, returning the capped name it emits.
+func buildCappedName(t *testing.T, stateRoot, workflowDir, slug, id string) string {
+	t.Helper()
+	ep := filepath.Join(stateRoot, slug+".md")
+	writeFile(t, ep, entityFMID(id, "Thing", "backlog"))
+	stdin := mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    ep,
+		"workflow_dir":   workflowDir,
+		"stage":          "backlog",
+		"checklist":      []string{"- a"},
+		"team_name":      "fixture-team",
+		"bare_mode":      false,
+	}, nil)
+	native := runNative(stdin, "build", "--workflow-dir", workflowDir)
+	if native.exit != 0 {
+		t.Fatalf("build %s exit=%d\nstderr:\n%s", slug, native.exit, native.stderr)
+	}
+	return nameFromStdout(t, native.stdout)
+}
+
+func newNameCapReconcileFixture(t *testing.T) *nameCapReconcileFixture {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoRoot := t.TempDir()
+	teamName := "team-namecap-001"
+
+	workflowDir := filepath.Join(repoRoot, "docs", "wf")
+	writeFile(t, filepath.Join(workflowDir, "README.md"), sdb32NameReadme)
+	stateRoot := filepath.Join(workflowDir, ".spacedock-state")
+	gitInit(t, repoRoot)
+
+	// Emit the capped name for the archived long-slug entity (idAlpha) and the
+	// active long-slug sibling (idBravo). The build writes both entity files into
+	// the active state root first; we then move the archived one under _archive.
+	archivedName := buildCappedName(t, stateRoot, workflowDir, longSlug, idAlpha)
+	activeName := buildCappedName(t, stateRoot, workflowDir, longSlugShare, idBravo)
+
+	// Move the archived entity's file into the _archive convention dir; rewrite it
+	// with status=done so the archived-branch of classA fires. The active sibling
+	// stays in the active dir with a non-terminal status.
+	archiveDir := filepath.Join(stateRoot, "_archive")
+	writeFile(t, filepath.Join(archiveDir, longSlug+".md"), entityFMID(idAlpha, "Thing", "done"))
+	if err := os.Remove(filepath.Join(stateRoot, longSlug+".md")); err != nil {
+		t.Fatalf("remove archived source: %v", err)
+	}
+	// Active sibling: non-terminal status so it must NOT classify as Class-A.
+	writeFile(t, filepath.Join(stateRoot, longSlugShare+".md"), entityFMID(idBravo, "Thing", "implementation"))
+
+	// Team config: team-lead (exempt) plus both capped-name ensigns.
+	cfgPath := filepath.Join(home, ".claude", "teams", teamName, "config.json")
+	writeFile(t, cfgPath, teamConfigJSON(teamName, []claudeteam.ReconcileMember{
+		{Name: "team-lead", AgentType: "team-lead", Model: "claude-opus-4-7"},
+		{Name: archivedName, AgentType: "spacedock:ensign", Model: "claude-opus-4-7"},
+		{Name: activeName, AgentType: "spacedock:ensign", Model: "claude-opus-4-7"},
+	}))
+
+	return &nameCapReconcileFixture{
+		t:            t,
+		home:         home,
+		repoRoot:     repoRoot,
+		workflowDir:  workflowDir,
+		stateRoot:    stateRoot,
+		teamName:     teamName,
+		archivedName: archivedName,
+		activeName:   activeName,
+	}
+}
+
+func (f *nameCapReconcileFixture) run() reconcileResult {
+	f.t.Helper()
+	var stdout, stderr bytes.Buffer
+	opts := reconcileOpts{
+		workflowDir: f.workflowDir,
+		teamName:    f.teamName,
+		repoRoot:    f.repoRoot,
+		include:     map[string]bool{"A": true, "B": true, "C": true, "D": true, "E": true},
+		home:        f.home,
+		roster:      claudeteam.LoadReconcileTeam,
+		gh:          func(string) (string, error) { return "", nil },
+		git:         gitRunnerExec,
+	}
+	code := Reconcile(opts, &stdout, &stderr)
+	if code != 0 {
+		f.t.Fatalf("Reconcile exit=%d stderr=%s", code, stderr.String())
+	}
+	var result reconcileResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		f.t.Fatalf("decode result: %v\nstdout=%s", err, stdout.String())
+	}
+	return result
+}
+
+// TestReconcileCappedNameResolvesArchived — AC3: the capped name of an archived
+// long-slug sd-b32 entity classifies Class-A against the CORRECT slug (resolved
+// by id-prefix), and does NOT mis-resolve to the active sibling sharing the slug
+// prefix. The expectation is bound to the seeded on-disk id set.
+func TestReconcileCappedNameResolvesArchived(t *testing.T) {
+	if !hasGit(t) {
+		t.Skip("git not available")
+	}
+	f := newNameCapReconcileFixture(t)
+	result := f.run()
+
+	byClass := groupDriftByClass(result.Drift)
+	as := byClass["A"]
+	if len(as) != 1 {
+		t.Fatalf("expected exactly 1 Class-A entry (archived only); got %d: %s",
+			len(as), formatDrift(result.Drift))
+	}
+	a := as[0]
+	if a.Name != f.archivedName {
+		t.Errorf("Class-A name=%q, want archived capped name %q", a.Name, f.archivedName)
+	}
+	// Resolution must recover the archived entity's REAL slug from the id-prefix,
+	// not the active sibling's slug.
+	if a.Slug != longSlug {
+		t.Errorf("Class-A slug=%q, want %q (id-prefix mis-resolved?)", a.Slug, longSlug)
+	}
+	if a.Slug == longSlugShare {
+		t.Errorf("Class-A mis-resolved to the active sibling slug %q", longSlugShare)
+	}
+}
+
+// TestReconcileCappedNameNoFalseClassA — AC4: the capped name of a STILL-ACTIVE
+// long-slug sd-b32 entity produces NO Class-A entry (guards the false-shutdown
+// hazard — a capped name must not be flagged as lingering against a live worker).
+func TestReconcileCappedNameNoFalseClassA(t *testing.T) {
+	if !hasGit(t) {
+		t.Skip("git not available")
+	}
+	f := newNameCapReconcileFixture(t)
+	result := f.run()
+
+	for _, d := range result.Drift {
+		if d.Class == "A" && d.Name == f.activeName {
+			t.Errorf("active sibling's capped name %q falsely classified Class-A: %+v",
+				f.activeName, d)
+		}
+	}
+}

--- a/internal/dispatch/reconcile_namecap_test.go
+++ b/internal/dispatch/reconcile_namecap_test.go
@@ -218,3 +218,78 @@ func TestReconcileCappedNameNoFalseClassA(t *testing.T) {
 		}
 	}
 }
+
+// Adversarial id sets pinning resolveSlugToken's two safety properties. The
+// AC3/AC4 end-to-end fixture seeds ids that diverge at char 0, so it cannot
+// exercise either property; these prefix-sharing ids do. All are 24-char ids
+// from the sd-b32 alphabet (0123456789abcdefghjkmnpqrstvwxyz).
+const (
+	// idShareShort + idShareShortSibling share only a 6-char prefix (aaaaaa) and
+	// diverge by char 10, so the full 10-char token discriminates them but a
+	// 2-char comparison would not.
+	idShareShort        = "aaaaaa0000bbbbccccddddee"
+	idShareShortSibling = "aaaaaa1111bbbbccccddddee"
+	// idShareLong + idShareLongSibling share a 10-char prefix (cccccccccc), so a
+	// 10-char id-prefix token matches BOTH — the ambiguity case.
+	idShareLong        = "cccccccccc0000000011112e"
+	idShareLongSibling = "cccccccccc1111111122223e"
+)
+
+// TestResolveSlugTokenSafetyProperties pins the two safety properties of the
+// id-prefix resolver directly against real code (no mocks). The AC3/AC4 fixture's
+// ids diverge at char 0 and so leave both properties untested; an adversarial
+// reviewer could weaken the ambiguity guard (count != 1 → count < 1) or the
+// over-match comparison (full token → token[:2]) and stay green against that
+// fixture. These cases turn RED under each weakening.
+func TestResolveSlugTokenSafetyProperties(t *testing.T) {
+	// Full-token discrimination (refutes the token[:SDB32MinPrefix] over-match
+	// edit): two ids sharing only a 6-char prefix, both ACTIVE. The 10-char token
+	// of one is a prefix of exactly one id, so it must resolve to that entity. A
+	// 2-char-only comparison would match both ids → ambiguous → unclassified,
+	// failing this assertion.
+	t.Run("full-token discriminates a short-shared-prefix sibling", func(t *testing.T) {
+		active := map[string]entityRecord{
+			"alpha-slug": {slug: "alpha-slug", id: idShareShort},
+			"beta-slug":  {slug: "beta-slug", id: idShareShortSibling},
+		}
+		archived := map[string]entityRecord{}
+		token := idShareShort[:sdB32NameIDPrefixLen] // 10 chars: "aaaaaa0000"
+		got, ok := resolveSlugToken(token, active, archived)
+		if !ok {
+			t.Fatalf("token %q should resolve uniquely; got ok=false (over-match would see both ids)", token)
+		}
+		if got != "alpha-slug" {
+			t.Errorf("token %q resolved to %q, want alpha-slug (the only id with this 10-char prefix)", token, got)
+		}
+	})
+
+	// Ambiguity guard (refutes the count < 1 edit): two ACTIVE ids share a ≥10-char
+	// prefix, so the 10-char token is a prefix of BOTH. The resolver must leave the
+	// token UNCLASSIFIED (ok=false) — resolving to either would be a false Class-A
+	// against the live sibling, the exact #366 hazard. A count < 1 guard would
+	// pass an arbitrary one through.
+	t.Run("ambiguous 10-char prefix stays unclassified", func(t *testing.T) {
+		active := map[string]entityRecord{
+			"gamma-slug": {slug: "gamma-slug", id: idShareLong},
+			"delta-slug": {slug: "delta-slug", id: idShareLongSibling},
+		}
+		archived := map[string]entityRecord{}
+		token := idShareLong[:sdB32NameIDPrefixLen] // 10 chars: "cccccccccc" (prefix of both)
+		got, ok := resolveSlugToken(token, active, archived)
+		if ok {
+			t.Errorf("ambiguous token %q resolved to %q, want unclassified (count==2 must not classify)", token, got)
+		}
+	})
+
+	// Exact-slug-first still wins (the uncapped common case is untouched): a token
+	// equal to a real slug resolves to that slug even when an unrelated id exists.
+	t.Run("exact slug match wins over id-prefix", func(t *testing.T) {
+		active := map[string]entityRecord{
+			"alpha-slug": {slug: "alpha-slug", id: idShareShort},
+		}
+		got, ok := resolveSlugToken("alpha-slug", active, map[string]entityRecord{})
+		if !ok || got != "alpha-slug" {
+			t.Errorf("exact slug token resolved to (%q,%v), want (alpha-slug,true)", got, ok)
+		}
+	})
+}

--- a/internal/status/identity.go
+++ b/internal/status/identity.go
@@ -20,6 +20,10 @@ const (
 	sdB32MinPrefix = 2
 )
 
+// SDB32MinPrefix is the minimum sd-b32 address-prefix length consumers resolve
+// against (a shorter prefix is treated as too ambiguous to resolve).
+const SDB32MinPrefix = sdB32MinPrefix
+
 var (
 	idStyles    = map[string]bool{"sequential": true, "slug": true, "sd-b32": true}
 	sdB32IDRe   = regexp.MustCompile(`^[` + sdB32Chars + `]{24}$`)
@@ -48,10 +52,20 @@ func isValidSDB32ID(value string) bool {
 	return sdB32IDRe.MatchString(value)
 }
 
+// IsValidSDB32ID reports whether value is a well-formed 24-char sd-b32 stored id.
+func IsValidSDB32ID(value string) bool {
+	return isValidSDB32ID(value)
+}
+
 // isDigits reports whether s is a non-empty run of ASCII digits (Python's
 // str.isdigit for the simple cases the oracle relies on).
 func isDigits(s string) bool {
 	return allDigitsRe.MatchString(s)
+}
+
+// IsDigits reports whether s is a non-empty run of ASCII digits.
+func IsDigits(s string) bool {
+	return isDigits(s)
 }
 
 // workflowIDStyle reads the README id-style. Returns ("", err) on an

--- a/skills/first-officer/references/claude-fo-dispatch.md
+++ b/skills/first-officer/references/claude-fo-dispatch.md
@@ -172,7 +172,7 @@ In bare mode, dispatch blocks until the subagent completes — concurrent dispat
 ```
 Agent(
     subagent_type="{dispatch_agent_id}",
-    name="{worker_key}-{slug}-{stage}",
+    name="{worker_key}-{slug}-{stage}",  // if this exceeds 64 chars, cap it the way `spacedock dispatch build` does: keep the {worker_key} prefix and -{stage} suffix and, on id-style: sd-b32, replace the slug with a fixed-length prefix of the entity id (id-less slug workflows truncate the slug head instead)
     team_name="{team_name}",
     model="{effective_model}",
     prompt="## First action\n\nBefore anything else, invoke your operating contract:\n\n    Skill(skill=\"spacedock:ensign\")\n\nThis loads the shared ensign discipline (stage-report format, BashOutput polling, worktree ownership, completion signal protocol). Do not paraphrase; call the tool.\n\nYou are working on: {entity title}\n\nStage: {stage}\n\n### Stage definition:\n\n{copy stage subsection from README verbatim}\n\nRead the entity file at {entity_file_path}.\n\n### Completion checklist\n\n{numbered checklist}\n\n### Summary\n{brief description of what was accomplished}\n\n### Stage report\n\nAppend a Stage Report section at the end of the entity file (per the shared-core Stage Report Protocol). Use the title `Stage Report: {stage}`. Account for every checklist item above with a `- DONE:` / `- SKIPPED:` / `- FAILED:` entry. Use the checklist item text verbatim when possible.\n\n### Completion Signal\n\nSendMessage(to=\"team-lead\", message=\"Done: {entity title} completed {stage}. Report written to {entity_file_path}.\")"


### PR DESCRIPTION
Long-slugged dispatches hit Claude's 64-char Agent-name limit and failed outright; cap the worker name so every dispatch proceeds.

## What changed
- Cap the `dispatch build` worker name at 64 chars, only on overflow.
- On overflow, substitute a fixed sd-b32 id-prefix for the slug (id-first).
- Resolve capped names in reconcile by id-prefix, preserving cohort/teardown classification.
- Truncate the slug head for id-less (`slug`-style) workflows.
- Note the cap in the FO break-glass dispatch template.

## Evidence
- `go test ./internal/dispatch/` — 211/211 passed (10 new id-cap + reconcile-resolve tests).
- Detached adversarial audit refuted the false-Class-A hazard; `TestResolveSlugTokenSafetyProperties` guards it.

## Review guidance
`reconcile.go`'s id-prefix resolution is load-bearing — a wrong match would spuriously shut down a live worker; AC3/AC4 + the safety test pin it.

---
[8e](/spacedock-dev/spacedock/blob/ec99c12a2c9d23ad5f9fc7b9c61acf63ed9fb9d2/dispatch-build-name-cap.md)
Closes #366
