### PR TITLE
lean-boot: prove zero-discover boot report-and-stops (no filesystem sweep)

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -165,13 +165,18 @@ jobs:
       - name: Set archivable CLAUDE_CONFIG_DIR
         run: echo "CLAUDE_CONFIG_DIR=$RUNNER_TEMP/spacedock-claude-config/${{ matrix.model }}" >> "$GITHUB_ENV"
 
+      # TestLiveEnsignCycle is the full lifecycle canary; TestLiveZeroDiscoverReportsAndStops
+      # is the cheap boot-only lean-boot guard (a zero-`status --discover` fixture: the FO
+      # must report no workflow found and STOP, taking no broad filesystem sweep). Both are
+      # boot/front-door drives, so they share this step and `-run` alternation rather than a
+      # second job.
       - name: Run live ensign cycle
         env:
           SPACEDOCK_LIVE_MODEL: ${{ matrix.model }}
         run: |
           set -o pipefail
           mkdir -p "$SPACEDOCK_LIVE_ARTIFACT_DIR"
-          go test -tags live -count=1 -run TestLiveEnsignCycle ./internal/ensigncycle/ -v 2>&1 | tee live-e2e-transcript.txt
+          go test -tags live -count=1 -run 'TestLiveEnsignCycle|TestLiveZeroDiscoverReportsAndStops' ./internal/ensigncycle/ -v 2>&1 | tee live-e2e-transcript.txt
 
       # The shared scenario suite: the Claude lane runs the SAME host-neutral
       # gate/rejection/merge-hook scenarios the codex-live lane runs, through the

--- a/internal/ensigncycle/broad_search_detect_impl_test.go
+++ b/internal/ensigncycle/broad_search_detect_impl_test.go
@@ -1,0 +1,162 @@
+// ABOUTME: Pure detector that reds when a zero-discover FO boot broad-searches the
+// ABOUTME: filesystem to hunt a workflow instead of report-and-stop — lean-boot guard.
+package ensigncycle
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// detectBroadSearchAtBoot scans a captured FO boot stream for the lean-boot
+// violation the captain observed (2026-06-14): after `spacedock status --discover`
+// returned zero workflows, an FO ran a broad `find`/`grep -r`/`ls -R` filesystem
+// sweep to hunt a workflow down instead of obeying the contract's terminal zero
+// branch (Startup step 3: zero → report no workflow found and STOP). A broad sweep
+// at boot is both a discipline violation (the zero branch is report-and-stop) and a
+// cost/latency regression — the opposite of lean boot.
+//
+// Like detectWrongRootBoot it is model-agnostic (it reads the tool-call stream, not
+// any model phrasing) and pure (stream + fixtureRoot in, error out), with its own
+// offline test. It iterates ALL tool_use blocks of each entry (not just the first),
+// so a sweep cannot evade it by riding as a second block of a multi-tool turn. The
+// reddable sweep signatures, all observable in the boot stream:
+//
+//   - a `Bash` command invoking find / grep -r / rg / fd / ls -R whose target is the
+//     project root or a broad ancestor (not a scoped path under a resolved workflow),
+//   - a `Glob` tool_use with a recursive workflow-hunting pattern (e.g. **/README.md),
+//   - a `Grep` tool_use whose path is the project root / unset (a repo-wide search).
+//
+// A correct zero-discover boot touches none of these: it runs --version,
+// git rev-parse, status --discover (zero), then reports no-workflow-found and stops.
+// The detector passes that and reds the sweep. It guards STRICTLY the zero-discover
+// branch's substituted sweep — a scoped search under an already-resolved workflow
+// dir is legitimate and must pass (keyed on the target being the root / a recursive
+// pattern, not on the tool name alone).
+func detectBroadSearchAtBoot(stream, fixtureRoot string) error {
+	clean := filepath.Clean(fixtureRoot)
+	for _, line := range strings.Split(stream, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var e streamEntry
+		if json.Unmarshal([]byte(line), &e) != nil {
+			continue
+		}
+		for _, b := range e.toolUseBlocks() {
+			switch b.Name {
+			case "Bash":
+				if sig, ok := broadSweepCommand(b.Input.Command, clean); ok {
+					return fmt.Errorf("FO broad-searched the filesystem at boot: command %q runs %s over the project root %q — after a zero `status --discover` the Startup zero branch is report-and-stop, not a filesystem sweep to hunt a workflow",
+						strings.TrimSpace(b.Input.Command), sig, clean)
+				}
+			case "Glob":
+				if recursiveHuntPattern(b.Input.Pattern) {
+					return fmt.Errorf("FO broad-searched the filesystem at boot: a recursive Glob %q hunts a workflow project-wide — after a zero `status --discover` the Startup zero branch is report-and-stop",
+						b.Input.Pattern)
+				}
+			case "Grep":
+				if repoWideGrep(b.Input.Path, clean) {
+					return fmt.Errorf("FO broad-searched the filesystem at boot: a repo-wide Grep for %q (path %q) hunts a workflow project-wide — after a zero `status --discover` the Startup zero branch is report-and-stop",
+						b.Input.Pattern, b.Input.Path)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// broadSweepTools are the recursive-search shell tools a workflow-hunting sweep
+// uses. `grep -r`/`ls -R` need the recursive flag; the rest are recursive by use.
+var broadSweepTools = []string{"find", "rg", "fd"}
+
+// broadSweepCommand reports whether a Bash command is a broad filesystem sweep
+// aimed at the project root or a broad ancestor (not a scoped path under a resolved
+// workflow dir). It returns the matched signature for the error message. A search
+// whose only path arguments stay UNDER the fixture root's subtree (e.g. a scoped
+// grep inside an already-resolved workflow dir) is legitimate and not flagged.
+func broadSweepCommand(command, fixtureRoot string) (string, bool) {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return "", false
+	}
+	tool := fields[0]
+
+	var sig string
+	switch {
+	case contains(broadSweepTools, tool):
+		sig = tool
+	case tool == "grep" && hasRecursiveFlag(fields):
+		sig = "grep -r"
+	case tool == "ls" && hasRecursiveFlag(fields):
+		sig = "ls -R"
+	default:
+		return "", false
+	}
+
+	// A sweep is broad when it targets the project root / a broad ancestor — i.e. it
+	// names no path scoped under the fixture's subtree. A path equal to the fixture
+	// root itself is the root sweep (red); a path strictly under it (a resolved
+	// workflow dir) is scoped (pass). A sweep with NO path arg defaults to cwd (the
+	// boot root) — also broad.
+	for _, tok := range fields[1:] {
+		if strings.HasPrefix(tok, "-") {
+			continue
+		}
+		if !filepath.IsAbs(tok) {
+			continue
+		}
+		p := filepath.Clean(tok)
+		if p != fixtureRoot && isUnder(p, fixtureRoot) {
+			return "", false // scoped under a resolved workflow dir — legitimate
+		}
+	}
+	return sig, true
+}
+
+// hasRecursiveFlag reports whether a grep/ls command carries its recursive flag
+// (-r/-R, possibly bundled like -rn or -Rl).
+func hasRecursiveFlag(fields []string) bool {
+	for _, f := range fields[1:] {
+		if !strings.HasPrefix(f, "-") || strings.HasPrefix(f, "--") {
+			continue
+		}
+		if strings.ContainsAny(f, "rR") {
+			return true
+		}
+	}
+	return false
+}
+
+// recursiveHuntPattern reports whether a Glob pattern recursively hunts a workflow
+// project-wide — a `**/` recursive descent (e.g. **/README.md, **/*.md). A scoped
+// non-recursive pattern is not a project-wide hunt.
+func recursiveHuntPattern(pattern string) bool {
+	return strings.Contains(pattern, "**")
+}
+
+// repoWideGrep reports whether a Grep tool_use searches the project root / a broad
+// ancestor (an unset path is repo-wide by default; a path equal to the fixture root
+// is the root sweep). A path scoped under the fixture root is legitimate.
+func repoWideGrep(path, fixtureRoot string) bool {
+	if path == "" {
+		return true
+	}
+	if !filepath.IsAbs(path) {
+		return false
+	}
+	p := filepath.Clean(path)
+	return p == fixtureRoot || !isUnder(p, fixtureRoot)
+}
+
+// contains reports whether s is in list.
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ensigncycle/broad_search_detect_test.go
+++ b/internal/ensigncycle/broad_search_detect_test.go
@@ -1,0 +1,143 @@
+// ABOUTME: Offline test for the broad-search-at-boot detector — proves it reds a
+// ABOUTME: zero-discover boot that filesystem-sweeps to hunt a workflow, passes report-and-stop.
+package ensigncycle
+
+import (
+	"strings"
+	"testing"
+)
+
+// globLine builds one assistant-with-Glob-tool_use stream-json line carrying the
+// given pattern, the shape detectBroadSearchAtBoot scans for a recursive sweep.
+func globLine(pattern string) string {
+	return `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Glob","input":{"pattern":` +
+		mustJSONString(pattern) + `}}]}}`
+}
+
+// grepLine builds one assistant-with-Grep-tool_use stream-json line carrying the
+// given pattern and search path (path "" → repo-wide).
+func grepLine(pattern, path string) string {
+	return `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Grep","input":{"pattern":` +
+		mustJSONString(pattern) + `,"path":` + mustJSONString(path) + `}}]}}`
+}
+
+// TestDetectBroadSearchAtBoot covers the pure detector both ways: it reds a
+// zero-discover boot that broad-searches the filesystem to hunt a workflow (a
+// repo-rooted find / grep -r / ls -R Bash, or a recursive Glob/Grep over the
+// project root), and passes a clean report-and-stop boot, a scoped search under an
+// already-resolved workflow dir, and an empty stream.
+func TestDetectBroadSearchAtBoot(t *testing.T) {
+	const fixtureRoot = "/tmp/TestLiveZeroDiscover/001"
+
+	cases := []struct {
+		name      string
+		lines     []string
+		wantRed   bool
+		wantNames string // substring the error must name when wantRed
+	}{
+		{
+			name: "repo_rooted_find_reds",
+			lines: []string{
+				streamLine(`spacedock --version`),
+				streamLine(`spacedock status --discover`),
+				streamLine(`find ` + fixtureRoot + ` -name README.md`),
+			},
+			wantRed:   true,
+			wantNames: "find",
+		},
+		{
+			name: "grep_r_repo_root_reds",
+			lines: []string{
+				streamLine(`spacedock status --discover`),
+				streamLine(`grep -r "commissioned-by: spacedock@" ` + fixtureRoot),
+			},
+			wantRed:   true,
+			wantNames: "grep -r",
+		},
+		{
+			name: "ls_recursive_repo_root_reds",
+			lines: []string{
+				streamLine(`spacedock status --discover`),
+				streamLine(`ls -R ` + fixtureRoot),
+			},
+			wantRed:   true,
+			wantNames: "ls -R",
+		},
+		{
+			name: "recursive_glob_readme_reds",
+			lines: []string{
+				streamLine(`spacedock status --discover`),
+				globLine(`**/README.md`),
+			},
+			wantRed:   true,
+			wantNames: "**/README.md",
+		},
+		{
+			name: "repo_wide_grep_tool_reds",
+			lines: []string{
+				streamLine(`spacedock status --discover`),
+				grepLine(`commissioned-by`, ""),
+			},
+			wantRed:   true,
+			wantNames: "commissioned-by",
+		},
+		{
+			name: "clean_report_and_stop_passes",
+			lines: []string{
+				streamLine(`spacedock --version`),
+				streamLine(`git rev-parse --show-toplevel`),
+				streamLine(`spacedock status --discover`),
+			},
+			wantRed: false,
+		},
+		{
+			name: "scoped_grep_under_resolved_workflow_passes",
+			lines: []string{
+				streamLine(`spacedock status --discover`),
+				streamLine(`grep -r "stages:" ` + fixtureRoot + `/docs/dev/README.md`),
+				grepLine(`feedback-to`, fixtureRoot+`/docs/dev`),
+			},
+			wantRed: false,
+		},
+		{
+			name:    "empty_stream_passes",
+			lines:   nil,
+			wantRed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stream := strings.Join(tc.lines, "\n")
+			err := detectBroadSearchAtBoot(stream, fixtureRoot)
+			if tc.wantRed {
+				if err == nil {
+					t.Fatalf("detector passed a boot that broad-searched the filesystem — want a red\nstream:\n%s", stream)
+				}
+				if tc.wantNames != "" && !strings.Contains(err.Error(), tc.wantNames) {
+					t.Errorf("error must name the offending search %q: %v", tc.wantNames, err)
+				}
+			} else if err != nil {
+				t.Errorf("detector red a legitimate boot: %v\nstream:\n%s", err, stream)
+			}
+		})
+	}
+}
+
+// TestDetectBroadSearchAtBootSecondBlock proves the detector iterates ALL tool_use
+// blocks of a multi-tool assistant turn, not just the first — a broad-search Bash
+// riding as a second block must still red (it cannot be evaded by block ordering).
+func TestDetectBroadSearchAtBootSecondBlock(t *testing.T) {
+	const fixtureRoot = "/tmp/TestLiveZeroDiscover/001"
+	// One assistant turn with a benign first tool_use and a repo-rooted find second.
+	line := `{"type":"assistant","message":{"content":[` +
+		`{"type":"tool_use","name":"Bash","input":{"command":` + mustJSONString(`spacedock status --discover`) + `}},` +
+		`{"type":"tool_use","name":"Bash","input":{"command":` + mustJSONString(`find `+fixtureRoot+` -name README.md`) + `}}]}}`
+	err := detectBroadSearchAtBoot(line, fixtureRoot)
+	if err == nil {
+		t.Fatal("detector missed a broad-search Bash in the SECOND tool_use block of a multi-tool turn")
+	}
+	if !strings.Contains(err.Error(), "find") {
+		t.Errorf("error must name the offending find command: %v", err)
+	}
+}

--- a/internal/ensigncycle/streamwatch_test.go
+++ b/internal/ensigncycle/streamwatch_test.go
@@ -540,6 +540,12 @@ type streamToolInput struct {
 	// FilePath is the target of a Read/Write tool_use, used the same way (a workflow
 	// README read from outside the fixture root is a wander signature).
 	FilePath string `json:"file_path"`
+	// Pattern is the glob/search pattern of a Glob/Grep tool_use, read by the
+	// broad-search-at-boot detector to spot a recursive workflow-hunting sweep.
+	Pattern string `json:"pattern"`
+	// Path is the search root of a Grep tool_use (unset or the project root means a
+	// repo-wide sweep), read by the broad-search-at-boot detector.
+	Path string `json:"path"`
 }
 
 // toolUseBlock returns the first tool_use block of an assistant entry, or nil —
@@ -554,6 +560,22 @@ func (e streamEntry) toolUseBlock() *streamBlock {
 		}
 	}
 	return nil
+}
+
+// toolUseBlocks returns ALL tool_use blocks of an assistant entry (not just the
+// first, unlike toolUseBlock) — a broad-search Bash can ride as a second block in
+// a multi-tool assistant turn, which a first-block-only scan would miss.
+func (e streamEntry) toolUseBlocks() []*streamBlock {
+	if e.Type != "assistant" || e.Message == nil {
+		return nil
+	}
+	var out []*streamBlock
+	for i := range e.Message.Content {
+		if e.Message.Content[i].Type == "tool_use" {
+			out = append(out, &e.Message.Content[i])
+		}
+	}
+	return out
 }
 
 // resultBlocks returns the tool_result blocks of a user entry.

--- a/internal/ensigncycle/zero_discover_live_test.go
+++ b/internal/ensigncycle/zero_discover_live_test.go
@@ -1,0 +1,110 @@
+//go:build live
+
+// ABOUTME: Live BEHAVIORAL test that a zero-discover FO boot reports-and-stops —
+// ABOUTME: no TeamCreate, no broad filesystem sweep (gated, -tags live only).
+package ensigncycle
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestLiveZeroDiscoverReportsAndStops is the behavioral half of the lean-boot
+// hardening AC-1's offline detector cannot stand in for: a REAL `spacedock claude`
+// FO booted against a ZERO-discover fixture (a git-init'd tmpdir with NO
+// `commissioned-by: spacedock@` README), driven through the front door exactly like
+// TestLiveEnsignCycle. The captain observed (2026-06-14) an FO, after a zero
+// `status --discover`, run a broad find/grep filesystem sweep to hunt a workflow
+// instead of obeying the contract's terminal zero branch (Startup step 3: zero →
+// report no workflow found and STOP). This test proves the real boot:
+//
+//	(a) reaches its greet/no-workflow report WITHOUT a TeamCreate (no workflow to
+//	    drive → no team is engaged), and
+//	(b) takes NO broad filesystem sweep — detectBroadSearchAtBoot(transcript, root)
+//	    returns nil. On a sweep the detector reds and names the offending command.
+//
+// The proof is the captured transcript driven through the AC-1 detector — a real
+// model boot, observed behavior, not prose. The `//go:build live` tag keeps it out
+// of the offline suite; it runs only under `-tags live` with auth present.
+func TestLiveZeroDiscoverReportsAndStops(t *testing.T) {
+	binary := spacedockBinary(t)
+	repoRoot := repoRoot(t)
+	model := envOr("SPACEDOCK_LIVE_MODEL", "sonnet")
+
+	childEnv := isolatedClaudeEnv(t, os.Getenv("HOME"))
+	childEnv = withBinaryOnPath(childEnv, binary)
+
+	// The zero-discover fixture: a bare git-init'd root with NO commissioned README.
+	// status --discover gates on `commissioned-by: spacedock@` frontmatter
+	// (livefixture_discover_test.go), so this root yields zero workflows (empty
+	// stdout, exit 0) — the exact condition whose terminal zero branch this guards.
+	root := t.TempDir()
+	gitInit(t, root)
+
+	task := "Use $spacedock:first-officer for this whole run."
+
+	// The same front door as TestLiveEnsignCycle: --plugin-dir loads the local v1
+	// plugin checkout and relaxes the contract gate; every host flag rides after `--`.
+	// drivePrompt keeps the generic anti-early-shutdown override so the boot timing is
+	// governed the same way; with no workflow the FO never creates a team.
+	drivePrompt := "Drive the workflow. " + antiShutdownOverride
+	cmd := exec.Command(binary, "claude",
+		"--plugin-dir", repoRoot,
+		"--skip-contract-check",
+		"--",
+		"-p", drivePrompt,
+		"--permission-mode", "bypassPermissions",
+		"--output-format", "stream-json",
+		"--verbose",
+		"--model", model,
+		task,
+	)
+	cmd.Dir = root
+	cmd.Env = childEnv
+
+	pr, pw := io.Pipe()
+	cmd.Stdout = pw
+	cmd.Stderr = pw
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spacedock claude failed to start: %v", err)
+	}
+
+	poller := newCmdPoller(cmd, pw)
+	watcher := newStreamWatcher(newPipeLineSource(pr), poller, func(line string) { t.Log(line) })
+	defer poller.kill()
+
+	// A zero-discover boot has NO watched progress beat (no TeamCreate, no dispatch):
+	// the FO greets, reports no workflow found, and ends its turn — the subprocess
+	// exits on its own. drainToExit runs it to exit while accumulating the FULL
+	// transcript, bounded by the no-progress quiet budget so a silent hang trips fast
+	// and localized rather than running to the suite timeout.
+	transcript, err := watcher.drainToExit(quietBudgetDefault, "zero-discover boot")
+	if err != nil {
+		t.Fatalf("zero-discover boot made no stream progress / did not exit: %v", err)
+	}
+
+	// (a) NO TeamCreate: with no workflow to drive, the FO must not engage a team.
+	for _, line := range strings.Split(transcript, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var e streamEntry
+		if json.Unmarshal([]byte(line), &e) != nil {
+			continue
+		}
+		if isTeamCreate(e) {
+			t.Fatalf("zero-discover boot engaged a TeamCreate — the FO must report no workflow found and STOP, not create a team\nTranscript:\n%s", transcript)
+		}
+	}
+
+	// (b) NO broad filesystem sweep: the detector (AC-1) returns nil on a clean
+	// report-and-stop boot and reds a sweep, naming the offending command.
+	if sweep := detectBroadSearchAtBoot(transcript, root); sweep != nil {
+		t.Fatalf("zero-discover boot broad-searched the filesystem instead of report-and-stop: %v\nTranscript:\n%s", sweep, transcript)
+	}
+}


### PR DESCRIPTION
Prove the FO obeys Startup step 3's terminal zero branch — a zero `status --discover` boot must report-and-stop, never broad-search the filesystem (a lean-boot violation observed live).

## What changed
- Add a model-agnostic stream-scanner `detectBroadSearchAtBoot` that reds when a zero-discover boot runs a repo-rooted find/grep -r/rg/ls -R, a recursive Glob, or a repo-wide Grep to hunt a workflow.
- Keys on the search TARGET (project root / `**` pattern), not tool name, so a scoped search under a resolved workflow dir passes; iterates all tool_use blocks (no block-order evasion).
- Register `TestLiveZeroDiscoverReportsAndStops` in the live-e2e gate's `-run` alternation so CI actually invokes it.

## Evidence
- AC-1 detector: 8/8 table + second-block + a 17-case adversarial harness (all required reds/passes, false-red edge holds).
- CI registration verified: `go test -list` confirms the gate's `-run` pattern selects the test; offline gate + `go vet -tags live` green. Diff is CI yaml + test files only.

---
[58](/spacedock-dev/spacedock/blob/255a2cee71e448e33c60187f52f13534b419030f/lean-boot-hardening.md)