### PR TITLE
FO contract refs: ethos hoist + mod-block collapse + cascade (behavior-preserving)

### DIFF
--- a/skills/first-officer/SKILL.md
+++ b/skills/first-officer/SKILL.md
@@ -13,6 +13,13 @@ If this skill is invoked directly in a non-interactive run and the prompt names 
 - before the final response, explicitly shut down any worker that is no longer needed for later routing or gate handling
 - once the bounded stop condition is satisfied, send one concise final response and exit immediately
 
+## How the first officer operates
+
+You are dispatcher, responsible for making sure the work is done by the crew. What awesome looks like:
+- Begin with the end; be clear about the value.
+- Do the hardest things first; de-risk while it is cheap.
+- Communicate and act concisely, choose the simplest approach, JFDI.
+
 ## Operating contract
 
 @references/first-officer-shared-core.md

--- a/skills/first-officer/references/claude-first-officer-runtime.md
+++ b/skills/first-officer/references/claude-first-officer-runtime.md
@@ -10,7 +10,7 @@ When filing a new task, read `id_style` from `status --boot --json`, then use `s
 
 ## Merge reference (load at terminalization)
 
-The terminal merge-and-cleanup machinery for this host — the Merge-and-Cleanup ceremony, the Ship-Local ceremony, worktree-removal safety, Mod-Block Enforcement, and Mod-Block Enforcement at Terminal Transitions (the `TERMINAL_TEARDOWN_BOUNDED` bounded-teardown marker) — lives in `references/claude-fo-merge.md`. Read it at the terminal boundary, when an entity reaches its terminal stage — the same lazy precedent as `present-gate` / `feedback-rejection-flow`. A boot, dispatch, or gate that never terminalizes never reads it.
+The terminal merge-and-cleanup machinery for this host — the Merge-and-Cleanup ceremony, the Ship-Local ceremony, worktree-removal safety, Mod-Block Enforcement, and the bounded terminal teardown (the `TERMINAL_TEARDOWN_BOUNDED` marker) — lives in `references/claude-fo-merge.md`. Read it at the terminal boundary, when an entity reaches its terminal stage — the same lazy precedent as `present-gate` / `feedback-rejection-flow`. A boot, dispatch, or gate that never terminalizes never reads it.
 
 ## Captain Interaction
 

--- a/skills/first-officer/references/claude-fo-merge.md
+++ b/skills/first-officer/references/claude-fo-merge.md
@@ -61,24 +61,7 @@ Merge hooks can block (captain approval before pushing, waiting for PR merge). T
 - **Enforced at the mechanism level** — `status --set` and `status --archive` also refuse terminal transitions and archival when merge hooks (`_mods/*.md` with `## Hook: merge`) are registered AND `pr` is empty AND `mod-block` is empty. `--force` bypasses. `merge: local` exempts only the pr-requirement; `verdict=rejected` likewise exempts only the pr-requirement on both surfaces (a rejected entity never ran the merge ceremony, so the requirement is vacuous); the mod-block-pending and combined-clear refusals remain. See the Ship-Local Ceremony.
 - **Survives session resume** — the FO reads `mod-block` from frontmatter on boot and resumes the pending action.
 
-## Mod-Block Enforcement at Terminal Transitions
-
-Before advancing an entity into Merge and Cleanup, the FO MUST:
-
-1. Check whether merge hooks are registered (from boot-time MODS data).
-2. If merge hooks exist, set `mod-block` before invoking the first hook.
-3. Invoke merge hooks in order. If a hook blocks (sets `pr`, requires captain approval), leave `mod-block` set and report the pending state.
-4. Clear `mod-block` only after the blocking condition is resolved (PR merged, captain chose alternative, hook completed without blocking).
-5. Proceed to terminal frontmatter updates (completed, verdict, worktree clear) and archival only after `mod-block` is clear.
-
-**The mechanism enforces this even if you forget.** `status --set` and `status --archive` refuse terminal transitions (status to a terminal stage, completed, verdict, worktree clear) and archival when all of the following hold true:
-
-- the workflow registers at least one merge hook (`_mods/*.md` with `## Hook: merge`),
-- the entity's `pr` field is empty,
-- the entity's `mod-block` field is empty,
-- `--force` was not passed.
-
-In that state the merge hook has provably not run. The refusal names the blocking hook so you can recover by: setting `mod-block=merge:{mod_name}` and invoking the hook (normal flow), letting the hook set `pr` (which satisfies the invariant), or passing `--force` (captain explicitly approved bypassing the hook). Do NOT pass `--force` merely to clear the guard — it exists to catch exactly the mistake of skipping the hook.
+In the empty-pr/empty-mod-block state the merge hook has provably not run. The refusal names the blocking hook so you can recover by: setting `mod-block=merge:{mod_name}` and invoking the hook (normal flow), letting the hook set `pr` (which satisfies the invariant), or passing `--force` (captain explicitly approved bypassing the hook). Do NOT pass `--force` merely to clear the guard — it exists to catch exactly the mistake of skipping the hook.
 
 On session resume, scan entities with non-empty `mod-block` and resume the pending action. Do not re-run the hook from scratch — check what it left (PR created? branch pushed?) and continue from there.
 

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -2,15 +2,6 @@
 
 Shared first-officer semantics — the boot-resident core. The dispatch and merge machinery live in lazily-loaded references named at their load points (the dispatch reference at first dispatch, the merge reference at terminalization); neither is read at boot.
 
-## Operating principles (ethos)
-
-You are dispatcher and responsible for making sure the work is done by the crew. What awesome looks like for the crew:
-- Begin with the end, be clear about the value.
-- Do the hardest things first, de-risk when it is cheap.
-- Communicate and act concisely, choose the simplest approach, JFDI.
-
-These principles govern how the FO frames work and adjudicates gates. The Working Principles below fold under them.
-
 ## Startup
 
 **Launcher command invariant:** When `SPACEDOCK_BIN` is set by `spacedock claude` or `spacedock codex`, prefer that launcher for every Spacedock helper call; when unset, empty, or unusable, fall back to `spacedock` on `$PATH`. Shell examples may use bare `spacedock` as shorthand for `${SPACEDOCK_BIN:-spacedock}`.
@@ -196,7 +187,7 @@ Supported lifecycle points:
 - `idle`
 - `merge`
 
-Hooks are additive and run alphabetically by mod filename. The MODS-REPORT at boot reads the boot JSON `mods` map (which hooks are registered at which point) without opening a mod file. The mod-block enforcement that guards a terminal transition travels with the deferred merge module, loaded at terminalization.
+Hooks are additive and run alphabetically by mod filename. The boot MODS-REPORT reads the `mods` map without opening a mod file (Startup step 5). The mod-block enforcement that guards a terminal transition travels with the deferred merge module, loaded at terminalization.
 
 The standing-teammate concepts (first-boot-wins lifecycle, team-scope teardown, the by-name routing contract, the declaration layout) travel with the deferred dispatch module — they apply only once a team exists at first dispatch.
 
@@ -204,19 +195,19 @@ The standing-teammate concepts (first-boot-wins lifecycle, team-scope teardown, 
 
 Ask the human before dispatch when requirements are materially ambiguous, a design choice would change output meaningfully, or scope is too unclear to produce concrete criteria.
 
-Do not ask whether to take a step this contract already allows — proceed. If one entity is blocked on clarification, keep dispatching other ready entities. Report workflow state once on idle or at a gate; do not repeat status updates while waiting.
+Don't ask permission for a step the contract already allows (the reversible-work principle); keep dispatching other ready entities when one blocks. Report state once on idle or at a gate, not repeatedly while waiting.
 
 ## Working Principles
 
-These habits govern how the FO frames work and adjudicates gates.
+These habits implement the operating posture stated in the skill entry point — they are how the FO frames work and adjudicates gates in practice.
 
 **Prefer a code gate over a prose-only rule.** When a guarantee can be enforced by the binary or a failing test (a `status` guard, a test that fails on violation), prefer that. A prose-only rule's ceiling is "the wording is present"; wording-present is not behavior. A prose-only rule must not count as AC satisfaction on its own: if the guarantee matters, the real assurance is a code-level gate underneath, and the prose points at it. An AC of the form "the contract says X" is satisfied only by "the binary or a test enforces X, and here is the run that proves it." The gate's AC cross-check refuses a criterion whose only proof is review of the entity's own prose.
 
 **FO posture:**
 
-- **Name the end value before starting.** State the outcome — the change in the world the captain gets — before mechanism. End-value framing is judgeable; step-framing has to be reverse-engineered.
-- **Lead with a recommendation the captain can say yes to.** Open with one clear recommended direction approvable in a single "yes," then supply detail. Do not bury under a menu of equally-weighted options.
-- **Do obvious reversible work without ceremony.** Obvious reversible steps (a dispatch the contract already allows, a status read, a routine state transition) just happen. Reserve asking for choices that are hard to reverse or genuinely matter.
+- **Name the end value before starting** (entry-point principle 1) — state the outcome before mechanism; end-value framing is judgeable, step-framing is not.
+- **Lead with a recommendation the captain can say yes to** — one recommended direction, not a menu; the gate rendering enforces the lede-first spine (see `present-gate`).
+- **Do obvious reversible work without ceremony** (entry-point principle 3) — reversible steps the contract allows just happen; reserve asking for choices that are hard to reverse or genuinely matter.
 - **Speak the workflow's declared label, not the generic "entity".** When the FO produces captain-facing prose — gate presentations, status narration, conversation — it names entities by the declared `entity-label` / `entity-label-plural` read at Startup step 4, wherever it would otherwise write "entity" / "entities". A workflow declaring `entity-label: ticket` reads "ticket(s)"; one declaring `experiment` reads "experiment(s)"; a default `entity` workflow is unchanged. Only the human-facing noun localizes — the contract mechanics (`entity_path`, the entity-read line, the abstraction prose, machine output) stay generic "entity".
 
 ## Probe and Ideation Discipline


### PR DESCRIPTION
Slim the FO contract refs under the operating ethos: hoist the ethos to the always-loaded entry point, collapse duplicated obligations, and compress restatement — behavior-preserving, proven by a word-level audit against the prior tree.

## What changed
- Hoist the FO operating principles into `SKILL.md` (self-explanatory, label/meta-framing dropped); delete from shared-core; point the Working-Principles lede up.
- Collapse `claude-fo-merge.md`'s two `## Mod-Block` sections into one; turn the shared-core MODS-REPORT restatement into a pointer; de-dangle the runtime-adapter merge-ref inventory.
- Compress C-a + three Working-Principles posture bullets (keep speak-label + prefer-code-gate verbatim).

## Evidence
- Detached word-level audit vs the #367 baseline: no MUST/MUST-NOT/qualifier dropped or inverted across all changes; `TERMINAL_TEARDOWN_BOUNDED` marker byte-intact at its real home; ethos single-home; no dangling cross-file refs.
- `grep -c '^## Mod-Block'` == 1; `go test ./...` incl. internal/contractlint reference-closure green. Net 14 insertions / ~34 deletions.

---
[5e](/spacedock-dev/spacedock/blob/4dd7efb5643c08a52ee8eccc1333fa0e5e526f87/fo-refs-inmodule-restructure.md)