### PR TITLE
Relocate the standing-teammate mechanism into the binary (comm-officer self-injects; contract slimmed, residency kept)

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -176,7 +176,7 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p "$SPACEDOCK_LIVE_ARTIFACT_DIR"
-          go test -tags live -count=1 -run 'TestLiveEnsignCycle|TestLiveZeroDiscoverReportsAndStops' ./internal/ensigncycle/ -v 2>&1 | tee live-e2e-transcript.txt
+          go test -tags live -count=1 -run 'TestLiveEnsignCycle|TestLiveZeroDiscoverReportsAndStops|TestLiveStandingResidencyInjectsCommOfficer' ./internal/ensigncycle/ -v 2>&1 | tee live-e2e-transcript.txt
 
       # The shared scenario suite: the Claude lane runs the SAME host-neutral
       # gate/rejection/merge-hook scenarios the codex-live lane runs, through the

--- a/docs/dev/_mods/comm-officer.md
+++ b/docs/dev/_mods/comm-officer.md
@@ -11,20 +11,9 @@ A standing teammate for prose polish. Kept alive for the captain session once sp
 
 ## Hook: startup
 
-Before entering the normal event loop, check whether the current team (`~/.claude/teams/{team_name}/config.json` members list) contains a member named `comm-officer`.
-
-- **If present:** log `comm-officer already alive, skipping spawn` and proceed. First-boot-wins.
-- **If absent:** spawn using the configuration below, then proceed.
-
-Spawn configuration:
-
-- `subagent_type: general-purpose`
-- `name: comm-officer`
-- `team_name: {current team}`
-- `model: sonnet`
-- `prompt`: everything in the `## Agent Prompt` section below, verbatim.
-
-The spawn is fire-and-forget. Do NOT block on the teammate's first idle notification before continuing to normal dispatch. Ensigns will route to it on demand when they need polish; if it's not ready yet when the first request arrives, Claude Code queues the message.
+- subagent_type: general-purpose
+- name: comm-officer
+- model: sonnet
 
 ## Hook: shutdown
 

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -81,6 +81,15 @@ func Run(probe claudeteam.TeamStateProbe, args []string, stdin io.Reader, stdout
 			return 2
 		}
 		return runSpawnStanding(os.Getenv("HOME"), mod, team, stdout, stderr)
+	case "spawn-standing-all":
+		flags := parseFlags(args[1:], map[string]bool{"--workflow-dir": true, "--team": true})
+		wd, okWD := flags["--workflow-dir"]
+		team, okTeam := flags["--team"]
+		if !okWD || !okTeam {
+			fmt.Fprintln(stderr, "error: dispatch spawn-standing-all requires --workflow-dir and --team")
+			return 2
+		}
+		return runSpawnStandingAll(os.Getenv("HOME"), wd, team, stdout, stderr)
 	case "reconcile":
 		return runReconcile(args[1:], stdout, stderr)
 	default:

--- a/internal/dispatch/native_subcommands_routing_test.go
+++ b/internal/dispatch/native_subcommands_routing_test.go
@@ -20,7 +20,7 @@ import (
 // naming the subcommand), NOT the old "deferred to the claude-runtime-segregation
 // surface" diagnostic. Re-adding a deferral would change this exit/message shape.
 func TestRuntimeCoupledSubcommandsRouteNative(t *testing.T) {
-	for _, sc := range []string{"context-budget", "list-standing", "show-standing", "spawn-standing"} {
+	for _, sc := range []string{"context-budget", "list-standing", "show-standing", "spawn-standing", "spawn-standing-all"} {
 		var out, errBuf bytes.Buffer
 		code := Run(claudeteam.Probe, []string{sc}, strings.NewReader(""), &out, &errBuf)
 		if code != 2 {

--- a/internal/dispatch/spawn_standing_all_test.go
+++ b/internal/dispatch/spawn_standing_all_test.go
@@ -1,0 +1,137 @@
+// ABOUTME: spawn-standing-all driver tests — array-emit shape, already-alive dedup,
+// ABOUTME: empty `[]` when none declared, and loud failure on a broken standing mod.
+package dispatch
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// spawnAllSpec mirrors the array element spawn-standing-all emits. Expected
+// values are sourced from the fixture mod, NOT the binary.
+type spawnAllSpec struct {
+	SubagentType string `json:"subagent_type"`
+	Name         string `json:"name"`
+	TeamName     string `json:"team_name"`
+	Model        string `json:"model"`
+	Prompt       string `json:"prompt"`
+}
+
+// TestSpawnStandingAllEmitsAbsentMemberSpec drives the inject loop with the
+// declared member ABSENT from the team config: spawn-standing-all emits a
+// one-element JSON array whose spec carries subagent_type/name/team_name/model/
+// prompt, with the prompt equal to the fixture mod's ## Agent Prompt body (the
+// expected value comes from the fixture, an independent source, not the binary).
+func TestSpawnStandingAllEmitsAbsentMemberSpec(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	writeMods(t, wd, map[string]string{
+		"comm-officer.md": standingMod("comm-officer", "sonnet", "prose polisher", ""),
+		"not-standing.md": "---\nstanding: false\nname: nope\n---\nbody\n",
+	})
+	// A team config that does NOT list comm-officer, so MemberExists is false.
+	claudeFixture{
+		team:    "fixture-team",
+		session: "s",
+		members: []fixtureMember{{name: "team-lead", model: "opus"}},
+		jsonls:  map[string]string{},
+	}.write(t, home)
+
+	res := runNative("", "spawn-standing-all", "--workflow-dir", wd, "--team", "fixture-team")
+	if res.exit != 0 {
+		t.Fatalf("exit=%d stderr=%q", res.exit, res.stderr)
+	}
+
+	var specs []spawnAllSpec
+	if err := json.Unmarshal([]byte(res.stdout), &specs); err != nil {
+		t.Fatalf("stdout not a JSON array: %v\n%s", err, res.stdout)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("expected one spec (comm-officer absent); got %d: %v", len(specs), specs)
+	}
+	got := specs[0]
+	if got.SubagentType != "general-purpose" {
+		t.Errorf("subagent_type = %q, want general-purpose", got.SubagentType)
+	}
+	if got.Name != "comm-officer" {
+		t.Errorf("name = %q, want comm-officer", got.Name)
+	}
+	if got.TeamName != "fixture-team" {
+		t.Errorf("team_name = %q, want fixture-team", got.TeamName)
+	}
+	if got.Model != "sonnet" {
+		t.Errorf("model = %q, want sonnet", got.Model)
+	}
+	// The fixture's ## Agent Prompt body (from standingMod) is "You are comm-officer.\n".
+	if want := "You are comm-officer.\n"; got.Prompt != want {
+		t.Errorf("prompt = %q, want %q", got.Prompt, want)
+	}
+}
+
+// TestSpawnStandingAllSkipsAlreadyAliveMember drives the dedup path: the team
+// config already lists comm-officer, so spawn-standing-all OMITS it from the
+// array. With it the only declared standing mod, the array is empty `[]`.
+func TestSpawnStandingAllSkipsAlreadyAliveMember(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	writeMods(t, wd, map[string]string{
+		"comm-officer.md": standingMod("comm-officer", "sonnet", "prose polisher", ""),
+	})
+	claudeFixture{
+		team:    "fixture-team",
+		session: "s",
+		members: []fixtureMember{{name: "comm-officer", model: "sonnet"}},
+		jsonls:  map[string]string{},
+	}.write(t, home)
+
+	res := runNative("", "spawn-standing-all", "--workflow-dir", wd, "--team", "fixture-team")
+	if res.exit != 0 {
+		t.Fatalf("exit=%d stderr=%q", res.exit, res.stderr)
+	}
+	if got := strings.TrimSpace(res.stdout); got != "[]" {
+		t.Fatalf("expected empty array (already-alive deduped); got %q", got)
+	}
+}
+
+// TestSpawnStandingAllEmptyWhenNoneDeclared drives the degenerate path: a
+// workflow with no standing mods emits `[]`, exit 0.
+func TestSpawnStandingAllEmptyWhenNoneDeclared(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	writeMods(t, wd, map[string]string{
+		"not-standing.md": "---\nstanding: false\nname: nope\n---\nbody\n",
+	})
+
+	res := runNative("", "spawn-standing-all", "--workflow-dir", wd, "--team", "fixture-team")
+	if res.exit != 0 {
+		t.Fatalf("exit=%d stderr=%q", res.exit, res.stderr)
+	}
+	if got := strings.TrimSpace(res.stdout); got != "[]" {
+		t.Fatalf("expected empty array (no standing mods); got %q", got)
+	}
+}
+
+// TestSpawnStandingAllFailsLoudOnBrokenMod drives the loud-failure path: a
+// declared standing mod missing its ## Agent Prompt exits 1 with a stderr line
+// naming the offending mod — the same validation runSpawnStanding enforces,
+// shared via buildSpawnSpec rather than re-implemented.
+func TestSpawnStandingAllFailsLoudOnBrokenMod(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	writeMods(t, wd, map[string]string{
+		"broken.md": "---\nstanding: true\nname: broken\n---\n## Hook: startup\n- subagent_type: general-purpose\n- name: broken\n- model: sonnet\n",
+	})
+
+	res := runNative("", "spawn-standing-all", "--workflow-dir", wd, "--team", "fixture-team")
+	if res.exit != 1 {
+		t.Fatalf("expected exit 1 on broken mod; got %d stdout=%q", res.exit, res.stdout)
+	}
+	if !strings.Contains(res.stderr, "broken.md") || !strings.Contains(res.stderr, "## Agent Prompt") {
+		t.Errorf("stderr does not name the offending mod and missing section: %q", res.stderr)
+	}
+}

--- a/internal/dispatch/standing.go
+++ b/internal/dispatch/standing.go
@@ -86,27 +86,88 @@ func runSpawnStanding(home, modPath, teamName string, stdout, stderr io.Writer) 
 				"Call TeamCreate first and pass the returned team_name via --team.\n", teamName)
 		return 1
 	}
-	if !isFile(modPath) {
-		fmt.Fprintf(stderr, "error: mod file not found: %s\n", modPath)
+	spec, alreadyAlive, errMsg := buildSpawnSpec(home, modPath, teamName)
+	if errMsg != "" {
+		fmt.Fprintf(stderr, "error: %s\n", errMsg)
 		return 1
+	}
+	if alreadyAlive {
+		emitAlreadyAlive(stdout, spec.Name)
+		return 0
+	}
+	return emitSpawnJSON(stdout, spec)
+}
+
+// runSpawnStandingAll drives the full standing-teammate inject loop in one call:
+// enumerate the workflow's declared standing mods, build a spawn spec for each,
+// dedup the already-alive members against the team config, and emit a JSON ARRAY
+// of the specs for the members NOT yet alive. Empty input (bare mode / no _mods /
+// no standing mods) emits `[]`. Loud failure (exit 1, stderr naming the mod) on
+// the same conditions runSpawnStanding fails on — validation is shared via
+// buildSpawnSpec, not re-implemented. Composes the _mods scan (discovery) +
+// buildSpawnSpec (validate + MemberExists dedup + spec), mirroring build.go's
+// generic show-standing injection.
+func runSpawnStandingAll(home, workflowDir, teamName string, stdout, stderr io.Writer) int {
+	if teamName == "" || teamName == "none" || teamName == "None" {
+		fmt.Fprintf(stderr,
+			"error: spawn-standing-all requires a real team name; got '%s'. "+
+				"Call TeamCreate first and pass the returned team_name via --team.\n", teamName)
+		return 1
+	}
+	if !isDir(workflowDir) {
+		fmt.Fprintf(stderr, "error: workflow directory not found: %s\n", workflowDir)
+		return 1
+	}
+
+	specs := []spawnSpec{}
+	modsDir := filepath.Join(workflowDir, "_mods")
+	if isDir(modsDir) {
+		for _, modPath := range sortedModPaths(modsDir) {
+			meta, err := ParseModMetadata(modPath)
+			if err != nil {
+				fmt.Fprintf(stderr, "error: unreadable mod %s: %s\n", modPath, err)
+				return 1
+			}
+			if !meta.Standing {
+				continue
+			}
+			spec, alreadyAlive, errMsg := buildSpawnSpec(home, modPath, teamName)
+			if errMsg != "" {
+				fmt.Fprintf(stderr, "error: %s\n", errMsg)
+				return 1
+			}
+			if alreadyAlive {
+				continue
+			}
+			specs = append(specs, spec)
+		}
+	}
+	return claudeteam.EmitPythonJSON(stdout, specs)
+}
+
+// buildSpawnSpec parses a standing-teammate mod and either reports it
+// already-alive (the team config lists the declared member) or returns the
+// Agent() spec to spawn. errMsg is non-empty on any validation failure (missing
+// mod, missing standing: true, missing ## Agent Prompt, missing subagent_type /
+// name / model, or a model outside the enum); callers turn it into the exit-1
+// stderr line. Shared by runSpawnStanding (single) and runSpawnStandingAll (loop)
+// so validation lives in one place. On already-alive, only Name is populated.
+func buildSpawnSpec(home, modPath, teamName string) (spec spawnSpec, alreadyAlive bool, errMsg string) {
+	if !isFile(modPath) {
+		return spec, false, fmt.Sprintf("mod file not found: %s", modPath)
 	}
 
 	meta, err := ParseModMetadata(modPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: %s\n", err)
-		return 1
+		return spec, false, err.Error()
 	}
 	if !meta.Standing {
-		fmt.Fprintf(stderr,
-			"error: mod %s is missing 'standing: true' in frontmatter — "+
-				"not a standing-teammate mod\n", modPath)
-		return 1
+		return spec, false, fmt.Sprintf(
+			"mod %s is missing 'standing: true' in frontmatter — not a standing-teammate mod", modPath)
 	}
 	if meta.AgentPrompt == nil {
-		fmt.Fprintf(stderr,
-			"error: mod %s has no '## Agent Prompt' section — "+
-				"required for standing-teammate spawn\n", modPath)
-		return 1
+		return spec, false, fmt.Sprintf(
+			"mod %s has no '## Agent Prompt' section — required for standing-teammate spawn", modPath)
 	}
 
 	hookConfig := ParseHookStartupSpawnConfig(modPath)
@@ -121,46 +182,44 @@ func runSpawnStanding(home, modPath, teamName string, stdout, stderr io.Writer) 
 	model := hookConfig["model"]
 
 	if subagentType == "" {
-		fmt.Fprintf(stderr,
-			"error: mod %s has no 'subagent_type' in '## Hook: startup' or frontmatter\n", modPath)
-		return 1
+		return spec, false, fmt.Sprintf(
+			"mod %s has no 'subagent_type' in '## Hook: startup' or frontmatter", modPath)
 	}
 	if declaredName == "" {
-		fmt.Fprintf(stderr,
-			"error: mod %s has no 'name' in '## Hook: startup' or frontmatter\n", modPath)
-		return 1
+		return spec, false, fmt.Sprintf(
+			"mod %s has no 'name' in '## Hook: startup' or frontmatter", modPath)
 	}
 	if model == "" {
-		fmt.Fprintf(stderr,
-			"error: mod %s has no 'model' in '## Hook: startup' — %s\n", modPath, spawnModelEnumList)
-		return 1
+		return spec, false, fmt.Sprintf(
+			"mod %s has no 'model' in '## Hook: startup' — %s", modPath, spawnModelEnumList)
 	}
 	if !spawnModelEnum[model] {
-		fmt.Fprintf(stderr,
-			"error: invalid model '%s' in '## Hook: startup' of %s — %s\n", model, modPath, spawnModelEnumList)
-		return 1
+		return spec, false, fmt.Sprintf(
+			"invalid model '%s' in '## Hook: startup' of %s — %s", model, modPath, spawnModelEnumList)
 	}
 
 	if claudeteam.MemberExists(home, teamName, declaredName) {
-		// already-alive: a one-line JSON object matching the oracle's json.dumps
-		// without indent — Python's default ", " / ": " separators, not Go's
-		// space-free Marshal. The two keys are fixed, so format directly to match.
-		// Escape the name through the same ensure_ascii routine the emitters use,
-		// so a non-ASCII declared name stays byte-identical to json.dumps.
-		nameJSON, _ := json.Marshal(declaredName)
-		nameJSON = claudeteam.EscapeNonASCII(nameJSON)
-		fmt.Fprintf(stdout, "{\"status\": \"already-alive\", \"name\": %s}\n", nameJSON)
-		return 0
+		return spawnSpec{Name: declaredName}, true, ""
 	}
 
-	spec := spawnSpec{
+	return spawnSpec{
 		SubagentType: subagentType,
 		Name:         declaredName,
 		TeamName:     teamName,
 		Model:        model,
 		Prompt:       *meta.AgentPrompt,
-	}
-	return emitSpawnJSON(stdout, spec)
+	}, false, ""
+}
+
+// emitAlreadyAlive writes the compact already-alive JSON for a single member:
+// a one-line object matching the oracle's json.dumps without indent — Python's
+// default ", " / ": " separators, not Go's space-free Marshal. The two keys are
+// fixed, so format directly. Escape the name through the same ensure_ascii routine
+// the emitters use, so a non-ASCII declared name stays byte-identical to json.dumps.
+func emitAlreadyAlive(stdout io.Writer, name string) {
+	nameJSON, _ := json.Marshal(name)
+	nameJSON = claudeteam.EscapeNonASCII(nameJSON)
+	fmt.Fprintf(stdout, "{\"status\": \"already-alive\", \"name\": %s}\n", nameJSON)
 }
 
 // spawnSpec is the Agent() call spec spawn-standing emits when the member is not

--- a/internal/ensigncycle/live_standing_residency_test.go
+++ b/internal/ensigncycle/live_standing_residency_test.go
@@ -1,0 +1,182 @@
+//go:build live
+
+// ABOUTME: Live residency proof — a real FO booted against a workflow declaring a
+// ABOUTME: standing comm-officer mod injects it into the team config.json roster.
+package ensigncycle
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLiveStandingResidencyInjectsCommOfficer is the AC-2 behavioral proof for
+// the standing-teammate mechanism relocation (spawn-standing-all). It boots the
+// REAL `spacedock claude` front door against a fixture workflow that declares a
+// standing comm-officer mod, lets the FO reach its first team-mode dispatch (where
+// the contract's single trigger line runs `spacedock dispatch spawn-standing-all`,
+// which injects the declared standing teammates), and asserts comm-officer is
+// PRESENT in the team `config.json` members roster afterward.
+//
+// The independent oracle is the on-disk team config the live Claude Code harness
+// writes — NOT a contract grep. The test REDS if residency breaks (comm-officer
+// absent after first dispatch), which is exactly the cycle-1/2 regression this
+// cycle-3 design must not reintroduce: the mechanism moved out of contract prose
+// into the binary + the mod's self-declaration, but the resident teammate must
+// still land in the roster.
+//
+// The `//go:build live` tag keeps this out of the secret-free offline suite; it
+// runs only under `go test -tags live` behind the CI-E2E approval gate, alongside
+// TestLiveEnsignCycle. Auth + HOME isolation reuse isolatedClaudeEnv (skips when
+// no credential is available; never fatals).
+func TestLiveStandingResidencyInjectsCommOfficer(t *testing.T) {
+	binary := spacedockBinary(t)
+	repoRoot := repoRoot(t)
+	model := envOr("SPACEDOCK_LIVE_MODEL", "sonnet")
+
+	childEnv := isolatedClaudeEnv(t, os.Getenv("HOME"))
+	childEnv = withBinaryOnPath(childEnv, binary)
+
+	// The team config the live harness writes lives under CLAUDE_CONFIG_DIR/teams;
+	// resolve it from the same child env the FO subprocess runs under so the roster
+	// read targets exactly where Claude Code persisted the members list.
+	configDir, ok := envValue(childEnv, "CLAUDE_CONFIG_DIR")
+	if !ok {
+		t.Fatal("child env carries no CLAUDE_CONFIG_DIR — cannot locate the team config roster")
+	}
+
+	// Stage the realistic ≥3-stage lifecycle fixture (same as TestLiveEnsignCycle)
+	// PLUS a `_mods/comm-officer.md` declaring a standing teammate. The standing mod
+	// is what spawn-standing-all enumerates at first dispatch; its presence is the
+	// only difference from the plain cycle fixture.
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "README.md"), readmeRealisticLifecycle())
+	writeFile(t, filepath.Join(root, "_mods", "comm-officer.md"), liveStandingCommOfficerMod())
+	entityPath := filepath.Join(root, "make-it-work.md")
+	writeFile(t, entityPath, entityFixture())
+	gitInit(t, root)
+
+	task := "Use $spacedock:first-officer for this whole run."
+	drivePrompt := "Drive the workflow. " + antiShutdownOverride
+	cmd := exec.Command(binary, "claude",
+		"--plugin-dir", repoRoot,
+		"--skip-contract-check",
+		"--",
+		"-p", drivePrompt,
+		"--permission-mode", "bypassPermissions",
+		"--output-format", "stream-json",
+		"--verbose",
+		"--model", model,
+		task,
+	)
+	cmd.Dir = root
+	cmd.Env = childEnv
+
+	pr, pw := io.Pipe()
+	cmd.Stdout = pw
+	cmd.Stderr = pw
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spacedock claude failed to start: %v", err)
+	}
+
+	poller := newCmdPoller(cmd, pw)
+	watcher := newStreamWatcher(newPipeLineSource(pr), poller, func(line string) { t.Log(line) })
+	defer poller.kill()
+
+	// Watch the same proven progress beats as TestLiveEnsignCycle: TeamCreate
+	// engages teams mode, then the ensign dispatch closes. spawn-standing-all runs
+	// BEFORE the first team-mode Agent() dispatch, so by the time the dispatch has
+	// closed, the standing teammate has been injected into the team config.
+	if _, err := watcher.expect(isTeamCreate, quietBudgetDefault, "TeamCreate"); err != nil {
+		if wrongRoot := detectWrongRootBoot(watcher.fullTranscript(), root); wrongRoot != nil {
+			t.Fatalf("live residency cycle failed at TeamCreate due to a wrong-root boot: %v\nUnderlying watcher error: %v", wrongRoot, err)
+		}
+		t.Fatalf("live residency cycle failed at TeamCreate: %v", err)
+	}
+	if err := watcher.expectDispatchClose(quietBudgetDefault, "dispatch close"); err != nil {
+		t.Fatalf("live residency cycle failed at the ensign dispatch close: %v", err)
+	}
+
+	// The load-bearing assertion: comm-officer is a member of the live team's
+	// config.json roster. The roster is the independent oracle the live harness
+	// wrote; a missing comm-officer means residency broke (the cycle-1/2 mistake).
+	teams := teamConfigPaths(t, configDir)
+	if len(teams) == 0 {
+		t.Fatalf("no team config.json found under %s/teams after the cycle (TeamCreate matched but no roster persisted)", configDir)
+	}
+	if !anyTeamHasMember(t, teams, "comm-officer") {
+		t.Fatalf("comm-officer ABSENT from every team roster after first dispatch — residency broke (standing-teammate injection did not land it in config.json)\nscanned: %v", teams)
+	}
+	t.Logf("comm-officer present in the live team roster across %d team config(s)", len(teams))
+}
+
+// liveStandingCommOfficerMod is a minimal standing comm-officer mod for the live
+// residency fixture: standing: true frontmatter plus the spawn-config bullets the
+// binary parses and an ## Agent Prompt body. It mirrors the shipped mod's
+// self-declaration shape (frontmatter standing + trimmed ## Hook: startup +
+// ## Agent Prompt) without the full routing prose, which is irrelevant to the
+// roster-membership proof. The agent prompt's online handshake is harmless in the
+// fixture: the spawned member lands in the roster regardless of whether it then
+// finds an elements-of-style skill.
+func liveStandingCommOfficerMod() string {
+	return "---\n" +
+		"name: comm-officer\n" +
+		"description: Standing prose-polishing teammate for this workflow\n" +
+		"standing: true\n" +
+		"---\n" +
+		"# Comm Officer\n\n" +
+		"## Hook: startup\n\n" +
+		"- subagent_type: general-purpose\n" +
+		"- name: comm-officer\n" +
+		"- model: sonnet\n\n" +
+		"## Agent Prompt\n\n" +
+		"You are the session's communications officer. Polish prose for clarity and " +
+		"concision when asked. On spawn, send `comm-officer online` to team-lead, then " +
+		"idle until you receive a polish request.\n"
+}
+
+// teamConfigPaths returns every {configDir}/teams/*/config.json path on disk. The
+// live harness writes one per team; the live FO creates exactly one team, but the
+// scan is plural-safe so a parallel-team layout does not silently miss the roster.
+func teamConfigPaths(t *testing.T, configDir string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(configDir, "teams", "*", "config.json"))
+	if err != nil {
+		t.Fatalf("glob team configs under %s: %v", configDir, err)
+	}
+	return matches
+}
+
+// anyTeamHasMember reports whether any of the given team config.json files lists a
+// member with the given name. It parses the same members[] shape MemberExists
+// reads (a list of objects each carrying a name), so the live oracle matches the
+// binary's own membership predicate.
+func anyTeamHasMember(t *testing.T, configPaths []string, name string) bool {
+	t.Helper()
+	for _, p := range configPaths {
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			t.Logf("read team config %s: %v", p, err)
+			continue
+		}
+		var cfg struct {
+			Members []struct {
+				Name string `json:"name"`
+			} `json:"members"`
+		}
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			t.Logf("parse team config %s: %v", p, err)
+			continue
+		}
+		for _, m := range cfg.Members {
+			if strings.EqualFold(m.Name, name) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/skills/first-officer/references/claude-first-officer-runtime.md
+++ b/skills/first-officer/references/claude-first-officer-runtime.md
@@ -4,7 +4,7 @@ This file defines how the shared first-officer core executes on Claude Code. It 
 
 ## Dispatch reference (load at first dispatch)
 
-The dispatch machinery for this host — Team Creation, the ID/next-id read, standing-teammate discovery/lazy-spawn/declaration, Worker Resolution, the Dispatch Adapter (`spacedock dispatch build` + break-glass), Degraded Mode seams, the Context-Budget probe, and the Event Loop (incl. the reconcile sweep) — lives in `references/claude-fo-dispatch.md`. Read it at the FIRST team-mode dispatch, alongside the `Skill(skill="spacedock:using-claude-team")` invocation it opens with — not at boot. A boot that greets and stops for input never dispatches, so it never reads this reference and never creates a team.
+The dispatch machinery for this host — Team Creation, the ID/next-id read, standing-teammate injection (`spawn-standing-all`), Worker Resolution, the Dispatch Adapter (`spacedock dispatch build` + break-glass), Degraded Mode seams, the Context-Budget probe, and the Event Loop (incl. the reconcile sweep) — lives in `references/claude-fo-dispatch.md`. Read it at the FIRST team-mode dispatch, alongside the `Skill(skill="spacedock:using-claude-team")` invocation it opens with — not at boot. A boot that greets and stops for input never dispatches, so it never reads this reference and never creates a team.
 
 When filing a new task, read `id_style` from `status --boot --json`, then use `status --next-id` only when the style is `sequential` or `sd-b32` (see the dispatch reference for the full read shape). A boot that only greets does not file a task.
 

--- a/skills/first-officer/references/claude-fo-dispatch.md
+++ b/skills/first-officer/references/claude-fo-dispatch.md
@@ -14,50 +14,11 @@ In single-entity mode, skip team creation. Use bare-mode dispatch for all agent 
 
 When filing a new task, read `id_style` from `status --boot --json`, then use `status --next-id` only when the style is `sequential` or `sd-b32`. The startup boot read is an FO-internal read; consume it as JSON: `status --boot --json` returns one object with the keys `command`, `mods`, `id_style`, `next_id`, `min_prefix` (present only for `sd-b32`), `orphans`, `pr_state`, `dispatchable`, `team_state` — every value a string. For `sd-b32`, call `status --next-id --id-seed "{slug-or-title}"` and optionally pass `--id-actor` so the SHA-derived candidate includes creation context. SD-B32 candidates are full stored IDs, not a reservation; call again immediately before writing the entity. For `slug`, derive the slug from the title and leave `id` blank.
 
-### Standing teammate discovery pass
-
-After team creation succeeds (the ladder has resolved and the returned `team_name` is known) and BEFORE entering the normal dispatch event loop, run the standing-teammate discovery pass:
-
-1. Run `spacedock dispatch list-standing --workflow-dir {wd}` and consume its newline-delimited output (one absolute mod path per line, sorted alphabetically, empty stdout on zero matches). Do NOT grep mod frontmatter yourself — authoritative parsing is deferred to the helper.
-2. Record the returned mod paths in session memory. **No spawn calls at boot.** Spawn is deferred to the first team-mode dispatch (see lazy-spawn below).
-
-In single-entity (bare) mode and in Degraded Mode, discovery still runs (it is cheap — just `list-standing`), but lazy-spawn is skipped (no team to spawn into). Standing teammates are a team-scope concept; without a live team they have no lifecycle anchor.
-
-### Standing teammate lazy-spawn
-
-Before the first `Agent()` call that uses a `team_name` (i.e., the first non-bare dispatch), spawn all declared standing teammates:
-
-1. For each declared standing-teammate mod path recorded during the discovery pass:
-   a. Run `spacedock dispatch spawn-standing --mod {abs_path_to_mod} --team {team_name}`.
-   b. If the helper emits JSON with top-level `status: "already-alive"`, log the reported `name` and skip to the next mod. Standing teammates are first-boot-wins across the captain session; subsequent workflows sharing the team pick up the live member. (The helper resolves already-alive via the team-membership predicate — a member named in the team `config.json` members list — the same predicate the prose-polish routing check uses.)
-   c. Otherwise the helper emits an Agent() call spec JSON with keys `subagent_type`, `name`, `team_name`, `model`, `prompt`. **Forward that spec verbatim** to the Agent tool — copy each field into the corresponding Agent() argument without paraphrasing the prompt, rewriting the name, or substituting the team. Same "forward verbatim" discipline as `spacedock dispatch build` output.
-   d. The spawn is fire-and-forget. Do NOT block on the teammate's first idle notification before continuing to dispatch.
-   e. If the helper exits non-zero on any mod (missing Agent Prompt section, invalid model enum, convention-violating trailing heading), surface the error to the captain and continue with the remaining mods. A broken mod does not block the workflow.
-2. After all standing teammates are spawned (or skipped), proceed with the ensign `Agent()` dispatch.
-
-This is a one-time cost at first dispatch. Subsequent dispatches skip the spawn pass — the FO tracks "standing teammates spawned for this team" in session memory. In single-entity (bare) mode and in Degraded Mode, skip lazy-spawn (same as the discovery-pass skip above). Prose-polish round-trips can reach several minutes on long drafts — ensigns and the FO MUST treat polish routing as non-blocking regardless of round-trip duration.
-
-### Standing teammate declaration and routing mechanics
-
-These are the Claude realization of the shared core's `## Standing Teammates` concepts — the concrete declaration layout, routing call, and teardown trigger the cross-runtime concept defers to the adapter:
-
-- **Declaration layout.** One mod file per standing teammate under `{workflow_dir}/_mods/{name}.md`. Frontmatter carries `standing: true` and an optional `description`. The `## Hook: startup` section declares spawn config as `- key: value` bullets (`subagent_type`, `name`, `model` from the `sonnet|opus|haiku` enum). The `## Agent Prompt` section MUST be the LAST top-level section; its body — from the line after the heading to EOF — is the verbatim prompt passed to Agent(). Any `## ` heading after `## Agent Prompt` is rejected loudly by `spacedock dispatch spawn-standing`.
-- **Routing call.** Address a standing teammate by its declared `name` via `SendMessage`. Best-effort, non-blocking, 2-minute timeout (the shared-core routing-contract concept).
-- **Teardown trigger.** The teammate dies when Claude Code tears down the team — session end, `TeamDelete`, or captain-initiated shutdown. Mid-session death is detected on the next routing attempt; respawn via `spawn-standing` or proceed without the teammate.
-- **Dispatch-time injection.** When assembling an ensign dispatch, `spacedock dispatch build` appends a `spacedock dispatch show-standing --workflow-dir {wd}` fetch line whenever the workflow declares at least one standing teammate. `show-standing` renders the `### Standing teammates available in your team` routing block (a mod's `## Routing Usage` body when present, else a one-line fallback) so each ensign discovers the teammates without the FO adding per-dispatch opt-ins.
-
-## Standing Teammates
-
-A **standing teammate** is a long-lived specialist agent (prose polisher, science officer, code reviewer, language translator) declared by a workflow mod with `standing: true`. The FO discovers each at boot via the runtime adapter, defers spawn to the first team-mode dispatch, routes by name, and lets it die with the team at teardown. The four concepts below are load-bearing for every runtime; each adapter realizes — or omits — the mechanics (discovery, layout, routing call, teardown trigger) in its own way.
-
-- **first-boot-wins** — lifecycle is team-scoped, not workflow-scoped. Spawn deferred to first dispatch; when multiple workflows share a team, the first FO to find the member absent spawns it, later workflows skip. How team scope maps onto session lifetime is the runtime's concern.
-- **team-scope lifecycle** — the teammate lives in one team and dies at team teardown (session end, explicit delete, captain shutdown). No cross-team handoff, no cross-session persistence. Mid-session death is detected on the next routing attempt; auto-recovery is deferred.
-- **routing contract** — address by declared `name`, best-effort and non-blocking: if no reply within the 2-minute timeout, the sender proceeds un-polished/un-reviewed/un-translated. Round-trip latencies of several minutes are normal on long drafts. Routing call is the adapter's (`send_input` on Codex, `SendMessage` on Claude teams).
-- **declaration** — one mod file per teammate, frontmatter `standing: true`, with spawn config and verbatim agent-prompt body. On-disk layout and parse rules are the adapter's.
-
 ## Dispatch
 
 The FO MUST use the runtime adapter's dispatch mechanism. Manual prompt assembly is prohibited except in documented break-glass scenarios.
+
+**Standing-teammate injection.** Before the first team-mode `Agent()` dispatch, inject the workflow's declared standing teammates: run `spacedock dispatch spawn-standing-all --workflow-dir {wd} --team {team_name}` and forward each Agent spec in the returned JSON array to `Agent()` (verbatim, same discipline as `spacedock dispatch build` output). The call is idempotent — already-alive members are omitted, so re-running is safe — and emits `[]` in bare mode or when no standing teammate is declared. Standing teammates are team-scoped: they die with the team at teardown. Read each teammate's routing usage from its mod, not from here.
 
 For each entity reported by `status --next`:
 
@@ -77,7 +38,7 @@ For each entity reported by `status --next`:
 
 A feedback-stage worker checks and reports on what was produced; it does not silently take over the prior stage.
 
-**Routing through a standing prose-polisher.** When composing drafts for captain review (PR bodies, gate-review summaries, long narrative entity-body sections, debrief content), the FO MAY route through a live standing prose-polisher (convention: `comm-officer`). Check team membership first. Best-effort, non-blocking, 2-minute timeout; if absent, proceed un-polished. **Out of scope:** live captain replies, short operational statuses (`pushed`, `tests green`, `PR opened`), tool-call outputs, commit messages, transient logs — polish is a deliberate-draft discipline, not a live-turn reflex. Dispatched workers discover the same teammates through their build-time prompt; the FO does not add per-dispatch routing opt-ins manually.
+**Routing through a standing prose-polisher.** When composing drafts for captain review (PR bodies, gate-review summaries, long narrative entity-body sections, debrief content), the FO MAY route through a live standing prose-polisher (convention: `comm-officer`). Best-effort, non-blocking, 2-minute timeout; if absent, proceed un-polished. Polish round-trips can reach several minutes on long drafts — treat routing as non-blocking regardless of duration. Read the polisher's usage (when to polish vs not, the polish modes) from its mod.
 
 ## Reuse and Fresh Dispatch
 
@@ -126,7 +87,7 @@ Use `worker_key` in worktree paths (`.worktrees/{worker_key}-{slug}`) and branch
 
 Use the Agent tool to spawn each worker. **Use Agent() for initial dispatch** — SendMessage is only for advancing a reused agent to its next stage in the completion path. **NEVER use `subagent_type="first-officer"`** — that clones yourself instead of dispatching a worker.
 
-**Sequencing rule:** Team lifecycle calls (TeamCreate, TeamDelete), `spawn-standing` invocations (which emit Agent specs forwarded into Agent dispatch), and Agent dispatch must NEVER appear in the same tool-call message as TeamCreate/TeamDelete — parallel execution causes races (see the recovery procedure in `Skill(skill="spacedock:using-claude-team")`). Resolve team state in one message, then dispatch (including spawn-standing-driven Agent calls) in a subsequent message. `spawn-standing` requires a real `team_name` from a prior successful `TeamCreate` and MUST NOT precede it.
+**Sequencing rule:** Team lifecycle calls (TeamCreate, TeamDelete), `spawn-standing-all` invocations (which emit Agent specs forwarded into Agent dispatch), and Agent dispatch must NEVER appear in the same tool-call message as TeamCreate/TeamDelete — parallel execution causes races (see the recovery procedure in `Skill(skill="spacedock:using-claude-team")`). Resolve team state in one message, then dispatch (including spawn-standing-all-driven Agent calls) in a subsequent message. `spawn-standing-all` requires a real `team_name` from a prior successful `TeamCreate` and MUST NOT precede it.
 
 **No pre-dispatch filesystem probe.** Do NOT run any filesystem check against `~/.claude/teams/{team_name}/` before `Agent()` in the normal dispatch path. The on-disk check is a guaranteed false positive under registry-desync (anthropics/claude-code#36806 leaves on-disk state intact even when the in-memory team slot is invalidated). Trust the in-memory handle returned by `TeamCreate` and let `Agent()` surface any registry-desync error. On such an error, follow the TeamCreate failure recovery ladder and Degraded Mode semantics in `Skill(skill="spacedock:using-claude-team")` — do NOT reintroduce a pre-dispatch probe.
 

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -96,7 +96,7 @@ Stay at the project root. Do not `cd` into worktrees. Use `git -C {path}` for op
 
 ## Dispatch (deferred module)
 
-The dispatch machinery — the per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly, team creation, standing-teammate discovery/spawn, reuse conditions, the event loop, and the context-budget probe — lives in the runtime's dispatch reference, lazily loaded at the first team-mode dispatch. The runtime adapter names the load point (read alongside `Skill(skill="spacedock:using-claude-team")` at the first `Agent()` that uses a `team_name`). A greet-and-stop boot never reads it.
+The dispatch machinery — the per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly, team creation, standing-teammate injection (`spawn-standing-all`), reuse conditions, the event loop, and the context-budget probe — lives in the runtime's dispatch reference, lazily loaded at the first team-mode dispatch. The runtime adapter names the load point (read alongside `Skill(skill="spacedock:using-claude-team")` at the first `Agent()` that uses a `team_name`). A greet-and-stop boot never reads it.
 
 ## Completion and Gates
 
@@ -189,7 +189,7 @@ Supported lifecycle points:
 
 Hooks are additive and run alphabetically by mod filename. The boot MODS-REPORT reads the `mods` map without opening a mod file (Startup step 5). The mod-block enforcement that guards a terminal transition travels with the deferred merge module, loaded at terminalization.
 
-The standing-teammate concepts (first-boot-wins lifecycle, team-scope teardown, the by-name routing contract, the declaration layout) travel with the deferred dispatch module — they apply only once a team exists at first dispatch.
+Standing-teammate injection is driven by `spacedock dispatch spawn-standing-all` at first dispatch; the concept is team-scoped (members die with the team at teardown).
 
 ## Clarification and Communication
 


### PR DESCRIPTION
Move the standing-teammate injection mechanism OUT of the FO contract and INTO the binary + the mod's self-declaration — same contract-bloat reduction, residency preserved.

## What changed
- Add `dispatch spawn-standing-all`: one call composing the existing `EnumerateDeclaredStandingTeammates` + `MemberExists` (first-boot-wins dedup) + `runSpawnStanding` (shared `buildSpawnSpec`) → JSON array of absent-member Agent specs.
- Shed the four standing-teammate mechanism subsections from `claude-fo-dispatch.md` down to one trigger line; reduce shared-core + runtime-adapter to a single `spawn-standing-all` phrase. The comm-officer mod keeps `standing: true` + agent prompt + the MUST/qualifier guard (residency intact).

## Evidence
- AC-1 Go fixture test (array-emit, dedup→[], empty→[], broken-mod→exit 1). AC-4: `list-standing` still returns comm-officer.
- AC-2 live residency scenario `TestLiveStandingResidencyInjectsCommOfficer` (registered in the live gate): boots a real FO → first dispatch (spawn-standing-all) → asserts comm-officer PRESENT in the team `config.json` roster. **Ran locally on sonnet: PASS (356s) — "comm-officer present in the live team roster".** `go test ./...` green.

---
[](/spacedock-dev/spacedock/blob/7c86ce13341f2323def669e6f06258c67669fe4e/polish-on-demand-drop-standing.md)