### PR TITLE
Extract host-neutral merge + dispatch contract — codex/pi name no merge reference and break at terminalization

### DIFF
--- a/internal/contractlint/boot_resident_closure_test.go
+++ b/internal/contractlint/boot_resident_closure_test.go
@@ -10,16 +10,39 @@ import (
 	"testing"
 )
 
-// bootResidentBodies are the two contract bodies the FO loader inlines/reads at
-// boot: the slimmed shared core and the Claude runtime adapter. AC-4 walks these
-// (NOT a SKILL.md, which the existing TestUserSkillReferenceClosureResolves reads)
-// because the loader reads the bodies directly, and only the bodies name the
-// deferred load-points the boot core defers to (a sibling reference path, a bare
-// skill invocation, a canonical mod file).
+// bootResidentBodies are the contract bodies the FO loader inlines/reads at boot:
+// the slimmed shared core and each host's runtime adapter. AC-4 walks these (NOT a
+// SKILL.md, which the existing TestUserSkillReferenceClosureResolves reads) because
+// the loader reads the bodies directly, and only the bodies name the deferred
+// load-points the boot core defers to (a sibling reference path, a bare skill
+// invocation, a canonical mod file). The codex and pi adapters join the Claude one
+// so the closure walk catches a dead-end merge/dispatch-seam reference on every
+// host, not only Claude.
 var bootResidentBodies = []string{
 	filepath.Join("skills", "first-officer", "references", "first-officer-shared-core.md"),
 	filepath.Join("skills", "first-officer", "references", "claude-first-officer-runtime.md"),
+	filepath.Join("skills", "first-officer", "references", "codex-first-officer-runtime.md"),
+	filepath.Join("skills", "first-officer", "references", "pi-first-officer-runtime.md"),
 }
+
+// hostRuntimeAdapters are the three per-host runtime adapters. Each one must, at its
+// terminal-merge and first-dispatch seams, name a merge reference and a dispatch
+// reference that resolve to a real file — so a codex or pi FO reaching its terminal
+// stage follows a seam pointer to an existing ceremony, not a dead-end the Claude
+// adapter alone avoids today.
+var hostRuntimeAdapters = []string{
+	filepath.Join("skills", "first-officer", "references", "claude-first-officer-runtime.md"),
+	filepath.Join("skills", "first-officer", "references", "codex-first-officer-runtime.md"),
+	filepath.Join("skills", "first-officer", "references", "pi-first-officer-runtime.md"),
+}
+
+// mergeCoreRefRe / dispatchCoreRefRe match a host adapter naming its host-neutral
+// merge / dispatch core reference. The seam may name the shared core directly
+// (fo-merge-core.md / fo-dispatch-core.md) or its own claude-fo-merge.md /
+// claude-fo-dispatch.md residue that in turn names the core; either is a resolving
+// merge/dispatch entry from the adapter's seam.
+var mergeCoreRefRe = regexp.MustCompile(`references/(?:fo-merge-core|claude-fo-merge)\.md`)
+var dispatchCoreRefRe = regexp.MustCompile(`references/(?:fo-dispatch-core|claude-fo-dispatch)\.md`)
 
 // bodyReferenceRe matches a sibling reference read-path named in a contract body
 // (the dispatch/merge references the split defers to), the same path shape the
@@ -153,5 +176,46 @@ func TestBootResidentDeferredLoadPointGuardFailsOnDanglingTarget(t *testing.T) {
 	}
 	if !sawReal {
 		t.Fatal("control: the real load-point (using-claude-team) was not resolved — the discriminator has nothing to contrast the dangling case against")
+	}
+}
+
+// TestEachHostNamesResolvingMergeAndDispatchReference is the AC-1 reference-closure
+// guard: from EACH host's runtime adapter (Claude, codex, pi), the named merge
+// reference and dispatch reference resolve to a real file on disk. The independent
+// source is the reference graph + the filesystem, exactly as
+// TestBootResidentDeferredLoadPointsResolve binds — this is the structural-existence
+// half: not only "is a named reference dangling" but "does each host NAME a merge
+// and a dispatch entry at all." Before the host-neutral cores exist, codex and pi
+// name neither, so this test dead-ends RED for them; after extraction every host's
+// seam names a resolving fo-merge-core / fo-dispatch-core (directly, or via its own
+// claude-fo-* residue). It owns "does the host's named merge/dispatch reference
+// os.Stat clean"; the four-ceremony-anchor content check is AC-2's
+// block-in-core-XOR-adapter, kept off the file/graph side of the quarantine line.
+func TestEachHostNamesResolvingMergeAndDispatchReference(t *testing.T) {
+	root := repoRoot(t)
+	foSkillDir := filepath.Join("skills", "first-officer")
+	for _, adapter := range hostRuntimeAdapters {
+		data, err := os.ReadFile(filepath.Join(root, adapter))
+		if err != nil {
+			t.Fatalf("read host runtime adapter %s: %v", adapter, err)
+		}
+		body := string(data)
+		for _, kind := range []struct {
+			label string
+			re    *regexp.Regexp
+		}{
+			{"merge", mergeCoreRefRe},
+			{"dispatch", dispatchCoreRefRe},
+		} {
+			named := kind.re.FindString(body)
+			if named == "" {
+				t.Errorf("%s names no %s reference — a FO on this host reaching its %s boundary follows the boot core's deferred-module pointer to a host seam that dead-ends", adapter, kind.label, kind.label)
+				continue
+			}
+			resolved := filepath.Join(foSkillDir, named)
+			if _, err := os.Stat(filepath.Join(root, resolved)); err != nil {
+				t.Errorf("%s names %s reference %q which resolves to %s — but no such file exists on disk: %v", adapter, kind.label, named, resolved, err)
+			}
+		}
 	}
 }

--- a/internal/contractlint/fo_core_single_source_test.go
+++ b/internal/contractlint/fo_core_single_source_test.go
@@ -1,0 +1,116 @@
+// ABOUTME: AC-2 single-source — each moved FO ceremony block lives in a host-neutral
+// ABOUTME: core XOR in any runtime adapter, so a copy-paste-into-a-host regression goes RED.
+package contractlint
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// foReferencesDir is the FO references tree both the cores and the host adapters
+// live under.
+func foReferencesDir() string {
+	return filepath.Join("skills", "first-officer", "references")
+}
+
+// hostAdapterFiles are the three runtime adapters plus the two Claude seam residues.
+// AC-2's absence half asserts no MOVED ceremony block is restated in ANY of them —
+// the seam files (claude-fo-merge/dispatch) are adapters too, so a block left behind
+// in a seam during extraction is caught here, not only a copy pasted into codex/pi.
+var hostAdapterFiles = []string{
+	"claude-first-officer-runtime.md",
+	"codex-first-officer-runtime.md",
+	"pi-first-officer-runtime.md",
+	"claude-fo-merge.md",
+	"claude-fo-dispatch.md",
+}
+
+// movedCeremonyBlock is one fingerprint of a ceremony block the extraction moved
+// into a host-neutral core: a distinctive verbatim sentence the block owns, the
+// core it must live in, and a human label. The fingerprint is chosen to be unique
+// to the moved block so its presence in the core and its absence from every adapter
+// is an unambiguous single-source signal.
+type movedCeremonyBlock struct {
+	label       string
+	fingerprint string
+	core        string
+}
+
+// movedCeremonyBlocks covers the merge ceremony blocks (mod-block set→invoke→clear,
+// the Ship-Local trunk step, the worktree-removal ladder, Mod-Block Enforcement) and
+// the dispatch blocks (the dispatch-build-mandatory rule, the reuse conditions, the
+// model-mismatch diagnostic) — the host-neutral text the design re-homed. Each must
+// be present in its named core and absent from every host adapter.
+var movedCeremonyBlocks = []movedCeremonyBlock{
+	{"mod-block set→invoke→clear sequence", "The set→invoke→clear sequence (steps 1, 2, 4) is mandatory whenever a merge hook is registered", "fo-merge-core.md"},
+	{"Ship-Local trunk resolution", "BASE=$(spacedock dispatch trunk --workflow-dir {workflow_dir})", "fo-merge-core.md"},
+	{"worktree-removal safety ladder", "If removal fails on untracked files, the FO MUST:", "fo-merge-core.md"},
+	{"Mod-Block Enforcement empty-state recovery", "In the empty-pr/empty-mod-block state the merge hook has provably not run", "fo-merge-core.md"},
+	{"dispatch-build-mandatory rule", "Do NOT assemble worker prompts manually", "fo-dispatch-core.md"},
+	{"reuse-routing condition", "Reuse-routing matches the entity's worktree state", "fo-dispatch-core.md"},
+	{"model-mismatch diagnostic anchor", "does not match next stage effective_model", "fo-dispatch-core.md"},
+}
+
+// readFORef reads one file in the FO references tree, repo-relative.
+func readFORef(t *testing.T, root, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, foReferencesDir(), name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// TestMovedCeremonyBlocksAreSingleSourced is the AC-2 single-source guard: every
+// moved ceremony block lives in its host-neutral core (present-in-core) AND in NONE
+// of the host adapters (absent-from-every-adapter) — the block lives in the core XOR
+// in any adapter. The independent source is the content-fingerprint over the two
+// cores and the five adapter files: a true single-source extraction passes; a
+// copy-paste-into-a-host regression (a block left in a seam during extraction, or
+// pasted into codex/pi) leaves the fingerprint in an adapter and goes RED. It is NOT
+// a tautological "grep finds the phrase in the core" — the load-bearing assertion is
+// the ABSENCE from every adapter, which a present-here-only grep never checks.
+func TestMovedCeremonyBlocksAreSingleSourced(t *testing.T) {
+	root := repoRoot(t)
+	if len(movedCeremonyBlocks) == 0 {
+		t.Fatal("no moved ceremony blocks declared — the single-source check would pass vacuously")
+	}
+	for _, blk := range movedCeremonyBlocks {
+		core := readFORef(t, root, blk.core)
+		if !strings.Contains(core, blk.fingerprint) {
+			t.Errorf("%s: fingerprint %q absent from its core %s — the block did not land in the core (or the fingerprint drifted)", blk.label, blk.fingerprint, blk.core)
+		}
+		for _, adapter := range hostAdapterFiles {
+			body := readFORef(t, root, adapter)
+			if strings.Contains(body, blk.fingerprint) {
+				t.Errorf("%s: fingerprint %q restated in host adapter %s — the moved ceremony block must live in the core XOR in any adapter; a copy-paste-into-a-host regression must be removed", blk.label, blk.fingerprint, adapter)
+			}
+		}
+	}
+}
+
+// TestMovedCeremonyControlFailsOnRestatedBlock is the AC-2 control: it proves the
+// single-source logic goes RED when a moved fingerprint is restated in an adapter.
+// It drives the same present-in-core + absent-from-adapter check the real guard uses
+// against an in-memory adapter set that includes a planted restatement, so the
+// control exercises the real discriminator rather than re-implementing it.
+func TestMovedCeremonyControlFailsOnRestatedBlock(t *testing.T) {
+	root := repoRoot(t)
+	blk := movedCeremonyBlocks[0]
+	core := readFORef(t, root, blk.core)
+	if !strings.Contains(core, blk.fingerprint) {
+		t.Fatalf("control precondition: fingerprint %q not in core %s", blk.fingerprint, blk.core)
+	}
+	// A planted adapter body that restates the moved block — the copy-paste regression.
+	planted := "## Some host seam\n\n" + blk.fingerprint + "\n"
+	if !strings.Contains(planted, blk.fingerprint) {
+		t.Fatal("control: planted adapter body unexpectedly lacks the restated fingerprint — the discriminator never exercises the absence check")
+	}
+	// And a clean adapter body that does not — the discriminator must distinguish them.
+	clean := "## Some host seam\n\nA host-specific note with no moved ceremony text.\n"
+	if strings.Contains(clean, blk.fingerprint) {
+		t.Fatal("control: clean adapter body unexpectedly contains the fingerprint — the discriminator has nothing to contrast the restatement against")
+	}
+}

--- a/internal/contractlint/structural_checks_test.go
+++ b/internal/contractlint/structural_checks_test.go
@@ -259,6 +259,10 @@ func TestNoUnexpectedModHookOrPRMergeIntroduced(t *testing.T) {
 		// example into the dispatch reference — both legitimately carry `## Hook:`.
 		filepath.Join("skills", "first-officer", "references", "claude-fo-merge.md"):    true,
 		filepath.Join("skills", "first-officer", "references", "claude-fo-dispatch.md"): true,
+		// The host-neutral extraction re-homed Mod-Block Enforcement (which names the
+		// `## Hook: merge` mechanism surface) into the merge core; it legitimately
+		// carries the `## Hook:` token the same way the claude-fo-merge seam did.
+		filepath.Join("skills", "first-officer", "references", "fo-merge-core.md"): true,
 	}
 	allowedPRMergeFiles := map[string]bool{
 		filepath.Join("mods", "pr-merge.md"): true,

--- a/skills/first-officer/references/claude-first-officer-runtime.md
+++ b/skills/first-officer/references/claude-first-officer-runtime.md
@@ -4,13 +4,13 @@ This file defines how the shared first-officer core executes on Claude Code. It 
 
 ## Dispatch reference (load at first dispatch)
 
-The dispatch machinery for this host — Team Creation, the ID/next-id read, standing-teammate injection (`spawn-standing-all`), Worker Resolution, the Dispatch Adapter (`spacedock dispatch build` + break-glass), Degraded Mode seams, the Context-Budget probe, and the Event Loop (incl. the reconcile sweep) — lives in `references/claude-fo-dispatch.md`. Read it at the FIRST team-mode dispatch, alongside the `Skill(skill="spacedock:using-claude-team")` invocation it opens with — not at boot. A boot that greets and stops for input never dispatches, so it never reads this reference and never creates a team.
+The host-neutral dispatch machinery — the per-entity dispatch procedure, Worker Resolution, the Dispatch Adapter (`spacedock dispatch build` + break-glass), standing-teammate injection (`spawn-standing-all`), the reuse contract, and the Event Loop skeleton — lives in `references/fo-dispatch-core.md`. The Claude seam — Team Creation, the ID/next-id read, the `Agent()` spawn call and `SendMessage` advance handle, the registry-desync rule (#36806), Degraded Mode seams, the Context-Budget probe, and the Event-Loop reconcile sweep + Backstop — lives in `references/claude-fo-dispatch.md`. Read both at the FIRST team-mode dispatch, alongside the `Skill(skill="spacedock:using-claude-team")` invocation the seam opens with — not at boot. A boot that greets and stops for input never dispatches, so it never reads either reference and never creates a team.
 
-When filing a new task, read `id_style` from `status --boot --json`, then use `status --next-id` only when the style is `sequential` or `sd-b32` (see the dispatch reference for the full read shape). A boot that only greets does not file a task.
+When filing a new task, read `id_style` from `status --boot --json`, then use `status --next-id` only when the style is `sequential` or `sd-b32` (see the dispatch seam for the full read shape). A boot that only greets does not file a task.
 
 ## Merge reference (load at terminalization)
 
-The terminal merge-and-cleanup machinery for this host — the Merge-and-Cleanup ceremony, the Ship-Local ceremony, worktree-removal safety, Mod-Block Enforcement, and the bounded terminal teardown (the `TERMINAL_TEARDOWN_BOUNDED` marker) — lives in `references/claude-fo-merge.md`. Read it at the terminal boundary, when an entity reaches its terminal stage — the same lazy precedent as `present-gate` / `feedback-rejection-flow`. A boot, dispatch, or gate that never terminalizes never reads it.
+The host-neutral terminal merge-and-cleanup machinery — the Merge-and-Cleanup ceremony (steps 1-9), the Ship-Local ceremony, worktree-removal safety, and Mod-Block Enforcement — lives in `references/fo-merge-core.md`. The Claude seam — the concrete step-10 terminal teardown and the bounded `TERMINAL_TEARDOWN_BOUNDED` marker — lives in `references/claude-fo-merge.md`. Read both at the terminal boundary, when an entity reaches its terminal stage — the same lazy precedent as `present-gate` / `feedback-rejection-flow`. A boot, dispatch, or gate that never terminalizes never reads either.
 
 ## Captain Interaction
 

--- a/skills/first-officer/references/claude-fo-dispatch.md
+++ b/skills/first-officer/references/claude-fo-dispatch.md
@@ -1,6 +1,10 @@
-# First Officer Dispatch Module (Claude)
+# First Officer Dispatch Seam (Claude)
 
-The team-creation, worker-resolution, dispatch-assembly, reuse, standing-teammate, and event-loop machinery. Lazily loaded at the first team-mode dispatch — the boot-resident core names this file at the dispatch load point and reads it only when the captain's direction first triggers a dispatch. A boot that greets and stops for input never reads it.
+The Claude residue of the dispatch boundary: the team-creation sequence, the `Agent()` spawn call and `SendMessage` advance handle the host-neutral core delegates, the registry-desync rule, Degraded Mode seams, the context-budget probe, and the event-loop reconcile sweep + backstop. Lazily loaded at the first team-mode dispatch alongside the host-neutral dispatch core. A boot that greets and stops for input never reads it.
+
+## Dispatch seam
+
+The host-neutral dispatch machinery — the per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly (`spacedock dispatch build` → spawn call), the reuse contract, worktree ownership, and the event-loop skeleton — lives in `references/fo-dispatch-core.md`. Read it at the first team-mode dispatch. This file supplies the Claude specifics the core defers to: the concrete spawn call is `Agent()`, the reuse-advance handle is `SendMessage`, the context-budget probe and the event-loop step-0 reconcile sweep are below.
 
 ## Team Creation
 
@@ -14,122 +18,33 @@ In single-entity mode, skip team creation. Use bare-mode dispatch for all agent 
 
 When filing a new task, read `id_style` from `status --boot --json`, then use `status --next-id` only when the style is `sequential` or `sd-b32`. The startup boot read is an FO-internal read; consume it as JSON: `status --boot --json` returns one object with the keys `command`, `mods`, `id_style`, `next_id`, `min_prefix` (present only for `sd-b32`), `orphans`, `pr_state`, `dispatchable`, `team_state` — every value a string. For `sd-b32`, call `status --next-id --id-seed "{slug-or-title}"` and optionally pass `--id-actor` so the SHA-derived candidate includes creation context. SD-B32 candidates are full stored IDs, not a reservation; call again immediately before writing the entity. For `slug`, derive the slug from the title and leave `id` blank.
 
-## Dispatch
+## Dispatch Adapter (Claude spawn call)
 
-The FO MUST use the runtime adapter's dispatch mechanism. Manual prompt assembly is prohibited except in documented break-glass scenarios.
-
-**Standing-teammate injection.** Before the first team-mode `Agent()` dispatch, inject the workflow's declared standing teammates: run `spacedock dispatch spawn-standing-all --workflow-dir {wd} --team {team_name}` and forward each Agent spec in the returned JSON array to `Agent()` (verbatim, same discipline as `spacedock dispatch build` output). The call is idempotent — already-alive members are omitted, so re-running is safe — and emits `[]` in bare mode or when no standing teammate is declared. Standing teammates are team-scoped: they die with the team at teardown. Read each teammate's routing usage from its mod, not from here.
-
-For each entity reported by `status --next`:
-
-1. Read the entity file and the target stage definition.
-2. Build a numbered checklist (≤3 items) of dispatch-specific linchpin signals from the target stage's `Outputs:` bullets and any entity-level acceptance criteria this stage is the natural place to advance. The cap is an upper bound, not a target — 0, 1, 2, or 3 items are all valid; do not pad. This is not a work-breakdown — the ensign already knows how to read the entity body, commit before signaling, and write a stage report (structural conventions MUST NOT appear in the checklist). Name what separates a good outcome from a ceremonial one. Entity-level acceptance criteria are properties of the finished entity, not stage actions — they live in the entity body's `## Acceptance criteria` section and are cross-checked at every gate (see `## Completion and Gates` in the boot-resident core), independent of this checklist's DONE/SKIPPED/FAILED accounting.
-3. Check for obvious conflicts if multiple worktree stages would touch overlapping files.
-4. Determine `dispatch_agent_id` from the stage `agent:` property. Default to `ensign` when absent.
-5. Update main-branch frontmatter for dispatch:
-   ```
-   spacedock status --workflow-dir {workflow_dir} --set {slug} status={next_stage} worktree=.worktrees/{worker_key}-{slug} started
-   ```
-   Omit `worktree=...` for non-worktree stages. Bare `started` auto-fills a UTC ISO 8601 timestamp (skipped if already set).
-6. Commit the state transition on main: `dispatch: {slug} entering {next_stage}`.
-7. Create the worktree on first dispatch to a worktree stage.
-8. Dispatch a worker via the runtime adapter. The assignment must include: entity identity and title, target stage name, the full stage definition, the entity path, the worktree path and branch when applicable, the checklist, and feedback instructions when the stage has `feedback-to`.
-9. Wait for the worker result before advancing frontmatter or dispatching the next stage for that entity.
-
-A feedback-stage worker checks and reports on what was produced; it does not silently take over the prior stage.
-
-**Routing through a standing prose-polisher.** When composing drafts for captain review (PR bodies, gate-review summaries, long narrative entity-body sections, debrief content), the FO MAY route through a live standing prose-polisher (convention: `comm-officer`). Best-effort, non-blocking, 2-minute timeout; if absent, proceed un-polished. Polish round-trips can reach several minutes on long drafts — treat routing as non-blocking regardless of duration. Read the polisher's usage (when to polish vs not, the polish modes) from its mod.
-
-## Reuse and Fresh Dispatch
-
-These conditions and procedures govern advancing a completed worker. The gate-presentation spine (the checklist review, the AC cross-check, the "not a stopping point" rule, and the gated-stage decisions) is in the boot-resident core's `## Completion and Gates`; the reuse machinery it defers to lives here.
-
-A completed worker is reusable only when it is still addressable through a live runtime handle AND all reuse conditions below pass. Otherwise dispatch fresh.
-
-**Reuse conditions** (all must hold — if any fails, dispatch fresh):
-0. Consult the runtime adapter's context-budget probe. If it reports the worker over budget, or the probe source is unavailable, dispatch fresh (fail-safe — never silent-reuse on an absent reading). If the adapter declares no probe, this condition is satisfied. (Codex declares none; Claude supplies one — see Context Budget below.)
-1. Not in bare mode (teams available).
-2. Next stage does NOT have `fresh: true`.
-3. Reuse-routing matches the entity's worktree state — if `worktree:` is set, route the next stage into the same worktree; if `worktree:` is empty and the next stage declares `worktree: true`, dispatch fresh so the new worktree's first agent is born inside it.
-4. The reused worker's stamped model matches the next stage's declared model — resolve through the runtime's model-for-member lookup and compare against `next_stage.effective_model`. Skip when `next_stage.effective_model` is null (null-declared stages accept any reused worker). Members stamped with captain-session fallback values (e.g., `"opus[1m]"`) never match enum values (`sonnet`, `opus`, `haiku`) and force a one-time fresh dispatch that re-stamps the canonical enum.
-
-When the comparator forces fresh dispatch due to model mismatch, the FO MUST emit a captain-visible diagnostic of the form `reused worker {name} model {X} does not match next stage effective_model {Y} — fresh-dispatching`. The anchor phrase `does not match next stage effective_model` must appear verbatim.
-
-**If reuse:** Keep the agent alive. Update frontmatter on main (`spacedock status --workflow-dir {workflow_dir} --set {slug} status={next_stage}`, commit: `advance: {slug} entering {next_stage}`). Send the next assignment:
-
-SendMessage(to="{agent}-{slug}-{completed_stage}", message="Advancing to next stage: {next_stage_name}\n\n### Stage definition:\n\n[STAGE_DEFINITION — copy the full ### stage subsection from the README verbatim]\n\n### Completion checklist\n\n[CHECKLIST — assemble from step 2]\n\nContinue working on {entity title} at {entity_file_path}. Commit before sending your completion message.")
-
-**If fresh dispatch:** If the next stage's `feedback-to` points at the completed stage, keep that agent alive while addressable and reuse-eligible; otherwise shut it down. Then run `status --next` and dispatch the next stage.
-
-**Supersede-shutdown.** On fresh dispatch from a `-cycleN` increment or a feedback-rework re-entering the prior stage, shut down the prior cohort BEFORE the new dispatch in a SEPARATE message. The prior cohort is every roster member whose handle decomposes to the same `(slug, stage)` pair as the new dispatch. Issue the adapter's cooperative-shutdown call and drop them from session memory. **Mandatory at the boundary; backstops, if any, are the adapter's.**
-
-## Worktree Ownership
-
-- For worktree-backed entities, active stage/status/report/body state — including `### Feedback Cycles` entries — lives in the worktree copy.
-- `pr:` mirrors on `main` for startup/discovery.
-- Ordinary active-state writes (`implementation -> validation`) do not land on `main`.
-
-### Split-Root Worktree Contract
-
-When the workflow is split-root (README declares `state:` checkout, e.g. `state: .spacedock-state`), a worktree stage isolates **the deliverable work product only**. Entities live in a separate, non-branched state checkout that a worktree of the main repo does not contain. The entity body and stage reports are written and committed to that state checkout at the entity's state-checkout path, **never** a worktree copy — the dispatch helper hands workers that path even under a worktree stage. The worktree still owns the deliverable: working directory, branch, and "commits MUST be on this branch" apply to deliverable-artifact changes only. The `pr:`-mirrored-on-`main` exception is unaffected.
-
-## Worker Resolution
-
-The default `dispatch_agent_id` is `spacedock:ensign`. When a stage defines `agent: {name}` in the README, use that value.
-
-Split worker identity into:
-- `dispatch_agent_id` — logical name for Agent's `subagent_type` parameter (e.g., `spacedock:ensign`)
-- `worker_key` — filesystem-safe stem for worktrees and branches. Replace `:` with `-` (`spacedock:ensign` → `spacedock-ensign`). For bare names without a namespace (e.g., `ensign`), `worker_key` equals `dispatch_agent_id`.
-
-Use `worker_key` in worktree paths (`.worktrees/{worker_key}-{slug}`) and branch names (`{worker_key}/{slug}`).
-
-## Dispatch Adapter
-
-Use the Agent tool to spawn each worker. **Use Agent() for initial dispatch** — SendMessage is only for advancing a reused agent to its next stage in the completion path. **NEVER use `subagent_type="first-officer"`** — that clones yourself instead of dispatching a worker.
+Use the Agent tool to spawn each worker — this is the spawn call `fo-dispatch-core.md` `## Dispatch Adapter` defers to. **Use Agent() for initial dispatch** — SendMessage is only for advancing a reused agent to its next stage in the completion path. **NEVER use `subagent_type="first-officer"`** — that clones yourself instead of dispatching a worker.
 
 **Sequencing rule:** Team lifecycle calls (TeamCreate, TeamDelete), `spawn-standing-all` invocations (which emit Agent specs forwarded into Agent dispatch), and Agent dispatch must NEVER appear in the same tool-call message as TeamCreate/TeamDelete — parallel execution causes races (see the recovery procedure in `Skill(skill="spacedock:using-claude-team")`). Resolve team state in one message, then dispatch (including spawn-standing-all-driven Agent calls) in a subsequent message. `spawn-standing-all` requires a real `team_name` from a prior successful `TeamCreate` and MUST NOT precede it.
 
 **No pre-dispatch filesystem probe.** Do NOT run any filesystem check against `~/.claude/teams/{team_name}/` before `Agent()` in the normal dispatch path. The on-disk check is a guaranteed false positive under registry-desync (anthropics/claude-code#36806 leaves on-disk state intact even when the in-memory team slot is invalidated). Trust the in-memory handle returned by `TeamCreate` and let `Agent()` surface any registry-desync error. On such an error, follow the TeamCreate failure recovery ladder and Degraded Mode semantics in `Skill(skill="spacedock:using-claude-team")` — do NOT reintroduce a pre-dispatch probe.
 
-**MANDATORY — Dispatch assembly via `spacedock dispatch build`:**
+On a zero-exit `spacedock dispatch build` (the host-neutral build flow in `fo-dispatch-core.md`), `host` is normally derived from `CLAUDECODE`; pass `--host claude` only for deliberate tests or cross-host tooling. Call `Agent()` with the emitted fields verbatim. Forward `output.model` as the `Agent()` `model=` parameter when present; when null, OMIT the `model=` argument entirely (do NOT pass `model=None` — default-inheritance only applies when the argument is absent):
+```
+Agent(
+    subagent_type=output.subagent_type,
+    name=output.name,                 // omit if bare mode (field absent)
+    team_name=output.team_name,       // omit if bare mode (field absent)
+    description=output.description,   // REQUIRED — Agent tool rejects missing description
+    model=output.model,               // omit when output.model is null
+    prompt=output.prompt              // ~175 chars; ensign Reads dispatch_file_path on first action
+)
+```
 
-Do NOT assemble `Agent()` prompts manually. Do NOT construct the `prompt` string yourself. Do NOT invent `name` values. ALWAYS route initial-dispatch input through `spacedock dispatch build` and forward its output to `Agent()` verbatim. The key fields that MUST come from helper output are `subagent_type`, `name`, `team_name`, `model`, and `prompt` (which contains the completion signal). Manual assembly is a protocol violation except in the documented break-glass fallback below.
+**Reuse dispatch (SendMessage advancement — the Claude reuse-advance handle):** When advancing a reused ensign per `fo-dispatch-core.md` `## Reuse and Fresh Dispatch` "If reuse", send the next assignment via:
 
-The only permitted path for initial `Agent()` dispatch is:
+SendMessage(to="{agent}-{slug}-{completed_stage}", message="Advancing to next stage: {next_stage_name}\n\n### Stage definition:\n\n[STAGE_DEFINITION — copy the full ### stage subsection from the README verbatim]\n\n### Completion checklist\n\n[CHECKLIST — assemble from Dispatch step 2]\n\nContinue working on {entity title} at {entity_file_path}. Commit before sending your completion message.")
 
-1. **REQUIRED — Write dispatch text inputs to files.** Create a checklist file with one checklist item per non-empty line. If scope notes or feedback context are needed, write each to its own file. Use files for Markdown, backticks, shell variables, reviewer text, and any other prose that would be fragile in shell quoting.
-2. **REQUIRED — Build the dispatch through the helper** (do NOT skip this step). `host` is normally derived from `CLAUDECODE`; pass `--host claude` only for deliberate tests or cross-host tooling:
-   ```
-   spacedock dispatch build \
-     --workflow-dir {workflow_dir} \
-     --entity-path {entity_file_path} \
-     --stage {target_stage_name} \
-     --checklist-file {checklist_file} \
-     [--scope-notes-file {scope_notes_file}] \
-     [--feedback-context-file {feedback_context_file}] \
-     [--team-name {team_name} | --bare-mode] \
-     [--feedback-reflow]
-   ```
-   `--bare-mode` must reflect the current dispatch context — read it from live team state, never infer from the stage. Add `--feedback-reflow` only when routing a rejection back to its `feedback-to` target stage.
-3. **JSON compatibility path.** Programmatic callers may still provide the schema-version-2 JSON request object on stdin, and may inspect it with `spacedock dispatch build --print-schema` or validate a file with `spacedock dispatch build --validate-only {request_file}`. For first-officer dispatch, prefer the flag/file form above.
-4. **REQUIRED — On exit 0, parse the stdout JSON and call `Agent()` with the emitted fields verbatim.** The `name`, `description`, `prompt`, and `model` fields MUST come from helper output unchanged. The `description` field is REQUIRED by the Agent tool — do not omit it. The `prompt` is a file-pointer (`Skill(...) ; then Read /tmp/spacedock-dispatch/{name}.md and treat its content as your assignment.`); the ensign Reads the file on first action and treats the body (including the SendMessage completion-signal section) as the inline assignment. Do not strip or rewrite the prompt. Forward `output.model` as the `Agent()` `model=` parameter when present; when null, OMIT the `model=` argument entirely (do NOT pass `model=None` — default-inheritance only applies when the argument is absent):
-   ```
-   Agent(
-       subagent_type=output.subagent_type,
-       name=output.name,                 // omit if bare mode (field absent)
-       team_name=output.team_name,       // omit if bare mode (field absent)
-       description=output.description,   // REQUIRED — Agent tool rejects missing description
-       model=output.model,               // omit when output.model is null
-       prompt=output.prompt              // ~175 chars; ensign Reads dispatch_file_path on first action
-   )
-   ```
-5. **On non-zero exit only** (or if the binary is unavailable): read stderr, report the helper failure to the captain, and fall back to Break-Glass Manual Dispatch below. A zero-exit run is never a break-glass trigger.
+The supersede-shutdown and the reuse-eligibility decision are in the core; this is only the concrete Claude messaging call.
 
-In bare mode, dispatch blocks until the subagent completes — concurrent dispatch is not possible. Dispatch one entity at a time and process completions inline.
-
-**Reuse dispatch (SendMessage advancement):** `spacedock dispatch build` serves only initial `Agent()` dispatch. When advancing a reused ensign via `SendMessage(to="{ensign_name}")`, assemble the advancement message directly — the helper is not involved in the reuse path.
-
-**Break-Glass Manual Dispatch (fallback ONLY when `spacedock dispatch build` exits non-zero or is unavailable):** Do NOT use this template while the helper is working. Report the helper failure to the captain before proceeding. Use this minimal template as a degraded fallback:
+**Break-Glass Manual Dispatch (Claude — fallback ONLY when `spacedock dispatch build` exits non-zero or is unavailable):** Do NOT use this template while the helper is working. Report the helper failure to the captain before proceeding. Use this minimal template as a degraded fallback:
 ```
 Agent(
     subagent_type="{dispatch_agent_id}",
@@ -150,7 +65,7 @@ Degraded Mode itself — triggers, effects, captain report template, cooperative
 
 ## Context Budget and Dead Ensign Handling
 
-This section is the Claude realization of the shared core's reuse-condition-0 budget probe (and the feedback-rejection budget check). On Claude, the probe IS provided — Codex declares none.
+This section is the Claude realization of the core's reuse-condition-0 budget probe (and the feedback-rejection budget check). On Claude, the probe IS provided — Codex declares none.
 
 **Context budget check:** Run `spacedock dispatch context-budget --name {ensign-name}`. Parse the JSON output. If `reuse_ok` is `false`, log to captain and fresh-dispatch with a recovery clause. The probe reads the named member's most recent `~/.claude/.../subagents/agent-*.jsonl` transcript and its team-`config.json` model.
 
@@ -177,11 +92,9 @@ In bare mode, the feedback rejection flow is sequential: dispatch fix agent (wai
 
 In teams mode, the fix agent and reviewer can interact via messaging. Keep the reviewer alive when entering the feedback rejection flow.
 
-## Event Loop
+## Event Loop (Claude reconcile seam)
 
-After each agent completion:
-
-These are FO-internal scheduling reads — parse them as JSON, not the padded human table. Each read below uses `--json` so the FO consumes a compact, byte-stable document (one rule: every value is a string) instead of scraping column padding that a token proxy can mangle. `--fields` narrows the read to the keys the FO needs. The `--json` envelopes are: `status`/`--where` → `{"command":"status","entities":[…]}`; `--next` → `{"command":"next","dispatchable":[{"id","slug","current","next","worktree"},…]}`. The captain-facing state display (shared-core) still forwards the human table verbatim — JSON is for the machine, the table is for the human.
+The host-neutral event-loop skeleton (steps 1-4) is in `fo-dispatch-core.md` `## Event Loop`. On Claude the loop opens with a step 0 the core leaves to this seam:
 
 0. **Reconcile sweep.** Run `spacedock dispatch reconcile --workflow-dir {workflow_dir} --team-name {team_name}` (a) at the first dispatch, AFTER the split-root `pull --rebase` and BEFORE the first `Agent()` dispatch; (b) at idle (step 4); (c) after each merge, immediately after Merge-and-Cleanup step 10. Pass your own `TeamCreate` `{team_name}` — the roster-derived classes (lingering/superseded/un-advanced-pr) require a team identity, so the sweep can only emit them against a roster it can trust. The team identity comes from either the explicit `--team-name {team_name}` or a current-session match (the helper narrows auto-discovery to the config whose `leadSessionId` equals this session). **Bare reconcile with no team identity is git-only**: it suppresses the roster-derived classes (a stale prior-session or parallel-session config must never be mistaken for the live team) and reports only the session-independent git/filesystem classes (stale-branch/local-main-drift), with a one-line stderr note. Stdout: `{"command":"reconcile","team_name":…,"drift":[{"class":"lingering|superseded|un-advanced-pr|stale-branch|local-main-drift",…}]}`. Empty `drift[]` is green. Act per drift class:
    - **lingering** / **superseded** → `SendMessage({"type":"shutdown_request"})` to `name`; drop from session memory.
@@ -190,12 +103,8 @@ These are FO-internal scheduling reads — parse them as JSON, not the padded hu
    - **local-main-drift** → behind only (`drift.behind > 0 && drift.ahead == 0`): `git -C {repo} fetch origin {drift.trunk} && git -C {repo} merge --ff-only origin/{drift.trunk} && cd {repo} && go build -o spacedock ./cmd/spacedock`. Ahead/unpushed or diverged (`drift.ahead > 0`): report-only — surface `drift.reason` to the captain and NEVER `reset --hard`; the captain decides push vs. manual reconcile.
 
    Non-zero helper exit (1 setup / 2 usage) surfaces to the captain; it does not block the loop. On drift, report one line: `reconcile: {N} entries: lingering={N} superseded={N} un-advanced-pr={N} stale-branch={N} local-main-drift={N} — acting`.
-1. **Check PR-pending entities** — Run `status --where "pr !=" --json --fields id,slug,pr`. For each entity in `entities`, check PR state via `gh pr view` and advance merged PRs. When advancing a merged PR, clear its `mod-block` if set: `status --set {slug} mod-block=`.
-2. **Check mod-blocked entities** — Run `status --where "mod-block !=" --json --fields id,slug,mod-block`. For each entity in `entities`, re-read the blocking mod and resume its pending action (e.g., re-present the PR summary). Do not dispatch new work for a mod-blocked entity.
-3. **Run `status --next --json --fields id,slug`** — Dispatch any newly ready entity in `dispatchable` (each row carries the fixed `id,slug,current,next,worktree` plus the named frontmatter keys; `--fields` is additive over the fixed five, since the computed dispatch columns are not projectable).
-4. **If nothing is dispatchable** — Fire `idle` hooks, re-run the step-0 reconcile sweep, then re-run `status --next`. Dispatch anything newly unblocked; otherwise end the iteration.
 
-Repeat from step 1 after each agent completion until the captain ends the session or, in single-entity mode, until the target entity is resolved.
+Step 4's "re-run the host's step-0 reconcile sweep" (`fo-dispatch-core.md`) resolves to this step 0 on Claude.
 
 ### Backstop (Claude)
 

--- a/skills/first-officer/references/claude-fo-merge.md
+++ b/skills/first-officer/references/claude-fo-merge.md
@@ -1,68 +1,15 @@
-# First Officer Merge Module (Claude)
+# First Officer Merge Seam (Claude)
 
-The terminal merge-and-cleanup ceremony, the mod-block enforcement that guards it, and the bounded terminal teardown. Lazily loaded at the terminal boundary — the boot-resident core names this file at the merge load point and reads it only when an entity reaches its terminal stage. A boot, dispatch, or gate that never terminalizes never reads it.
+The Claude residue of the terminal merge boundary: the concrete terminal-teardown ceremony that realizes the host-neutral core's step-10 obligation. Lazily loaded at the terminal boundary alongside the host-neutral merge core. A boot, dispatch, or gate that never terminalizes never reads it.
 
-## Merge and Cleanup
+## Merge seam
 
-When an entity reaches its terminal stage:
+The host-neutral merge-and-cleanup ceremony — the set→invoke→clear mod-block sequence, the Ship-Local ceremony, worktree-removal safety, and Mod-Block Enforcement (`## Merge and Cleanup` steps 1-9, `### Ship-Local Ceremony`, `### Worktree removal safety`, `## Mod-Block Enforcement`) — lives in `references/fo-merge-core.md`. Read it at the terminal boundary. This file supplies only the Claude half of step 10: the concrete agent teardown the core defers to.
 
-1. If merge hooks are registered, set the mod-block before invoking:
-   `spacedock status --workflow-dir {workflow_dir} --set {slug} mod-block=merge:{mod_name}`
-   Commit: `mod-block: {slug} awaiting merge:{mod_name}`.
-   The mechanism enforces this — `status --set` and `status --archive` refuse terminal updates while merge hooks exist with both `pr` and `mod-block` empty, unless `--force`, `merge: local`, or `verdict=rejected` exempts (a rejected entity never ran the merge ceremony). Setting `mod-block` also lets session resume identify which mod is blocking.
-2. Run merge hooks before local merge, archival, or status advancement.
-3. Detect hook completion via the state delta. A hook blocks if (a) `pr` is now set, (b) its prose requires captain approval and the captain has not responded, or (c) it declares an external wait. Otherwise it completed.
-4. If blocked, leave `mod-block` set, report the pending state, and do not local-merge.
-5. If completed without blocking, clear the mod-block in its own `--set` call:
-   `spacedock status --workflow-dir {workflow_dir} --set {slug} mod-block=`
-   Commit: `mod-block: {slug} cleared ({mod_name} completed)`.
-   The clear MUST be standalone — `status --set` exits 1 if `mod-block=` is combined with `status={terminal}`, `completed`, `verdict`, or `worktree=` in one call. Use two commits, or `--force` with captain approval only.
-6. If no merge hook handled the merge, perform the default local merge from the stage worktree branch.
-7. Update frontmatter: `spacedock status --workflow-dir {workflow_dir} --set {slug} completed verdict={verdict} worktree=`.
-8. Archive: `spacedock status --workflow-dir {workflow_dir} --archive {slug}`.
-9. Remove the worktree (`git worktree remove {path}`) and delete the local branch (`git branch -d {branch}`). Do NOT delete the remote branch while a PR is pending — the reviewer needs it. Remote cleanup belongs to the PR merge.
+## Terminal Teardown (Claude — Merge-and-Cleanup step 10)
+
+This realizes Merge-and-Cleanup step 10 (`fo-merge-core.md`) on Claude. Derive the entity's agent cohort from the live `TeamCreate` roster; the bounded `TeamDelete` teardown and the `TERMINAL_TEARDOWN_BOUNDED` marker are the Claude specifics the core leaves to this seam.
+
 10. **Teardown agents at terminal.** Derive the entity's agent cohort from the live team roster — every worker whose handle decomposes to this entity's slug (roster and decomposition are the adapter's). Issue the cooperative-shutdown call (best-effort, fire-and-forget) and drop them from session memory. Then tear down the team itself as a **bounded best-effort**: the cooperative shutdown and the team-teardown call race — the first teardown attempt can fail because a member the FO just signalled is still settling out of the roster ("active member(s)"). Do NOT end the turn on that first failure. Between attempts the FO MUST let the roster settle — re-issue the cooperative shutdown to any still-named active member, then **wait a short settle interval before the next teardown attempt** rather than re-firing in the same instant (an instant retry re-loses the same async registry race — a teardown that "retried but raced every time, then stopped" still hangs). Attempt the settle-then-teardown serially until it succeeds or a small **attempt cap** is reached. In an interactive session the roster clears as the member's session-end propagates, so teardown succeeds on an early attempt and the loop exits naturally. In a non-interactive session (single-entity `-p` mode), an approved-shutdown member can stay listed in the roster indefinitely (an upstream defect), so teardown can never succeed — "retry to success" is unreachable and a fast retry loop only re-hangs the subprocess. On **cap-exhaustion the FO STOPS teardown attempts and emits a defined terminal-status marker — `TERMINAL_TEARDOWN_BOUNDED: best-effort teardown exhausted; member(s) stuck in registry; holding for launcher.` (verbatim).** The PROCESS EXIT is the **launcher's** responsibility: the FO cannot self-exit while the roster is non-empty, so a non-interactive launcher (the live-e2e cycle's `kill()`, or a real automation's timeout) ends the subprocess once the marker has been emitted. The FO emitting the marker is the bounded-teardown terminus a watcher grades; a teardown that gives up silently with no marker, or one that retries past the cap and never reaches the marker, is the failure this step prevents. On a subsequent harness re-invocation with the roster still non-empty, the FO again runs the bounded best-effort and re-emits the marker — acceptable (the launcher ends the subprocess). What this step forbids is an UNBOUNDED retry loop that never reaches the marker. **Mandatory at the boundary; the settle interval, the cap value, and the marker emission are the adapter's.**
 
-### Ship-Local Ceremony
-
-When the merge boundary has no PR host (README declares `merge: local`, or pr-merge fallback applies — no `gh`, push failed, captain chose local), the FO runs one fixed ceremony per entity. The README's top-level `merge:` key (default `pr`) selects this ceremony or the PR path. The happy path uses no `--force`:
-
-1. Set the merge mod-block: `spacedock status --workflow-dir {workflow_dir} --set {slug} mod-block=merge:{mod_name}` (commit path-scoped).
-2. Resolve the integration trunk `BASE=$(spacedock dispatch trunk --workflow-dir {workflow_dir})` (configured trunk, default `main`), then invoke the merge hook (local `--no-ff` merge of `{branch}` onto `{BASE}`).
-3. Record the merge so the terminal guard is satisfied without `--force`:
-   - If `merge: local`, the policy exempts the pr-requirement — skip to step 4.
-   - Otherwise set the post-merge sentinel `spacedock status --workflow-dir {workflow_dir} --set {slug} pr=local-merge:{short-sha}` (the merge commit on `{BASE}`; set only after merge has landed; commit path-scoped). The status table renders as `{short-sha} (local)`.
-4. Clear the mod-block in a standalone `--set`: `spacedock status --workflow-dir {workflow_dir} --set {slug} mod-block=` (commit path-scoped). MUST be separate from terminalization — the guard refuses combining `mod-block=` with terminal fields.
-5. Terminalize: `spacedock status --workflow-dir {workflow_dir} --set {slug} completed verdict={verdict} worktree=`.
-6. Archive: `spacedock status --workflow-dir {workflow_dir} --archive {slug}`.
-7. Remove worktree, delete local branch (Merge-and-Cleanup step 9), and run the terminal agent teardown (step 10). Teardown is mandatory at the terminal boundary whether the merge ran locally or via a PR host.
-
-The set→invoke→clear sequence (steps 1, 2, 4) is mandatory whenever a merge hook is registered, regardless of `merge: local`. `--force` is never part of the happy path — if the guard refuses, a step was skipped, not a flag forgotten.
-
-### Worktree removal safety
-
-Use `git worktree remove {path}` (no `--force`). The default refuses to delete a worktree with untracked changes — that refusal is the safety net.
-
-If removal fails on untracked files, the FO MUST:
-
-1. Audit: `git -C {path} status --short` from the parent worktree.
-2. Decide per file: commit to the worktree branch (audit-essential per gitignore), move to a persistent location (experiment-output outside the worktree), or explicitly confirm destruction with the captain.
-3. ONLY after the audit, `--force` is permitted.
-
-`--force` is never default; it is an explicit captain-confirmed bypass.
-
-## Mod-Block Enforcement
-
-Merge hooks can block (captain approval before pushing, waiting for PR merge). The FO enforces through the entity `mod-block` field and a mechanism-level invariant in `status --set` / `status --archive`:
-
-- **Set** by the FO before invoking a merge hook: `mod-block=merge:{mod_name}`.
-- **Cleared** after the blocking action completes or the captain force-overrides. The clear runs in its own `--set` — combining `mod-block=` with terminal fields (`status={terminal}`, `completed`, `verdict`, `worktree=`) is refused without `--force`.
-- **Guarded** — `status --set` refuses terminal transitions while `mod-block` is non-empty unless `--force` is passed.
-- **Enforced at the mechanism level** — `status --set` and `status --archive` also refuse terminal transitions and archival when merge hooks (`_mods/*.md` with `## Hook: merge`) are registered AND `pr` is empty AND `mod-block` is empty. `--force` bypasses. `merge: local` exempts only the pr-requirement; `verdict=rejected` likewise exempts only the pr-requirement on both surfaces (a rejected entity never ran the merge ceremony, so the requirement is vacuous); the mod-block-pending and combined-clear refusals remain. See the Ship-Local Ceremony.
-- **Survives session resume** — the FO reads `mod-block` from frontmatter on boot and resumes the pending action.
-
-In the empty-pr/empty-mod-block state the merge hook has provably not run. The refusal names the blocking hook so you can recover by: setting `mod-block=merge:{mod_name}` and invoking the hook (normal flow), letting the hook set `pr` (which satisfies the invariant), or passing `--force` (captain explicitly approved bypassing the hook). Do NOT pass `--force` merely to clear the guard — it exists to catch exactly the mistake of skipping the hook.
-
-On session resume, scan entities with non-empty `mod-block` and resume the pending action. Do not re-run the hook from scratch — check what it left (PR created? branch pushed?) and continue from there.
-
-If the blocking mod file (`{workflow_dir}/_mods/{mod_name}.md`) is missing or unreadable, report to the captain: "Blocking mod {mod_name} is missing. The entity is stuck. Options: restore the mod file, or use `--force` to clear the block and resume normal flow." Wait for direction.
+The full `TeamDelete`-race / settle / attempt-cap machinery this step narrates lives in `Skill(skill="spacedock:using-claude-team")` `## Terminal Team Teardown`.

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -2,6 +2,20 @@
 
 This file defines how the shared first-officer core executes on Codex.
 
+## Dispatch seam
+
+The host-neutral dispatch machinery — the per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly (`spacedock dispatch build` → spawn call), the reuse contract, worktree ownership, and the event-loop skeleton — lives in `references/fo-dispatch-core.md`. Read it at the first dispatch. This file supplies the Codex specifics the core defers to: the spawn call is `spawn_agent`, the reuse-advance handle is `send_input`, the completion signal is the mailbox final-status notification, and Codex declares no context-budget probe (reuse-condition-0 is satisfied as unavailable → prefer fresh).
+
+## Merge seam
+
+The host-neutral merge-and-cleanup ceremony — the set→invoke→clear mod-block sequence, the Ship-Local ceremony, worktree-removal safety, and Mod-Block Enforcement — lives in `references/fo-merge-core.md`. Read it at the terminal boundary. This file supplies the Codex half of Merge-and-Cleanup step 10 below.
+
+### Terminal Teardown (Codex — Merge-and-Cleanup step 10)
+
+This realizes Merge-and-Cleanup step 10 (`fo-merge-core.md`) on Codex. Codex has no team registry and no `TeamDelete`, so there is no bounded team-teardown loop, settle interval, attempt cap, or terminal-status marker — those are Claude specifics, absent here. The obligation is still mandatory at the terminal boundary:
+
+10. **Teardown agents at terminal.** Derive the entity's worker cohort — every Codex worker whose task name decomposes to this entity's slug. Issue the cooperative-shutdown call over the mailbox surface (best-effort, fire-and-forget) and drop them from session memory. There is no team object to delete and no roster to settle, so teardown is a single cooperative-shutdown pass, not a retry loop. Teardown is mandatory whether the merge ran locally or via a PR host. Residual risk: per `## Backstop (Codex)`, there is no reconcile sweep, so a skipped teardown stays missed until session end — the boundary step is the only enforcement, so do not skip it.
+
 ## Team Creation
 
 Codex does not expose Claude Code's `TeamCreate` registry. Do not create or
@@ -14,23 +28,12 @@ unless the current task explicitly depends on the previous worker's context.
 
 ## Dispatch
 
-Use `spawn_agent` for initial worker dispatch. Assemble the dispatch input with
-`spacedock dispatch build`; Codex host is normally derived from
-`CODEX_THREAD_ID`, so pass `--host codex` only for deliberate tests or cross-host
-tooling. Write checklist, scope notes, and feedback context into files, then use
-the flag/file form:
-
-```
-spacedock dispatch build \
-  --workflow-dir {workflow_dir} \
-  --entity-path {entity_file_path} \
-  --stage {target_stage_name} \
-  --checklist-file {checklist_file} \
-  [--scope-notes-file {scope_notes_file}] \
-  [--feedback-context-file {feedback_context_file}] \
-  [--bare-mode] \
-  [--feedback-reflow]
-```
+The spawn call `fo-dispatch-core.md` `## Dispatch Adapter` defers to is `spawn_agent`
+for initial worker dispatch. Assemble the dispatch input through the core's
+mandatory `spacedock dispatch build` flow (write checklist, scope notes, and
+feedback context into files, then the flag/file form); Codex host is normally
+derived from `CODEX_THREAD_ID`, so pass `--host codex` only for deliberate tests or
+cross-host tooling.
 
 Forward the emitted prompt exactly as returned; for Codex it is a
 read-dispatch-file prompt. The FO must never forward a prompt containing `Skill(skill="spacedock:ensign")` to a Codex worker.

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -91,7 +91,7 @@ Stay at the project root. Do not `cd` into worktrees. Use `git -C {path}` for op
 
 ## Dispatch (deferred module)
 
-The dispatch machinery — the per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly, team creation, standing-teammate injection (`spawn-standing-all`), reuse conditions, the event loop, and the context-budget probe — lives in the runtime's dispatch reference, lazily loaded at the first team-mode dispatch. The runtime adapter names the load point (read alongside `Skill(skill="spacedock:using-claude-team")` at the first `Agent()` that uses a `team_name`). A greet-and-stop boot never reads it.
+The host-neutral dispatch machinery — the per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly, standing-teammate injection (`spawn-standing-all`), reuse conditions, and the event-loop skeleton — lives in `references/fo-dispatch-core.md`, lazily loaded at the first team-mode dispatch. The runtime adapter names its dispatch seam (team/worker creation, the spawn call, the reuse-advance handle, the context-budget probe, and the event-loop reconcile sweep) and is read alongside the core at the first dispatch. A greet-and-stop boot never reads either.
 
 ## Completion and Gates
 
@@ -122,7 +122,7 @@ If the stage is gated:
 
 ## Merge and Cleanup (deferred module)
 
-The terminal merge-and-cleanup ceremony — the set→invoke→clear mod-block sequence, the Ship-Local ceremony, worktree-removal safety, the mod-block enforcement, and the bounded terminal teardown (the `TERMINAL_TEARDOWN_BOUNDED` marker) — lives in the runtime's merge reference, lazily loaded at the terminal boundary. The FO reaches it the same way it reaches `present-gate` / `feedback-rejection-flow`: by naming the load point when an entity reaches its terminal stage. The runtime adapter names the merge reference. A boot, dispatch, or gate that never terminalizes never reads it.
+The host-neutral terminal merge-and-cleanup ceremony — the set→invoke→clear mod-block sequence, the Ship-Local ceremony, worktree-removal safety, and the mod-block enforcement — lives in `references/fo-merge-core.md`, lazily loaded at the terminal boundary. The FO reaches it the same way it reaches `present-gate` / `feedback-rejection-flow`: by naming the load point when an entity reaches its terminal stage. The runtime adapter names its merge seam, which supplies the host's concrete terminal teardown (step 10 — on Claude the bounded `TERMINAL_TEARDOWN_BOUNDED` teardown), read alongside the core. A boot, dispatch, or gate that never terminalizes never reads either.
 
 ## State Management
 

--- a/skills/first-officer/references/fo-dispatch-core.md
+++ b/skills/first-officer/references/fo-dispatch-core.md
@@ -1,0 +1,119 @@
+# First Officer Dispatch Core (host-neutral)
+
+The per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly, the reuse contract, worktree ownership, and the event-loop skeleton. Lazily loaded at the first team-mode dispatch — the boot-resident core names this file at the dispatch load point and reads it only when the captain's direction first triggers a dispatch. A boot that greets and stops for input never reads it. The host's runtime adapter names this core at its dispatch seam and supplies the host residue it delegates: the team/worker-creation sequence, the spawn call, the reuse-advance handle, the context-budget probe, and the event-loop reconcile/backstop.
+
+## Dispatch
+
+The FO MUST use the runtime adapter's dispatch mechanism. Manual prompt assembly is prohibited except in documented break-glass scenarios.
+
+**Standing-teammate injection.** Before the first team-mode dispatch, inject the workflow's declared standing teammates: run `spacedock dispatch spawn-standing-all --workflow-dir {wd} --team {team_name}` and forward each spawn spec in the returned JSON array to the runtime adapter's spawn call (verbatim, same discipline as `spacedock dispatch build` output). The call is idempotent — already-alive members are omitted, so re-running is safe — and emits `[]` in bare mode or when no standing teammate is declared. Standing teammates are team-scoped: they die with the team at teardown. Read each teammate's routing usage from its mod, not from here.
+
+For each entity reported by `status --next`:
+
+1. Read the entity file and the target stage definition.
+2. Build a numbered checklist (≤3 items) of dispatch-specific linchpin signals from the target stage's `Outputs:` bullets and any entity-level acceptance criteria this stage is the natural place to advance. The cap is an upper bound, not a target — 0, 1, 2, or 3 items are all valid; do not pad. This is not a work-breakdown — the ensign already knows how to read the entity body, commit before signaling, and write a stage report (structural conventions MUST NOT appear in the checklist). Name what separates a good outcome from a ceremonial one. Entity-level acceptance criteria are properties of the finished entity, not stage actions — they live in the entity body's `## Acceptance criteria` section and are cross-checked at every gate (see `## Completion and Gates` in the boot-resident core), independent of this checklist's DONE/SKIPPED/FAILED accounting.
+3. Check for obvious conflicts if multiple worktree stages would touch overlapping files.
+4. Determine `dispatch_agent_id` from the stage `agent:` property. Default to `ensign` when absent.
+5. Update main-branch frontmatter for dispatch:
+   ```
+   spacedock status --workflow-dir {workflow_dir} --set {slug} status={next_stage} worktree=.worktrees/{worker_key}-{slug} started
+   ```
+   Omit `worktree=...` for non-worktree stages. Bare `started` auto-fills a UTC ISO 8601 timestamp (skipped if already set).
+6. Commit the state transition on main: `dispatch: {slug} entering {next_stage}`.
+7. Create the worktree on first dispatch to a worktree stage.
+8. Dispatch a worker via the runtime adapter. The assignment must include: entity identity and title, target stage name, the full stage definition, the entity path, the worktree path and branch when applicable, the checklist, and feedback instructions when the stage has `feedback-to`.
+9. Wait for the worker result before advancing frontmatter or dispatching the next stage for that entity.
+
+A feedback-stage worker checks and reports on what was produced; it does not silently take over the prior stage.
+
+**Routing through a standing prose-polisher.** When composing drafts for captain review (PR bodies, gate-review summaries, long narrative entity-body sections, debrief content), the FO MAY route through a live standing prose-polisher (convention: `comm-officer`). Best-effort, non-blocking, 2-minute timeout; if absent, proceed un-polished. Polish round-trips can reach several minutes on long drafts — treat routing as non-blocking regardless of duration. Read the polisher's usage (when to polish vs not, the polish modes) from its mod.
+
+## Reuse and Fresh Dispatch
+
+These conditions and procedures govern advancing a completed worker. The gate-presentation spine (the checklist review, the AC cross-check, the "not a stopping point" rule, and the gated-stage decisions) is in the boot-resident core's `## Completion and Gates`; the reuse machinery it defers to lives here.
+
+A completed worker is reusable only when it is still addressable through a live runtime handle AND all reuse conditions below pass. Otherwise dispatch fresh.
+
+**Reuse conditions** (all must hold — if any fails, dispatch fresh):
+0. Consult the runtime adapter's context-budget probe. If it reports the worker over budget, or the probe source is unavailable, dispatch fresh (fail-safe — never silent-reuse on an absent reading). If the adapter declares no probe, this condition is satisfied. (Codex declares none; Claude supplies one — see the adapter's context-budget seam.)
+1. Not in bare mode (teams available).
+2. Next stage does NOT have `fresh: true`.
+3. Reuse-routing matches the entity's worktree state — if `worktree:` is set, route the next stage into the same worktree; if `worktree:` is empty and the next stage declares `worktree: true`, dispatch fresh so the new worktree's first agent is born inside it.
+4. The reused worker's stamped model matches the next stage's declared model — resolve through the runtime's model-for-member lookup and compare against `next_stage.effective_model`. Skip when `next_stage.effective_model` is null (null-declared stages accept any reused worker). Members stamped with captain-session fallback values (e.g., `"opus[1m]"`) never match enum values (`sonnet`, `opus`, `haiku`) and force a one-time fresh dispatch that re-stamps the canonical enum.
+
+When the comparator forces fresh dispatch due to model mismatch, the FO MUST emit a captain-visible diagnostic of the form `reused worker {name} model {X} does not match next stage effective_model {Y} — fresh-dispatching`. The anchor phrase `does not match next stage effective_model` must appear verbatim.
+
+**If reuse:** Keep the agent alive. Update frontmatter on main (`spacedock status --workflow-dir {workflow_dir} --set {slug} status={next_stage}`, commit: `advance: {slug} entering {next_stage}`). Send the next assignment through the runtime adapter's reuse-advance handle (the live-worker messaging call named in the dispatch seam) — the message carries: the next stage name, the full `### Stage definition` subsection copied from the README verbatim, the `### Completion checklist` assembled from Dispatch step 2, and an instruction to continue working on the entity at its path and commit before signaling completion. The reuse path does NOT route through `spacedock dispatch build` — assemble the advancement message directly.
+
+**If fresh dispatch:** If the next stage's `feedback-to` points at the completed stage, keep that agent alive while addressable and reuse-eligible; otherwise shut it down. Then run `status --next` and dispatch the next stage.
+
+**Supersede-shutdown.** On fresh dispatch from a `-cycleN` increment or a feedback-rework re-entering the prior stage, shut down the prior cohort BEFORE the new dispatch in a SEPARATE message. The prior cohort is every roster member whose handle decomposes to the same `(slug, stage)` pair as the new dispatch. Issue the adapter's cooperative-shutdown call and drop them from session memory. **Mandatory at the boundary; backstops, if any, are the adapter's.**
+
+## Worktree Ownership
+
+- For worktree-backed entities, active stage/status/report/body state — including `### Feedback Cycles` entries — lives in the worktree copy.
+- `pr:` mirrors on `main` for startup/discovery.
+- Ordinary active-state writes (`implementation -> validation`) do not land on `main`.
+
+### Split-Root Worktree Contract
+
+When the workflow is split-root (README declares `state:` checkout, e.g. `state: .spacedock-state`), a worktree stage isolates **the deliverable work product only**. Entities live in a separate, non-branched state checkout that a worktree of the main repo does not contain. The entity body and stage reports are written and committed to that state checkout at the entity's state-checkout path, **never** a worktree copy — the dispatch helper hands workers that path even under a worktree stage. The worktree still owns the deliverable: working directory, branch, and "commits MUST be on this branch" apply to deliverable-artifact changes only. The `pr:`-mirrored-on-`main` exception is unaffected.
+
+## Worker Resolution
+
+The default `dispatch_agent_id` is `spacedock:ensign`. When a stage defines `agent: {name}` in the README, use that value.
+
+Split worker identity into:
+- `dispatch_agent_id` — logical name for the spawn call's agent-type parameter (e.g., `spacedock:ensign`)
+- `worker_key` — filesystem-safe stem for worktrees and branches. Replace `:` with `-` (`spacedock:ensign` → `spacedock-ensign`). For bare names without a namespace (e.g., `ensign`), `worker_key` equals `dispatch_agent_id`.
+
+Use `worker_key` in worktree paths (`.worktrees/{worker_key}-{slug}`) and branch names (`{worker_key}/{slug}`).
+
+## Dispatch Adapter
+
+Use the runtime adapter's spawn call to spawn each worker. **Use the spawn call for initial dispatch** — the reuse-advance handle is only for advancing a reused agent to its next stage in the completion path.
+
+**MANDATORY — Dispatch assembly via `spacedock dispatch build`:**
+
+Do NOT assemble worker prompts manually. Do NOT construct the `prompt` string yourself. Do NOT invent `name` values. ALWAYS route initial-dispatch input through `spacedock dispatch build` and forward its output to the spawn call verbatim. The key fields that MUST come from helper output are `subagent_type`, `name`, `team_name`, `model`, and `prompt` (which contains the completion signal). Manual assembly is a protocol violation except in the documented break-glass fallback below.
+
+The only permitted path for initial dispatch is:
+
+1. **REQUIRED — Write dispatch text inputs to files.** Create a checklist file with one checklist item per non-empty line. If scope notes or feedback context are needed, write each to its own file. Use files for Markdown, backticks, shell variables, reviewer text, and any other prose that would be fragile in shell quoting.
+2. **REQUIRED — Build the dispatch through the helper** (do NOT skip this step). `host` is normally derived from the runtime environment; pass `--host {host}` only for deliberate tests or cross-host tooling:
+   ```
+   spacedock dispatch build \
+     --workflow-dir {workflow_dir} \
+     --entity-path {entity_file_path} \
+     --stage {target_stage_name} \
+     --checklist-file {checklist_file} \
+     [--scope-notes-file {scope_notes_file}] \
+     [--feedback-context-file {feedback_context_file}] \
+     [--team-name {team_name} | --bare-mode] \
+     [--feedback-reflow]
+   ```
+   `--bare-mode` must reflect the current dispatch context — read it from live team state, never infer from the stage. Add `--feedback-reflow` only when routing a rejection back to its `feedback-to` target stage.
+3. **JSON compatibility path.** Programmatic callers may still provide the schema-version-2 JSON request object on stdin, and may inspect it with `spacedock dispatch build --print-schema` or validate a file with `spacedock dispatch build --validate-only {request_file}`. For first-officer dispatch, prefer the flag/file form above.
+4. **REQUIRED — On exit 0, parse the stdout JSON and call the spawn call with the emitted fields verbatim.** The `name`, `description`, `prompt`, and `model` fields MUST come from helper output unchanged. The `description` field is REQUIRED — do not omit it. The `prompt` is a file-pointer (`Skill(...) ; then Read /tmp/spacedock-dispatch/{name}.md and treat its content as your assignment.`); the ensign Reads the file on first action and treats the body (including the completion-signal section) as the inline assignment. Do not strip or rewrite the prompt. Forward `output.model` as the spawn call's model parameter when present; when null, OMIT the model argument entirely (do NOT pass a null model — default-inheritance only applies when the argument is absent). The runtime adapter's dispatch seam names the concrete spawn call and how it maps these fields.
+5. **On non-zero exit only** (or if the binary is unavailable): read stderr, report the helper failure to the captain, and fall back to Break-Glass Manual Dispatch below. A zero-exit run is never a break-glass trigger.
+
+In bare mode, dispatch blocks until the subagent completes — concurrent dispatch is not possible. Dispatch one entity at a time and process completions inline.
+
+**Reuse dispatch (advance handle):** `spacedock dispatch build` serves only initial dispatch. When advancing a reused ensign via the runtime adapter's reuse-advance handle, assemble the advancement message directly — the helper is not involved in the reuse path.
+
+**Break-Glass Manual Dispatch (fallback ONLY when `spacedock dispatch build` exits non-zero or is unavailable):** Do NOT use this template while the helper is working. Report the helper failure to the captain before proceeding. The runtime adapter's dispatch seam supplies the host-shaped minimal template — it inlines the stage definition verbatim rather than referencing a `spacedock dispatch show-stage-def` fetch command (the helper is precisely what just failed, so the ensign cannot rely on it), and omits worktree instructions, feedback context, scope notes, the standing-teammates routing block, the FO-forwarding warning prose, and the per-stage operational prose the production helper emits. The `model` slot is conditional — include it only when the stage (or `stages.defaults`) declares a model from `sonnet | opus | haiku`; otherwise omit the entire model argument. Use only when the helper is unavailable.
+
+## Event Loop
+
+After each agent completion:
+
+These are FO-internal scheduling reads — parse them as JSON, not the padded human table. Each read below uses `--json` so the FO consumes a compact, byte-stable document (one rule: every value is a string) instead of scraping column padding that a token proxy can mangle. `--fields` narrows the read to the keys the FO needs. The `--json` envelopes are: `status`/`--where` → `{"command":"status","entities":[…]}`; `--next` → `{"command":"next","dispatchable":[{"id","slug","current","next","worktree"},…]}`. The captain-facing state display (shared-core) still forwards the human table verbatim — JSON is for the machine, the table is for the human.
+
+The runtime adapter's dispatch seam may insert a host step 0 (a roster-reconcile sweep) before step 1; a host with no roster source omits it. The host-neutral skeleton is:
+
+1. **Check PR-pending entities** — Run `status --where "pr !=" --json --fields id,slug,pr`. For each entity in `entities`, check PR state via `gh pr view` and advance merged PRs. When advancing a merged PR, clear its `mod-block` if set: `status --set {slug} mod-block=`.
+2. **Check mod-blocked entities** — Run `status --where "mod-block !=" --json --fields id,slug,mod-block`. For each entity in `entities`, re-read the blocking mod and resume its pending action (e.g., re-present the PR summary). Do not dispatch new work for a mod-blocked entity.
+3. **Run `status --next --json --fields id,slug`** — Dispatch any newly ready entity in `dispatchable` (each row carries the fixed `id,slug,current,next,worktree` plus the named frontmatter keys; `--fields` is additive over the fixed five, since the computed dispatch columns are not projectable).
+4. **If nothing is dispatchable** — Fire `idle` hooks, re-run the host's step-0 reconcile sweep when the adapter declares one, then re-run `status --next`. Dispatch anything newly unblocked; otherwise end the iteration.
+
+Repeat from step 1 after each agent completion until the captain ends the session or, in single-entity mode, until the target entity is resolved.

--- a/skills/first-officer/references/fo-merge-core.md
+++ b/skills/first-officer/references/fo-merge-core.md
@@ -1,0 +1,68 @@
+# First Officer Merge Core (host-neutral)
+
+The terminal merge-and-cleanup ceremony, the mod-block enforcement that guards it, and the host-neutral half of the terminal teardown. Lazily loaded at the terminal boundary — the boot-resident core names this file at the merge load point and reads it only when an entity reaches its terminal stage. A boot, dispatch, or gate that never terminalizes never reads it. The host's runtime adapter names this core at its merge seam and supplies the concrete terminal-teardown ceremony (step 10's per-host half).
+
+## Merge and Cleanup
+
+When an entity reaches its terminal stage:
+
+1. If merge hooks are registered, set the mod-block before invoking:
+   `spacedock status --workflow-dir {workflow_dir} --set {slug} mod-block=merge:{mod_name}`
+   Commit: `mod-block: {slug} awaiting merge:{mod_name}`.
+   The mechanism enforces this — `status --set` and `status --archive` refuse terminal updates while merge hooks exist with both `pr` and `mod-block` empty, unless `--force`, `merge: local`, or `verdict=rejected` exempts (a rejected entity never ran the merge ceremony). Setting `mod-block` also lets session resume identify which mod is blocking.
+2. Run merge hooks before local merge, archival, or status advancement.
+3. Detect hook completion via the state delta. A hook blocks if (a) `pr` is now set, (b) its prose requires captain approval and the captain has not responded, or (c) it declares an external wait. Otherwise it completed.
+4. If blocked, leave `mod-block` set, report the pending state, and do not local-merge.
+5. If completed without blocking, clear the mod-block in its own `--set` call:
+   `spacedock status --workflow-dir {workflow_dir} --set {slug} mod-block=`
+   Commit: `mod-block: {slug} cleared ({mod_name} completed)`.
+   The clear MUST be standalone — `status --set` exits 1 if `mod-block=` is combined with `status={terminal}`, `completed`, `verdict`, or `worktree=` in one call. Use two commits, or `--force` with captain approval only.
+6. If no merge hook handled the merge, perform the default local merge from the stage worktree branch.
+7. Update frontmatter: `spacedock status --workflow-dir {workflow_dir} --set {slug} completed verdict={verdict} worktree=`.
+8. Archive: `spacedock status --workflow-dir {workflow_dir} --archive {slug}`.
+9. Remove the worktree (`git worktree remove {path}`) and delete the local branch (`git branch -d {branch}`). Do NOT delete the remote branch while a PR is pending — the reviewer needs it. Remote cleanup belongs to the PR merge.
+10. **Teardown agents at terminal.** At the terminal boundary, derive the entity's worker cohort and run the host's terminal-teardown ceremony — cooperative shutdown of the cohort (best-effort, fire-and-forget), drop them from session memory, then the host's bounded team/worker teardown. Teardown is mandatory at the terminal boundary whether the merge ran locally or via a PR host. The cohort-derivation rule, the team/worker-teardown call, the settle interval, the attempt cap, and any terminal-status marker are the host's — the runtime adapter's merge seam supplies them. This core names none of them; it states only the boundary obligation.
+
+### Ship-Local Ceremony
+
+When the merge boundary has no PR host (README declares `merge: local`, or pr-merge fallback applies — no `gh`, push failed, captain chose local), the FO runs one fixed ceremony per entity. The README's top-level `merge:` key (default `pr`) selects this ceremony or the PR path. The happy path uses no `--force`:
+
+1. Set the merge mod-block: `spacedock status --workflow-dir {workflow_dir} --set {slug} mod-block=merge:{mod_name}` (commit path-scoped).
+2. Resolve the integration trunk `BASE=$(spacedock dispatch trunk --workflow-dir {workflow_dir})` (configured trunk, default `main`), then invoke the merge hook (local `--no-ff` merge of `{branch}` onto `{BASE}`).
+3. Record the merge so the terminal guard is satisfied without `--force`:
+   - If `merge: local`, the policy exempts the pr-requirement — skip to step 4.
+   - Otherwise set the post-merge sentinel `spacedock status --workflow-dir {workflow_dir} --set {slug} pr=local-merge:{short-sha}` (the merge commit on `{BASE}`; set only after merge has landed; commit path-scoped). The status table renders as `{short-sha} (local)`.
+4. Clear the mod-block in a standalone `--set`: `spacedock status --workflow-dir {workflow_dir} --set {slug} mod-block=` (commit path-scoped). MUST be separate from terminalization — the guard refuses combining `mod-block=` with terminal fields.
+5. Terminalize: `spacedock status --workflow-dir {workflow_dir} --set {slug} completed verdict={verdict} worktree=`.
+6. Archive: `spacedock status --workflow-dir {workflow_dir} --archive {slug}`.
+7. Remove worktree, delete local branch (Merge-and-Cleanup step 9), and run the terminal agent teardown (step 10). Teardown is mandatory at the terminal boundary whether the merge ran locally or via a PR host.
+
+The set→invoke→clear sequence (steps 1, 2, 4) is mandatory whenever a merge hook is registered, regardless of `merge: local`. `--force` is never part of the happy path — if the guard refuses, a step was skipped, not a flag forgotten.
+
+### Worktree removal safety
+
+Use `git worktree remove {path}` (no `--force`). The default refuses to delete a worktree with untracked changes — that refusal is the safety net.
+
+If removal fails on untracked files, the FO MUST:
+
+1. Audit: `git -C {path} status --short` from the parent worktree.
+2. Decide per file: commit to the worktree branch (audit-essential per gitignore), move to a persistent location (experiment-output outside the worktree), or explicitly confirm destruction with the captain.
+3. ONLY after the audit, `--force` is permitted.
+
+`--force` is never default; it is an explicit captain-confirmed bypass.
+
+## Mod-Block Enforcement
+
+Merge hooks can block (captain approval before pushing, waiting for PR merge). The FO enforces through the entity `mod-block` field and a mechanism-level invariant in `status --set` / `status --archive`:
+
+- **Set** by the FO before invoking a merge hook: `mod-block=merge:{mod_name}`.
+- **Cleared** after the blocking action completes or the captain force-overrides. The clear runs in its own `--set` — combining `mod-block=` with terminal fields (`status={terminal}`, `completed`, `verdict`, `worktree=`) is refused without `--force`.
+- **Guarded** — `status --set` refuses terminal transitions while `mod-block` is non-empty unless `--force` is passed.
+- **Enforced at the mechanism level** — `status --set` and `status --archive` also refuse terminal transitions and archival when merge hooks (`_mods/*.md` with `## Hook: merge`) are registered AND `pr` is empty AND `mod-block` is empty. `--force` bypasses. `merge: local` exempts only the pr-requirement; `verdict=rejected` likewise exempts only the pr-requirement on both surfaces (a rejected entity never ran the merge ceremony, so the requirement is vacuous); the mod-block-pending and combined-clear refusals remain. See the Ship-Local Ceremony.
+- **Survives session resume** — the FO reads `mod-block` from frontmatter on boot and resumes the pending action.
+
+In the empty-pr/empty-mod-block state the merge hook has provably not run. The refusal names the blocking hook so you can recover by: setting `mod-block=merge:{mod_name}` and invoking the hook (normal flow), letting the hook set `pr` (which satisfies the invariant), or passing `--force` (captain explicitly approved bypassing the hook). Do NOT pass `--force` merely to clear the guard — it exists to catch exactly the mistake of skipping the hook.
+
+On session resume, scan entities with non-empty `mod-block` and resume the pending action. Do not re-run the hook from scratch — check what it left (PR created? branch pushed?) and continue from there.
+
+If the blocking mod file (`{workflow_dir}/_mods/{mod_name}.md`) is missing or unreadable, report to the captain: "Blocking mod {mod_name} is missing. The entity is stuck. Options: restore the mod file, or use `--force` to clear the block and resume normal flow." Wait for direction.

--- a/skills/first-officer/references/pi-first-officer-runtime.md
+++ b/skills/first-officer/references/pi-first-officer-runtime.md
@@ -2,6 +2,14 @@
 
 This file defines how the shared first-officer core executes on Pi.
 
+## Dispatch seam
+
+The host-neutral dispatch machinery — the per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly (`spacedock dispatch build` → spawn call), the reuse contract, worktree ownership, and the event-loop skeleton — lives in `references/fo-dispatch-core.md`. Read it at the first dispatch. This file supplies the Pi specifics the core defers to: the spawn call is `subagent(...)` (default `pi-subagents`) or the `pi-agent-teams` adapter mapping, the completion signal is the subagent result (or the adapter's member notification), reuse defaults to fresh redispatch with the epoch-based stale-reuse guard, and Pi declares no context-budget probe.
+
+## Merge seam
+
+The host-neutral merge-and-cleanup ceremony — the set→invoke→clear mod-block sequence, the Ship-Local ceremony, worktree-removal safety, and Mod-Block Enforcement — lives in `references/fo-merge-core.md`. Read it at the terminal boundary. Merge-and-Cleanup step 10 (the host's terminal teardown) is the entry point for this file's existing `## Shutdown` section: for `pi-subagents` a completed child needs no shutdown (mark closed in FO memory); for `pi-agent-teams` use the adapter's `member_shutdown` / `team_done` mapping. Teardown is mandatory at the terminal boundary whether the merge ran locally or via a PR host.
+
 ## Runtime Shape
 
 Pi is a first-class runtime target, but it does not expose Claude Code team-tool signatures. Do not call or ask workers to call Claude team tools. Pi dispatch uses a Pi-native substrate selected by the launch/test harness:


### PR DESCRIPTION
Give the codex and pi first officers the terminal-merge contract they lacked, by extracting the host-neutral merge/dispatch ceremony into shared cores.

## What changed
- Extract host-neutral `fo-merge-core.md` + `fo-dispatch-core.md`; the boot-resident core names them.
- Reduce `claude-fo-merge.md`/`claude-fo-dispatch.md` to thin Claude seams (host residue only).
- Add codex's terminal-teardown seam and pi's shutdown repoint — codex/pi now resolve the contract.
- Extend `boot_resident_closure_test.go` to walk codex/pi (AC-1); add a single-source fingerprint test (AC-2).

## Evidence
- Structural: contractlint AC-1 (closure, RED-before genuine) + AC-2 (single-source, non-vacuous) + boundary-guard + marker-consistency green; detached audit refuted 3 claim-breaking edits.
- Offline: `go test ./...` (15 pkgs) + `go vet -tags live` green; `TERMINAL_TEARDOWN_BOUNDED` marker byte-identical; 0 MUSTs dropped.

## Review guidance
The `TERMINAL_TEARDOWN_BOUNDED` marker and the Claude-only residue (reconcile, budget probe, #36806) deliberately stay in the Claude seam, not the cores.

---
[2yf](/spacedock-dev/spacedock/blob/7f5c86de118dbfb0f17b9754682191a54b79c140/shared-merge-dispatch-contract.md)
