### PR TITLE
spacedock status read helper — entity/markdown FM + section-heading offsets for surgical reads

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -159,6 +159,10 @@ To list the tasks ready for dispatch (the query the first officer runs each loop
 spacedock status --workflow-dir docs/dev --next
 ```
 
+### Reading sections
+
+**Read one section, not the whole file.** `spacedock status --workflow-dir <wf> --read <entity-ref-or-path> --json` returns the file's frontmatter plus an ordered heading map (`text`, `level`, `offset`, `lines`). Pass a heading's `offset`/`lines` to `Read(path, offset, limit)` to load just that section — e.g. an entity's latest `## Stage Report`, or this README's `## Sprints`, without the rest.
+
 ## Runtime Live CI
 
 The live runtime lanes prove host behavior, not text shape: a static grep over workflow YAML or skill prose never substitutes for launching the real host front door, observing its output, and checking the resulting workflow state. The full reference (shared scenarios, fixtures, assertions, per-host runners, local live execution, and the GitHub setup) lives in [`docs/runtime-live-ci.md`](../runtime-live-ci.md). Add or change a runtime scenario there.

--- a/docs/site/reference/command-reference.md
+++ b/docs/site/reference/command-reference.md
@@ -43,7 +43,7 @@ The first officer runs these against workflow state as it moves entities; you op
 
 | Command | What it does |
 |---------|--------------|
-| `spacedock status` | Read or mutate the state: the entity table, `--next`, `--where`, `--set`, `--validate`, `--boot` |
+| `spacedock status` | Read or mutate the state: the entity table, `--next`, `--where`, `--set`, `--validate`, `--boot`, `--read <ref-or-path>` (a file's frontmatter + heading offset/lines map, for section-scoped reads) |
 | `spacedock new` | Create an entity (`new [--folder] SLUG`) from a body on stdin |
 | `spacedock dispatch` | Build the worker dispatch artifacts (`dispatch build`, `dispatch show-stage-def`) |
 | `spacedock state` | Manage a [split-root workflow](../advanced/split-root-state.md)'s state checkout (`state init` resumes one on a fresh clone, `state new` births one) |

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -535,15 +535,25 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 
 	// 4. Entity-read instruction. Under split root the entity lives in the state
 	// checkout; a non-split worktree stage rewrites the path into the worktree.
+	// The first entity read stays a whole-spec read; the trailing hint redirects
+	// only REPEAT reads of the body (e.g. finding the stage-report append point)
+	// to the section-scoped status --read, where the savings live.
+	readPath := entityPath
 	if worktreePath != "" && !splitRoot {
 		entityRel := pyRelpath(entityPath, gitRoot)
 		worktreeEntityPath = status.PyJoin(worktreePath, entityRel)
+		readPath = worktreeEntityPath
 		parts = append(parts, fmt.Sprintf(
 			"Read the entity file at %s for the full spec. It contains:\n", worktreeEntityPath))
 	} else {
 		parts = append(parts, fmt.Sprintf(
 			"Read the entity file at %s for the current spec.\n", entityPath))
 	}
+	parts = append(parts, fmt.Sprintf(
+		"For later re-reads of the body during work — e.g. to find the append point "+
+			"for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read %s --json` "+
+			"to fetch a section's offset/lines rather than re-reading the whole file.\n",
+		readPath))
 
 	// 6. Feedback context (conditional).
 	if feedbackContext != "" {

--- a/internal/dispatch/testdata/golden/build-abs-worktree.txt
+++ b/internal/dispatch/testdata/golden/build-abs-worktree.txt
@@ -36,6 +36,8 @@ Your git branch is spacedock-ensign/thing. All commits MUST be on this branch. D
 
 Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for the full spec. It contains:
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/.worktrees/spacedock-ensign-thing/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
@@ -36,6 +36,8 @@ Your git branch is spacedock-ensign/thing. All commits MUST be on this branch. D
 
 Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for the full spec. It contains:
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/.worktrees/spacedock-ensign-thing/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Feedback from prior review
 
 REJECTED: do better.

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+bare.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+bare.txt
@@ -31,6 +31,8 @@ Stage: backlog
 
 Read the entity file at <ROOT>/thing.md for the current spec.
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
@@ -32,6 +32,8 @@ Stage: backlog
 
 Read the entity file at <ROOT>/thing.md for the current spec.
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
@@ -36,6 +36,8 @@ Your git branch is spacedock-ensign/thing. All commits MUST be on this branch. D
 
 Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for the full spec. It contains:
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/.worktrees/spacedock-ensign-thing/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
@@ -36,6 +36,8 @@ Your git branch is spacedock-ensign/thing. All commits MUST be on this branch. D
 
 Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing/index.md for the full spec. It contains:
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/.worktrees/spacedock-ensign-thing/thing/index.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
@@ -37,6 +37,8 @@ This workflow is split-root: the entity body and your stage report live in the s
 
 Read the entity file at <ROOT>/state-checkout/thing.md for the current spec.
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/state-checkout/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
@@ -34,6 +34,8 @@ This workflow is split-root: the entity body and your stage report live in the s
 
 Read the entity file at <ROOT>/state-checkout/thing/index.md for the current spec.
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/state-checkout/thing/index.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
@@ -37,6 +37,8 @@ This workflow is split-root: the entity body and your stage report live in the s
 
 Read the entity file at <ROOT>/state-checkout/thing/index.md for the current spec.
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/state-checkout/thing/index.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-html-escape.txt
+++ b/internal/dispatch/testdata/golden/build-html-escape.txt
@@ -36,6 +36,8 @@ Your git branch is spacedock-ensign/thing. All commits MUST be on this branch. D
 
 Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for the full spec. It contains:
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/.worktrees/spacedock-ensign-thing/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Feedback from prior review
 
 compare a < b && c > d in <Tag> & raw &amp; ampersand

--- a/internal/dispatch/testdata/golden/build-mods.txt
+++ b/internal/dispatch/testdata/golden/build-mods.txt
@@ -33,6 +33,8 @@ Stage: backlog
 
 Read the entity file at <ROOT>/thing.md for the current spec.
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-nonascii-title.txt
+++ b/internal/dispatch/testdata/golden/build-nonascii-title.txt
@@ -32,6 +32,8 @@ Stage: backlog
 
 Read the entity file at <ROOT>/thing.md for the current spec.
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-space-path.txt
+++ b/internal/dispatch/testdata/golden/build-space-path.txt
@@ -32,6 +32,8 @@ Stage: backlog
 
 Read the entity file at <ROOT>/work dir/thing.md for the current spec.
 
+For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/work dir/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
+
 ### Completion checklist
 
 - a

--- a/internal/status/json_commands.go
+++ b/internal/status/json_commands.go
@@ -229,3 +229,36 @@ func resolveJSON(workflowDir string, e *entity) *jsonObj {
 func singletonJSON(cmd, key, value string) *jsonObj {
 	return newJSONObj().set("command", cmd).set(key, value)
 }
+
+// readJSON builds the {"command":"read",...} envelope for --read: the realpath'd
+// path, the file's total_lines, the frontmatter as a nested object (keys sorted
+// for byte stability, since ParseFrontmatter returns an unordered map), and the
+// ordered headings array (text/level/offset/lines, every value stringified to
+// hold the all-strings contract).
+func readJSON(path string, sr sectionRead) *jsonObj {
+	fm := newJSONObj()
+	keys := make([]string, 0, len(sr.frontmatter))
+	for k := range sr.frontmatter {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fm.set(k, sr.frontmatter[k])
+	}
+
+	headings := make(jsonArr, 0, len(sr.headings))
+	for _, h := range sr.headings {
+		headings = append(headings, newJSONObj().
+			set("text", h.text).
+			set("level", strconv.Itoa(h.level)).
+			set("offset", strconv.Itoa(h.offset)).
+			set("lines", strconv.Itoa(h.lines)))
+	}
+
+	return newJSONObj().
+		set("command", "read").
+		set("path", realpathOf(path)).
+		set("total_lines", strconv.Itoa(sr.totalLines)).
+		setValue("frontmatter", fm).
+		setValue("headings", headings)
+}

--- a/internal/status/native_runner.go
+++ b/internal/status/native_runner.go
@@ -98,6 +98,10 @@ func dispatch(probe claudeteam.TeamStateProbe, args []string, dir string, e env,
 	if err != nil {
 		return errExit(stderr, err.Error())
 	}
+	readRef, err := parseSingleArg(args, "--read", "reference-or-path")
+	if err != nil {
+		return errExit(stderr, err.Error())
+	}
 	newSlug, err := parseNewArg(args)
 	if err != nil {
 		return errExit(stderr, err.Error())
@@ -204,6 +208,9 @@ func dispatch(probe claudeteam.TeamStateProbe, args []string, dir string, e env,
 		if showValidate {
 			incompatible = append(incompatible, "--validate")
 		}
+		if readRef != "" {
+			incompatible = append(incompatible, "--read")
+		}
 		if len(incompatible) > 0 {
 			return errExit(stderr, "--next-id cannot be combined with "+strings.Join(incompatible, ", "))
 		}
@@ -258,6 +265,9 @@ func dispatch(probe claudeteam.TeamStateProbe, args []string, dir string, e env,
 		if showValidate {
 			incompatible = append(incompatible, "--validate")
 		}
+		if readRef != "" {
+			incompatible = append(incompatible, "--read")
+		}
 		if len(incompatible) > 0 {
 			return errExit(stderr, "--resolve cannot be combined with "+strings.Join(incompatible, ", "))
 		}
@@ -296,6 +306,9 @@ func dispatch(probe claudeteam.TeamStateProbe, args []string, dir string, e env,
 		if showValidate {
 			incompatible = append(incompatible, "--validate")
 		}
+		if readRef != "" {
+			incompatible = append(incompatible, "--read")
+		}
 		if rootPath != "" {
 			incompatible = append(incompatible, "--root")
 		}
@@ -303,6 +316,47 @@ func dispatch(probe claudeteam.TeamStateProbe, args []string, dir string, e env,
 			return errExit(stderr, "--short-id cannot be combined with "+strings.Join(incompatible, ", "))
 		}
 		return printShortIDOrExit(roots, shortIDRef, asJSON, stdout, stderr)
+	}
+
+	if readRef != "" {
+		var incompatible []string
+		if showNext {
+			incompatible = append(incompatible, "--next")
+		}
+		if showBoot {
+			incompatible = append(incompatible, "--boot")
+		}
+		if showNextID {
+			incompatible = append(incompatible, "--next-id")
+		}
+		if includeArchive {
+			incompatible = append(incompatible, "--archived")
+		}
+		if len(whereFilters) > 0 {
+			incompatible = append(incompatible, "--where")
+		}
+		if hasFieldsFlag {
+			incompatible = append(incompatible, "--fields/--all-fields")
+		}
+		if archiveSlug != "" {
+			incompatible = append(incompatible, "--archive")
+		}
+		if setResult != nil {
+			incompatible = append(incompatible, "--set")
+		}
+		if resolveRef != "" {
+			incompatible = append(incompatible, "--resolve")
+		}
+		if showValidate {
+			incompatible = append(incompatible, "--validate")
+		}
+		if rootPath != "" {
+			incompatible = append(incompatible, "--root")
+		}
+		if len(incompatible) > 0 {
+			return errExit(stderr, "--read cannot be combined with "+strings.Join(incompatible, ", "))
+		}
+		return runReadSection(roots, readRef, asJSON, stdout, stderr)
 	}
 
 	if rootPath != "" {
@@ -525,7 +579,7 @@ func runDiscover(args []string, dir string, stderr, stdout io.Writer) int {
 	incompatibleFlags := map[string]bool{
 		"--boot": true, "--next": true, "--next-id": true, "--archived": true, "--where": true,
 		"--set": true, "--archive": true, "--fields": true, "--all-fields": true, "--workflow-dir": true,
-		"--validate": true, "--resolve": true, "--short-id": true, "--id-seed": true, "--id-actor": true,
+		"--validate": true, "--resolve": true, "--short-id": true, "--read": true, "--id-seed": true, "--id-actor": true,
 	}
 	var found map[string]bool = map[string]bool{}
 	for _, a := range args {

--- a/internal/status/section_read.go
+++ b/internal/status/section_read.go
@@ -1,0 +1,196 @@
+// ABOUTME: --read section helper — parses a markdown file's frontmatter plus an
+// ABOUTME: ordered ATX-heading map (text/level/1-based offset/section line count).
+package status
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// heading is one ATX heading found in a file's body: its text, level, 1-based
+// line offset (identical to Read(offset, …) semantics), and the section's line
+// count (offset through the line before the next heading of level <= its own;
+// the final heading runs to EOF). text/level/offset/lines map directly to the
+// --read JSON object's four string fields.
+type heading struct {
+	text   string
+	level  int
+	offset int // 1-based line number of the heading line
+	lines  int // section line count, so Read(offset, lines) returns exactly it
+}
+
+// sectionRead is the parsed result of reading a markdown file: its frontmatter,
+// the ordered heading map, and the file's total line count (the exact append
+// offset a caller adds a new trailing section after).
+type sectionRead struct {
+	frontmatter map[string]string
+	headings    []heading
+	totalLines  int
+}
+
+// readSections parses path into its frontmatter plus an ordered heading map.
+// Frontmatter reuses ParseFrontmatter verbatim. Headings are every ATX heading
+// (`#`..`######` followed by a space) in the body, with fenced-code-block lines
+// skipped. Returns (sectionRead, true) on a readable file, (zero, false) when
+// the file cannot be read.
+func readSections(path string) (sectionRead, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return sectionRead{}, false
+	}
+	lines := splitLines(string(data))
+	headings := scanHeadings(lines)
+	return sectionRead{
+		frontmatter: ParseFrontmatter(path),
+		headings:    headings,
+		totalLines:  len(lines),
+	}, true
+}
+
+// scanHeadings returns the ordered ATX headings in lines, with each heading's
+// section line count resolved by the level-aware ownership rule: a heading owns
+// from its line to the line before the next heading of level <= its own; the
+// final heading runs to the last line. Lines inside a fenced code block
+// (``` ``` ``` / `~~~`) are not eligible to be headings. lines is the splitLines
+// view, so a heading's `offset` is its 1-based index (i+1).
+func scanHeadings(lines []string) []heading {
+	var headings []heading
+	fence := ""
+	for i, line := range lines {
+		if marker := codeFenceMarker(line); marker != "" {
+			switch {
+			case fence == "":
+				fence = marker
+			case strings.HasPrefix(strings.TrimSpace(line), fence):
+				fence = ""
+			}
+			continue
+		}
+		if fence != "" {
+			continue
+		}
+		level, text, ok := parseATXHeading(line)
+		if !ok {
+			continue
+		}
+		headings = append(headings, heading{text: text, level: level, offset: i + 1})
+	}
+	assignSectionLines(headings, len(lines))
+	return headings
+}
+
+// assignSectionLines fills each heading's `lines` by the level-aware ownership
+// rule: a heading runs to the line before the next heading of level <= its own,
+// and the final-by-ownership heading runs to totalLines. Operates in place over
+// the offset-ordered slice.
+func assignSectionLines(headings []heading, totalLines int) {
+	for i := range headings {
+		end := totalLines // default: to EOF
+		for j := i + 1; j < len(headings); j++ {
+			if headings[j].level <= headings[i].level {
+				end = headings[j].offset - 1
+				break
+			}
+		}
+		headings[i].lines = end - headings[i].offset + 1
+	}
+}
+
+// parseATXHeading reports whether line is an ATX heading (1-6 leading `#`
+// followed by a space), returning its level and trimmed heading text. The text
+// is the content after the `# ` marker with surrounding whitespace and any
+// trailing closing `#` run stripped, matching the rendered heading text.
+func parseATXHeading(line string) (level int, text string, ok bool) {
+	hashes := 0
+	for hashes < len(line) && line[hashes] == '#' {
+		hashes++
+	}
+	if hashes == 0 || hashes > 6 {
+		return 0, "", false
+	}
+	if hashes >= len(line) || line[hashes] != ' ' {
+		return 0, "", false
+	}
+	body := strings.TrimSpace(line[hashes+1:])
+	body = strings.TrimRight(body, "#")
+	body = strings.TrimRight(body, " ")
+	return hashes, body, true
+}
+
+// runReadSection handles --read <ref-or-path>: it resolves the argument to a
+// file (an existing filesystem path is read directly; otherwise the argument is
+// resolved as an entity reference the same way --resolve resolves it), parses
+// the file into frontmatter + heading map, and emits the JSON envelope (--json)
+// or the key=value text mirror. Returns the exit code.
+func runReadSection(roots roots, ref string, asJSON bool, stdout, stderr io.Writer) int {
+	path, rc := resolveReadTarget(roots, ref, stderr)
+	if rc != 0 {
+		return rc
+	}
+	sr, ok := readSections(path)
+	if !ok {
+		return errExit(stderr, "cannot read file: "+path)
+	}
+	if asJSON {
+		emitJSON(stdout, readJSON(path, sr))
+		return 0
+	}
+	fmt.Fprint(stdout, formatReadText(path, sr))
+	return 0
+}
+
+// resolveReadTarget turns --read's argument into a file path: an existing
+// regular file is used verbatim, so the README and any report-shaped markdown
+// are addressable without being a tracked entity; otherwise the argument is
+// resolved as an entity reference (the --resolve resolver), and an
+// unknown/ambiguous ref fails with that resolver's error shape. Returns
+// (path, 0) on success or ("", 1) after printing the error.
+func resolveReadTarget(roots roots, ref string, stderr io.Writer) (string, int) {
+	if isRegularFile(ref) {
+		return ref, 0
+	}
+	idStyle, err := workflowIDStyle(roots.definitionDir)
+	if err != nil {
+		return "", errExit(stderr, err.Error())
+	}
+	res := resolveReferenceCandidates(roots.definitionDir, roots.entityDir, ref, true, idStyle, stderr)
+	if res.status != "ok" {
+		for _, e := range res.errors {
+			fmt.Fprintln(stderr, e)
+		}
+		return "", 1
+	}
+	return res.matches[0].path, 0
+}
+
+// formatReadText renders the key=value text mirror of a --read result: a header
+// line carrying the realpath'd path and total line count, then one line per
+// heading with its level, offset, lines, and text.
+func formatReadText(path string, sr sectionRead) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "path=%s total_lines=%d\n", realpathOf(path), sr.totalLines)
+	for _, h := range sr.headings {
+		fmt.Fprintf(&b, "level=%d offset=%d lines=%d text=%s\n", h.level, h.offset, h.lines, h.text)
+	}
+	return b.String()
+}
+
+// codeFenceMarker returns the fence marker (``` ``` ``` or `~~~`) when line opens
+// or closes a fenced code block, else "". A fence is a line whose first
+// non-whitespace run is three or more `` ` `` or `~`; the returned marker is the
+// three-char prefix so a closing fence is matched by the same opening marker.
+func codeFenceMarker(line string) string {
+	trimmed := strings.TrimSpace(line)
+	for _, ch := range []byte{'`', '~'} {
+		run := 0
+		for run < len(trimmed) && trimmed[run] == ch {
+			run++
+		}
+		if run >= 3 {
+			return strings.Repeat(string(ch), 3)
+		}
+	}
+	return ""
+}

--- a/internal/status/section_read_test.go
+++ b/internal/status/section_read_test.go
@@ -1,0 +1,253 @@
+// ABOUTME: --read AC1-AC5 — frontmatter parity, heading-map byte location,
+// ABOUTME: fenced-code skip, entity-ref resolution, and flag incompatibility.
+package status
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// fixturePath is the committed known-structure markdown the oracle-based --read
+// tests slice against (FM + multi-level + fenced-code + stage-report sections).
+func fixturePath(t *testing.T) string {
+	t.Helper()
+	p, err := filepath.Abs(filepath.Join("testdata", "section-reader", "fixture.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// fixtureLines returns the fixture's lines via splitLines (the same view the
+// reader indexes), so an `offset` slices these directly: lines[offset-1:...].
+func fixtureLines(t *testing.T) []string {
+	t.Helper()
+	data, err := os.ReadFile(fixturePath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return splitLines(string(data))
+}
+
+// TestReadFrontmatterParity (AC1) asserts the emitted frontmatter equals
+// ParseFrontmatter over the same file — every top-level scalar key/value.
+func TestReadFrontmatterParity(t *testing.T) {
+	path := fixturePath(t)
+	sr, ok := readSections(path)
+	if !ok {
+		t.Fatalf("readSections(%q) failed", path)
+	}
+	want := ParseFrontmatter(path)
+	if len(sr.frontmatter) != len(want) {
+		t.Fatalf("frontmatter key count = %d, want %d", len(sr.frontmatter), len(want))
+	}
+	for k, v := range want {
+		if sr.frontmatter[k] != v {
+			t.Errorf("frontmatter[%q] = %q, want %q", k, sr.frontmatter[k], v)
+		}
+	}
+}
+
+// TestReadHeadingMapLocatesBytes (AC2) is the in-process equivalent of the
+// spike's Read(offset,limit) exercise: for every emitted heading, slicing the
+// fixture by offset/lines must equal the section's known text — heading line
+// through the line before the next heading of level <= its own (final to EOF).
+// The oracle is the fixture's structure (cat -n line numbers), computed here as
+// expected (offset, lines) pairs, never a prose match.
+func TestReadHeadingMapLocatesBytes(t *testing.T) {
+	path := fixturePath(t)
+	lines := fixtureLines(t)
+	sr, ok := readSections(path)
+	if !ok {
+		t.Fatalf("readSections(%q) failed", path)
+	}
+
+	// Expected structure, by the fixture's cat -n line numbers (the external
+	// oracle): heading text -> {level, offset, lines}.
+	want := []heading{
+		{text: "Problem", level: 2, offset: 10, lines: 4},
+		{text: "Proposed approach", level: 2, offset: 14, lines: 13},
+		{text: "Sub-detail", level: 3, offset: 18, lines: 9},
+		{text: "Stage Report: ideation", level: 2, offset: 27, lines: 3},
+	}
+	if len(sr.headings) != len(want) {
+		t.Fatalf("heading count = %d, want %d (%+v)", len(sr.headings), len(want), sr.headings)
+	}
+	for i, w := range want {
+		got := sr.headings[i]
+		if got.text != w.text || got.level != w.level || got.offset != w.offset || got.lines != w.lines {
+			t.Fatalf("heading[%d] = %+v, want %+v", i, got, w)
+		}
+		// Slice the fixture by the emitted offset/lines (1-based, Read semantics)
+		// and assert it equals the section's bytes recomputed independently from
+		// the known structure (offset through next-heading-of-level<=own minus 1).
+		gotSlice := strings.Join(lines[got.offset-1:got.offset-1+got.lines], "\n")
+		end := w.offset - 1 + w.lines
+		wantSlice := strings.Join(lines[w.offset-1:end], "\n")
+		if gotSlice != wantSlice {
+			t.Fatalf("heading[%d] %q slice mismatch\n--- got ---\n%s\n--- want ---\n%s", i, w.text, gotSlice, wantSlice)
+		}
+	}
+}
+
+// TestReadFencedHeadingsSkipped (AC3) asserts a `#`-prefixed line inside a code
+// fence does NOT appear in the heading map.
+func TestReadFencedHeadingsSkipped(t *testing.T) {
+	sr, ok := readSections(fixturePath(t))
+	if !ok {
+		t.Fatal("readSections failed")
+	}
+	for _, h := range sr.headings {
+		if strings.Contains(h.text, "not a heading") {
+			t.Fatalf("fenced heading leaked into map: %+v", h)
+		}
+	}
+	// The fixture's fence holds a `#` and a `##` line; the only real `##`/`###`
+	// headings are the four asserted in AC2. A fence leak would inflate the count.
+	if len(sr.headings) != 4 {
+		t.Fatalf("heading count = %d, want 4 (a fenced `#` line leaked)", len(sr.headings))
+	}
+}
+
+// TestReadEntityRefResolvesLikeResolve (AC4) drives the runner: a valid slug
+// yields the map for that entity's file, and an unknown ref exits 1 with the
+// resolver's error shape.
+func TestReadEntityRefResolvesLikeResolve(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("testdata", "seq-workflow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := pinnedEnv(t)
+
+	t.Run("valid slug yields its entity's map", func(t *testing.T) {
+		out, stderr, code := runNative(t, root, env, "--workflow-dir", root, "--read", "003-wire-cli", "--json")
+		if code != 0 {
+			t.Fatalf("exit=%d stderr=%q", code, stderr)
+		}
+		var env map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(out), &env); err != nil {
+			t.Fatalf("output is not JSON: %v\n%s", err, out)
+		}
+		var cmd string
+		json.Unmarshal(env["command"], &cmd)
+		if cmd != "read" {
+			t.Fatalf("command = %q, want read", cmd)
+		}
+		// The resolved path must be the entity's own file (folder-form
+		// 003-wire-cli/index.md), proving --read resolved the ref to its file.
+		var path string
+		json.Unmarshal(env["path"], &path)
+		if !strings.Contains(path, "003-wire-cli") {
+			t.Fatalf("resolved path = %q, want it under 003-wire-cli", path)
+		}
+		// frontmatter must carry the resolved entity's own id/slug, not another's.
+		var fm map[string]string
+		json.Unmarshal(env["frontmatter"], &fm)
+		if fm["slug"] != "" && fm["slug"] != "003-wire-cli" {
+			t.Fatalf("frontmatter slug = %q, want 003-wire-cli or absent", fm["slug"])
+		}
+	})
+
+	t.Run("unknown ref exits 1 with resolver error", func(t *testing.T) {
+		out, stderr, code := runNative(t, root, env, "--workflow-dir", root, "--read", "no-such-entity")
+		if code != 1 {
+			t.Fatalf("exit=%d (want 1) stdout=%q", code, out)
+		}
+		if !strings.Contains(stderr, "unknown reference") {
+			t.Fatalf("stderr = %q, want resolver 'unknown reference' error", stderr)
+		}
+	})
+}
+
+// TestReadPathFormResolvesPlainFile asserts the path form: --read of a plain
+// filesystem path (not a tracked entity) reads it directly. Drives the binary
+// against the committed fixture and checks the heading map matches AC2.
+func TestReadPathFormResolvesPlainFile(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("testdata", "seq-workflow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := pinnedEnv(t)
+	out, stderr, code := runNative(t, root, env, "--workflow-dir", root, "--read", fixturePath(t), "--json")
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	var doc struct {
+		Command    string `json:"command"`
+		TotalLines string `json:"total_lines"`
+		Headings   []struct {
+			Text   string `json:"text"`
+			Level  string `json:"level"`
+			Offset string `json:"offset"`
+			Lines  string `json:"lines"`
+		} `json:"headings"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, out)
+	}
+	if doc.Command != "read" {
+		t.Fatalf("command = %q, want read", doc.Command)
+	}
+	if len(doc.Headings) != 4 {
+		t.Fatalf("heading count = %d, want 4", len(doc.Headings))
+	}
+	// Every value is a string (the all-strings contract): level/offset/lines
+	// must parse as ints.
+	for _, h := range doc.Headings {
+		for _, v := range []string{h.Level, h.Offset, h.Lines} {
+			if _, err := strconv.Atoi(v); err != nil {
+				t.Fatalf("non-int string field %q in %+v", v, h)
+			}
+		}
+	}
+	// total_lines is the exact append offset; the fixture is 29 lines.
+	if doc.TotalLines != "29" {
+		t.Fatalf("total_lines = %q, want 29", doc.TotalLines)
+	}
+}
+
+// TestReadFlagIncompatibility (AC5) asserts --read combined with each
+// conflicting action flag exits 1 with the established "cannot be combined
+// with" message naming --read (the --read branch is checked first, so it owns
+// the message for every pairing).
+func TestReadFlagIncompatibility(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("testdata", "seq-workflow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := pinnedEnv(t)
+
+	cases := []struct {
+		name  string
+		extra []string
+	}{
+		{"set", []string{"--set", "003-wire-cli", "status=done"}},
+		{"next", []string{"--next"}},
+		{"boot", []string{"--boot"}},
+		{"validate", []string{"--validate"}},
+		{"resolve", []string{"--resolve", "003-wire-cli"}},
+		{"next-id", []string{"--next-id"}},
+		{"archive", []string{"--archive", "003-wire-cli"}},
+		{"where", []string{"--where", "status=ideation"}},
+		{"fields", []string{"--fields", "worktree"}},
+		{"all-fields", []string{"--all-fields"}},
+		{"archived", []string{"--archived"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			args := append([]string{"--workflow-dir", root, "--read", "003-wire-cli"}, tc.extra...)
+			out, stderr, code := runNative(t, root, env, args...)
+			if code != 1 {
+				t.Fatalf("exit=%d (want 1) stdout=%q", code, out)
+			}
+			if !strings.Contains(stderr, "cannot be combined with") {
+				t.Fatalf("stderr = %q, want 'cannot be combined with' message", stderr)
+			}
+		})
+	}
+}

--- a/internal/status/testdata/section-reader/fixture.md
+++ b/internal/status/testdata/section-reader/fixture.md
@@ -1,0 +1,29 @@
+---
+id: e6aaveste2tm0nsyqt407k55
+title: section reader fixture
+status: implementation
+score: "0.40"
+---
+
+Intro prose before the first heading. This belongs to no section.
+
+## Problem
+
+The body reads whole files to reach one part.
+
+## Proposed approach
+
+A read helper that emits a heading map.
+
+### Sub-detail
+
+A nested level-3 heading owned by Proposed approach.
+
+```
+# not a heading inside a fence
+## also not a heading
+```
+
+## Stage Report: ideation
+
+- DONE: design the contract

--- a/skills/ensign/references/ensign-shared-core.md
+++ b/skills/ensign/references/ensign-shared-core.md
@@ -15,7 +15,7 @@ Read the assignment context provided by the first officer. It defines:
 
 ## Working
 
-1. Read the entity file before making changes.
+1. Read the entity file before making changes — when you need only specific sections (the relevant stage-def section, your prior report), `status --read <entity-path> --json` returns each section's `offset`/`lines` for a scoped `Read`, rather than the whole body.
 2. If you were given a worktree path, keep all reads, writes, and commits under that worktree.
 3. Perform the work described in the stage definition.
 4. Update the entity file body, not the frontmatter.
@@ -89,7 +89,7 @@ Rules:
 - Every checklist item must appear.
 - Use the checklist item text verbatim for `{item text}` when possible (copy/paste).
 - Do not use markdown checkbox markers.
-- Append the report at the end of the entity file — do not read the entire entity body to find an insertion point.
+- Append the report at the end of the entity file — get the file's `total_lines` from `status --read <entity-path> --json` and append after it; do not read the entire entity body to find an insertion point.
 - If redoing a stage after rejection, append a new `## Stage Report: {stage_name} (cycle N)` section at the end rather than locating and overwriting the prior report.
 
 ## Completion

--- a/skills/first-officer/references/claude-first-officer-runtime.md
+++ b/skills/first-officer/references/claude-first-officer-runtime.md
@@ -36,7 +36,7 @@ For the dispatch-idle and idle-hallucination guardrails, see `## Awaiting Comple
 
 ## Entity-Body Inspection
 
-See `## Probe and Ideation Discipline` in the shared core for the Grep-over-Read rule. The Claude Code runtime is where the Read-then-Bash-mutation staleness echo fires — avoid a full-file Read for targeted section lookups and trust `status --set` stdout (`field: old -> new`) for mutation narration.
+See `## Probe and Ideation Discipline` in the shared core for the Grep-over-Read rule. The Claude Code runtime is where the Read-then-Bash-mutation staleness echo fires — avoid a full-file Read for targeted section lookups (use the shared core's `status --read` section-read upgrade) and trust `status --set` stdout (`field: old -> new`) for mutation narration.
 
 ## Filing New Entities
 

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -97,7 +97,7 @@ The dispatch machinery — the per-entity dispatch procedure, worker resolution,
 
 When a worker completes:
 
-1. Read the entity file's last `## Stage Report` section.
+1. Read the entity file's last `## Stage Report` section — `status --read <ref> --json`, take the last `## Stage Report` heading's `offset`/`lines`, then `Read(offset, limit)` that range, instead of loading the whole body.
 2. Review it against the checklist. Every dispatched item must appear as DONE, SKIPPED, or FAILED.
 3. If items are missing, send the worker back once to repair the report.
 4. Check whether the completed stage is gated.
@@ -209,7 +209,7 @@ These habits implement the operating posture stated in the skill entry point —
 
 - When a dispatched-ideation design rests on an unverified mechanism (format round-trip, runtime handoff, a tool actually supporting a flag), exercise the riskiest path end-to-end first — the smallest run that would invalidate the work if it broke. Evidence goes in the entity body; "no spike needed" is recorded with proven mechanisms. The integration-level analog of the AC rule: arrive at the gate with the riskiest claim demonstrated, not asserted.
 - When checking whether tool X supports Y, read X's schema via ToolSearch before grepping for callers — usage presence is not existence evidence.
-- Prefer Grep over Read for targeted entity-body inspection. Anchor on heading or field name (`## Stage Report`, `### Feedback Cycles`, a specific frontmatter field). Read only when you need the full text.
+- Prefer Grep over Read for targeted entity-body inspection. Anchor on heading or field name (`## Stage Report`, `### Feedback Cycles`, a specific frontmatter field). Read only when you need the full text. To pull a whole named section, `status --read <ref> --json` returns its `offset`/`lines` so the follow-up `Read(offset, limit)` is section-scoped, not whole-file.
 - On Claude Code, a `Read` followed by a Bash mutation of the same file (including `status --set`) triggers the file-staleness safety net, echoing the file back as cache-write tokens. Grep does not participate. Trust `status --set` stdout (`field: old -> new`, `field: old -> ` for clear-to-empty, `field:  -> {timestamp}` for bare-timestamp auto-fill) to narrate mutations without re-reading.
 
 ## Issue Filing


### PR DESCRIPTION
A recurring FO/ensign token sink is whole-file reads; `status --read` returns a file's frontmatter plus a section-heading→offset map so callers load just the section they need.

## What changed
- Add `status --read <ref-or-path> --json`: frontmatter plus an ordered heading map (text/level/1-based offset/lines).
- Resolve entity-refs like `--resolve`; read any markdown by path; skip fenced-code headings; level-aware section ownership.
- Wire six FO/ensign contract read-sites to prefer section-scoped reads; add a re-read hint to every dispatch prompt.
- Regenerate the dispatch golden-prompt suite to carry the additive hint.

## Evidence
- `go test ./...` — 15/15 packages passed; AC1–AC5 unit/behavior tests and the AC7 dispatch goldens green.
- AC6 live drive: `status --read` then `Read(209,14)` returned exactly the target section (14 of ~205 body lines); a detached adversarial audit over ~16 edge-case fixtures refuted nothing material.

## Review guidance
The parser's level-aware section ownership and fenced-code skipping live in `internal/status/section_read.go`.

---
[e6a](/spacedock-dev/spacedock/blob/3ef7bdb3b285d50d2e738ebed11f55e2346a7b07/status-section-reader.md)
