### PR TITLE
Restructure shipped commission templates — lead-with-the-end + defer universal rules to the FO/ensign contract

### DIFF
--- a/internal/contractlint/template_defer_test.go
+++ b/internal/contractlint/template_defer_test.go
@@ -1,0 +1,147 @@
+// ABOUTME: AC-2/AC-3 structural checks for the commission templates — the universal
+// ABOUTME: doctrine has a single contract owner (not restated per-template) and each template leads with its outcome.
+package contractlint
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// commissionTemplates is the set of shipped commission-template files the
+// defer-to-contract restructure governs, each with the contract file that
+// solely owns the universal doctrine markers it used to restate.
+var commissionTemplates = []string{
+	"skills/commission/references/templates/development.md",
+	"skills/commission/references/templates/experiment.md",
+	"skills/commission/references/templates/refinement.md",
+}
+
+// doctrineMarker pins one canonical contract phrasing to its sole owning file.
+// The marker set binds two independent, divergeable sources — the contract's own
+// wording and whatever a template carries — so the check reds precisely when a
+// template re-restates the doctrine, not merely because we wrote the words.
+type doctrineMarker struct {
+	phrase string
+	owner  string
+}
+
+var doctrineMarkers = []doctrineMarker{
+	{"Prefer a code gate over a prose-only rule", "skills/first-officer/references/first-officer-shared-core.md"},
+	{"wording-present is not behavior", "skills/first-officer/references/first-officer-shared-core.md"},
+	{"Prove by exercising, not by re-reading", "skills/ensign/references/ensign-shared-core.md"},
+	{"A substring search is not proof of behavior", "skills/ensign/references/ensign-shared-core.md"},
+}
+
+// TestUniversalDoctrineHasSingleSource is the AC-2 single-source / dedup check: each
+// universal-doctrine marker the templates used to paraphrase appears in exactly ONE
+// file under skills/+agents/ — its owning contract — and a second copy (a template
+// re-restating it) reds the test. This is not a presence tautology: it binds the
+// contract's content against every other shipped file, so it fails when the doctrine
+// drifts back into a template, the drift regression the restructure prevents.
+func TestUniversalDoctrineHasSingleSource(t *testing.T) {
+	root := repoRoot(t)
+	for _, marker := range doctrineMarkers {
+		var sources []string
+		for _, tree := range []string{"skills", "agents"} {
+			base := filepath.Join(root, tree)
+			err := filepath.WalkDir(base, func(p string, d os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() || filepath.Ext(p) != ".md" {
+					return nil
+				}
+				b, readErr := os.ReadFile(p)
+				if readErr != nil {
+					return readErr
+				}
+				if strings.Contains(string(b), marker.phrase) {
+					rel, _ := filepath.Rel(root, p)
+					sources = append(sources, rel)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("walk %s: %v", tree, err)
+			}
+		}
+		if len(sources) != 1 || sources[0] != marker.owner {
+			t.Errorf("doctrine marker %q has sources %v, want exactly [%s] (single source of truth — a template re-restating it reds this)", marker.phrase, sources, marker.owner)
+		}
+	}
+}
+
+// TestTemplatesCarryWorkflowSpecificRulesSlot is the AC-2 heading-presence half: each
+// commission template carries a `## Workflow-specific rules` section. This is a
+// structural section-presence property a machine can see — the slot that holds each
+// shape's unique rules after the generic doctrine is deferred to the contract — not a
+// doctrine-substring match.
+func TestTemplatesCarryWorkflowSpecificRulesSlot(t *testing.T) {
+	root := repoRoot(t)
+	const heading = "## Workflow-specific rules"
+	for _, rel := range commissionTemplates {
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Errorf("read %s: %v", rel, err)
+			continue
+		}
+		if !strings.Contains(string(data), heading) {
+			t.Errorf("%s carries no %q section — the workflow-specific-rules slot is missing", rel, heading)
+		}
+	}
+}
+
+// TestTemplatesLeadWithOutcome is the AC-3 structural lede-position check: each
+// template opens with a non-empty prose paragraph (the workflow's outcome) positioned
+// between its frontmatter and the first `## ` mechanics heading. This is a
+// positional/ordering assertion over the file — lead-with-the-end shape is
+// structurally present — not a value-judgement substring match; the qualitative
+// "does the lede actually lead with value" judgement is a human gate-review item.
+func TestTemplatesLeadWithOutcome(t *testing.T) {
+	root := repoRoot(t)
+	for _, rel := range commissionTemplates {
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Errorf("read %s: %v", rel, err)
+			continue
+		}
+		doc := string(data)
+		fm, ok := frontmatter(doc)
+		if !ok {
+			t.Errorf("%s has no parseable frontmatter — cannot locate the lede", rel)
+			continue
+		}
+		// The body begins after the closing `---` of the frontmatter block.
+		body := doc[strings.Index(doc, fm)+len(fm):]
+		if i := strings.Index(body, "\n---"); i >= 0 {
+			body = body[i+len("\n---"):]
+		}
+		firstHeading := strings.Index(body, "\n## ")
+		if firstHeading < 0 {
+			t.Errorf("%s has no `## ` mechanics heading — cannot bound the lede", rel)
+			continue
+		}
+		// The title `# ...` line is the workflow name, not the lede; the lede is the
+		// prose between the title and the first `## ` mechanics heading.
+		lede := body[:firstHeading]
+		lede = strings.TrimSpace(stripTitleLine(lede))
+		if lede == "" {
+			t.Errorf("%s has no lede paragraph before its first `## ` mechanics heading", rel)
+		}
+	}
+}
+
+// stripTitleLine removes a leading `# Title` line (and surrounding blank lines) from
+// a template body so the lede check measures the prose paragraph, not the H1.
+func stripTitleLine(body string) string {
+	body = strings.TrimLeft(body, "\n")
+	if strings.HasPrefix(body, "# ") {
+		if nl := strings.Index(body, "\n"); nl >= 0 {
+			return body[nl+1:]
+		}
+		return ""
+	}
+	return body
+}

--- a/skills/commission/references/templates/development.md
+++ b/skills/commission/references/templates/development.md
@@ -85,7 +85,7 @@ Terminal state: the task's PR is merged (tracked via the `pr` field and the `pr-
 
 ## Workflow-specific rules
 
-The FO/ensign operating contract already governs generic stage semantics and proof discipline — prefer a code gate over a prose-only rule, prove by exercising rather than re-reading, and reject any AC proven only by review of its own prose. Tasks in a commissioned development workflow inherit that from the contract their FO loads at boot; the rules below add only the dev-shape specifics.
+The FO/ensign operating contract already governs generic stage semantics and proof discipline — prefer a code gate over a prose-only rule, prove by exercising rather than re-reading, and reject any AC whose only proof is a review of its own prose. Tasks in a commissioned development workflow inherit these rules from the contract their FO loads at boot; the rules below add only the dev-shape specifics.
 
 - **Repo-mutation worktree layer.** `implementation` and `validation` run in a worktree against the codebase, and `validation` is `fresh` so an independent agent checks the AC. PR state lives on the `pr` field, managed by the `pr-merge` mod — there is no `pr_open` or `awaiting_merge` stage.
 - **Opt-in proof disciplines (copy into the `validation` stage when commissioning).** These are recommended dev-shape practices, not universal — a non-development workflow's acceptance proof may legitimately be a published artifact, a metric, or a human review. Adopt the ones the mission needs by folding them into the `validation` stage's Outputs and Bad lists:

--- a/skills/commission/references/templates/development.md
+++ b/skills/commission/references/templates/development.md
@@ -27,7 +27,7 @@ stages:
 
 # Development Workflow Template
 
-Refinement specialization for code that ships via PR/merge. Tasks move from a captain-curated backlog through ideation, get built in a dedicated worktree, are independently validated against the acceptance criteria, and land via PR review. The repo-mutation layer is active on `implementation` and `validation`; the `pr-merge` mod handles the PR lifecycle.
+Tasks move from a captain-curated backlog through ideation, get built in a dedicated worktree, are independently validated against the acceptance criteria, and land via PR review. This is the refinement shape specialized for code that ships via PR/merge: the repo-mutation layer is active on `implementation` and `validation`, and the `pr-merge` mod handles the PR lifecycle.
 
 Use this template when the captain's mission is to ship code in a repo where work is reviewed and merged via PR. The bucket-noun stage names (`implementation`, `validation`, `done`) describe where the entity is sitting; the `pr-merge` mod removes any temptation to add `pr_open` or `awaiting_merge` stages because PR state is tracked on the `pr` field, not as a stage.
 
@@ -65,76 +65,36 @@ Every task file has YAML frontmatter. Fields are documented below; see **Task Te
 
 ### `backlog`
 
-A task enters backlog when it is first proposed. It carries a seed description but no design work. This is a captain-curated holding stage with a gate — the captain decides which tasks advance to ideation.
-
-- **Inputs:** None — this is the initial state
-- **Outputs:** A seed task file with title, source, brief description
-- **Good:** Clear enough to recognize what the task is about
-- **Bad:** Empty stub that even the captain cannot triage
+A task enters backlog when it is first proposed: a seed description, no design work. Captain-curated holding stage — the gate decides which tasks advance to ideation.
 
 ### `ideation`
 
-A task moves to ideation when the captain greenlights it for design work. The work here is to flesh out the problem, propose an approach, define acceptance criteria, and write a test plan.
-
-- **Inputs:** The seed description and any relevant context (existing code, captain notes, related tasks)
-- **Outputs:** A fleshed-out task body with problem statement, proposed approach, acceptance criteria (entity-level end-state properties with `Verified by:` clauses), and a test plan
-- **Good:** Behavior-first, scoped, addresses a real need, AC items name end-state properties (not stage actions), test plan matches the AC's level of abstraction
-- **Bad:** Vague hand-waving, scope creep, AC items written as imperative verbs, test plans that prove the wrong thing
+The captain greenlights a task for design: flesh out the problem, propose an approach, define acceptance criteria as entity-level end-state properties with `Verified by:` clauses, and write a test plan that matches the AC's level of abstraction.
 
 ### `implementation`
 
-A task moves to implementation once its design is approved. The work happens in a dedicated worktree on a feature branch.
-
-- **Inputs:** The fleshed-out task body from ideation with approach and acceptance criteria
-- **Outputs:** The deliverable committed to the worktree branch with a stage report describing what was produced and where
-- **Good:** Minimal changes that satisfy the AC, clean code, tests where appropriate, deliverable self-contained for validation
-- **Bad:** Over-engineering, unrelated refactoring, skipping tests, leaving the deliverable incomplete for validation to finish
+The design is approved and the deliverable is built in a dedicated worktree on a feature branch — minimal changes that satisfy the AC, self-contained for validation.
 
 ### `validation`
 
-A task moves to validation after implementation is complete. A fresh agent independently verifies the deliverable meets the AC defined in ideation. The validator does not produce the deliverable — it checks what was produced.
-
-- **Inputs:** The implementation summary, the AC from the task body, the worktree branch
-- **Outputs:** A validation report covering each AC, with PASS/FAIL per criterion. Either gate-approval to `done` or rejection back to `implementation` with concrete fixes.
-- **Good:** Reproduces each AC's `Verified by:` clause, reports actual evidence not assertions, exercises edge cases the AC implies
-- **Bad:** Trusting implementation's self-report, skipping AC items, accepting "should work" without running the check
+A `fresh` agent independently verifies the deliverable against the ideation AC, reproducing each `Verified by:` clause rather than trusting the implementation's self-report. The validator checks what was produced; it does not produce it. Either gate-approval to `done` or rejection back to `implementation` with concrete fixes.
 
 ### `done`
 
-Terminal state. The task's PR is merged and the entity is archived.
+Terminal state: the task's PR is merged (tracked via the `pr` field and the `pr-merge` mod), `completed` set, `verdict: PASSED`, entity archived. Reached via real merge, not a manual flag flip.
 
-- **Inputs:** A merged PR (tracked via the `pr` field and the `pr-merge` mod's startup/idle hooks)
-- **Outputs:** None — terminal. `completed` set, `verdict: PASSED`, entity archived.
-- **Good:** Reached terminal via real merge, not by manual flag flip
-- **Bad:** Marking done before the PR actually merged
+## Workflow-specific rules
 
-## Recommended practices (opt-in)
+The FO/ensign operating contract already governs generic stage semantics and proof discipline — prefer a code gate over a prose-only rule, prove by exercising rather than re-reading, and reject any AC proven only by review of its own prose. Tasks in a commissioned development workflow inherit that from the contract their FO loads at boot; the rules below add only the dev-shape specifics.
 
-These are proven dev-workflow disciplines a captain can adopt into this workflow's validation stage. They are recommended, not mandatory — the universal first-officer contract does not impose them, because a non-development workflow's acceptance proof may legitimately be a published artifact, a metric, or a human review rather than a test or command. Adopt them by copying the guidance into the `validation` stage's Outputs and Bad lists above when commissioning a code-shipping workflow.
+- **Repo-mutation worktree layer.** `implementation` and `validation` run in a worktree against the codebase, and `validation` is `fresh` so an independent agent checks the AC. PR state lives on the `pr` field, managed by the `pr-merge` mod — there is no `pr_open` or `awaiting_merge` stage.
+- **Opt-in proof disciplines (copy into the `validation` stage when commissioning).** These are recommended dev-shape practices, not universal — a non-development workflow's acceptance proof may legitimately be a published artifact, a metric, or a human review. Adopt the ones the mission needs by folding them into the `validation` stage's Outputs and Bad lists:
+  - **Test-first authoring** — for a code or fixture deliverable, write the failing test first, watch it fail for the right reason, then write the minimum code to pass. The test is what the gate judges.
+  - **External-proof acceptance criteria** — each AC's evidence must come from a check outside the task body (a test, a command's output or exit code, a file the change produces, on-disk state). Reject self-referential ACs whose only proof is review of the task's own prose; if nothing ships, the decision belongs in the roadmap, not a terminal dev task.
+  - **Detached adversarial audit** — for high-stakes surfaces (a front-door launcher, status/guard mutation paths, shipped contract/scaffolding, CI/release machinery), run a read-only audit on a throwaway checkout that tries to refute the validation with an edit the deliverable's own tests should catch. `Material:` findings route back through the validation→implementation feedback flow; "refuted nothing material" is a valid recorded outcome.
+  - **Live scenario for runtime claims** — when an AC's truth is what an agent or model *does* at runtime, prove it with a scripted live scenario graded on durable before→after state plus observed output, with a negative case that reds the grade. Mark the AC `Verified by: live <ci-run:<id> | session:<path>>`; an offline proxy or a contract-text check proves the watcher or the words, never the runtime behavior.
 
-### Test-first authoring
-
-For a code or fixture deliverable, write the failing test first: write a test that captures the desired behavior, run it and watch it fail for the right reason, then write the minimum code to make it pass, and refactor green. The test is what the gate judges. This is a dev-workflow discipline — recommended, not mandatory; the universal contract does not impose it, because a non-development workflow's deliverable (a PRD, an analysis verdict, a published artifact) is judged against its own pre-fixed success criteria, not a test-first ritual.
-
-### External-proof acceptance criteria
-
-At the validation gate, require that each AC's cited evidence comes from a check OUTSIDE the task body — a test, a command's output or exit code, a file the change produces, or the resulting on-disk state. An AC whose only cited proof is review of the task's own prose ("verified by reviewing this task's decision section") proves only that the prose exists; it can never fail, so it does not satisfy the AC. Reject self-referential ACs. If the task's only deliverable is a decision with nothing shipped, do not recommend PASSED — the decision belongs in the roadmap, not a terminal dev task. (Behavioral enforcement of this rule, when a workflow wants it, is a workflow-opt-in `spacedock status --validate` guard — the workflow declares it; it is not universal binary behavior.)
-
-### Detached adversarial audit
-
-For high-stakes surfaces — a front-door launcher, the status/guard mutation paths, shipped contract/scaffolding, or CI/release machinery — treat a passing validation as necessary but not sufficient. Before merging, run (or dispatch) a read-only adversarial audit on a detached checkout of the merge result:
-
-- **When:** the high-stakes surfaces above; routine low-blast-radius changes do not need it.
-- **What:** the auditor works on a separate throwaway checkout (never the implementation worktree) and never mutates the deliverable. It tries to REFUTE the validation — construct an adversarial edit the deliverable's own tests should catch, and confirm they do. A test that stays green under a claim-breaking edit is a hole. Findings come in two tiers — `Material:` (a real correctness or test-strength hole) and `Polish:` (non-blocking); "refuted nothing material" is a valid recorded outcome.
-- **How recorded:** material findings route back through the validation→implementation feedback flow (a `### Feedback Cycles` entry naming the audit and its adversarial edit); the gate is not clean until they close.
-
-The audit catches the class of hole where the test passes but would also pass on a broken future edit — which a green suite cannot see itself.
-
-### Live scenario for runtime claims
-
-Choose the proof at the claim's altitude. When an AC's truth is what an agent or model DOES at runtime — it actually exits, it actually clears the hang, it actually produces the right durable state — the proof is a scripted live scenario, not an offline proxy. A recording proves the WATCHER (the consumer reads a frozen stream correctly), never the PRODUCER (does the real model, reading the contract, actually exit?). A contract-text check proves the WORDS are present, never the behaviour. Both pass while the runtime claim is still false — exactly the slip where a fix passed every offline check and three adversarial audits, was merged `pending-live-run`, and the live retrigger then showed it never closed the flake.
-
-A live scenario is authored as a triple: a descriptive **runbook** (the prompt/instructions a real agent runs), a **setup** (the fixture/state the run starts from), and **durable-outcome assertions** (entity state before→after plus observed output — NOT transcript phrasing, which is non-deterministic). Run it against a real agent and grade on the durable outcomes, with at least one negative case where a deliberately broken outcome reds the grade. Mark such an AC `Verified by: live <ci-run:<id> | session:<path>>`; under an external-proof opt-in workflow the live-run guard refuses to terminalize it until that citation resolves, so `pending-live-run` is an enforced state, not a hopeful label.
+  The generic rationale for each — why a prose-only proof never satisfies a behavioral claim — lives in the FO/ensign contract; the disciplines above are the dev-shape applications a captain opts into.
 
 ## Workflow State
 

--- a/skills/commission/references/templates/experiment.md
+++ b/skills/commission/references/templates/experiment.md
@@ -117,7 +117,7 @@ Terminal state for hypotheses that failed at any tier (`smoke`, `analysis`, or `
 
 ## Workflow-specific rules
 
-The FO/ensign operating contract already governs generic stage semantics and proof discipline — prefer a code gate over a prose-only rule, prove by exercising rather than re-reading, fix success criteria before the evidence. Experiments inherit that from the contract their FO loads at boot; the rules below add only the experiment-shape specifics.
+The FO/ensign operating contract already governs generic stage semantics and proof discipline — prefer a code gate over a prose-only rule, prove by exercising rather than re-reading, fix success criteria before gathering evidence. Experiments inherit these rules from the contract their FO loads at boot; the rules below add only the experiment-shape specifics.
 
 - **Falsifiable hypothesis, criteria fixed first.** The hypothesis must be falsifiable and its accept/reject success criteria must be written down before any evidence is gathered, so the verdict cannot be rationalized after seeing results.
 - **Tier-gating.** Evidence promotes through `smoke → run → analysis → holdout` and a tier never skips: smoke fails fast before the run is burned, analysis applies the criteria as written, and a decisive smoke or analysis can reject without continuing.

--- a/skills/commission/references/templates/experiment.md
+++ b/skills/commission/references/templates/experiment.md
@@ -52,7 +52,7 @@ stages:
 
 # Experiment Workflow Template
 
-Refinement specialization with parked tiers and a structured entity body. Each experiment is a hypothesis tested through tiers of evidence: a cheap smoke pre-flight, the main run, an analysis gate, an out-of-sample holdout, then accepted or rejected. The parked-stages layer is active on `smoke`, `run`, and `holdout`; the `silence-watcher` idle-mod is offered for any parked stage with timeout/nudge semantics.
+Each experiment is a hypothesis tested through tiers of evidence: a cheap smoke pre-flight, the main run, an analysis gate, an out-of-sample holdout, then accepted or rejected. This is the refinement shape specialized with parked tiers and a structured entity body: the parked-stages layer is active on `smoke`, `run`, and `holdout`, and the `silence-watcher` idle-mod is offered for any parked stage with timeout/nudge semantics.
 
 Use this template when the captain's mission is to learn whether something works: hypothesis-test-learn loops, A/B tests, model evals, intervention trials, multi-tier evidence-driven promotion. Industry-of-art for the multi-tier evidence-driven promotion shape is **stage-gate** (Cooper, *Winning at New Products*); we use `experiment` as the captain-facing name for first-contact recognition and surface the lineage here for advanced captains.
 
@@ -89,62 +89,40 @@ Every experiment file has YAML frontmatter. Fields are documented below; see **E
 
 ### `hypothesis`
 
-The experiment is being defined. Captain-curated gate before tier work begins.
-
-- **Inputs:** A research lead, prior result, or captain hunch
-- **Outputs:** A hypothesis statement, the methodology that will test it, the success criteria for accepting vs rejecting, and the smoke pre-flight design
-- **Good:** Falsifiable hypothesis, success criteria fixed before evidence is gathered, methodology is reproducible
-- **Bad:** Vague directional claims, success criteria invented after seeing results, methodology that cannot be re-run
+The experiment is being defined behind a captain-curated gate: a falsifiable hypothesis, the reproducible methodology that tests it, the success criteria fixed before any evidence is gathered, and the smoke pre-flight design.
 
 ### `smoke`
 
-A cheap pre-flight that catches obvious failures (broken instrumentation, no signal at all, infrastructure not in place) before committing to the full run. Parked: the entity sits here while the smoke executes.
-
-- **Inputs:** The methodology and smoke design from `hypothesis`
-- **Outputs:** A smoke result captured in the experiment body. Either gate-approval to `run` (smoke passes — proceed to the real run) or rejection with notes (smoke fails — typically back to `hypothesis` to revise the methodology)
-- **Good:** Smoke is genuinely cheap (minutes, not days), tests instrumentation and at-least-some-signal, fails fast when the experiment is doomed
-- **Bad:** Smoke that takes nearly as long as the real run, smoke that "passes" without checking the dimensions that matter, skipping the smoke and burning the run on a broken setup
+A genuinely cheap pre-flight (minutes, not days) that catches broken instrumentation or no-signal-at-all before the full run. Parked while it executes. Gate-approval to `run`, or rejection back to `hypothesis` to revise the methodology.
 
 ### `run`
 
-The main experiment execution. Parked: the entity sits here while the run accumulates evidence.
-
-- **Inputs:** The smoke-validated methodology
-- **Outputs:** Run result captured in the experiment body — raw evidence, sample sizes, intermediate metrics
-- **Good:** Run executes the same methodology that was smoke-validated, evidence is captured in a form analysis can re-use
-- **Bad:** Methodology drift between smoke and run, evidence captured in a form only the runner can interpret
+The main execution, parked while evidence accumulates. Run the same methodology that was smoke-validated and capture the evidence — raw data, sample sizes, intermediate metrics — in a form analysis can re-use.
 
 ### `analysis`
 
-The run evidence is interpreted against the success criteria from `hypothesis`. Gate: the analyst decides whether the evidence supports advancing to holdout, or whether the experiment should be rejected outright.
-
-- **Inputs:** The run result and the success criteria from the hypothesis
-- **Outputs:** An analysis verdict in the experiment body. Either gate-approval to `holdout` (evidence supports the hypothesis — verify out-of-sample) or rejection straight to `rejected` (evidence does not support).
-- **Good:** Analysis applies the success criteria as written, distinguishes signal from noise, calls out confidence honestly
-- **Bad:** Moving the goalposts, p-hacking, accepting noise as signal, deferring the verdict indefinitely
+The run evidence is interpreted against the hypothesis's pre-fixed success criteria, behind a gate that distinguishes signal from noise without moving the goalposts. Gate-approval to `holdout` (verify out-of-sample), or rejection straight to `rejected`.
 
 ### `holdout`
 
-Out-of-sample verification. The accepted hypothesis is re-tested on data or a setting the run did not see. Parked while the holdout executes; fresh agent runs the holdout independently of whoever ran the analysis.
-
-- **Inputs:** The analysis-accepted hypothesis and the methodology
-- **Outputs:** Holdout result captured in the experiment body. Verdict drives the terminal: holdout supports → `accepted`; holdout fails → `rejected`.
-- **Good:** Holdout is genuinely out-of-sample (different data, different population, different time window), executed by someone independent of the analyst
-- **Bad:** Holdout that overlaps the run sample, holdout interpreted by the analyst (defeats the independence), skipping holdout for "obvious" results
+Out-of-sample verification: the accepted hypothesis is re-tested on data or a setting the run did not see, parked while it executes. A `fresh` agent runs it independently of whoever ran the analysis. Holdout supports → `accepted`; holdout fails → `rejected`.
 
 ### `accepted`
 
-Terminal state for hypotheses the holdout supported.
-
-- **Inputs:** The holdout-supported hypothesis
-- **Outputs:** None — terminal. `completed` set, `verdict: PASSED`, archived.
+Terminal state for hypotheses the holdout supported. `completed` set, `verdict: PASSED`, archived.
 
 ### `rejected`
 
-Terminal state for hypotheses that failed at any tier.
+Terminal state for hypotheses that failed at any tier (`smoke`, `analysis`, or `holdout`). `completed` set, `verdict: REJECTED`, archived — the body retains why, so future captains avoid re-running it.
 
-- **Inputs:** A failure verdict from `smoke` (back-out path is `hypothesis` for a revise; if hypothesis is abandoned, transition straight to `rejected`), `analysis`, or `holdout`
-- **Outputs:** None — terminal. `completed` set, `verdict: REJECTED`, archived. The experiment body retains why it was rejected so future captains can avoid re-running it.
+## Workflow-specific rules
+
+The FO/ensign operating contract already governs generic stage semantics and proof discipline — prefer a code gate over a prose-only rule, prove by exercising rather than re-reading, fix success criteria before the evidence. Experiments inherit that from the contract their FO loads at boot; the rules below add only the experiment-shape specifics.
+
+- **Falsifiable hypothesis, criteria fixed first.** The hypothesis must be falsifiable and its accept/reject success criteria must be written down before any evidence is gathered, so the verdict cannot be rationalized after seeing results.
+- **Tier-gating.** Evidence promotes through `smoke → run → analysis → holdout` and a tier never skips: smoke fails fast before the run is burned, analysis applies the criteria as written, and a decisive smoke or analysis can reject without continuing.
+- **Holdout out-of-sample independence.** The holdout must be genuinely out-of-sample (different data, population, or time window) and run by a `fresh` agent independent of the analyst — a holdout that overlaps the run sample or is interpreted by the analyst defeats its purpose.
+- **Parked tiers + silence-watcher.** The parked-stages layer marks `smoke`, `run`, and `holdout` as normal-to-sit-in rather than stalled; the `silence-watcher` mod is offered for any parked stage with timeout/nudge semantics.
 
 ## Workflow State
 

--- a/skills/commission/references/templates/refinement.md
+++ b/skills/commission/references/templates/refinement.md
@@ -21,7 +21,7 @@ stages:
 
 # Refinement Workflow Template
 
-Iterate on an artifact through stages of improvement until it is locked. This is the universal base shape: an entity is drafted, reviewed for whether it is ready, polished if accepted, and marked done when finished. No layers active.
+Track an artifact through rounds of improvement to a locked, shipped result. This is the universal base shape: an entity is drafted, reviewed for whether it is ready, polished if accepted, and marked done when finished. No layers active.
 
 Use this template when the captain's mission is to track an artifact through rounds of improvement with a human-in-the-loop quality bar — design docs, PRDs, content pieces, outreach replies, integration records, anything where the work is "make this thing good enough." Variants in the Adoption section adapt the stage list and entity body to common end-use shapes (outreach, integration, content production, PRD authoring) without changing the underlying structure.
 
@@ -58,39 +58,27 @@ Every artifact file has YAML frontmatter. Fields are documented below; see **Art
 
 ### `draft`
 
-The artifact is being produced or revised. Work happens here every time the artifact enters the loop, including after a review bounce.
-
-- **Inputs:** The brief, prior reviewer notes (if this is a re-entry from review), source material
-- **Outputs:** A complete artifact body ready for review
-- **Good:** Addresses the brief, integrates prior feedback when re-entering, ready to be evaluated end-to-end
-- **Bad:** Half-finished sections, ignores reviewer notes from the prior round, produces something that cannot be evaluated as a whole
+The artifact is produced or revised — every time it enters the loop, including after a review bounce. The draft integrates prior reviewer notes and is complete enough to be evaluated end-to-end.
 
 ### `review`
 
-A reviewer reads the draft and decides: accept (advance to polish) or bounce back to draft with notes. This is an approval gate.
-
-- **Inputs:** The draft artifact
-- **Outputs:** Reviewer notes captured in the artifact body; either gate-approval to polish or rejection back to draft with concrete notes
-- **Good:** Specific, actionable notes; clear accept/reject decision; the reviewer reads the whole draft before deciding
-- **Bad:** Vague "this needs work" with no concrete asks, accepting things that have not been read carefully, deferring the decision indefinitely
+A reviewer reads the whole draft and makes a clear accept/reject decision behind an approval gate: gate-approval to `polish`, or rejection back to `draft` with specific, actionable notes.
 
 ### `polish`
 
-Final cleanup before the artifact is locked: formatting, copy edits, last-pass consistency, nothing structural.
-
-- **Inputs:** The accepted draft from review
-- **Outputs:** A polished artifact ready to be marked done
-- **Good:** Cosmetic improvements only, preserves the substance the reviewer accepted
-- **Bad:** Reopening structural decisions, introducing new content that should have gone through review
+Final cleanup before the artifact is locked — formatting, copy edits, last-pass consistency. Cosmetic only; preserves the substance the reviewer accepted and reopens nothing structural.
 
 ### `done`
 
-Terminal state. The artifact is locked and considered shipped (or filed, depending on the variant).
+Terminal state: the artifact is locked and shipped (or filed, per the variant). `completed` set, `verdict: PASSED`, archived. Start a new entity rather than reopening a done one.
 
-- **Inputs:** The polished artifact
-- **Outputs:** None — this is a terminal state. Mark `completed`, set `verdict: PASSED`, and archive.
-- **Good:** Clean handoff, terminal state set deliberately
-- **Bad:** Reopening a done artifact instead of starting a new one
+## Workflow-specific rules
+
+The FO/ensign operating contract already governs generic stage semantics and proof discipline. Refinement is the universal base shape, so most of its discipline is the contract's; the rules below add only the refinement-shape specifics.
+
+- **Human-in-the-loop quality bar.** `review` is an approval gate a human reviewer owns — the reviewer reads the whole draft and makes an explicit accept/reject call with concrete notes, never a vague "this needs work." `polish` is cosmetic-only; new content that should have gone through review does not belong there.
+- **No layers by default.** The base shape touches no repo and waits on no external event, so no structural layers fire. Variants that need them (e.g. outreach's `watching` stage) activate the layer through the variant, not the base.
+- **Variant menu.** Common end-use shapes are refinement with adjusted stages and a different entity body — `outreach`, `integration`, `content-production`, `prd-authoring` (see `## Adoption` → Surface variants). A variant changes the stage list and snippet, never the underlying draft → review → ship structure.
 
 ## Workflow State
 

--- a/skills/commission/references/templates/refinement.md
+++ b/skills/commission/references/templates/refinement.md
@@ -74,7 +74,7 @@ Terminal state: the artifact is locked and shipped (or filed, per the variant). 
 
 ## Workflow-specific rules
 
-The FO/ensign operating contract already governs generic stage semantics and proof discipline. Refinement is the universal base shape, so most of its discipline is the contract's; the rules below add only the refinement-shape specifics.
+The FO/ensign operating contract already governs generic stage semantics and proof discipline. Refinement is the universal base shape, so most of its discipline lives in the contract; the rules below add only the refinement-shape specifics.
 
 - **Human-in-the-loop quality bar.** `review` is an approval gate a human reviewer owns — the reviewer reads the whole draft and makes an explicit accept/reject call with concrete notes, never a vague "this needs work." `polish` is cosmetic-only; new content that should have gone through review does not belong there.
 - **No layers by default.** The base shape touches no repo and waits on no external event, so no structural layers fire. Variants that need them (e.g. outreach's `watching` stage) activate the layer through the variant, not the base.


### PR DESCRIPTION
Every commissioned workflow inherits these templates; this slims them to lead with the outcome and defer universal proof/stage discipline to the FO/ensign contract rather than restating it.

## What changed
- Restructure development.md / experiment.md / refinement.md: value-first lede, remove restated universal doctrine, add a `## Workflow-specific rules` slot keeping only each shape's unique rules.
- Rewire development.md's validation-stage cross-reference to the new slot; compact per-stage Good/Bad.
- Add contractlint guards: single-source over four contract-owned doctrine markers, per-template slot presence, lede position.

## Evidence
- AC-1 live: a workflow commissioned from the restructured development.md still rejects a tautological-AC entity (durable REJECTED end-state, offline grader PASS, offline-negative reds); the commissioned README restates zero doctrine markers — governance reaches it via the contract, not template prose.
- AC-2/AC-3 contractlint green; `go test ./...` 15/15 packages.

## Review guidance
The single-source check reds on realistic copy-paste doctrine drift; an intentional paraphrase is a documented, accepted coverage limitation, not a blocker.

---
[48](/spacedock-dev/spacedock/blob/867b5c55e422f269587c30e29fe209064644f5ae/commission-templates-defer-to-contract.md)
