### PR TITLE
Make the host-neutral dispatch core genuinely runtime-neutral

### DIFF
--- a/internal/contractlint/structural_checks_test.go
+++ b/internal/contractlint/structural_checks_test.go
@@ -452,6 +452,118 @@ func TestPortabilityCheckDiscriminatesHostSpecific(t *testing.T) {
 	}
 }
 
+// claudeTeamDispatchTokens are the LITERAL Claude-team command/flag tokens that
+// must NOT appear as core dispatch imperatives in the host-neutral dispatch core.
+// Their presence on a non-exempt line is itself the defect (structural-absence,
+// same family as retiredPluginPrivatePaths) — not a prose property. The
+// narrowly-paraphrasable phrase `team-mode` is deliberately NOT in this set: its
+// fix is the prose move, not a token ban, and banning a paraphrasable word would
+// be the prose-grep tautology the quarantine policy forbids.
+var claudeTeamDispatchTokens = []string{
+	"spawn-standing-all",
+	"--team {team_name}",
+}
+
+// adapterAsSubjectExemptions are the PHRASE-LEVEL exemptions: a token line is
+// allowed only when its sentence's subject is the adapter REALIZING the call. A
+// bare same-line `runtime adapter` mention is deliberately NOT an exemption — the
+// real current leak (line 9) names the adapter only as the forward destination
+// ("forward each spawn spec … to the runtime adapter's spawn call") while still
+// issuing the host command imperatively, so a bare-word exemption false-negatives
+// it. The exemption must name the adapter as the actor.
+var adapterAsSubjectExemptions = []string{
+	"Claude adapter",
+	"the adapter realizes",
+	"adapter maps",
+	"Claude realization",
+}
+
+// lineLeaksClaudeTeamDispatch reports whether a line carries a literal Claude-team
+// dispatch token UNEXEMPTED by a phrase-level adapter-as-subject phrase. This is the
+// scanner the host-neutral-core check and its discriminator control both drive.
+func lineLeaksClaudeTeamDispatch(line string) bool {
+	carriesToken := false
+	for _, tok := range claudeTeamDispatchTokens {
+		if strings.Contains(line, tok) {
+			carriesToken = true
+			break
+		}
+	}
+	if !carriesToken {
+		return false
+	}
+	for _, exempt := range adapterAsSubjectExemptions {
+		if strings.Contains(line, exempt) {
+			return false
+		}
+	}
+	return true
+}
+
+// TestDispatchCoreHasNoClaudeTeamImperative is a structural-ABSENCE check: the
+// host-neutral dispatch core (fo-dispatch-core.md) must carry no LITERAL Claude-team
+// command/flag token (`spawn-standing-all`, `--team {team_name}`) as a core
+// imperative. Codex and Pi load this core too, so a host command issued here reads
+// to them like a universal requirement they cannot satisfy. The expected value
+// comes from the rule (these are literal host command tokens that must not appear as
+// core imperatives), not from the file's own prose, so a host-neutral paraphrase
+// that drops the literal passes and an inverted/host-coupled imperative fails — same
+// family as TestRetiredPluginPrivatePathsAbsent. The Claude realization legitimately
+// lives in claude-fo-dispatch.md, whose lines name the adapter as the actor. The
+// paired discriminator control below keeps this from passing vacuously.
+func TestDispatchCoreHasNoClaudeTeamImperative(t *testing.T) {
+	path := filepath.Join(skillsRoot(t), "first-officer", "references", "fo-dispatch-core.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read dispatch core %s: %v", path, err)
+	}
+	for i, line := range strings.Split(string(data), "\n") {
+		if lineLeaksClaudeTeamDispatch(line) {
+			t.Errorf("%s:%d carries a Claude-team dispatch imperative in the host-neutral core (Codex/Pi load this too); move the host realization to claude-fo-dispatch.md: %q", path, i+1, strings.TrimSpace(line))
+		}
+	}
+}
+
+// TestDispatchCoreClaudeTeamScannerDiscriminates is the DISCRIMINATOR control for
+// the host-neutral-core check: it proves the scanner flags a genuinely host-coupled
+// line and passes a host-neutral paraphrase, an adapter-as-subject realization, and
+// a meaning-inverting paraphrase — so TestDispatchCoreHasNoClaudeTeamImperative can
+// never pass vacuously (e.g. by a typo'd token never matching anything).
+func TestDispatchCoreClaudeTeamScannerDiscriminates(t *testing.T) {
+	// Host-coupled imperative — the real current-leak shape. MUST flag.
+	mustFlag := "run `spacedock dispatch spawn-standing-all --workflow-dir {wd} --team {team_name}` and forward each spawn spec to the runtime adapter's spawn call"
+	if !lineLeaksClaudeTeamDispatch(mustFlag) {
+		t.Errorf("discriminator control: host-coupled imperative was NOT flagged (the scanner would pass vacuously): %q", mustFlag)
+	}
+
+	// A bare same-line `runtime adapter` forward-target mention is NOT a sufficient
+	// exemption — the real leak carries exactly this and must still flag.
+	bareAdapterWord := "forward each spawn spec to the runtime adapter's spawn call via `spawn-standing-all`"
+	if !lineLeaksClaudeTeamDispatch(bareAdapterWord) {
+		t.Errorf("discriminator control: a bare `runtime adapter` forward-target word wrongly exempted a token line (false negative on the real leak shape): %q", bareAdapterWord)
+	}
+
+	// Host-neutral paraphrase that drops the literal token. MUST pass.
+	hostNeutral := "Before the first worker dispatch, inject standing teammates via the runtime adapter's standing-injection call."
+	if lineLeaksClaudeTeamDispatch(hostNeutral) {
+		t.Errorf("discriminator control: a host-neutral paraphrase was wrongly flagged: %q", hostNeutral)
+	}
+
+	// Adapter-as-subject realization naming the host command. MUST pass (this is the
+	// shape that legitimately lives in claude-fo-dispatch.md).
+	adapterSubject := "The Claude adapter realizes the standing-injection call: run `spacedock dispatch spawn-standing-all --team {team_name}` and forward each spawn spec to Agent()."
+	if lineLeaksClaudeTeamDispatch(adapterSubject) {
+		t.Errorf("discriminator control: an adapter-as-subject realization was wrongly flagged: %q", adapterSubject)
+	}
+
+	// Meaning-inverting paraphrase that still drops the literal. MUST pass — proving
+	// the check is not a prose-grep that a paraphrase could defeat.
+	inverted := "Standing teammates are NEVER injected before any dispatch on any host."
+	if lineLeaksClaudeTeamDispatch(inverted) {
+		t.Errorf("discriminator control: a meaning-inverting host-neutral paraphrase was wrongly flagged: %q", inverted)
+	}
+}
+
 // shippedInstructionMarkdown returns every markdown file under skills/ (excluding
 // the test-only integration dir) plus the canonical mods/ — the full shipped
 // instruction surface the structural-absence and portability checks walk. This is

--- a/skills/first-officer/references/claude-fo-dispatch.md
+++ b/skills/first-officer/references/claude-fo-dispatch.md
@@ -50,12 +50,17 @@ Agent(
 ```
 This is the concrete Claude form of fo-dispatch-core.md's Break-Glass template; the contract (what it omits, the conditional `model=` slot, "use only when the helper is unavailable") is stated there.
 
+## Standing-Teammate Injection (Claude)
+
+The Claude realization of the core's standing-injection call (fo-dispatch-core.md `## Dispatch`): before the first team-mode dispatch, run `spacedock dispatch spawn-standing-all --workflow-dir {wd} --team {team_name}` and forward each spawn spec in the returned JSON array to `Agent()`. The call is idempotent (already-alive members omitted) and emits `[]` in bare mode or when none is declared. Standing teammates are team-scoped: they die with the team at teardown. (The `## Spawn Call (Agent)` sequencing rule above already states `spawn-standing-all` requires a real `team_name` from a prior `TeamCreate`.)
+
 ## Degraded Mode (spacedock seams)
 
 Degraded Mode itself — triggers, effects, captain report template, cooperative shutdown sweep — lives in `Skill(skill="spacedock:using-claude-team")`. Two spacedock-specific points the generic block references abstractly:
 
 - **Trigger:** the captain command `/spacedock bare` is the explicit operator-initiated degrade.
 - **Bare-mode dispatch emission:** the generic "no `team_name` on subsequent dispatch" effect is realized by building the dispatch in bare mode (`team_name: null`, `bare_mode: true`); `spacedock dispatch build` then emits a bare-mode Agent call with `name` and `team_name` absent.
+- **Bare-mode blocking dispatch:** in Claude bare mode the `Agent()` call blocks until the subagent completes — concurrent dispatch is not possible, so dispatch one entity at a time and process completions inline. (This is the Claude realization of fo-dispatch-core.md `## Dispatch Adapter`'s "when the adapter's dispatch is blocking" clause.)
 
 ## Context Budget and Dead Ensign Handling
 

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -35,6 +35,8 @@ recover, or tear down. Use Codex task names and mailbox notifications as the
 worker handle. Do not use Claude `SendMessage` completion syntax in Codex
 dispatch prompts.
 
+Codex has no shared standing-teammate surface; the core's standing-injection call is a no-op.
+
 ## Reuse And Feedback Routing
 
 Route feedback or continuation to an existing Codex worker with `send_input`.

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -91,7 +91,7 @@ Stay at the project root. Do not `cd` into worktrees. Use `git -C {path}` for op
 
 ## Dispatch (deferred module)
 
-The dispatch machinery — the per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly, standing-teammate injection (`spawn-standing-all`), reuse conditions, and the event-loop skeleton — lives in `references/fo-dispatch-core.md`, lazily loaded at the first team-mode dispatch. The runtime adapter supplies the host-specific dispatch parts it delegates (team/worker creation, the spawn call, the reuse-advance handle, the context-budget probe, and the event-loop reconcile sweep), read alongside the core at the first dispatch. A greet-and-stop boot never reads either.
+The dispatch machinery — the per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly, standing-teammate injection (`spawn-standing-all`), reuse conditions, and the event-loop skeleton — lives in `references/fo-dispatch-core.md`, lazily loaded at the first worker dispatch. The runtime adapter supplies the host-specific dispatch parts it delegates (team/worker creation, the spawn call, the reuse-advance handle, the context-budget probe, and the event-loop reconcile sweep), read alongside the core at the first dispatch. A greet-and-stop boot never reads either.
 
 ## Completion and Gates
 

--- a/skills/first-officer/references/fo-dispatch-core.md
+++ b/skills/first-officer/references/fo-dispatch-core.md
@@ -1,12 +1,12 @@
 # First Officer Dispatch Core (host-neutral)
 
-The per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly, the reuse contract, worktree ownership, and the event-loop skeleton. Lazily loaded at the first team-mode dispatch (named by the boot-resident core); a greet-and-stop boot never reads it. The runtime adapter supplies the host-specific parts this core delegates: team/worker creation, the spawn call, the reuse-advance handle, the context-budget probe, and the event-loop reconcile/backstop.
+The per-entity dispatch procedure, worker resolution, the dispatch-adapter assembly, the reuse contract, worktree ownership, and the event-loop skeleton. Lazily loaded at the first worker dispatch (named by the boot-resident core); a greet-and-stop boot never reads it. The runtime adapter supplies the host-specific parts this core delegates: team/worker creation, the spawn call, the reuse-advance handle, the context-budget probe, and the event-loop reconcile/backstop.
 
 ## Dispatch
 
 The FO MUST use the runtime adapter's dispatch mechanism. Manual prompt assembly is prohibited except in documented break-glass scenarios.
 
-**Standing-teammate injection.** Before the first team-mode dispatch, inject the workflow's declared standing teammates: run `spacedock dispatch spawn-standing-all --workflow-dir {wd} --team {team_name}` and forward each spawn spec in the returned JSON array to the runtime adapter's spawn call (verbatim, same discipline as `spacedock dispatch build` output). The call is idempotent — already-alive members are omitted, so re-running is safe — and emits `[]` in bare mode or when no standing teammate is declared. Standing teammates are team-scoped: they die with the team at teardown. Read each teammate's routing usage from its mod, not from here.
+**Standing-teammate injection.** Before the first worker dispatch, inject the workflow's declared standing teammates via the runtime adapter's standing-injection call. The adapter resolves the workflow's declared standing teammates and forwards each returned spawn spec to its spawn call (verbatim, same discipline as `spacedock dispatch build` output). Injection is idempotent — already-alive members are omitted, so re-running is safe — and is a no-op when no standing teammate is declared or the runtime has no shared-teammate surface. Standing-teammate lifetime is the adapter's (team-scoped where the runtime has teams). Read each teammate's routing usage from its mod, not from here.
 
 For each entity reported by `status --next`:
 
@@ -34,7 +34,7 @@ Advancing a completed worker. The gate-presentation spine (checklist review, AC 
 
 **Reuse conditions** (all must hold — if any fails, dispatch fresh):
 0. Consult the runtime adapter's context-budget probe. If it reports the worker over budget, or the probe source is unavailable, dispatch fresh (fail-safe — never silent-reuse on an absent reading). If the adapter declares no probe, this condition is satisfied. (Codex declares none; Claude supplies one — see the runtime adapter.)
-1. Not in bare mode (teams available).
+1. The runtime adapter exposes a live, reusable handle to the completed worker (its reuse-advance handle). When the adapter has no reusable-handle surface, this condition fails and the FO dispatches fresh.
 2. Next stage does NOT have `fresh: true`.
 3. Reuse-routing matches the entity's worktree state — if `worktree:` is set, route the next stage into the same worktree; if `worktree:` is empty and the next stage declares `worktree: true`, dispatch fresh so the new worktree's first agent is born inside it.
 4. The reused worker's stamped model matches the next stage's declared model — resolve through the runtime's model-for-member lookup and compare against `next_stage.effective_model`. Skip when `next_stage.effective_model` is null (null-declared stages accept any reused worker). Members stamped with captain-session fallback values (e.g., `"opus[1m]"`) never match enum values (`sonnet`, `opus`, `haiku`) and force a one-time fresh dispatch that re-stamps the canonical enum.
@@ -73,7 +73,7 @@ Use the runtime adapter's spawn call to spawn each worker. **Use the spawn call 
 
 **MANDATORY — Dispatch assembly via `spacedock dispatch build`:**
 
-Do NOT assemble worker prompts manually. Do NOT construct the `prompt` string yourself. Do NOT invent `name` values. ALWAYS route initial-dispatch input through `spacedock dispatch build` and forward its output to the spawn call verbatim. The key fields that MUST come from helper output are `subagent_type`, `name`, `team_name`, `model`, and `prompt` (which contains the completion signal). Manual assembly is a protocol violation except in the documented break-glass fallback below.
+Do NOT assemble worker prompts manually. Do NOT construct the `prompt` string yourself. Do NOT invent `name` values. ALWAYS route initial-dispatch input through `spacedock dispatch build` and forward its output to the spawn call verbatim. The key fields that MUST come from helper output are `subagent_type`, `name`, `model`, and `prompt` (which contains the completion signal), plus any host-scoped fields the adapter declares (e.g. Claude `team_name`). The adapter names which emitted fields map to its spawn call and which are absent on its host. Manual assembly is a protocol violation except in the documented break-glass fallback below.
 
 The only permitted path for initial dispatch is:
 
@@ -95,7 +95,7 @@ The only permitted path for initial dispatch is:
 4. **REQUIRED — On exit 0, parse the stdout JSON and call the spawn call with the emitted fields verbatim.** The `name`, `description`, `prompt`, and `model` fields MUST come from helper output unchanged. The `description` field is REQUIRED — do not omit it. The `prompt` is a file-pointer (`Skill(...) ; then Read /tmp/spacedock-dispatch/{name}.md and treat its content as your assignment.`); the ensign Reads the file on first action and treats the body (including the completion-signal section) as the inline assignment. Do not strip or rewrite the prompt. Forward `output.model` as the spawn call's model parameter when present; when null, OMIT the model argument entirely (do NOT pass a null model — default-inheritance only applies when the argument is absent). The runtime adapter names the concrete spawn call and how it maps these fields.
 5. **On non-zero exit only** (or if the binary is unavailable): read stderr, report the helper failure to the captain, and fall back to Break-Glass Manual Dispatch below. A zero-exit run is never a break-glass trigger.
 
-In bare mode, dispatch blocks until the subagent completes — concurrent dispatch is not possible. Dispatch one entity at a time and process completions inline.
+Whether a dispatch blocks until worker completion or returns a handle to await later is the adapter's behavior, not a host-neutral invariant. When the adapter's dispatch is blocking, dispatch one entity at a time and process each completion inline before the next.
 
 **Reuse dispatch (advance handle):** `spacedock dispatch build` serves only initial dispatch. When advancing a reused ensign via the runtime adapter's reuse-advance handle, assemble the advancement message directly — the helper is not involved in the reuse path.
 

--- a/skills/first-officer/references/pi-first-officer-runtime.md
+++ b/skills/first-officer/references/pi-first-officer-runtime.md
@@ -23,6 +23,8 @@ For Spacedock stage dispatches through `pi-subagents`, call `subagent(...)` with
 
 For Spacedock stage dispatches through `pi-subagents`, do not use the `subagent(... acceptance: ...)` contract. Put acceptance requirements in the task prompt/dispatch content instead. Spacedock owns the independent implementation-to-validation workflow: the gate is verification via entity stage reports, product/state commits, and independent validation, not same-agent acceptance finalization by the child that did the work.
 
+For the core's standing-injection call: `pi-subagents` has no standing surface (no-op); `pi-agent-teams` MAY map injection to `member_spawn` per the adapter's lifecycle mapping.
+
 ## Awaiting Completion
 
 For `pi-subagents`, the completion signal is the subagent result returned to the parent. After the result arrives, read the entity file and verify the stage report exactly as the shared core requires. Do not advance state based only on a cheerful worker summary.


### PR DESCRIPTION
Make the host-neutral dispatch core genuinely runtime-neutral, so Codex and Pi first officers no longer load Claude-team language as if it were universal.

## What changed
- Move five Claude/team-only imperatives out of `fo-dispatch-core.md` into the Claude adapter; keep the cores split.
- Reframe the core as host-neutral: first-worker dispatch, adapter-declared `team_name`, adapter-exposed reuse handle, adapter-owned blocking.
- Add Codex and Pi one-line standing-injection mappings.
- Add a structural contractlint check that fails on Claude-team command tokens in the host-neutral core.

## Evidence
- `go test ./...` green; the AC-1 check is written failing-first and non-tautological (discriminator + fresh perturbation); AC-2 Codex `send_input` reuse and AC-3 Claude gates green.
- Detached adversarial audit on a throwaway checkout refuted nothing material; no reachability gap.

## Review guidance
Scrutinize `internal/contractlint/structural_checks_test.go` — the AC-1 check is a structural-absence token scan with a phrase-level adapter-as-subject exemption, not a prose-grep.

---
[ezf](/spacedock-dev/spacedock/blob/31446e6d2b274062e26151a31a1efc1e23d5a1a6/runtime-neutral-dispatch-core-cleanup/index.md)
