### PR TITLE
Measure journeymetrics read adoption and trim the redundant dispatch-prompt hint

### DIFF
--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -535,25 +535,15 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 
 	// 4. Entity-read instruction. Under split root the entity lives in the state
 	// checkout; a non-split worktree stage rewrites the path into the worktree.
-	// The first entity read stays a whole-spec read; the trailing hint redirects
-	// only REPEAT reads of the body (e.g. finding the stage-report append point)
-	// to the section-scoped status --read, where the savings live.
-	readPath := entityPath
 	if worktreePath != "" && !splitRoot {
 		entityRel := pyRelpath(entityPath, gitRoot)
 		worktreeEntityPath = status.PyJoin(worktreePath, entityRel)
-		readPath = worktreeEntityPath
 		parts = append(parts, fmt.Sprintf(
 			"Read the entity file at %s for the full spec. It contains:\n", worktreeEntityPath))
 	} else {
 		parts = append(parts, fmt.Sprintf(
 			"Read the entity file at %s for the current spec.\n", entityPath))
 	}
-	parts = append(parts, fmt.Sprintf(
-		"For later re-reads of the body during work — e.g. to find the append point "+
-			"for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read %s --json` "+
-			"to fetch a section's offset/lines rather than re-reading the whole file.\n",
-		readPath))
 
 	// 6. Feedback context (conditional).
 	if feedbackContext != "" {

--- a/internal/dispatch/testdata/golden/build-abs-worktree.txt
+++ b/internal/dispatch/testdata/golden/build-abs-worktree.txt
@@ -36,8 +36,6 @@ Your git branch is spacedock-ensign/thing. All commits MUST be on this branch. D
 
 Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for the full spec. It contains:
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/.worktrees/spacedock-ensign-thing/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
@@ -36,8 +36,6 @@ Your git branch is spacedock-ensign/thing. All commits MUST be on this branch. D
 
 Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for the full spec. It contains:
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/.worktrees/spacedock-ensign-thing/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Feedback from prior review
 
 REJECTED: do better.

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+bare.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+bare.txt
@@ -31,8 +31,6 @@ Stage: backlog
 
 Read the entity file at <ROOT>/thing.md for the current spec.
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
@@ -32,8 +32,6 @@ Stage: backlog
 
 Read the entity file at <ROOT>/thing.md for the current spec.
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
@@ -36,8 +36,6 @@ Your git branch is spacedock-ensign/thing. All commits MUST be on this branch. D
 
 Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for the full spec. It contains:
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/.worktrees/spacedock-ensign-thing/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
@@ -36,8 +36,6 @@ Your git branch is spacedock-ensign/thing. All commits MUST be on this branch. D
 
 Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing/index.md for the full spec. It contains:
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/.worktrees/spacedock-ensign-thing/thing/index.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
@@ -37,8 +37,6 @@ This workflow is split-root: the entity body and your stage report live in the s
 
 Read the entity file at <ROOT>/state-checkout/thing.md for the current spec.
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/state-checkout/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
@@ -34,8 +34,6 @@ This workflow is split-root: the entity body and your stage report live in the s
 
 Read the entity file at <ROOT>/state-checkout/thing/index.md for the current spec.
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/state-checkout/thing/index.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
@@ -37,8 +37,6 @@ This workflow is split-root: the entity body and your stage report live in the s
 
 Read the entity file at <ROOT>/state-checkout/thing/index.md for the current spec.
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/state-checkout/thing/index.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-html-escape.txt
+++ b/internal/dispatch/testdata/golden/build-html-escape.txt
@@ -36,8 +36,6 @@ Your git branch is spacedock-ensign/thing. All commits MUST be on this branch. D
 
 Read the entity file at <ROOT>/.worktrees/spacedock-ensign-thing/thing.md for the full spec. It contains:
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/.worktrees/spacedock-ensign-thing/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Feedback from prior review
 
 compare a < b && c > d in <Tag> & raw &amp; ampersand

--- a/internal/dispatch/testdata/golden/build-mods.txt
+++ b/internal/dispatch/testdata/golden/build-mods.txt
@@ -33,8 +33,6 @@ Stage: backlog
 
 Read the entity file at <ROOT>/thing.md for the current spec.
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-nonascii-title.txt
+++ b/internal/dispatch/testdata/golden/build-nonascii-title.txt
@@ -32,8 +32,6 @@ Stage: backlog
 
 Read the entity file at <ROOT>/thing.md for the current spec.
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Completion checklist
 
 - a

--- a/internal/dispatch/testdata/golden/build-space-path.txt
+++ b/internal/dispatch/testdata/golden/build-space-path.txt
@@ -32,8 +32,6 @@ Stage: backlog
 
 Read the entity file at <ROOT>/work dir/thing.md for the current spec.
 
-For later re-reads of the body during work — e.g. to find the append point for your stage report — use `${SPACEDOCK_BIN:-spacedock} status --read <ROOT>/work dir/thing.md --json` to fetch a section's offset/lines rather than re-reading the whole file.
-
 ### Completion checklist
 
 - a

--- a/internal/journeymetrics/claude.go
+++ b/internal/journeymetrics/claude.go
@@ -21,6 +21,8 @@ func ParseClaudeJSONL(data []byte) (ClaudeParseResult, error) {
 	assistantUsageSeen := map[string]bool{}
 	toolIDs := map[string]string{}
 	toolCallsByName := map[string]int{}
+	statusReadCalls := 0
+	scopedReadCalls := 0
 	var assistantUsage TokenTotals
 	var terminalUsage *TokenTotals
 	var terminalCost float64
@@ -73,6 +75,16 @@ func ParseClaudeJSONL(data []byte) (ClaudeParseResult, error) {
 				}
 				toolIDs[toolID] = block.Name
 				toolCallsByName[block.Name]++
+				switch block.Name {
+				case "Bash":
+					if commandInvokesStatusRead(bashCommand(block.Input)) {
+						statusReadCalls++
+					}
+				case "Read":
+					if readInputIsScoped(block.Input) {
+						scopedReadCalls++
+					}
+				}
 			}
 		case "result":
 			result, err := parseClaudeResult(row)
@@ -106,6 +118,8 @@ func ParseClaudeJSONL(data []byte) (ClaudeParseResult, error) {
 			Turns:           len(assistantIDs),
 			ToolCalls:       len(toolIDs),
 			ToolCallsByName: toolCallsByName,
+			StatusReadCalls: statusReadCalls,
+			ScopedReadCalls: scopedReadCalls,
 			Tokens:          tokens,
 			TotalCostUSD:    terminalCost,
 			ModelUsage:      terminalModelUsage,
@@ -212,9 +226,10 @@ type claudeAssistant struct {
 }
 
 type claudeContent struct {
-	Type string `json:"type"`
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	Type  string          `json:"type"`
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
 }
 
 func parseClaudeAssistant(raw json.RawMessage) (claudeAssistant, error) {

--- a/internal/journeymetrics/codex.go
+++ b/internal/journeymetrics/codex.go
@@ -15,6 +15,7 @@ type CodexCharacterization struct {
 	FieldsByEvent   map[string][]string `json:"fields_by_event"`
 	ToolCalls       int                 `json:"tool_calls,omitempty"`
 	ToolCallsByName map[string]int      `json:"tool_calls_by_name,omitempty"`
+	StatusReadCalls int                 `json:"status_read_calls,omitempty"`
 }
 
 func CharacterizeCodexExecJSONL(data []byte) (CodexCharacterization, error) {
@@ -23,6 +24,7 @@ func CharacterizeCodexExecJSONL(data []byte) (CodexCharacterization, error) {
 	fields := map[string]map[string]bool{}
 	toolSeen := map[string]bool{}
 	toolCallsByName := map[string]int{}
+	statusReadCalls := 0
 	model := ""
 	lineNo := 0
 	for scanner.Scan() {
@@ -50,6 +52,9 @@ func CharacterizeCodexExecJSONL(data []byte) (CodexCharacterization, error) {
 			if !toolSeen[callID] {
 				toolSeen[callID] = true
 				toolCallsByName[rawString(row["name"])]++
+				if commandInvokesStatusRead(codexCommand(row["arguments"])) {
+					statusReadCalls++
+				}
 			}
 		}
 		if fields[typ] == nil {
@@ -78,6 +83,7 @@ func CharacterizeCodexExecJSONL(data []byte) (CodexCharacterization, error) {
 		FieldsByEvent:   fieldsByEvent,
 		ToolCalls:       len(toolSeen),
 		ToolCallsByName: toolCallsByName,
+		StatusReadCalls: statusReadCalls,
 	}, nil
 }
 

--- a/internal/journeymetrics/readadoption.go
+++ b/internal/journeymetrics/readadoption.go
@@ -1,0 +1,88 @@
+// ABOUTME: Detects `status --read` adoption in a tool-call command string,
+// ABOUTME: launcher-agnostic and flag-order independent, shared by both runtimes.
+package journeymetrics
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// statusReadLaunchers are the command prefixes under which `status` is the
+// spacedock subcommand: the two installed binaries plus the
+// ${SPACEDOCK_BIN:-spacedock} form the fetch commands emit.
+var statusReadLaunchers = map[string]bool{
+	"spacedock":                   true,
+	"sd":                          true,
+	"${SPACEDOCK_BIN:-spacedock}": true,
+}
+
+// commandInvokesStatusRead reports whether cmd invokes the spacedock `status`
+// subcommand with a `--read` flag. The `status` token must be the subcommand —
+// either the first token (a bare `status --read`) or immediately preceded by a
+// recognized launcher — so a `status` substring quoted as an argument to a
+// different command (e.g. `echo 'status --read'`) does not match. The `--read`
+// flag may appear in any order among status's flags.
+func commandInvokesStatusRead(cmd string) bool {
+	tokens := strings.Fields(cmd)
+	for i, tok := range tokens {
+		if tok != "status" {
+			continue
+		}
+		isSubcommand := i == 0 || statusReadLaunchers[tokens[i-1]]
+		if !isSubcommand {
+			continue
+		}
+		for _, rest := range tokens[i+1:] {
+			if rest == "--read" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// readInputIsScoped reports whether a Read tool_use input is a scoped read — one
+// carrying a non-zero offset or limit (the line-range fields). A whole-file Read
+// carries only file_path, so neither field is present and the read is unscoped.
+func readInputIsScoped(input json.RawMessage) bool {
+	if len(input) == 0 {
+		return false
+	}
+	var scope struct {
+		Offset int `json:"offset"`
+		Limit  int `json:"limit"`
+	}
+	if err := json.Unmarshal(input, &scope); err != nil {
+		return false
+	}
+	return scope.Offset != 0 || scope.Limit != 0
+}
+
+// bashCommand extracts the command string from a Bash tool_use input.
+func bashCommand(input json.RawMessage) string {
+	if len(input) == 0 {
+		return ""
+	}
+	var args struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return ""
+	}
+	return args.Command
+}
+
+// codexCommand extracts the shell command string from a codex tool_call.started
+// arguments object (file reads and CLI calls both go through the shell on codex).
+func codexCommand(arguments json.RawMessage) string {
+	if len(arguments) == 0 {
+		return ""
+	}
+	var args struct {
+		Cmd string `json:"cmd"`
+	}
+	if err := json.Unmarshal(arguments, &args); err != nil {
+		return ""
+	}
+	return args.Cmd
+}

--- a/internal/journeymetrics/readadoption_test.go
+++ b/internal/journeymetrics/readadoption_test.go
@@ -1,0 +1,115 @@
+package journeymetrics
+
+import "testing"
+
+func TestParseClaudeSurfacesStatusReadAndScopedReadCounts(t *testing.T) {
+	// WITH: one `status --read` Bash tool_use and one scoped Read (offset/limit).
+	got, err := ParseClaudeJSONL(readTestdata(t, "claude_read_adoption.stream.jsonl"))
+	if err != nil {
+		t.Fatalf("ParseClaudeJSONL: %v", err)
+	}
+	if got.Observation.StatusReadCalls != 1 {
+		t.Errorf("status_read_calls = %d, want 1", got.Observation.StatusReadCalls)
+	}
+	if got.Observation.ScopedReadCalls != 1 {
+		t.Errorf("scoped_read_calls = %d, want 1", got.Observation.ScopedReadCalls)
+	}
+
+	// The counts flow through BuildRecord onto the emitted Record, exactly as
+	// ToolCallsByName does — so the release ledger surfaces them.
+	record := BuildRecord(JourneySpec{ScenarioID: "x", Source: "s"}, BehaviorResult{Passed: true}, got.Observation)
+	if record.StatusReadCalls != 1 || record.ScopedReadCalls != 1 {
+		t.Errorf("record counts = (%d,%d), want (1,1)", record.StatusReadCalls, record.ScopedReadCalls)
+	}
+
+	// WITHOUT: a plain `spacedock status` Bash and a full-file Read (no offset/limit).
+	none, err := ParseClaudeJSONL(readTestdata(t, "claude_no_read_adoption.stream.jsonl"))
+	if err != nil {
+		t.Fatalf("ParseClaudeJSONL (no adoption): %v", err)
+	}
+	if none.Observation.StatusReadCalls != 0 {
+		t.Errorf("status_read_calls without adoption = %d, want 0", none.Observation.StatusReadCalls)
+	}
+	if none.Observation.ScopedReadCalls != 0 {
+		t.Errorf("scoped_read_calls without adoption = %d, want 0", none.Observation.ScopedReadCalls)
+	}
+}
+
+func TestStatusReadCallsDedupAcrossDeltas(t *testing.T) {
+	// Real runner streams are MULTI-DELTA: the same tool_use block (same tool id)
+	// is carried across two assistant rows. The status-read count dedups on the
+	// same toolID key the existing tool-call dedup uses, so a repeated delta does
+	// not double-count. Shape mirrors TestParseClaudeTurnsMergesToolUseAcrossDeltas.
+	stream := `{"type":"assistant","message":{"id":"msg_x","model":"claude-sonnet-4-6","usage":{"input_tokens":50},"content":[{"type":"tool_use","id":"toolu_sr","name":"Bash","input":{"command":"spacedock status --read /path/entity.md --json"}}]}}
+{"type":"assistant","message":{"id":"msg_x","model":"claude-sonnet-4-6","usage":{"input_tokens":50},"content":[{"type":"tool_use","id":"toolu_sr","name":"Bash","input":{"command":"spacedock status --read /path/entity.md --json"}}]}}`
+
+	got, err := ParseClaudeJSONL([]byte(stream))
+	if err != nil {
+		t.Fatalf("ParseClaudeJSONL: %v", err)
+	}
+	if got.Observation.StatusReadCalls != 1 {
+		t.Errorf("status_read_calls = %d, want 1 (the repeated delta must not double-count)", got.Observation.StatusReadCalls)
+	}
+}
+
+func TestCodexCharacterizationSurfacesStatusReadCalls(t *testing.T) {
+	// Codex carries the shell command in tool_call.started arguments.cmd. The
+	// Bash-arg detector reuses the shared commandInvokesStatusRead helper.
+	withRead := `{"type":"session.started","session_id":"c","model":"gpt-5-codex"}
+{"type":"tool_call.started","call_id":"call-1","name":"exec_command","arguments":{"cmd":"spacedock status --read /path/entity.md --json"}}
+{"type":"tool_call.completed","call_id":"call-1","name":"exec_command","exit_code":0}`
+	got, err := CharacterizeCodexExecJSONL([]byte(withRead))
+	if err != nil {
+		t.Fatalf("CharacterizeCodexExecJSONL: %v", err)
+	}
+	if got.StatusReadCalls != 1 {
+		t.Errorf("codex status_read_calls = %d, want 1", got.StatusReadCalls)
+	}
+
+	plain := `{"type":"session.started","session_id":"c","model":"gpt-5-codex"}
+{"type":"tool_call.started","call_id":"call-1","name":"exec_command","arguments":{"cmd":"spacedock status --json"}}`
+	none, err := CharacterizeCodexExecJSONL([]byte(plain))
+	if err != nil {
+		t.Fatalf("CharacterizeCodexExecJSONL (plain): %v", err)
+	}
+	if none.StatusReadCalls != 0 {
+		t.Errorf("codex status_read_calls for plain status = %d, want 0", none.StatusReadCalls)
+	}
+}
+
+func TestCommandInvokesStatusRead(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		// Launcher-agnostic positives: spacedock, sd, the ${SPACEDOCK_BIN:-spacedock}
+		// fetch-command form, and a bare status invocation.
+		{"spacedock launcher", "spacedock status --read /path/entity.md", true},
+		{"sd launcher", "sd status --read /path/entity.md", true},
+		{"SPACEDOCK_BIN launcher", "${SPACEDOCK_BIN:-spacedock} status --read /path/entity.md", true},
+		{"bare status", "status --read /path/entity.md", true},
+		// Flag order independence: --read after another flag still counts.
+		{"flag order independent", "spacedock status --json --read /path/entity.md", true},
+		// --json default appears too; the --read token anywhere after status counts.
+		{"read then json", "spacedock status --read /path/entity.md --json", true},
+
+		// Negatives: status without --read.
+		{"plain status", "spacedock status", false},
+		{"status boot", "spacedock status --boot", false},
+		{"status discover json", "spacedock status --discover --json", false},
+		// A non-status subcommand, even one that happens to carry --read elsewhere.
+		{"non-status command", "spacedock dispatch show-stage-def --stage implementation", false},
+		// status as a quoted argument to a different command is NOT a status invocation.
+		{"echo quoted status read", "echo 'status --read'", false},
+		// --read on a non-status command is not a status --read.
+		{"readonly other flag", "spacedock dispatch build --readme", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := commandInvokesStatusRead(tc.cmd); got != tc.want {
+				t.Errorf("commandInvokesStatusRead(%q) = %v, want %v", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/journeymetrics/record.go
+++ b/internal/journeymetrics/record.go
@@ -53,6 +53,8 @@ func BuildRecord(spec JourneySpec, result BehaviorResult, observation Observatio
 		Turns:           observation.Turns,
 		ToolCalls:       observation.ToolCalls,
 		ToolCallsByName: observation.ToolCallsByName,
+		StatusReadCalls: observation.StatusReadCalls,
+		ScopedReadCalls: observation.ScopedReadCalls,
 		Tokens:          observation.Tokens.withTotal(),
 		TotalCostUSD:    observation.TotalCostUSD,
 		ModelUsage:      normalizeModelUsage(observation.ModelUsage),

--- a/internal/journeymetrics/testdata/claude_no_read_adoption.stream.jsonl
+++ b/internal/journeymetrics/testdata/claude_no_read_adoption.stream.jsonl
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init","model":"claude-sonnet-4-6"}
+{"type":"assistant","message":{"id":"msg_1","model":"claude-sonnet-4-6","usage":{"input_tokens":100,"output_tokens":10},"content":[{"type":"tool_use","id":"toolu_plainstatus","name":"Bash","input":{"command":"spacedock status --json"}}]}}
+{"type":"assistant","message":{"id":"msg_2","model":"claude-sonnet-4-6","usage":{"input_tokens":120,"output_tokens":12},"content":[{"type":"tool_use","id":"toolu_fullread","name":"Read","input":{"file_path":"/path/entity.md"}}]}}
+{"type":"result","subtype":"success","usage":{"input_tokens":300,"output_tokens":40},"total_cost_usd":0.05}

--- a/internal/journeymetrics/testdata/claude_read_adoption.stream.jsonl
+++ b/internal/journeymetrics/testdata/claude_read_adoption.stream.jsonl
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init","model":"claude-sonnet-4-6"}
+{"type":"assistant","message":{"id":"msg_1","model":"claude-sonnet-4-6","usage":{"input_tokens":100,"output_tokens":10},"content":[{"type":"tool_use","id":"toolu_statusread","name":"Bash","input":{"command":"spacedock status --read /path/entity.md --json"}}]}}
+{"type":"assistant","message":{"id":"msg_2","model":"claude-sonnet-4-6","usage":{"input_tokens":120,"output_tokens":12},"content":[{"type":"tool_use","id":"toolu_scopedread","name":"Read","input":{"file_path":"/path/entity.md","offset":96,"limit":14}}]}}
+{"type":"result","subtype":"success","usage":{"input_tokens":300,"output_tokens":40},"total_cost_usd":0.05}

--- a/internal/journeymetrics/types.go
+++ b/internal/journeymetrics/types.go
@@ -43,6 +43,8 @@ type Observation struct {
 	Turns           int
 	ToolCalls       int
 	ToolCallsByName map[string]int
+	StatusReadCalls int
+	ScopedReadCalls int
 	Tokens          TokenTotals
 	TotalCostUSD    float64
 	ModelUsage      map[string]ModelUsage
@@ -112,6 +114,8 @@ type Record struct {
 	Turns           int                    `json:"turns,omitempty"`
 	ToolCalls       int                    `json:"tool_calls,omitempty"`
 	ToolCallsByName map[string]int         `json:"tool_calls_by_name,omitempty"`
+	StatusReadCalls int                    `json:"status_read_calls,omitempty"`
+	ScopedReadCalls int                    `json:"scoped_read_calls,omitempty"`
 	Tokens          TokenTotals            `json:"tokens,omitempty"`
 	TotalCostUSD    float64                `json:"total_cost_usd,omitempty"`
 	ModelUsage      map[string]ModelUsage  `json:"model_usage,omitempty"`
@@ -135,6 +139,8 @@ type recordJSON struct {
 	Turns           int                    `json:"turns,omitempty"`
 	ToolCalls       int                    `json:"tool_calls,omitempty"`
 	ToolCallsByName map[string]int         `json:"tool_calls_by_name,omitempty"`
+	StatusReadCalls int                    `json:"status_read_calls,omitempty"`
+	ScopedReadCalls int                    `json:"scoped_read_calls,omitempty"`
 	Tokens          *TokenTotals           `json:"tokens,omitempty"`
 	TotalCostUSD    float64                `json:"total_cost_usd,omitempty"`
 	ModelUsage      map[string]ModelUsage  `json:"model_usage,omitempty"`
@@ -169,6 +175,8 @@ func (r Record) MarshalJSON() ([]byte, error) {
 		Turns:           r.Turns,
 		ToolCalls:       r.ToolCalls,
 		ToolCallsByName: r.ToolCallsByName,
+		StatusReadCalls: r.StatusReadCalls,
+		ScopedReadCalls: r.ScopedReadCalls,
 		Tokens:          tokens,
 		TotalCostUSD:    r.TotalCostUSD,
 		ModelUsage:      r.ModelUsage,


### PR DESCRIPTION
Measure `status --read` adoption via journeymetrics and recover per-dispatch prompt bloat by trimming the redundant re-read hint.

## What changed
- Surface `status_read_calls` + `scoped_read_calls` on the journey record by decoding the tool-use `input` the parser previously dropped.
- Add a launcher-agnostic `commandInvokesStatusRead` helper shared by the claude and codex parsers; dedup on the existing `toolID` key.
- Trim the redundant site-6 dispatch-prompt re-read hint from `build.go`; regenerate the 13 affected goldens (deletion only).
- Retain sites 4/5 (`ensign-shared-core.md`) as the repeat-read contract.

## Evidence
- `go test ./...` green; AC-1..AC-4 perturbation-proven (forcing either detector false FAILs); AC-5/AC-6 verified via the golden diff (13 goldens, 0 additions, whole-spec read + sites 4/5 retained).
- Detached adversarial audit on a throwaway checkout refuted nothing blocking.

## Review guidance
The metric parses the FO front-door stream, not the dispatched ensign's session, so AC-7 (adoption-not-regress) rests on the redundancy of sites 4/5 — a follow-up is filed to fold the ensign transcript into the metric.

---
[hf](/spacedock-dev/spacedock/blob/1f54f882d8d931a01a768c3e71be32fcce7970ea/journeymetrics-read-adoption-metric.md)
Related: supersedes read-hint-adoption-bloat-trim (folded as the trim)
