### PR TITLE
Retire two prose-grep doctrine guards; close AC-5 install-script comment-out hole

### DIFF
--- a/internal/contractlint/structural_checks_test.go
+++ b/internal/contractlint/structural_checks_test.go
@@ -292,50 +292,25 @@ func TestNoUnexpectedModHookOrPRMergeIntroduced(t *testing.T) {
 	}
 }
 
-// TestStartupGateGuidanceHasSingleSource is a DEDUP / single-source check: the
-// startup-gate abort guidance lives in exactly ONE prose file
-// (first-officer-shared-core.md), and agents/first-officer.md delegates rather than
-// mirroring it. A second copy would let the two surfaces drift — a real structural
-// defect (not a prose property): the count of files carrying the gate markers must
-// be exactly one.
-func TestStartupGateGuidanceHasSingleSource(t *testing.T) {
-	root := repoRoot(t)
-	markers := []string{"Contract version gate", "per-class remedy", "spacedock doctor"}
-
-	var sources []string
-	for _, tree := range []string{"skills", "agents"} {
-		base := filepath.Join(root, tree)
-		err := filepath.WalkDir(base, func(p string, d os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if d.IsDir() || filepath.Ext(p) != ".md" {
-				return nil
-			}
-			b, readErr := os.ReadFile(p)
-			if readErr != nil {
-				return readErr
-			}
-			text := string(b)
-			for _, m := range markers {
-				if strings.Contains(text, m) {
-					rel, _ := filepath.Rel(root, p)
-					sources = append(sources, rel)
-					return nil
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatalf("walk %s: %v", tree, err)
-		}
-	}
-
-	const sole = "skills/first-officer/references/first-officer-shared-core.md"
-	if len(sources) != 1 || sources[0] != sole {
-		t.Errorf("startup-gate prose has sources %v, want exactly [%s] (single source of truth)", sources, sole)
-	}
-}
+// The startup-gate single-source guard was RETIRED here per the package policy in
+// doc_test.go:11 ("delete the read and report the owed test"). It walked skills/+agents/
+// for hardcoded gate phrases (`"Contract version gate"`, `"per-class remedy"`,
+// `"spacedock doctor"`) and required exactly one file to carry them, claiming to red
+// when the guidance is mirrored so "the two surfaces drift". But the drift it guards
+// is a MEANING mirrored, not a byte copy: agents/first-officer.md could restate the
+// gate in its own words and the phrase-grep would stay green, so the check did not
+// actually prove the single-source property it advertised — it proved only that those
+// exact bytes appear once. That is the banned prose-grep (a literal-phrase substring
+// as a proxy for "the gate guidance is not restated elsewhere"); narrowing it to
+// verbatim-absence keeps it a prose-phrase-absence standing in for the meaning. No
+// token here IS the gate guidance, so the genuine-structural path (cf. the literal
+// claudeTeamDispatchTokens command tokens, where the token IS the thing) does not
+// apply. OWED PROOF: the human gate-review of the FO contract is what verifies the
+// startup gate is owned by first-officer-shared-core.md and delegated to (not mirrored
+// by) agents/first-officer.md — agents/first-officer.md today carries only the
+// delegating line "begin the Startup procedure from the shared core", which is the
+// design that keeps the surfaces from drifting; that delegation is prose a machine
+// cannot distinguish from a paraphrased mirror.
 
 // homeRootedClaudeRe matches only HOME-rooted personal-config forms: a `~/.claude`
 // tilde path, or `$HOME` / `os.UserHomeDir` joined with `.claude` on the same line.

--- a/internal/contractlint/template_defer_test.go
+++ b/internal/contractlint/template_defer_test.go
@@ -18,60 +18,25 @@ var commissionTemplates = []string{
 	"skills/commission/references/templates/refinement.md",
 }
 
-// doctrineMarker pins one canonical contract phrasing to its sole owning file.
-// The marker set binds two independent, divergeable sources — the contract's own
-// wording and whatever a template carries — so the check reds precisely when a
-// template re-restates the doctrine, not merely because we wrote the words.
-type doctrineMarker struct {
-	phrase string
-	owner  string
-}
-
-var doctrineMarkers = []doctrineMarker{
-	{"Prefer a code gate over a prose-only rule", "skills/first-officer/references/first-officer-shared-core.md"},
-	{"wording-present is not behavior", "skills/first-officer/references/first-officer-shared-core.md"},
-	{"Prove by exercising, not by re-reading", "skills/ensign/references/ensign-shared-core.md"},
-	{"A substring search is not proof of behavior", "skills/ensign/references/ensign-shared-core.md"},
-}
-
-// TestUniversalDoctrineHasSingleSource is the AC-2 single-source / dedup check: each
-// universal-doctrine marker the templates used to paraphrase appears in exactly ONE
-// file under skills/+agents/ — its owning contract — and a second copy (a template
-// re-restating it) reds the test. This is not a presence tautology: it binds the
-// contract's content against every other shipped file, so it fails when the doctrine
-// drifts back into a template, the drift regression the restructure prevents.
-func TestUniversalDoctrineHasSingleSource(t *testing.T) {
-	root := repoRoot(t)
-	for _, marker := range doctrineMarkers {
-		var sources []string
-		for _, tree := range []string{"skills", "agents"} {
-			base := filepath.Join(root, tree)
-			err := filepath.WalkDir(base, func(p string, d os.DirEntry, err error) error {
-				if err != nil {
-					return err
-				}
-				if d.IsDir() || filepath.Ext(p) != ".md" {
-					return nil
-				}
-				b, readErr := os.ReadFile(p)
-				if readErr != nil {
-					return readErr
-				}
-				if strings.Contains(string(b), marker.phrase) {
-					rel, _ := filepath.Rel(root, p)
-					sources = append(sources, rel)
-				}
-				return nil
-			})
-			if err != nil {
-				t.Fatalf("walk %s: %v", tree, err)
-			}
-		}
-		if len(sources) != 1 || sources[0] != marker.owner {
-			t.Errorf("doctrine marker %q has sources %v, want exactly [%s] (single source of truth — a template re-restating it reds this)", marker.phrase, sources, marker.owner)
-		}
-	}
-}
+// The AC-2 doctrine single-source guard was RETIRED here per doc_test.go's policy
+// (this package's own rule, line 11): "Do not add prose-to-code consistency checks
+// as behavior substitutes ... if no behavior test exists yet, delete the read and
+// report the owed test." It walked skills/+agents/ for a hardcoded doctrine phrase
+// (`strings.Contains(b, "Prefer a code gate over a prose-only rule")`, etc.) and
+// claimed to red when "the doctrine drifts back into a template". A doctrine is a
+// MEANING, not a literal: a paraphrased restatement ("Favor an enforceable code gate
+// rather than a prose-only rule…") carries the doctrine while dropping the bytes, so
+// the byte-grep stayed green on exactly the drift it advertised. That is the banned
+// prose-grep — a literal-phrase substring used as a proxy for whether a meaning is
+// present — and unlike the sibling claudeTeamDispatchTokens absence check (where the
+// literal command token IS the thing and a meaning-inverting paraphrase necessarily
+// drops it), no token here IS the doctrine; detecting paraphrase-drift requires
+// interpreting prose, which a machine cannot. Narrowing it to "verbatim-phrase
+// absence" would still be a prose-phrase-absence standing in for the meaning, i.e.
+// the same banned grep. OWED PROOF (#388 "templates defer doctrine to the contract"):
+// the human gate-review of the commission templates, the same review that owns the
+// qualitative lede judgement in TestTemplatesLeadWithOutcome below. The structural
+// half of AC-2 that a machine CAN see survives as TestTemplatesCarryWorkflowSpecificRulesSlot.
 
 // TestTemplatesCarryWorkflowSpecificRulesSlot is the AC-2 heading-presence half: each
 // commission template carries a `## Workflow-specific rules` section. This is a

--- a/internal/release/cilog_clean_output_workflow_test.go
+++ b/internal/release/cilog_clean_output_workflow_test.go
@@ -75,19 +75,24 @@ func TestLiveWorkflowInstallsPinnedGotestsum(t *testing.T) {
 		t.Errorf("expected an Install gotestsum step in all three live jobs, found %d", installs)
 	}
 
-	script := readGotestsumInstallScript(t)
-	if !strings.Contains(script, `VERSION="`) {
-		t.Error("install-gotestsum.sh does not pin a fixed VERSION")
+	// Read the EXECUTABLE commands, not the raw text: commenting out every
+	// verify/pin line leaves the phrases in the file but renders the script inert,
+	// so a raw strings.Contains would stay green on a script that no longer
+	// verifies anything. executableShellCommands strips comment/blank lines and
+	// joins continuations, so a commented-out verification disappears here.
+	active := strings.Join(executableShellCommands(readGotestsumInstallScript(t)), "\n")
+	if !strings.Contains(active, `VERSION="`) {
+		t.Error("install-gotestsum.sh does not pin a fixed VERSION on an executable line")
 	}
-	if strings.Contains(script, "@latest") || strings.Contains(script, "/latest/") {
+	if strings.Contains(active, "@latest") || strings.Contains(active, "/latest/") {
 		t.Error("install-gotestsum.sh uses a floating @latest reference (must be a pinned release)")
 	}
-	if !strings.Contains(script, "shasum -a 256 -c") {
+	if !strings.Contains(active, "shasum -a 256 -c") {
 		t.Error("install-gotestsum.sh does not sha256-verify the downloaded tarball before use")
 	}
 	// At least one concrete pinned checksum must be present (the linux_amd64 one
 	// the CI runners use); a bare `sha=""` would defeat the verification.
-	if !strings.Contains(script, "linux_amd64)") || !strings.Contains(script, "sha=\"") {
+	if !strings.Contains(active, "linux_amd64)") || !strings.Contains(active, "sha=\"") {
 		t.Error("install-gotestsum.sh is missing a concrete pinned checksum for the CI runner platform")
 	}
 }


### PR DESCRIPTION
Ship the v0.20.4 contract surface with honest test-strength: retire two hollow prose-grep doctrine guards the pre-cut antipattern audit flagged.

## What changed
- Remove `TestUniversalDoctrineHasSingleSource` and `TestStartupGateGuidanceHasSingleSource` — literal-phrase greps that missed paraphrase drift, violating the package's own `doc_test.go:11` policy.
- Record the owed human gate-review at each removal site (the property is a meaning, not a token — no honest machine check exists).
- Close the AC-5 install-script comment-out hole via `executableShellCommands()`.

## Evidence
- Detached adversarial re-audit clean; `go build/vet/test` green (15 packages).
- AC-5 check now REDs on the comment-out attack where the old raw-text check stayed green; the surviving structural guards discriminate.

---
[xh](/spacedock-dev/spacedock/blob/b857d7687752dde9b602b0d79c709f2a7f96fadb/contractlint-antidrift-guard-hardening.md)
