### PR TITLE
wrong-root boot guard: strip trailing shell separator from compound boots

### DIFF
--- a/internal/ensigncycle/wrong_root_detect_impl_test.go
+++ b/internal/ensigncycle/wrong_root_detect_impl_test.go
@@ -101,21 +101,36 @@ func wanderTarget(command, fixtureRoot string) (string, bool) {
 // bootPathArgs pulls the path arguments a boot command supplies: the target of a
 // leading `cd`, and the value after `--workflow-dir`. It splits on whitespace (the
 // boot commands are simple `cd …`, `spacedock status --boot --workflow-dir …`
-// forms; quoting is not exercised by the real boot stream).
+// forms; quoting is not exercised by the real boot stream). A compound boot chains
+// the path token straight into a shell separator with no preceding space —
+// `cd <root>; ls`, `cd <root>&& ls` — so each extracted token has any trailing
+// `;`/`&&`/`|` trimmed before it reaches the isUnder check.
 func bootPathArgs(command string) []string {
 	fields := strings.Fields(command)
 	var paths []string
 	for i, f := range fields {
 		switch {
 		case f == "cd" && i+1 < len(fields):
-			paths = append(paths, fields[i+1])
+			paths = append(paths, trimBootSeparator(fields[i+1]))
 		case f == "--workflow-dir" && i+1 < len(fields):
-			paths = append(paths, fields[i+1])
+			paths = append(paths, trimBootSeparator(fields[i+1]))
 		case strings.HasPrefix(f, "--workflow-dir="):
-			paths = append(paths, strings.TrimPrefix(f, "--workflow-dir="))
+			paths = append(paths, trimBootSeparator(strings.TrimPrefix(f, "--workflow-dir=")))
 		}
 	}
 	return paths
+}
+
+// trimBootSeparator strips a single trailing shell separator (`;`, `&&`, `|`) that a
+// compound boot glues onto a path token with no preceding space. It leaves an
+// already-clean path untouched.
+func trimBootSeparator(tok string) string {
+	for _, sep := range []string{"&&", ";", "|"} {
+		if strings.HasSuffix(tok, sep) {
+			return strings.TrimSuffix(tok, sep)
+		}
+	}
+	return tok
 }
 
 // isUnder reports whether path p is nested under dir (both already cleaned).

--- a/internal/ensigncycle/wrong_root_detect_test.go
+++ b/internal/ensigncycle/wrong_root_detect_test.go
@@ -115,6 +115,39 @@ func TestDetectWrongRootBoot(t *testing.T) {
 		}
 	})
 
+	t.Run("compound_cd_into_fixture_passes", func(t *testing.T) {
+		// Latest-opus chains its boot in one bash call: `cd <fixtureRoot>; ls; …`.
+		// strings.Fields glues the trailing `;` onto the path token (`<fixtureRoot>;`),
+		// which must not be read as a wander off the (correct) fixture root.
+		stream := streamLine(`cd ` + fixtureRoot + `; ls -la; echo "===README==="; sed -n '1,60p' README.md`)
+		if err := detectWrongRootBoot(stream, fixtureRoot); err != nil {
+			t.Errorf("detector red a `;`-glued compound cd into the fixture root: %v", err)
+		}
+	})
+
+	t.Run("compound_cd_into_fixture_amp_passes", func(t *testing.T) {
+		// The `&&`-glued-with-no-space form (`cd <fixtureRoot>&& ls`) glues `&&` onto
+		// the path token the same way; it must also not flag a wander.
+		stream := streamLine(`cd ` + fixtureRoot + `&& ls`)
+		if err := detectWrongRootBoot(stream, fixtureRoot); err != nil {
+			t.Errorf("detector red a `&&`-glued compound cd into the fixture root: %v", err)
+		}
+	})
+
+	t.Run("compound_cd_away_from_fixture_reds", func(t *testing.T) {
+		// The no-false-negative direction: a genuine off-fixture compound boot must
+		// STILL red, naming both roots. Guards the trim against over-stripping and
+		// silently disabling detection.
+		stream := streamLine(`cd ` + realRepo + `; ls -la; cat README.md`)
+		err := detectWrongRootBoot(stream, fixtureRoot)
+		if err == nil {
+			t.Fatal("detector passed a compound boot cd'ing into the real repo — want a wrong-root error")
+		}
+		if !strings.Contains(err.Error(), fixtureRoot) || !strings.Contains(err.Error(), realRepo) {
+			t.Errorf("error must name both expected (%q) and actual (%q): %v", fixtureRoot, realRepo, err)
+		}
+	})
+
 	t.Run("empty_stream_does_not_false_red", func(t *testing.T) {
 		// No Bash commands at all (e.g. a launch failure stream) is not a wrong-root
 		// boot — it is a different failure the caller's own checks surface.


### PR DESCRIPTION
Stop the wrong-root boot guard from false-positiving the opus claude-live lane when the FO chains exploration after a correct `cd` boot.

## What changed
- Add `trimBootSeparator`, stripping one trailing `;`/`&&`/`|` from each extracted path token.
- Apply it at the three `bootPathArgs` extraction points (the `cd` target and both `--workflow-dir` forms).
- Add `TestDetectWrongRootBoot` subcases: compound `;`- and `&&`-glued `cd`-into-fixture boots pass; an off-fixture compound boot still reds.

## Evidence
- `TestDetectWrongRootBoot` 10/10 passed (3 new + 7 existing); `go vet` clean.
- Test-harness-only (no product or contract caller); a detached-audit neutralization of the trim confirmed the new cases fail-first.

---
[3e](/spacedock-dev/spacedock/blob/118ed755ed9e51d40621d9cf83d331f3c8775937/wrong-root-guard-compound-boot.md)
