### PR TITLE
state-repo verbs: spacedock state commit / ready / sweep (rebase-HALT enforced by the verb)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -333,15 +333,17 @@ func newNewCommand(ctx context.Context, env []string, dir string, stdin io.Reade
 	return cmd
 }
 
-// newStateCommand wires `spacedock state init|new` for split-root state-checkout
-// management. Flag parsing is disabled so the post-subcommand argv (the optional
-// --workflow-dir) reaches the handler verbatim. `init` resumes a cloned workflow's
-// state checkout; `new` births one around a present split-root README. An unknown
-// or missing subcommand is a usage error (exit 2).
+// newStateCommand wires `spacedock state init|new|ready|sweep|commit` for split-root
+// state-checkout management. Flag parsing is disabled so the post-subcommand argv
+// (the optional --workflow-dir, a commit <slug>) reaches the handler verbatim.
+// `init` resumes a cloned workflow's state checkout; `new` births one; `ready`
+// integrates peers' state on boot; `sweep` lists merged-but-not-terminalized
+// entities; `commit <slug>` path-scoped-commits and syncs one entity. An unknown or
+// missing subcommand is a usage error (exit 2).
 func newStateCommand(ctx context.Context, env []string, dir string, stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
-		Use:                "state init|new [--workflow-dir DIR]",
-		Short:              "Manage a split-root workflow's state checkout (init resumes, new births)",
+		Use:                "state init|new|ready|sweep|commit [--workflow-dir DIR]",
+		Short:              "Manage a split-root workflow's state checkout (init/new births, ready/sweep/commit sync)",
 		GroupID:            "workflow",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -349,7 +351,7 @@ func newStateCommand(ctx context.Context, env []string, dir string, stdout, stde
 				return cmd.Help()
 			}
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "spacedock state: unknown subcommand (want: init or new)")
+				fmt.Fprintln(stderr, "spacedock state: unknown subcommand (want: init|new|ready|sweep|commit)")
 				return exitCodeError{2}
 			}
 			var code int
@@ -358,8 +360,14 @@ func newStateCommand(ctx context.Context, env []string, dir string, stdout, stde
 				code = runStateInit(ctx, args[1:], env, dir, stdout, stderr)
 			case "new":
 				code = runStateNew(ctx, args[1:], env, dir, stdout, stderr)
+			case "ready":
+				code = runStateReady(ctx, args[1:], env, dir, stdout, stderr)
+			case "sweep":
+				code = runStateSweep(ctx, args[1:], env, dir, stdout, stderr)
+			case "commit":
+				code = runStateCommit(ctx, args[1:], env, dir, stdout, stderr)
 			default:
-				fmt.Fprintln(stderr, "spacedock state: unknown subcommand (want: init or new)")
+				fmt.Fprintln(stderr, "spacedock state: unknown subcommand (want: init|new|ready|sweep|commit)")
 				return exitCodeError{2}
 			}
 			if code != 0 {
@@ -554,7 +562,7 @@ _spacedock() {
   fi
   case "${COMP_WORDS[1]}" in
     status) COMPREPLY=( $(compgen -W "$status_flags" -- "$cur") ) ;;
-    state) COMPREPLY=( $(compgen -W "init --workflow-dir" -- "$cur") ) ;;
+    state) COMPREPLY=( $(compgen -W "init new ready sweep commit --workflow-dir" -- "$cur") ) ;;
     completion) COMPREPLY=( $(compgen -W "bash zsh" -- "$cur") ) ;;
   esac
 }
@@ -574,7 +582,7 @@ _spacedock() {
   fi
   case "${words[2]}" in
     status) compadd -- $status_flags ;;
-    state) compadd -- init --workflow-dir ;;
+    state) compadd -- init new ready sweep commit --workflow-dir ;;
     completion) compadd -- bash zsh ;;
   esac
 }

--- a/internal/cli/state_commit_test.go
+++ b/internal/cli/state_commit_test.go
@@ -1,0 +1,236 @@
+// ABOUTME: Real-git e2e for `state commit <slug>` — the rebase-HALT (AC-1), path-
+// ABOUTME: scoped commit (AC-2), multi-writer happy path (AC-3), no-origin (AC-4).
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// twoHostStateWorkflow builds a bare origin carrying a commissioned split-root
+// workflow (code branch + orphan state branch + one seeded entity), then resumes
+// two host clones (A and B) each with a linked-worktree state checkout on the
+// shared spacedock-state/dev branch — the realistic two-writer split-root setup the
+// sync verbs operate against. Returns each host's workflow dir and the state
+// branch.
+func twoHostStateWorkflow(t *testing.T) (bare, workflowA, workflowB, stateBranch string) {
+	t.Helper()
+	bare = filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+
+	hostA := filepath.Join(t.TempDir(), "hostA")
+	git(t, t.TempDir(), "clone", "-q", bare, hostA)
+	git(t, hostA, "config", "user.email", "a@t")
+	git(t, hostA, "config", "user.name", "hostA")
+	workflowA, stateBranch, _ = commissionSplitWorkflow(t, hostA)
+	git(t, hostA, "push", "-q", "origin", "HEAD")
+
+	// hostB clones the code branch, then `state init` fetches the orphan state branch
+	// and adds B's own linked worktree at the gitignored state path.
+	hostB := filepath.Join(t.TempDir(), "hostB")
+	git(t, t.TempDir(), "clone", "-q", bare, hostB)
+	git(t, hostB, "config", "user.email", "b@t")
+	git(t, hostB, "config", "user.name", "hostB")
+	workflowB = filepath.Join(hostB, "docs", "dev")
+	stateInit(t, hostB, workflowB)
+	return bare, workflowA, workflowB, stateBranch
+}
+
+// stateInit runs `spacedock state init` for workflowDir from the host clone, failing
+// the test on a non-zero exit.
+func stateInit(t *testing.T, hostDir, workflowDir string) {
+	t.Helper()
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "init", "--workflow-dir", workflowDir},
+		os.Environ(), hostDir, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("state init exit=%d stderr=%q", code, errBuf.String())
+	}
+}
+
+// writeEntity overwrites slug's entity file in the workflow's state checkout with
+// body (no git ops — the verb does the staging/commit).
+func writeEntity(t *testing.T, workflowDir, slug, body string) {
+	t.Helper()
+	checkout := filepath.Join(workflowDir, ".spacedock-state")
+	if err := os.WriteFile(filepath.Join(checkout, slug+".md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// runStateCommitCmd runs `spacedock state commit slug` for workflowDir and returns
+// the exit code plus captured stdout/stderr.
+func runStateCommitCmd(t *testing.T, hostDir, workflowDir, slug string, extra ...string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errBuf strings.Builder
+	args := append([]string{"state", "commit", slug, "--workflow-dir", workflowDir}, extra...)
+	code = run(context.Background(), args, os.Environ(), hostDir, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	return code, out.String(), errBuf.String()
+}
+
+// TestStateCommitHaltsOnSameEntityConflict pins AC-1, the load-bearing halt: two
+// writers edit the SAME entity's frontmatter; A pushes first; the verb runs as B
+// and must exit 3, name the conflicting entity path on stderr, leave the checkout
+// clean (rebase aborted), never force-push (a plain re-push stays rejected), and
+// leave A's edit — not B's — on origin. Seeded by the ideation spike harness.
+func TestStateCommitHaltsOnSameEntityConflict(t *testing.T) {
+	bare, workflowA, workflowB, stateBranch := twoHostStateWorkflow(t)
+	checkoutB := filepath.Join(workflowB, ".spacedock-state")
+
+	// A edits first-task's frontmatter and pushes via the verb.
+	writeEntity(t, workflowA, "first-task", "---\nstatus: implementation\n---\n# First Task (A)\n")
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+	if code, _, errOut := runStateCommitCmd(t, hostA, workflowA, "first-task", "-m", "A: -> implementation"); code != 0 {
+		t.Fatalf("A's commit should succeed (exit 0); got exit=%d stderr=%q", code, errOut)
+	}
+
+	// B edits the SAME entity concurrently; the verb must HALT (exit 3).
+	writeEntity(t, workflowB, "first-task", "---\nstatus: review\n---\n# First Task (B)\n")
+	hostB := filepath.Dir(filepath.Dir(workflowB))
+	code, _, errOut := runStateCommitCmd(t, hostB, workflowB, "first-task", "-m", "B: -> review")
+	if code != 3 {
+		t.Fatalf("same-entity conflict must HALT with exit 3; got exit=%d stderr=%q", code, errOut)
+	}
+	// stderr names the conflicting entity path.
+	if !strings.Contains(errOut, "first-task.md") {
+		t.Fatalf("HALT stderr should name the conflicting entity path; got:\n%s", errOut)
+	}
+	// The checkout is clean: rebase aborted, no rebase-in-progress dir.
+	if porcelain := git(t, checkoutB, "status", "--porcelain"); strings.TrimSpace(porcelain) != "" {
+		t.Fatalf("HALT must leave a clean checkout; porcelain:\n%s", porcelain)
+	}
+	gitDir := strings.TrimSpace(git(t, checkoutB, "rev-parse", "--git-path", "rebase-merge"))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(checkoutB, gitDir)
+	}
+	if _, err := os.Stat(gitDir); err == nil {
+		t.Fatalf("rebase still in progress after HALT (rebase-merge present at %s)", gitDir)
+	}
+	// B did NOT force-push — a plain push stays rejected, so A's edit survives.
+	if _, ok := gitOK(t, checkoutB, "push", "origin", stateBranch); ok {
+		t.Fatalf("a plain push after HALT must stay rejected; B must not have force-pushed")
+	}
+	// A's edit is what's on origin — no silent clobber of the peer's frontmatter.
+	originFirst := showOriginFile(t, bare, stateBranch, "first-task.md")
+	if !strings.Contains(originFirst, "status: implementation") {
+		t.Fatalf("origin first-task should carry A's edit (status: implementation); got:\n%s", originFirst)
+	}
+}
+
+// TestStateCommitIsPathScoped pins AC-2: a sibling dirty/untracked file in the
+// state checkout is NOT swept into the commit (the verb stages exactly the entity,
+// never `add -A`). This is the w4 2/3 `cd && git add -A` drift the verb deletes.
+func TestStateCommitIsPathScoped(t *testing.T) {
+	_, workflowA, _, _ := twoHostStateWorkflow(t)
+	checkoutA := filepath.Join(workflowA, ".spacedock-state")
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+
+	// Edit the entity AND drop a sibling untracked file in the same checkout.
+	writeEntity(t, workflowA, "first-task", "---\nstatus: implementation\n---\n# First Task (A)\n")
+	if err := os.WriteFile(filepath.Join(checkoutA, "sibling-junk.md"), []byte("untracked sibling\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code, _, errOut := runStateCommitCmd(t, hostA, workflowA, "first-task", "-m", "A: scoped"); code != 0 {
+		t.Fatalf("commit should succeed; got exit=%d stderr=%q", code, errOut)
+	}
+	// The commit lists ONLY the entity path.
+	names := git(t, checkoutA, "show", "--name-only", "--pretty=format:", "HEAD")
+	if !strings.Contains(names, "first-task.md") {
+		t.Fatalf("commit should include first-task.md; name-only:\n%s", names)
+	}
+	if strings.Contains(names, "sibling-junk.md") {
+		t.Fatalf("path-scoped commit must NOT sweep the sibling; name-only:\n%s", names)
+	}
+	// The sibling stays untracked.
+	if porcelain := git(t, checkoutA, "status", "--porcelain"); !strings.Contains(porcelain, "sibling-junk.md") {
+		t.Fatalf("sibling should remain untracked after the scoped commit; porcelain:\n%s", porcelain)
+	}
+}
+
+// TestStateCommitMultiWriterHappyPath pins AC-3: two writers commit DIFFERENT
+// entities; A pushes first; the verb runs as B, its push is rejected non-ff, it
+// pull --rebases the disjoint peer commit and re-pushes (exit 0) with both entities
+// present and history linear (no merge commit).
+func TestStateCommitMultiWriterHappyPath(t *testing.T) {
+	bare, workflowA, workflowB, stateBranch := twoHostStateWorkflow(t)
+	checkoutB := filepath.Join(workflowB, ".spacedock-state")
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+	hostB := filepath.Dir(filepath.Dir(workflowB))
+
+	// A commits a distinct NEW entity and pushes first.
+	writeEntity(t, workflowA, "alpha-task", "---\nstatus: ideation\n---\n# Alpha (A)\n")
+	if code, _, errOut := runStateCommitCmd(t, hostA, workflowA, "alpha-task", "-m", "A: add alpha"); code != 0 {
+		t.Fatalf("A's commit should succeed; exit=%d stderr=%q", code, errOut)
+	}
+
+	// B commits a DIFFERENT new entity — push rejected non-ff → pull --rebase → re-push.
+	writeEntity(t, workflowB, "beta-task", "---\nstatus: ideation\n---\n# Beta (B)\n")
+	code, _, errOut := runStateCommitCmd(t, hostB, workflowB, "beta-task", "-m", "B: add beta")
+	if code != 0 {
+		t.Fatalf("B's commit should succeed via pull --rebase + re-push (exit 0); got exit=%d stderr=%q", code, errOut)
+	}
+	// Both entities present in B's tree after the rebase.
+	for _, slug := range []string{"alpha-task", "beta-task"} {
+		if _, err := os.Stat(filepath.Join(checkoutB, slug+".md")); err != nil {
+			t.Fatalf("B tree missing %s after commit: %v", slug, err)
+		}
+	}
+	// Linear history: no merge commit on the state branch.
+	if merges := git(t, checkoutB, "log", "--merges", "--oneline"); strings.TrimSpace(merges) != "" {
+		t.Fatalf("history not linear; merge commits:\n%s", merges)
+	}
+	// B's entity reached origin.
+	originBeta := showOriginFile(t, bare, stateBranch, "beta-task.md")
+	if !strings.Contains(originBeta, "Beta (B)") {
+		t.Fatalf("origin should carry B's beta-task; got:\n%s", originBeta)
+	}
+}
+
+// TestStateCommitNoOriginLocalOnly pins AC-4: in a no-origin state checkout the verb
+// commits path-scoped locally and reports local-only success (exit 0, --json result
+// "local-only") without attempting push/pull.
+func TestStateCommitNoOriginLocalOnly(t *testing.T) {
+	_, workflowA, _, _ := twoHostStateWorkflow(t)
+	checkoutA := filepath.Join(workflowA, ".spacedock-state")
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+
+	// Drop the origin remote from the state checkout (linked worktree shares the
+	// host's config, so remove origin on the host repo's config).
+	git(t, checkoutA, "remote", "remove", "origin")
+	headBefore := strings.TrimSpace(git(t, checkoutA, "rev-parse", "HEAD"))
+
+	writeEntity(t, workflowA, "first-task", "---\nstatus: implementation\n---\n# First Task (A)\n")
+	code, stdout, errOut := runStateCommitCmd(t, hostA, workflowA, "first-task", "-m", "A: local", "--json")
+	if code != 0 {
+		t.Fatalf("no-origin commit should succeed local-only (exit 0); got exit=%d stderr=%q", code, errOut)
+	}
+	if !strings.Contains(stdout, `"result": "local-only"`) {
+		t.Fatalf("no-origin commit should report result local-only; json:\n%s", stdout)
+	}
+	// The commit landed locally (HEAD advanced).
+	headAfter := strings.TrimSpace(git(t, checkoutA, "rev-parse", "HEAD"))
+	if headAfter == headBefore {
+		t.Fatalf("no-origin commit should advance local HEAD; before=%s after=%s", headBefore, headAfter)
+	}
+}
+
+// TestStateCommitNoOpWhenClean pins the clean no-op: committing a slug with no
+// pending change is exit 0 with result "no-op", not an error.
+func TestStateCommitNoOpWhenClean(t *testing.T) {
+	_, workflowA, _, _ := twoHostStateWorkflow(t)
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+
+	code, stdout, errOut := runStateCommitCmd(t, hostA, workflowA, "first-task", "--json")
+	if code != 0 {
+		t.Fatalf("clean no-op commit should be exit 0; got exit=%d stderr=%q", code, errOut)
+	}
+	if !strings.Contains(stdout, `"result": "no-op"`) {
+		t.Fatalf("clean commit should report result no-op; json:\n%s", stdout)
+	}
+}

--- a/internal/cli/state_ready_test.go
+++ b/internal/cli/state_ready_test.go
@@ -1,0 +1,146 @@
+// ABOUTME: Real-git e2e for `state ready` — boot pull integration + the same-entity
+// ABOUTME: boot-conflict HALT (AC-5), inline no-op and absent-checkout resume (AC-6).
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// runStateReadyCmd runs `spacedock state ready` for workflowDir and returns the
+// exit code plus captured stdout/stderr.
+func runStateReadyCmd(t *testing.T, hostDir, workflowDir string, extra ...string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errBuf strings.Builder
+	args := append([]string{"state", "ready", "--workflow-dir", workflowDir}, extra...)
+	code = run(context.Background(), args, os.Environ(), hostDir, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	return code, out.String(), errBuf.String()
+}
+
+// TestStateReadyIntegratesPeerState pins AC-5 clean case: A commits+pushes a new
+// entity via the verb; B runs `state ready`, whose single pull --rebase integrates
+// A's commit (exit 0) and leaves A's entity present in B's checkout.
+func TestStateReadyIntegratesPeerState(t *testing.T) {
+	_, workflowA, workflowB, _ := twoHostStateWorkflow(t)
+	checkoutB := filepath.Join(workflowB, ".spacedock-state")
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+	hostB := filepath.Dir(filepath.Dir(workflowB))
+
+	// A pushes a distinct new entity.
+	writeEntity(t, workflowA, "alpha-task", "---\nstatus: ideation\n---\n# Alpha (A)\n")
+	if code, _, errOut := runStateCommitCmd(t, hostA, workflowA, "alpha-task", "-m", "A: add alpha"); code != 0 {
+		t.Fatalf("A's commit should succeed; exit=%d stderr=%q", code, errOut)
+	}
+
+	// B's checkout does not yet have alpha-task; `state ready` pulls it in.
+	if _, err := os.Stat(filepath.Join(checkoutB, "alpha-task.md")); err == nil {
+		t.Fatalf("precondition: B should NOT yet have alpha-task before ready")
+	}
+	code, _, errOut := runStateReadyCmd(t, hostB, workflowB)
+	if code != 0 {
+		t.Fatalf("state ready clean integration should exit 0; got exit=%d stderr=%q", code, errOut)
+	}
+	if _, err := os.Stat(filepath.Join(checkoutB, "alpha-task.md")); err != nil {
+		t.Fatalf("state ready should pull A's alpha-task into B's checkout: %v", err)
+	}
+}
+
+// TestStateReadyHaltsOnBootConflict pins AC-5 conflict case: B has an unpushed local
+// commit on the SAME entity A pushed; `state ready`'s boot pull --rebase conflicts
+// and must HALT identically to commit — exit 3, checkout left clean (rebase aborted).
+func TestStateReadyHaltsOnBootConflict(t *testing.T) {
+	bare, workflowA, workflowB, stateBranch := twoHostStateWorkflow(t)
+	checkoutB := filepath.Join(workflowB, ".spacedock-state")
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+
+	// A edits first-task and pushes.
+	writeEntity(t, workflowA, "first-task", "---\nstatus: implementation\n---\n# First Task (A)\n")
+	if code, _, errOut := runStateCommitCmd(t, hostA, workflowA, "first-task", "-m", "A: -> implementation"); code != 0 {
+		t.Fatalf("A's commit should succeed; exit=%d stderr=%q", code, errOut)
+	}
+
+	// B makes a CONFLICTING local commit on the same entity (committed, NOT pushed),
+	// then runs `state ready` — the boot pull --rebase conflicts.
+	writeEntity(t, workflowB, "first-task", "---\nstatus: review\n---\n# First Task (B)\n")
+	git(t, checkoutB, "add", "first-task.md")
+	git(t, checkoutB, "commit", "-q", "-m", "B: -> review", "--", "first-task.md")
+	hostB := filepath.Dir(filepath.Dir(workflowB))
+
+	code, _, errOut := runStateReadyCmd(t, hostB, workflowB)
+	if code != 3 {
+		t.Fatalf("same-entity boot conflict must HALT with exit 3; got exit=%d stderr=%q", code, errOut)
+	}
+	if porcelain := git(t, checkoutB, "status", "--porcelain"); strings.TrimSpace(porcelain) != "" {
+		t.Fatalf("ready HALT must leave a clean checkout; porcelain:\n%s", porcelain)
+	}
+	// A's edit survives on origin.
+	originFirst := showOriginFile(t, bare, stateBranch, "first-task.md")
+	if !strings.Contains(originFirst, "status: implementation") {
+		t.Fatalf("origin first-task should carry A's edit after ready HALT; got:\n%s", originFirst)
+	}
+}
+
+// TestStateReadyInlineNoOp pins AC-6 inline case: an inline workflow is a clean
+// no-op (exit 0, nothing to sync, no git network op).
+func TestStateReadyInlineNoOp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	wf := filepath.Join(root, "wf")
+	if err := os.MkdirAll(wf, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wf, "README.md"),
+		[]byte("---\ncommissioned-by: spacedock@1\nid-style: slug\nstate: $inline\nstages:\n  states:\n    - name: ideation\n      initial: true\n    - name: done\n      terminal: true\n---\n\n# Inline WF\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, root, "init", "-q")
+	git(t, root, "add", "-A")
+	git(t, root, "commit", "-q", "-m", "init")
+
+	code, stdout, errOut := runStateReadyCmd(t, root, wf)
+	if code != 0 {
+		t.Fatalf("inline state ready should be a clean no-op (exit 0); got exit=%d stderr=%q", code, errOut)
+	}
+	if stdout == "" {
+		t.Fatalf("inline state ready should print a one-liner; stdout empty")
+	}
+}
+
+// TestStateReadyResumesAbsentCheckout pins AC-6 resume case: a split-root checkout
+// that is absent on a fresh clone is resumed by `state ready` (present afterward),
+// reusing the `state init` fetch + worktree-add path.
+func TestStateReadyResumesAbsentCheckout(t *testing.T) {
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+
+	hostA := filepath.Join(t.TempDir(), "hostA")
+	git(t, t.TempDir(), "clone", "-q", bare, hostA)
+	git(t, hostA, "config", "user.email", "a@t")
+	git(t, hostA, "config", "user.name", "hostA")
+	commissionSplitWorkflow(t, hostA)
+	git(t, hostA, "push", "-q", "origin", "HEAD")
+
+	// Fresh clone: code branch only, state checkout absent.
+	fresh := filepath.Join(t.TempDir(), "fresh")
+	git(t, t.TempDir(), "clone", "-q", bare, fresh)
+	git(t, fresh, "config", "user.email", "f@t")
+	git(t, fresh, "config", "user.name", "fresh")
+	freshWorkflow := filepath.Join(fresh, "docs", "dev")
+	freshState := filepath.Join(freshWorkflow, ".spacedock-state")
+
+	if _, err := os.Stat(freshState); !os.IsNotExist(err) {
+		t.Fatalf("precondition: fresh clone should NOT yet have the state checkout (err=%v)", err)
+	}
+	code, _, errOut := runStateReadyCmd(t, fresh, freshWorkflow)
+	if code != 0 {
+		t.Fatalf("state ready on an absent checkout should resume it (exit 0); got exit=%d stderr=%q", code, errOut)
+	}
+	if _, err := os.Stat(freshState); err != nil {
+		t.Fatalf("state ready should have resumed the absent checkout: %v", err)
+	}
+}

--- a/internal/cli/state_sweep_test.go
+++ b/internal/cli/state_sweep_test.go
@@ -1,0 +1,75 @@
+// ABOUTME: Real-git e2e — `state sweep` is read-only (HEAD unchanged, AC-7), and the
+// ABOUTME: state verbs' usage/routing exit codes (AC-8).
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// TestStateSweepIsReadOnly pins AC-7's read-only property at the verb level: `state
+// sweep` makes no commit, push, or state mutation — the state checkout's HEAD is
+// unchanged across the verb. Entities carry no `pr:`, so the un-advanced-PR scan is
+// offline (no gh call) and deterministic.
+func TestStateSweepIsReadOnly(t *testing.T) {
+	_, workflowA, _, _ := twoHostStateWorkflow(t)
+	checkoutA := filepath.Join(workflowA, ".spacedock-state")
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+
+	headBefore := strings.TrimSpace(git(t, checkoutA, "rev-parse", "HEAD"))
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "sweep", "--workflow-dir", workflowA, "--json"},
+		os.Environ(), hostA, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("state sweep should exit 0; got exit=%d stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), `"command": "state sweep"`) {
+		t.Fatalf("sweep --json should carry the command envelope; json:\n%s", out.String())
+	}
+	headAfter := strings.TrimSpace(git(t, checkoutA, "rev-parse", "HEAD"))
+	if headAfter != headBefore {
+		t.Fatalf("state sweep must be read-only; HEAD changed %s -> %s", headBefore, headAfter)
+	}
+	// No mutation: a clean checkout afterward.
+	if porcelain := git(t, checkoutA, "status", "--porcelain"); strings.TrimSpace(porcelain) != "" {
+		t.Fatalf("state sweep must leave a clean checkout; porcelain:\n%s", porcelain)
+	}
+}
+
+// TestStateVerbUsageExitCodes pins AC-8: each verb exits 2 on a missing/unknown
+// required argument with a diagnostic naming the subcommand, and `state <unknown>`
+// exits 2 enumerating init|new|ready|sweep|commit.
+func TestStateVerbUsageExitCodes(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		wantCode  int
+		wantInErr string
+	}{
+		{"commit missing slug", []string{"state", "commit"}, 2, "state commit"},
+		{"commit unknown flag", []string{"state", "commit", "slug", "--bogus"}, 2, "state commit"},
+		{"commit extra positional", []string{"state", "commit", "one", "two"}, 2, "state commit"},
+		{"ready unknown arg", []string{"state", "ready", "--bogus"}, 2, "state ready"},
+		{"sweep unknown arg", []string{"state", "sweep", "--bogus"}, 2, "state sweep"},
+		{"unknown subcommand", []string{"state", "frobnicate"}, 2, "init|new|ready|sweep|commit"},
+		{"missing subcommand", []string{"state"}, 2, "init|new|ready|sweep|commit"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out, errBuf strings.Builder
+			code := run(context.Background(), tc.args, os.Environ(), t.TempDir(), nil, &out, &errBuf, &status.NativeRunner{}, nil)
+			if code != tc.wantCode {
+				t.Fatalf("args %v: want exit %d, got %d (stderr=%q)", tc.args, tc.wantCode, code, errBuf.String())
+			}
+			if !strings.Contains(errBuf.String(), tc.wantInErr) {
+				t.Fatalf("args %v: stderr should contain %q; got:\n%s", tc.args, tc.wantInErr, errBuf.String())
+			}
+		})
+	}
+}

--- a/internal/cli/state_sync.go
+++ b/internal/cli/state_sync.go
@@ -1,0 +1,440 @@
+// ABOUTME: `spacedock state commit <slug>` / `state ready` — path-scoped state
+// ABOUTME: commit+push and boot-pull, each HALTing (exit 3) on a same-entity rebase conflict.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spacedock-dev/spacedock/internal/dispatch"
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// syncResult is the small JSON object the state-sync verbs emit under --json. The
+// result field is the verb's outcome verb (committed/pushed/local-only/no-op/
+// halted/ready); conflictingPaths is populated only on a halt. reason carries a
+// human one-liner for the prose and the JSON alike.
+type syncResult struct {
+	Command          string   `json:"command"`
+	Slug             string   `json:"slug,omitempty"`
+	Result           string   `json:"result"`
+	StateBranch      string   `json:"state_branch,omitempty"`
+	ConflictingPaths []string `json:"conflicting_paths,omitempty"`
+	Reason           string   `json:"reason"`
+}
+
+// emitSync writes the result as JSON (jsonOut) or as a one-line prose summary, then
+// returns code. Centralizing the dual rendering keeps every verb's exit path
+// identical: the JSON envelope and the prose say the same thing.
+func emitSync(stdout io.Writer, jsonOut bool, res syncResult, code int) int {
+	if jsonOut {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(res)
+		return code
+	}
+	fmt.Fprintln(stdout, res.Reason)
+	return code
+}
+
+// runStateCommit implements `spacedock state commit <slug>`. It resolves <slug> to
+// its entity file under the split-root state checkout, then runs the path-scoped
+// commit → push → on-reject pull --rebase → re-push sequence. A same-entity rebase
+// conflict HALTS: the rebase is aborted (clean tree restored), no force-push is
+// ever issued, and the verb exits 3 with the conflicting path named — so a caller
+// cannot proceed on an unmerged tree. The halt is the exit code, not the model's
+// discipline.
+func runStateCommit(ctx context.Context, args []string, env []string, dir string, stdout, stderr io.Writer) int {
+	slug, workflowDir, msg, jsonOut, code := parseStateCommitArgs(args, dir, stderr)
+	if code != 0 {
+		return code
+	}
+
+	checkout, branch, mode, code := resolveStateCheckout("state commit", workflowDir, stderr)
+	if code != 0 {
+		return code
+	}
+	if mode == status.StateInline {
+		return emitSync(stdout, jsonOut, syncResult{
+			Command: "state commit", Slug: slug, Result: "no-op",
+			Reason: "Inline workflow — entities live beside the README; nothing to commit to a state checkout.",
+		}, 0)
+	}
+
+	entityPath, ok := resolveEntityPath(checkout, slug)
+	if !ok {
+		fmt.Fprintf(stderr, "spacedock state commit: no entity %q under %s (looked for %s.md and %s/index.md)\n", slug, checkout, slug, slug)
+		return 1
+	}
+	if msg == "" {
+		msg = fmt.Sprintf("state: update %s", slug)
+	}
+
+	// Path-scoped commit. A clean tree (nothing staged for this entity) is a no-op
+	// success, not an error — the FO may call commit defensively after a --set that
+	// changed nothing.
+	if ok, out := commitEntityPathScoped(checkout, entityPath, msg); !ok {
+		fmt.Fprintf(stderr, "spacedock state commit: git commit failed:\n%s\n", out)
+		return 1
+	} else if out == "" {
+		// out=="" is the no-op sentinel from commitEntityPathScoped (nothing staged).
+		return emitSync(stdout, jsonOut, syncResult{
+			Command: "state commit", Slug: slug, Result: "no-op", StateBranch: branch,
+			Reason: fmt.Sprintf("Nothing to commit for %s — state checkout already up to date.", slug),
+		}, 0)
+	}
+
+	// No origin → local-only success (mirrors the boot `remote: none` carve-out).
+	if !stateHasOrigin(checkout) {
+		return emitSync(stdout, jsonOut, syncResult{
+			Command: "state commit", Slug: slug, Result: "local-only", StateBranch: branch,
+			Reason: fmt.Sprintf("Committed %s locally; no origin remote — state is local-only until an origin is configured.", slug),
+		}, 0)
+	}
+
+	// Push; on a non-fast-forward rejection, pull --rebase and re-push.
+	if ok, _ := runGit(checkout, "push", "origin", branch); ok {
+		return emitSync(stdout, jsonOut, syncResult{
+			Command: "state commit", Slug: slug, Result: "pushed", StateBranch: branch,
+			Reason: fmt.Sprintf("Committed and pushed %s to %s.", slug, branch),
+		}, 0)
+	}
+
+	// Push rejected (non-ff or other). Integrate peers' state via pull --rebase,
+	// reading git's OWN exit status (never piped through anything that swallows it).
+	rebaseOK, rebaseOut := runGit(checkout, "pull", "--rebase", "origin", branch)
+	if !rebaseOK {
+		if rebaseInProgress(checkout) {
+			return haltOnConflict(stdout, stderr, jsonOut, "state commit", slug, branch, checkout, entityPath, rebaseOut)
+		}
+		// Non-conflict pull failure (network, auth) — leave the local commit, report.
+		fmt.Fprintf(stderr, "spacedock state commit: push rejected and pull --rebase failed (not a conflict):\n%s\n", rebaseOut)
+		return 1
+	}
+
+	// Clean rebase replayed our commit atop the peer's — re-push.
+	if ok, out := runGit(checkout, "push", "origin", branch); !ok {
+		fmt.Fprintf(stderr, "spacedock state commit: re-push after pull --rebase failed:\n%s\n", out)
+		return 1
+	}
+	return emitSync(stdout, jsonOut, syncResult{
+		Command: "state commit", Slug: slug, Result: "pushed", StateBranch: branch,
+		Reason: fmt.Sprintf("Committed %s, integrated peers' state, and pushed to %s.", slug, branch),
+	}, 0)
+}
+
+// runStateReady implements `spacedock state ready`. It is the boot gate: an inline
+// workflow is a clean no-op; a split-root checkout that is absent is resumed (the
+// same fetch+worktree-add resume `state init` does); a present origin-backed
+// checkout integrates peers' state with one pull --rebase. A same-entity boot
+// conflict HALTS identically to `state commit` (abort, exit 3, name the paths).
+func runStateReady(ctx context.Context, args []string, env []string, dir string, stdout, stderr io.Writer) int {
+	workflowDir, jsonOut, code := parseWorkflowJSONArgs("state ready", args, dir, stderr)
+	if code != 0 {
+		return code
+	}
+
+	checkout, branch, mode, code := resolveStateCheckout("state ready", workflowDir, stderr)
+	if code != 0 {
+		return code
+	}
+	if mode == status.StateInline {
+		return emitSync(stdout, jsonOut, syncResult{
+			Command: "state ready", Result: "ready",
+			Reason: "Inline workflow — entities live beside the README; nothing to sync.",
+		}, 0)
+	}
+
+	// Absent checkout → resume it (reuse `state init`'s fetch + worktree-add path).
+	if !dirExists(checkout) {
+		if code := runStateInit(ctx, []string{"--workflow-dir", workflowDir}, env, dir, stdout, stderr); code != 0 {
+			return code
+		}
+	}
+
+	// No origin → ready, local-only (no network integration to do).
+	if !stateHasOrigin(checkout) {
+		return emitSync(stdout, jsonOut, syncResult{
+			Command: "state ready", Result: "ready", StateBranch: branch,
+			Reason: "State checkout ready (no origin remote — state is local-only).",
+		}, 0)
+	}
+
+	// Integrate peers' state with one pull --rebase, reading git's own exit status.
+	rebaseOK, rebaseOut := runGit(checkout, "pull", "--rebase", "origin", branch)
+	if !rebaseOK {
+		if rebaseInProgress(checkout) {
+			return haltOnConflict(stdout, stderr, jsonOut, "state ready", "", branch, checkout, "", rebaseOut)
+		}
+		fmt.Fprintf(stderr, "spacedock state ready: pull --rebase failed (not a conflict):\n%s\n", rebaseOut)
+		return 1
+	}
+	return emitSync(stdout, jsonOut, syncResult{
+		Command: "state ready", Result: "ready", StateBranch: branch,
+		Reason: fmt.Sprintf("State checkout ready — integrated peers' state from %s.", branch),
+	}, 0)
+}
+
+// runStateSweep implements `spacedock state sweep`. It is the state-repo's
+// read-only view of entities whose code PR merged but whose state is not yet
+// terminalized — the merged-PR iteration the FO sweeps each loop. It makes no
+// commit, push, or mutation; it delegates to dispatch.Sweep, which reuses
+// reconcile's un-advanced-PR detection rather than re-implementing merged-state.
+func runStateSweep(ctx context.Context, args []string, env []string, dir string, stdout, stderr io.Writer) int {
+	workflowDir, jsonOut, code := parseWorkflowJSONArgs("state sweep", args, dir, stderr)
+	if code != 0 {
+		return code
+	}
+	return dispatch.Sweep(workflowDir, dispatch.GhRunnerExec, jsonOut, stdout, stderr)
+}
+
+// haltOnConflict is the shared HALT both verbs run on a same-entity rebase
+// conflict: abort the rebase to restore a clean tree, NEVER force-push, NEVER
+// auto-resolve, and exit 3 with the conflicting paths named on stderr. The exit
+// code is the enforcement: a caller cannot proceed on an unmerged tree.
+func haltOnConflict(stdout, stderr io.Writer, jsonOut bool, command, slug, branch, checkout, entityPath, rebaseOut string) int {
+	conflicting := conflictingPaths(checkout)
+	// Restore a clean tree so the next operation starts fresh. abort failure is
+	// surfaced but the exit is still the halt.
+	runGit(checkout, "rebase", "--abort")
+	if len(conflicting) == 0 && entityPath != "" {
+		// Fall back to the named entity when git's conflict list could not be read.
+		conflicting = []string{relToCheckout(checkout, entityPath)}
+	}
+	fmt.Fprintf(stderr, "spacedock %s: HALT — same-entity rebase conflict on %s.\n", command, branch)
+	fmt.Fprintf(stderr, "Conflicting path(s): %s\n", strings.Join(conflicting, ", "))
+	fmt.Fprintf(stderr, "The rebase was aborted (checkout left clean) and nothing was force-pushed; a peer's edit is preserved on origin. Manual intervention is required.\n")
+	return emitSync(stdout, jsonOut, syncResult{
+		Command: command, Slug: slug, Result: "halted", StateBranch: branch,
+		ConflictingPaths: conflicting,
+		Reason:           fmt.Sprintf("HALT: same-entity rebase conflict on %s — rebase aborted, nothing force-pushed, manual intervention required.", strings.Join(conflicting, ", ")),
+	}, 3)
+}
+
+// commitEntityPathScoped stages and commits exactly entityPath (never `add -A`),
+// retrying the staging on index.lock contention. It returns (true, "") for a
+// clean no-op (nothing staged for the entity → success), (true, output) for a
+// landed commit, and (false, output) on a real git failure. The `git -C` argv
+// form (via runGit) has no rendered command string for a weak model to paraphrase.
+func commitEntityPathScoped(checkout, entityPath, msg string) (ok bool, output string) {
+	rel := relToCheckout(checkout, entityPath)
+	if ok, out := runGitRetryLock(checkout, "add", "--", rel); !ok {
+		return false, out
+	}
+	// Nothing staged for this entity → clean no-op success.
+	if clean, _ := runGit(checkout, "diff", "--cached", "--quiet", "--", rel); clean {
+		return true, ""
+	}
+	ok, out := runGitRetryLock(checkout, "commit", "-m", msg, "--", rel)
+	if !ok {
+		return false, out
+	}
+	return true, out
+}
+
+// runGitRetryLock runs a git command, retrying on index.lock contention up to a
+// bounded number of times (~2s total) before failing. The shared state index is a
+// single non-branched git index; a sibling writer's add/commit can hold the lock.
+func runGitRetryLock(checkout string, gitArgs ...string) (bool, string) {
+	const maxRetries = 4
+	const wait = 500 * time.Millisecond
+	for attempt := 0; ; attempt++ {
+		ok, out := runGit(checkout, gitArgs...)
+		if ok || attempt >= maxRetries || !strings.Contains(out, "index.lock") {
+			return ok, out
+		}
+		time.Sleep(wait)
+	}
+}
+
+// rebaseInProgress reports whether a rebase is in progress in checkout, asking git
+// for the worktree-correct path (`git rev-parse --git-path`) rather than assuming
+// `<checkout>/.git/rebase-merge` — a linked-worktree state checkout keeps its git
+// dir elsewhere, so a hardcoded path would miss the conflict and let the halt slip.
+func rebaseInProgress(checkout string) bool {
+	for _, name := range []string{"rebase-merge", "rebase-apply"} {
+		ok, out := runGit(checkout, "rev-parse", "--git-path", name)
+		if !ok {
+			continue
+		}
+		p := strings.TrimSpace(out)
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(checkout, p)
+		}
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// conflictingPaths returns the entity paths git reports as unmerged during the
+// in-progress rebase (`git diff --name-only --diff-filter=U`), relative to the
+// checkout. Read BEFORE the rebase --abort clears the conflict state.
+func conflictingPaths(checkout string) []string {
+	ok, out := runGit(checkout, "diff", "--name-only", "--diff-filter=U")
+	if !ok {
+		return nil
+	}
+	var paths []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths
+}
+
+// resolveEntityPath finds the entity file for slug under checkout, returning the
+// absolute path. It accepts both the flat `{slug}.md` and the directory
+// `{slug}/index.md` entity layouts (matching loadEntityFrontmatter's scan).
+func resolveEntityPath(checkout, slug string) (string, bool) {
+	flat := filepath.Join(checkout, slug+".md")
+	if fileExists(flat) {
+		return flat, true
+	}
+	nested := filepath.Join(checkout, slug, "index.md")
+	if fileExists(nested) {
+		return nested, true
+	}
+	return "", false
+}
+
+// relToCheckout returns entityPath relative to checkout for the path-scoped git
+// pathspec. An already-relative path is returned as-is.
+func relToCheckout(checkout, entityPath string) string {
+	if !filepath.IsAbs(entityPath) {
+		return entityPath
+	}
+	rel, err := filepath.Rel(checkout, entityPath)
+	if err != nil {
+		return filepath.Base(entityPath)
+	}
+	return rel
+}
+
+// resolveStateCheckout reads the workflow README to resolve the split-root state
+// checkout path and its state branch, classifying the mode. An inline workflow
+// returns mode=StateInline with empty checkout/branch (the caller no-ops). A
+// missing README or a malformed state: field is a setup failure (exit 1).
+func resolveStateCheckout(command, workflowDir string, stderr io.Writer) (checkout, branch string, mode status.StateMode, code int) {
+	readme := filepath.Join(workflowDir, "README.md")
+	if !fileExists(readme) {
+		fmt.Fprintf(stderr, "spacedock %s: no README.md at %s\n", command, workflowDir)
+		return "", "", status.StateInline, 1
+	}
+	fm := status.ParseFrontmatter(readme)
+	m, relPath, err := status.ClassifyState(fm["state"])
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock %s: %v\n", command, err)
+		return "", "", status.StateInline, 1
+	}
+	if m == status.StateInline {
+		return "", "", status.StateInline, 0
+	}
+	b, err := status.StateBranch(workflowDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock %s: %v\n", command, err)
+		return "", "", status.StateInline, 1
+	}
+	return filepath.Join(workflowDir, relPath), b, status.StateSplitRoot, 0
+}
+
+// parseStateCommitArgs reads the positional <slug> plus `--workflow-dir DIR`,
+// `-m MSG`, and `--json`. A missing slug is a usage error (exit 2).
+func parseStateCommitArgs(args []string, dir string, stderr io.Writer) (slug, workflowDir, msg string, jsonOut bool, code int) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--workflow-dir":
+			if i+1 >= len(args) {
+				fmt.Fprintln(stderr, "spacedock state commit: --workflow-dir requires a path")
+				return "", "", "", false, 2
+			}
+			workflowDir = args[i+1]
+			i++
+		case "-m", "--message":
+			if i+1 >= len(args) {
+				fmt.Fprintln(stderr, "spacedock state commit: -m requires a message")
+				return "", "", "", false, 2
+			}
+			msg = args[i+1]
+			i++
+		case "--json":
+			jsonOut = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				fmt.Fprintf(stderr, "spacedock state commit: unknown flag %q\n", args[i])
+				return "", "", "", false, 2
+			}
+			if slug != "" {
+				fmt.Fprintf(stderr, "spacedock state commit: unexpected extra argument %q (one slug only)\n", args[i])
+				return "", "", "", false, 2
+			}
+			slug = args[i]
+		}
+	}
+	if slug == "" {
+		fmt.Fprintln(stderr, "spacedock state commit: missing required <slug> argument")
+		return "", "", "", false, 2
+	}
+	workflowDir, code = resolveWorkflowDir("state commit", workflowDir, dir, stderr)
+	return slug, workflowDir, msg, jsonOut, code
+}
+
+// parseWorkflowJSONArgs reads the `--workflow-dir DIR` + `--json` arg shape shared
+// by `state ready` and `state sweep` (neither takes a positional). command names
+// the verb in diagnostics.
+func parseWorkflowJSONArgs(command string, args []string, dir string, stderr io.Writer) (workflowDir string, jsonOut bool, code int) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--workflow-dir":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "spacedock %s: --workflow-dir requires a path\n", command)
+				return "", false, 2
+			}
+			workflowDir = args[i+1]
+			i++
+		case "--json":
+			jsonOut = true
+		default:
+			fmt.Fprintf(stderr, "spacedock %s: unknown argument %q\n", command, args[i])
+			return "", false, 2
+		}
+	}
+	workflowDir, code = resolveWorkflowDir(command, workflowDir, dir, stderr)
+	return workflowDir, jsonOut, code
+}
+
+// resolveWorkflowDir resolves the workflow dir: an explicit relative --workflow-dir
+// is joined against dir; an empty one is discovered from dir. Mirrors the
+// init/new arg handling so all four state verbs agree on workflow discovery.
+func resolveWorkflowDir(command, workflowDir, dir string, stderr io.Writer) (string, int) {
+	if workflowDir == "" {
+		discovered, ok := status.DiscoverWorkflowDir(dir)
+		if !ok {
+			fmt.Fprintf(stderr, "spacedock %s: no workflow here — pass --workflow-dir or run inside a workflow\n", command)
+			return "", 1
+		}
+		return discovered, 0
+	}
+	if !filepath.IsAbs(workflowDir) {
+		return filepath.Join(dir, workflowDir), 0
+	}
+	return workflowDir, 0
+}
+
+// stateHasOrigin reports whether the state checkout has a named `origin` remote,
+// asking the exact named-remote question via `git remote get-url origin` (network-
+// free, true iff exit 0). Mirrors status.stateHasOrigin so these verbs agree with
+// boot's STATE_BACKEND origin line by construction. A non-repo dir or any git
+// failure reports false → the verb degrades to local-only.
+func stateHasOrigin(checkout string) bool {
+	ok, _ := runGit(checkout, "remote", "get-url", "origin")
+	return ok
+}

--- a/internal/dispatch/reconcile.go
+++ b/internal/dispatch/reconcile.go
@@ -76,6 +76,14 @@ type rosterLoader func(home, teamName, sessionID string) (claudeteam.ReconcileTe
 // "MERGED", "OPEN"). Tests inject a stub; production passes ghRunnerExec.
 type ghRunner func(prRef string) (string, error)
 
+// GhRunner is the exported alias of ghRunner so callers outside this package (the
+// `state sweep` verb) can inject a stub for tests and pass GhRunnerExec in
+// production, sharing the one merged-detection probe.
+type GhRunner = ghRunner
+
+// GhRunnerExec is the exported production gh probe `state sweep` passes.
+func GhRunnerExec(prRef string) (string, error) { return ghRunnerExec(prRef) }
+
 // gitRunner runs `git -C dir args...` returning combined output and error.
 // Tests inject a stub when they need a fixture-controlled answer; production
 // passes gitRunnerExec.
@@ -641,6 +649,64 @@ func classC(active map[string]entityRecord, gh ghRunner) []driftItem {
 		}
 	}
 	return out
+}
+
+// sweptEntity is one merged-but-not-terminalized entity in the `state sweep`
+// report — the state-repo's read-only view of the un-advanced-PR drift class.
+type sweptEntity struct {
+	Slug   string `json:"slug"`
+	PR     string `json:"pr"`
+	Reason string `json:"reason"`
+}
+
+// sweepResult is the `state sweep` JSON envelope. swept is the merged-but-not-
+// terminalized set; an empty sweep encodes an empty array, never null.
+type sweepResult struct {
+	Command     string        `json:"command"`
+	StateBranch string        `json:"state_branch,omitempty"`
+	Swept       []sweptEntity `json:"swept"`
+	Reason      string        `json:"reason"`
+}
+
+// Sweep is the read-only `state sweep` computation: the entities whose code PR has
+// MERGED but whose state has not been terminalized. It reuses classC's un-advanced-
+// PR detection over the split-root state checkout's active entities — NO second
+// merged-detection path — and makes no commit, push, or mutation. The gh probe is
+// injected so tests pin a deterministic merged-state; production passes
+// GhRunnerExec. An inline (single-root) workflow sweeps its own dir. Exit 0 the
+// sweep ran (set may be empty or populated); 1 setup failure (no README/state).
+func Sweep(workflowDir string, gh GhRunner, jsonOut bool, stdout, stderr io.Writer) int {
+	if info, err := os.Stat(workflowDir); err != nil || !info.IsDir() {
+		fmt.Fprintf(stderr, "spacedock state sweep: workflow directory not found: %s\n", workflowDir)
+		return 1
+	}
+	stateRoot := splitRootStateCheckout(workflowDir)
+	if stateRoot == "" {
+		stateRoot = workflowDir
+	}
+	active := loadEntityFrontmatter(activeEntityDir(stateRoot))
+	drift := classC(active, gh)
+
+	swept := make([]sweptEntity, 0, len(drift))
+	for _, d := range drift {
+		swept = append(swept, sweptEntity{Slug: d.Slug, PR: d.PR, Reason: d.Reason})
+	}
+	branch, _ := status.StateBranch(workflowDir)
+	reason := fmt.Sprintf("%d entity(ies) merged but not yet terminalized.", len(swept))
+
+	if jsonOut {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(sweepResult{
+			Command: "state sweep", StateBranch: branch, Swept: swept, Reason: reason,
+		})
+		return 0
+	}
+	fmt.Fprintln(stdout, reason)
+	for _, s := range swept {
+		fmt.Fprintf(stdout, "  %s (PR %s): %s\n", s.Slug, s.PR, s.Reason)
+	}
+	return 0
 }
 
 // classD flags worktrees whose branch HEAD is behind origin/{trunk}. The remedy

--- a/internal/dispatch/sweep_test.go
+++ b/internal/dispatch/sweep_test.go
@@ -1,0 +1,112 @@
+// ABOUTME: Sweep reuses reconcile's un-advanced-PR detection — the swept set is the
+// ABOUTME: merged-but-not-terminalized entities, computed from an injected gh stub.
+package dispatch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSweepReportsMergedNotTerminalized pins AC-7's reported-set property: Sweep
+// returns exactly the entities whose PR is MERGED and whose status is not done,
+// reusing classC's detection. The gh stub pins a deterministic merged-state so the
+// test is offline. pr-merged (merged, status!=done) IS swept; pr-open (OPEN) and
+// pr-merged-done (status=done) are NOT — the two negative conjuncts.
+func TestSweepReportsMergedNotTerminalized(t *testing.T) {
+	repoRoot := t.TempDir()
+	workflowDir := filepath.Join(repoRoot, "docs", "wf")
+	writeFile(t, filepath.Join(workflowDir, "README.md"), `---
+entity-type: task
+state: .spacedock-state
+stages:
+  states:
+    - name: ideation
+      initial: true
+    - name: done
+      terminal: true
+---
+`)
+	stateRoot := filepath.Join(workflowDir, ".spacedock-state")
+
+	writeFile(t, filepath.Join(stateRoot, "pr-merged", "index.md"), reconcileEntityFM(map[string]string{
+		"id": "id-m", "title": "merged", "slug": "pr-merged", "status": "implementation", "pr": "42",
+	}))
+	writeFile(t, filepath.Join(stateRoot, "pr-open", "index.md"), reconcileEntityFM(map[string]string{
+		"id": "id-o", "title": "open", "slug": "pr-open", "status": "implementation", "pr": "43",
+	}))
+	writeFile(t, filepath.Join(stateRoot, "pr-merged-done", "index.md"), reconcileEntityFM(map[string]string{
+		"id": "id-md", "title": "merged done", "slug": "pr-merged-done", "status": "done", "pr": "44",
+	}))
+
+	gh := func(pr string) (string, error) {
+		switch pr {
+		case "42", "44":
+			return "MERGED", nil
+		default:
+			return "OPEN", nil
+		}
+	}
+
+	var out, errBuf strings.Builder
+	code := Sweep(workflowDir, gh, true, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("Sweep should exit 0; got %d stderr=%q", code, errBuf.String())
+	}
+
+	var res sweepResult
+	if err := json.Unmarshal([]byte(out.String()), &res); err != nil {
+		t.Fatalf("Sweep --json should emit valid JSON: %v\n%s", err, out.String())
+	}
+	gotSlugs := map[string]bool{}
+	for _, s := range res.Swept {
+		gotSlugs[s.Slug] = true
+	}
+	if !gotSlugs["pr-merged"] {
+		t.Fatalf("sweep should report pr-merged (merged, status!=done); swept=%v", res.Swept)
+	}
+	if gotSlugs["pr-open"] {
+		t.Fatalf("sweep must NOT report pr-open (PR not merged); swept=%v", res.Swept)
+	}
+	if gotSlugs["pr-merged-done"] {
+		t.Fatalf("sweep must NOT report pr-merged-done (already terminalized); swept=%v", res.Swept)
+	}
+	if len(res.Swept) != 1 {
+		t.Fatalf("sweep should report exactly the one merged-not-done entity; swept=%v", res.Swept)
+	}
+}
+
+// TestSweepEmptyIsEmptyArray pins the empty case: no merged-not-done entities yields
+// an empty swept array (never null), exit 0.
+func TestSweepEmptyIsEmptyArray(t *testing.T) {
+	repoRoot := t.TempDir()
+	workflowDir := filepath.Join(repoRoot, "docs", "wf")
+	writeFile(t, filepath.Join(workflowDir, "README.md"), `---
+state: .spacedock-state
+stages:
+  states:
+    - name: ideation
+      initial: true
+    - name: done
+      terminal: true
+---
+`)
+	stateRoot := filepath.Join(workflowDir, ".spacedock-state")
+	if err := os.MkdirAll(stateRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(stateRoot, "no-pr", "index.md"), reconcileEntityFM(map[string]string{
+		"id": "id-np", "title": "no pr", "slug": "no-pr", "status": "ideation",
+	}))
+
+	gh := func(string) (string, error) { return "OPEN", nil }
+	var out, errBuf strings.Builder
+	if code := Sweep(workflowDir, gh, true, &out, &errBuf); code != 0 {
+		t.Fatalf("Sweep should exit 0; got %d stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), `"swept": []`) {
+		t.Fatalf("empty sweep should emit an empty array, not null; json:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
Make the split-root state-sync sequence a binary the FO calls, so a same-entity rebase conflict halts on a non-zero exit instead of relying on prose discipline.

## What changed
- Add `spacedock state commit <slug>`: path-scoped commit → push → on-reject `pull --rebase` → re-push, HALTing (exit 3, rebase aborted, no force-push) on a same-entity conflict.
- Add `spacedock state ready`: integrate peers' state on boot with the identical conflict HALT.
- Add `spacedock state sweep`: read-only list of merged-but-not-terminalized entities, reusing reconcile's `un-advanced-pr` detection (no second merged-detection path).
- Enumerate the new subcommands in grouped help and bash/zsh completion.

## Evidence
- `internal/cli` + `internal/dispatch` real-git tests: 13/13 passed (the 8 ACs, real bare-origin + linked-worktree checkouts); `go vet` clean.
- Detached adversarial audit: four claim-breaking edits to the HALT (drop exit-3, swallow git's rebase exit, force-push past the conflict, force-push inside the HALT) — each caught at a distinct assertion.

---
[rgq](/spacedock-dev/spacedock/blob/3cc60d391ca788efe39937268c844f738173ed83/state-verbs.md)
