### PR TITLE
merge-guard verb: spacedock merge guard <slug> (atomic mod-block set→invoke→clear→terminalize)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -147,6 +147,7 @@ func newRootCommand(ctx context.Context, rawArgs []string, env []string, dir str
 		newStatusCommand(ctx, env, dir, stdin, stdout, stderr, runner),
 		newNewCommand(ctx, env, dir, stdin, stdout, stderr, runner),
 		newStateCommand(ctx, env, dir, stdout, stderr),
+		newMergeCommand(ctx, env, dir, stdout, stderr),
 		newCompletionCommand(stdout, stderr),
 		newDispatchCommand(dispatchProbe, stdin, stdout, stderr),
 	)
@@ -378,6 +379,41 @@ func newStateCommand(ctx context.Context, env []string, dir string, stdout, stde
 	}
 }
 
+// newMergeCommand wires `spacedock merge guard <slug>` for the terminal
+// merge-finalize ceremony. Flag parsing is disabled so the post-subcommand argv
+// (the slug plus --workflow-dir / --verdict / --json / --quiet) reaches the
+// handler verbatim. `guard` drives the atomic mod-block set->invoke->clear->
+// terminalize sequence; an unknown or missing subcommand is a usage error (exit 2).
+func newMergeCommand(ctx context.Context, env []string, dir string, stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "merge guard <slug> --verdict passed|rejected",
+		Short:              "Run the terminal merge-finalize ceremony for an entity",
+		GroupID:            "workflow",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if wantsHelp(args) {
+				return cmd.Help()
+			}
+			if len(args) == 0 {
+				fmt.Fprintln(stderr, "spacedock merge: unknown subcommand (want: guard)")
+				return exitCodeError{2}
+			}
+			switch args[0] {
+			case "guard":
+				if code := status.MergeGuard(args[1:], dir, stdout, stderr); code != 0 {
+					return exitCodeError{code}
+				}
+				return nil
+			default:
+				fmt.Fprintln(stderr, "spacedock merge: unknown subcommand (want: guard)")
+				return exitCodeError{2}
+			}
+		},
+	}
+	setMergeHelp(cmd, stdout)
+	return cmd
+}
+
 // newCompletionCommand wires `spacedock completion bash|zsh`, emitting a static
 // completion script to stdout (exit 0). An unknown or missing shell prints the
 // named usage error and returns 2 — the CLI-layer usage-error code, matching the
@@ -554,7 +590,7 @@ _spacedock() {
   local cur prev verbs status_flags
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
-  verbs="claude codex pi install doctor status new state completion dispatch --version --help"
+  verbs="claude codex pi install doctor status new state merge completion dispatch --version --help"
   status_flags="--workflow-dir --next --next-id --boot --validate --archived --json --quiet --new --folder --set --where --archive --resolve --short-id --discover --root"
   if [ "$COMP_CWORD" -eq 1 ]; then
     COMPREPLY=( $(compgen -W "$verbs" -- "$cur") )
@@ -563,6 +599,7 @@ _spacedock() {
   case "${COMP_WORDS[1]}" in
     status) COMPREPLY=( $(compgen -W "$status_flags" -- "$cur") ) ;;
     state) COMPREPLY=( $(compgen -W "init new ready sweep commit --workflow-dir" -- "$cur") ) ;;
+    merge) COMPREPLY=( $(compgen -W "guard" -- "$cur") ) ;;
     completion) COMPREPLY=( $(compgen -W "bash zsh" -- "$cur") ) ;;
   esac
 }
@@ -574,7 +611,7 @@ const zshCompletion = `#compdef spacedock
 # spacedock zsh completion
 _spacedock() {
   local -a verbs status_flags
-  verbs=(claude codex pi install doctor status new state completion dispatch --version --help)
+  verbs=(claude codex pi install doctor status new state merge completion dispatch --version --help)
   status_flags=(--workflow-dir --next --next-id --boot --validate --archived --json --quiet --new --folder --set --where --archive --resolve --short-id --discover --root)
   if (( CURRENT == 2 )); then
     compadd -- $verbs
@@ -583,6 +620,7 @@ _spacedock() {
   case "${words[2]}" in
     status) compadd -- $status_flags ;;
     state) compadd -- init new ready sweep commit --workflow-dir ;;
+    merge) compadd -- guard ;;
     completion) compadd -- bash zsh ;;
   esac
 }

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -27,6 +27,7 @@ Workflow
   status      [args]                 Show or update workflow state
   new         [--folder] SLUG        Create an entity from a stdin body (auto-discovers the workflow)
   state       init                   Initialize a cloned split-root workflow's state checkout
+  merge       guard <slug>           Run the terminal merge-finalize ceremony for an entity
   completion  bash|zsh               Print a bash or zsh completion script
   dispatch    build | show-stage-def Build worker dispatch artifacts
 
@@ -141,6 +142,39 @@ Examples:
   spacedock new my-task < body.md
   spacedock new --folder my-task < body.md
   spacedock new my-task --workflow-dir docs/dev < body.md
+`)
+	})
+}
+
+// setMergeHelp installs a per-command help renderer for `merge`: the `guard`
+// subcommand synopsis, its flag surface, and the three-phase ceremony it drives,
+// instead of the root's grouped menu (cobra walks to the parent HelpFunc only when
+// a child has none).
+func setMergeHelp(cmd *cobra.Command, w io.Writer) {
+	cmd.SetHelpFunc(func(c *cobra.Command, _ []string) {
+		fmt.Fprint(w, c.Short+`
+
+Usage:
+  spacedock merge guard <slug> --verdict passed|rejected [--workflow-dir DIR]
+
+Drive the terminal merge ceremony for an entity as one ordered envelope: arm the
+mod-block before the hook, detect hook completion by the state delta, clear the
+mod-block in a standalone step, then terminalize and archive. The verb owns the
+sequence so the steps cannot be combined, skipped, or reordered; it does NOT
+invoke the merge hook or make the merge verdict (you pass that in with --verdict).
+
+Re-run guard after invoking the hook: it resumes from the entity's current state
+(armed -> blocked on an open PR, or armed -> finalized once the merge has landed).
+
+Flags:
+  --verdict passed|rejected   The merge decision (required; a verdict-less finalize is refused)
+  --workflow-dir DIR          Target this workflow explicitly (skips auto-discovery)
+  --json                      Emit the phase signal as JSON
+  --quiet                     Emit a terse machine-readable phase signal
+
+Examples:
+  spacedock merge guard my-task --verdict passed
+  spacedock merge guard my-task --verdict rejected --workflow-dir docs/dev
 `)
 	})
 }

--- a/internal/cli/merge_test.go
+++ b/internal/cli/merge_test.go
@@ -1,0 +1,154 @@
+// ABOUTME: `merge guard` routing/help/completion (AC-7) and the end-to-end ceremony
+// ABOUTME: through cobra — armed/finalized/refused drive the real status handler.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// stageMergeFixture copies a status-package merge fixture into a fresh
+// git-initialized temp dir and returns its root, so `merge guard` drives the real
+// --set/--archive ceremony end-to-end through cobra (mutations resolve git_root).
+func stageMergeFixture(t *testing.T, fixture string) string {
+	t.Helper()
+	src, err := filepath.Abs(filepath.Join("..", "status", "testdata", fixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := t.TempDir()
+	if err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, path)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, b, 0o644)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"init", "-q"}, {"add", "-A"}, {"-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "seed"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dst
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dst
+}
+
+func runMergeCLI(t *testing.T, dir string, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	code = run(context.Background(), args, os.Environ(), dir, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	return out.String(), errBuf.String(), code
+}
+
+// TestMergeGuardHelpRenders (AC-7): `merge guard --help` exits 0 with usage text.
+func TestMergeGuardHelpRenders(t *testing.T) {
+	for _, args := range [][]string{{"merge", "--help"}, {"merge", "guard", "--help"}} {
+		out, errOut, code := runMergeCLI(t, t.TempDir(), args...)
+		if code != 0 {
+			t.Fatalf("%v exit=%d stderr=%q", args, code, errOut)
+		}
+		if !strings.Contains(out, "merge guard") || !strings.Contains(out, "--verdict") {
+			t.Fatalf("%v help missing usage/--verdict:\n%s", args, out)
+		}
+	}
+}
+
+// TestMergeGuardInGroupedHelp (AC-7): `merge guard <slug>` appears in the
+// top-level grouped help workflow group.
+func TestMergeGuardInGroupedHelp(t *testing.T) {
+	out, _, code := runMergeCLI(t, t.TempDir(), "--help")
+	if code != 0 {
+		t.Fatalf("--help exit=%d", code)
+	}
+	if !strings.Contains(out, "merge") || !strings.Contains(out, "guard <slug>") {
+		t.Fatalf("grouped help missing the merge guard row:\n%s", out)
+	}
+}
+
+// TestMergeInCompletionScripts (AC-7): both completion scripts list `merge` as a
+// verb and complete `guard` under it.
+func TestMergeInCompletionScripts(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh"} {
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"completion", shell}, &stdout, &stderr); code != 0 {
+			t.Fatalf("completion %s exit=%d stderr=%q", shell, code, stderr.String())
+		}
+		script := stdout.String()
+		if !strings.Contains(script, " merge ") && !strings.Contains(script, " merge\n") {
+			t.Fatalf("completion %s script does not list merge as a verb:\n%s", shell, script)
+		}
+		if !strings.Contains(script, "merge)") || !strings.Contains(script, "guard") {
+			t.Fatalf("completion %s script missing the merge) guard case:\n%s", shell, script)
+		}
+	}
+}
+
+// TestMergeUnknownSubcommand (AC-7 companion): `merge bogus` is a usage error
+// (exit 2), matching the state-verb unknown-subcommand contract.
+func TestMergeUnknownSubcommand(t *testing.T) {
+	_, errOut, code := runMergeCLI(t, t.TempDir(), "merge", "bogus")
+	if code != 2 {
+		t.Fatalf("merge bogus must exit 2, got %d", code)
+	}
+	if !strings.Contains(errOut, "unknown subcommand") {
+		t.Fatalf("stderr should name the unknown subcommand, got %q", errOut)
+	}
+}
+
+// TestMergeGuardEndToEndArmFinalize drives the whole ceremony through cobra on a
+// merge: local fixture: the first `merge guard` arms, the second finalizes and
+// archives — proving the verb routes to the handler and the real --set/--archive
+// paths run end to end.
+func TestMergeGuardEndToEndArmFinalize(t *testing.T) {
+	root := stageMergeFixture(t, "merge-local-workflow")
+
+	out1, err1, code1 := runMergeCLI(t, root, "merge", "guard", "020-no-sentinel", "--verdict", "passed", "--workflow-dir", root)
+	if code1 != 0 {
+		t.Fatalf("arm exit=%d stderr=%q", code1, err1)
+	}
+	if !strings.Contains(out1, "armed") {
+		t.Fatalf("first run should arm, got %q", out1)
+	}
+
+	out2, err2, code2 := runMergeCLI(t, root, "merge", "guard", "020-no-sentinel", "--verdict", "passed", "--workflow-dir", root)
+	if code2 != 0 {
+		t.Fatalf("finalize exit=%d stderr=%q", code2, err2)
+	}
+	if !strings.Contains(out2, "finalized") {
+		t.Fatalf("second run should finalize, got %q", out2)
+	}
+	if !fileExists(filepath.Join(root, "_archive", "020-no-sentinel.md")) {
+		t.Fatal("finalize should archive the entity")
+	}
+}
+
+// TestMergeGuardEndToEndRefusalPropagated drives the AC-5 refusal through cobra:
+// the merge-hook guard's exit 1 + stderr reaches the process exit code unchanged.
+func TestMergeGuardEndToEndRefusalPropagated(t *testing.T) {
+	root := stageMergeFixture(t, "merge-pr-workflow")
+	out, errOut, code := runMergeCLI(t, root, "merge", "guard", "020-no-sentinel", "--verdict", "passed", "--workflow-dir", root)
+	if code != 1 {
+		t.Fatalf("refusal should propagate exit 1, got %d (stdout=%q)", code, out)
+	}
+	if !strings.Contains(errOut, "cannot advance to terminal") {
+		t.Fatalf("guard refusal should reach stderr verbatim, got %q", errOut)
+	}
+}

--- a/internal/status/merge.go
+++ b/internal/status/merge.go
@@ -1,0 +1,248 @@
+// ABOUTME: `spacedock merge guard <slug>` drives the terminal merge ceremony as one
+// ABOUTME: ordered envelope: arm the mod-block, detect completion by state delta, clear, terminalize, archive.
+package status
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// MergeGuard is the entry point for `spacedock merge guard <slug>`. It owns the
+// ordered mod-block set->invoke->clear->terminalize sequence so a weak first
+// officer cannot combine, skip, or reorder the steps. It does NOT invoke the
+// merge hook, make the merge verdict (passed in via --verdict), or run the host
+// agent-teardown; it emits the already-proven --set/--archive paths in the
+// mandatory order and propagates — never bypasses — their guard refusals.
+//
+// args is the post-`guard` argv: the positional <slug>, --workflow-dir DIR,
+// --verdict {passed|rejected}, and --json/--quiet. dir is the working directory
+// used to resolve a relative --workflow-dir and to discover the enclosing
+// workflow when no --workflow-dir is passed. The exit domain is {0,1}: 0 for a
+// completed signal (armed / blocked / finalized), 1 for a usage error or a
+// propagated guard refusal.
+func MergeGuard(args []string, dir string, stdout, stderr io.Writer) int {
+	workflowDir, rest, err := parseWorkflowDir(args)
+	if err != nil {
+		return errExit(stderr, err.Error())
+	}
+	asJSON := contains(rest, "--json")
+	quiet := contains(rest, "--quiet")
+
+	verdict, err := parseSingleArg(rest, "--verdict", "passed|rejected")
+	if err != nil {
+		return errExit(stderr, err.Error())
+	}
+	// Verdict gate: a verdict-less finalize is structurally unreachable — the verb
+	// requires the FO/captain's decision up front so it can never write a terminal
+	// status without a verdict in the same mutation (the team-mode-verdict-omission
+	// fix). Refuse BEFORE resolving the workflow so the omission is reported even on
+	// a malformed workflow.
+	if verdict == "" {
+		return errExit(stderr, "merge guard requires --verdict {passed|rejected}")
+	}
+	if verdict != "passed" && verdict != "rejected" {
+		return errExit(stderr, fmt.Sprintf("merge guard --verdict must be 'passed' or 'rejected', not '%s'", verdict))
+	}
+
+	slug := ""
+	for i := 0; i < len(rest); i++ {
+		a := rest[i]
+		switch {
+		case a == "--json" || a == "--quiet":
+			continue
+		case a == "--verdict":
+			i++ // skip the flag's value, already parsed by parseSingleArg
+			continue
+		case strings.HasPrefix(a, "--"):
+			return errExit(stderr, "unknown argument: "+a)
+		case slug != "":
+			return errExit(stderr, "merge guard takes a single <slug> argument")
+		default:
+			slug = a
+		}
+	}
+	if slug == "" {
+		return errExit(stderr, "merge guard requires a <slug> argument")
+	}
+
+	pipelineDir := workflowDir
+	if pipelineDir == "" {
+		if discovered, ok := DiscoverWorkflowDir(dir); ok {
+			pipelineDir = discovered
+		} else if resolved, rc := discoverWorkflowDownward(dir, stderr); rc != 0 {
+			return rc
+		} else {
+			pipelineDir = resolved
+		}
+	}
+
+	roots, err := resolveRoots(pipelineDir, dir)
+	if err != nil {
+		return errExit(stderr, err.Error())
+	}
+
+	resolved, rc := resolveMutationEntity(roots, slug, stderr)
+	if rc != 0 {
+		return rc
+	}
+	slug = resolved.slug
+	entityPath := resolveEntityPath(roots.entityDir, slug, stderr)
+	if entityPath == "" {
+		return errExit(stderr, "entity not found: "+slug)
+	}
+
+	policy, perr := resolveMergePolicy(roots.definitionDir)
+	if perr != nil {
+		return errExit(stderr, perr.Error())
+	}
+
+	fields := ParseFrontmatter(entityPath)
+	modBlock := strings.TrimSpace(fields["mod-block"])
+	pr := strings.TrimSpace(fields["pr"])
+	mergeHooks := scanMods(roots.definitionDir)["merge"]
+	hookRegistered := len(mergeHooks) > 0
+
+	// State-delta classifier (the one genuinely-new logic): a pure read of
+	// pr/mod-block/verdict plus the policy decides armed / blocked / finalize. No
+	// new mutation primitive — every transition below emits a proven --set/--archive.
+	switch {
+	case pr != "" && verdict != "rejected":
+		// Phase B blocked: the hook opened a PR. Leave mod-block + pr intact, do not
+		// terminalize. A rejected verdict overrides — a rejected entity finalizes
+		// regardless of a stale pr.
+		return signalBlocked(slug, pr, quiet, asJSON, stdout)
+
+	case verdict == "rejected":
+		// A rejected entity never merged, so the pr-requirement is vacuous: finalize
+		// straight through, clearing an in-flight mod-block standalone first (AC-6).
+		return finalize(roots, slug, modBlock, verdict, quiet, asJSON, stdout, stderr)
+
+	case policy == mergeLocal && modBlock == "" && hookRegistered:
+		// Phase A arm (merge: local): the verb owns the full local-merge ceremony, so
+		// it arms the mod-block before the FO invokes the hook. Under merge: pr the
+		// arm+hook step opens a PR (outward-facing, captain-approval-gated) and stays
+		// the FO's; the verb resumes at Phase B once the hook has run.
+		return arm(roots, slug, mergeHooks[0], quiet, asJSON, stdout, stderr)
+
+	default:
+		// Phase C finalize. Under merge: local a cleared/clearable mod-block stands as
+		// completion. Under merge: pr with no pr and a passed verdict the terminalize
+		// --set hits the merge-hook guard, which refuses (cannot advance to terminal);
+		// the verb propagates that exit 1 verbatim rather than --forcing past it (AC-5).
+		return finalize(roots, slug, modBlock, verdict, quiet, asJSON, stdout, stderr)
+	}
+}
+
+// arm performs Phase A: set mod-block=merge:{hook} in its own --set and signal the
+// FO to invoke the hook. The underlying runSet is the proven mutation path.
+func arm(roots roots, slug, hook string, quiet, asJSON bool, stdout, stderr io.Writer) int {
+	modValue := "merge:" + hook
+	if rc := emitSet(roots, slug, []fieldUpdate{{field: "mod-block", value: modValue, hasValue: true}}, stderr); rc != 0 {
+		return rc
+	}
+	return signalArmed(slug, hook, quiet, asJSON, stdout)
+}
+
+// finalize performs Phase C: clear an in-flight mod-block in a STANDALONE --set,
+// terminalize status+verdict+completed in ONE --set, then archive. Each step is a
+// proven guarded path; the verb refuses to proceed to a later step if an earlier
+// one's guard refuses, propagating the guard's exit 1 + stderr verbatim and never
+// passing --force.
+func finalize(roots roots, slug, modBlock, verdict string, quiet, asJSON bool, stdout, stderr io.Writer) int {
+	if modBlock != "" {
+		if rc := emitSet(roots, slug, []fieldUpdate{{field: "mod-block", value: "", hasValue: true}}, stderr); rc != 0 {
+			return rc
+		}
+	}
+	terminal := terminalStageName(roots.definitionDir)
+	if terminal == "" {
+		return errExit(stderr, fmt.Sprintf("workflow %s declares no terminal stage — cannot finalize", roots.definitionDir))
+	}
+	terminalize := []fieldUpdate{
+		{field: "status", value: terminal, hasValue: true},
+		{field: "verdict", value: verdict, hasValue: true},
+		{field: "completed", hasValue: false},
+	}
+	if rc := emitSet(roots, slug, terminalize, stderr); rc != 0 {
+		return rc
+	}
+	if rc := runArchive(roots.definitionDir, roots.entityDir, roots.entityDirSpelling, slug, false, true, false, io.Discard, stderr); rc != 0 {
+		return rc
+	}
+	return signalFinalized(slug, terminal, verdict, quiet, asJSON, stdout)
+}
+
+// emitSet runs one proven --set mutation through runSet, discarding its success
+// narration (the verb emits its own phase signal) while propagating a guard
+// refusal's stderr verbatim. It never passes --force.
+func emitSet(roots roots, slug string, updates []fieldUpdate, stderr io.Writer) int {
+	set := &setUpdate{slug: slug, updates: updates}
+	return runSet(roots, set, nil, nil,
+		false, false, false, false, false, false, true, false,
+		io.Discard, stderr)
+}
+
+// terminalStageName returns the workflow's terminal stage name, or "" when the
+// README declares none. The verb terminalizes into this stage by name rather than
+// hardcoding "done", so a workflow with a differently-named terminal stage works.
+func terminalStageName(definitionDir string) string {
+	readme := definitionDir + "/README.md"
+	if !fileExists(readme) {
+		return ""
+	}
+	for _, s := range parseStagesBlock(readme) {
+		if s.terminal {
+			return s.Name
+		}
+	}
+	return ""
+}
+
+// signalArmed reports the arm outcome: the mod-block is set and the FO must now
+// invoke the named merge hook.
+func signalArmed(slug, hook string, quiet, asJSON bool, stdout io.Writer) int {
+	switch {
+	case asJSON:
+		emitJSON(stdout, newJSONObj().
+			set("command", "merge-guard").set("slug", slug).
+			set("signal", "armed").set("action", "invoke-hook").set("hook", hook))
+	case quiet:
+		fmt.Fprintf(stdout, "merge-guard slug=%s signal=armed action=invoke-hook hook=%s\n", slug, hook)
+	default:
+		fmt.Fprintf(stdout, "armed: mod-block set to merge:%s — invoke the %s merge hook, then re-run `merge guard %s`.\n", hook, hook, slug)
+	}
+	return 0
+}
+
+// signalBlocked reports the blocked outcome: the hook opened a PR, so the verb
+// leaves the mod-block intact and waits.
+func signalBlocked(slug, pr string, quiet, asJSON bool, stdout io.Writer) int {
+	switch {
+	case asJSON:
+		emitJSON(stdout, newJSONObj().
+			set("command", "merge-guard").set("slug", slug).
+			set("signal", "blocked").set("action", "await-pr").set("pr", pr))
+	case quiet:
+		fmt.Fprintf(stdout, "merge-guard slug=%s signal=blocked action=await-pr pr=%s\n", slug, pr)
+	default:
+		fmt.Fprintf(stdout, "blocked: PR %s is pending — mod-block left intact. Re-run `merge guard %s` after it lands.\n", pr, slug)
+	}
+	return 0
+}
+
+// signalFinalized reports the finalize outcome: the entity is terminal, verdict
+// recorded, archived.
+func signalFinalized(slug, terminal, verdict string, quiet, asJSON bool, stdout io.Writer) int {
+	switch {
+	case asJSON:
+		emitJSON(stdout, newJSONObj().
+			set("command", "merge-guard").set("slug", slug).
+			set("signal", "finalized").set("status", terminal).set("verdict", verdict))
+	case quiet:
+		fmt.Fprintf(stdout, "merge-guard slug=%s signal=finalized status=%s verdict=%s\n", slug, terminal, verdict)
+	default:
+		fmt.Fprintf(stdout, "finalized: %s -> %s (verdict %s), archived.\n", slug, terminal, verdict)
+	}
+	return 0
+}

--- a/internal/status/merge_guard_test.go
+++ b/internal/status/merge_guard_test.go
@@ -51,6 +51,47 @@ func TestMergeGuardArmsUnderLocal(t *testing.T) {
 	}
 }
 
+// TestMergeGuardArmIsPolicyGated is the load-bearing inversion pin (AC-1 vs AC-5).
+// On the IDENTICAL precondition — empty mod-block, empty pr, `--verdict passed` —
+// the ONLY differing variable is the `merge:` policy, and it must flip the
+// outcome: merge: local ARMS (exit 0, sets mod-block, does not terminalize), while
+// merge: pr REFUSES at the merge-hook guard (exit 1, no arm, entity unchanged).
+// This resolves the policy-blindness contradiction between the Phase A prose and
+// AC-5: an empty-mod-block / empty-pr entity is indistinguishable as "armable" vs
+// "ceremony-skipping" by frontmatter, so a policy-blind arm cannot satisfy AC-5.
+// Gating arm to merge: local (fully in-process, safe to auto-drive) while merge: pr
+// routes the unarmed finalize to the guard refusal uniquely satisfies the oracle.
+// Flipping arm back to policy-blind turns the merge: pr leg RED (it would arm,
+// exit 0, instead of refusing).
+func TestMergeGuardArmIsPolicyGated(t *testing.T) {
+	// merge: local leg — arms.
+	localRoot, localOut, localErr, localCode := driveMergeGuard(t, "merge-local-workflow", "020-no-sentinel", "--verdict", "passed")
+	if localCode != 0 {
+		t.Fatalf("merge: local empty-mod-block --verdict passed must ARM (exit 0), got %d (stderr=%q)", localCode, localErr)
+	}
+	if !strings.Contains(localOut, "armed") {
+		t.Fatalf("merge: local leg must signal armed, got %q", localOut)
+	}
+	if got := frontmatterField(t, filepath.Join(localRoot, "020-no-sentinel.md"), "mod-block"); got != "merge:local-merge" {
+		t.Fatalf("merge: local arm must set mod-block, got %q", got)
+	}
+
+	// merge: pr leg — refuses, does NOT arm. Same precondition, opposite outcome.
+	prRoot, prOut, prErr, prCode := driveMergeGuard(t, "merge-pr-workflow", "020-no-sentinel", "--verdict", "passed")
+	if prCode != 1 {
+		t.Fatalf("merge: pr empty-mod-block --verdict passed must REFUSE (exit 1, not arm), got %d (stdout=%q)", prCode, prOut)
+	}
+	if strings.Contains(prOut, "armed") {
+		t.Fatalf("merge: pr leg must NOT arm, got %q", prOut)
+	}
+	if !strings.Contains(prErr, "cannot advance to terminal") {
+		t.Fatalf("merge: pr leg must propagate the merge-hook refusal, got %q", prErr)
+	}
+	if got := frontmatterField(t, filepath.Join(prRoot, "020-no-sentinel.md"), "mod-block"); got != "" {
+		t.Fatalf("merge: pr refusal must NOT arm a mod-block, got %q", got)
+	}
+}
+
 // TestMergeGuardArmThenFinalizeLocal (AC-1, the happy path): arm, then a second
 // run finalizes — the entity ends terminal+passed, archived, mod-block cleared.
 func TestMergeGuardArmThenFinalizeLocal(t *testing.T) {

--- a/internal/status/merge_guard_test.go
+++ b/internal/status/merge_guard_test.go
@@ -1,0 +1,226 @@
+// ABOUTME: merge guard verb behavior — arm / blocked / finalize over the proven
+// ABOUTME: --set/--archive paths, propagating (never bypassing) the guard refusals.
+package status
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// driveMergeGuard runs `merge guard` against a fresh staged fixture, returning the
+// staged root plus the three channels. The fixture is git-initialized (mutations
+// resolve git_root), and --workflow-dir points at the staged copy so the verb
+// drives the real --set/--archive paths against it.
+func driveMergeGuard(t *testing.T, fixture string, args ...string) (root, stdout, stderr string, code int) {
+	t.Helper()
+	root = stageFixture(t, fixture)
+	var out, errBuf bytes.Buffer
+	full := append([]string{"--workflow-dir", root}, args...)
+	code = MergeGuard(full, root, &out, &errBuf)
+	return root, out.String(), errBuf.String(), code
+}
+
+// frontmatterField reads one top-level frontmatter field from a staged entity.
+func frontmatterField(t *testing.T, path, field string) string {
+	t.Helper()
+	return strings.TrimSpace(ParseFrontmatter(path)[field])
+}
+
+// TestMergeGuardArmsUnderLocal (AC-1, Phase A): on a merge: local entity with no
+// mod-block, the first guard run arms — it sets mod-block=merge:{hook}, signals
+// `armed`/invoke-hook, exits 0, and does NOT terminalize or archive.
+func TestMergeGuardArmsUnderLocal(t *testing.T) {
+	root, out, errOut, code := driveMergeGuard(t, "merge-local-workflow", "020-no-sentinel", "--verdict", "passed")
+	if code != 0 {
+		t.Fatalf("arm should exit 0, got %d (stderr=%q)", code, errOut)
+	}
+	if !strings.Contains(out, "armed") {
+		t.Fatalf("stdout should signal armed, got %q", out)
+	}
+	entity := filepath.Join(root, "020-no-sentinel.md")
+	if got := frontmatterField(t, entity, "mod-block"); got != "merge:local-merge" {
+		t.Fatalf("arm should set mod-block=merge:local-merge, got %q", got)
+	}
+	if got := frontmatterField(t, entity, "status"); got != "implementation" {
+		t.Fatalf("arm must NOT terminalize, status=%q", got)
+	}
+	if fileExists(filepath.Join(root, "_archive", "020-no-sentinel.md")) {
+		t.Fatal("arm must NOT archive")
+	}
+}
+
+// TestMergeGuardArmThenFinalizeLocal (AC-1, the happy path): arm, then a second
+// run finalizes — the entity ends terminal+passed, archived, mod-block cleared.
+func TestMergeGuardArmThenFinalizeLocal(t *testing.T) {
+	root := stageFixture(t, "merge-local-workflow")
+	entity := filepath.Join(root, "020-no-sentinel.md")
+
+	var out1, err1 bytes.Buffer
+	if code := MergeGuard([]string{"--workflow-dir", root, "020-no-sentinel", "--verdict", "passed"}, root, &out1, &err1); code != 0 {
+		t.Fatalf("arm exit=%d stderr=%q", code, err1.String())
+	}
+	if got := frontmatterField(t, entity, "mod-block"); got != "merge:local-merge" {
+		t.Fatalf("post-arm mod-block=%q", got)
+	}
+
+	var out2, err2 bytes.Buffer
+	code := MergeGuard([]string{"--workflow-dir", root, "020-no-sentinel", "--verdict", "passed"}, root, &out2, &err2)
+	if code != 0 {
+		t.Fatalf("finalize should exit 0, got %d (stderr=%q)", code, err2.String())
+	}
+	if !strings.Contains(out2.String(), "finalized") {
+		t.Fatalf("stdout should signal finalized, got %q", out2.String())
+	}
+	archived := filepath.Join(root, "_archive", "020-no-sentinel.md")
+	if !fileExists(archived) {
+		t.Fatal("finalize should archive the entity")
+	}
+	if got := frontmatterField(t, archived, "status"); got != "done" {
+		t.Fatalf("archived status=%q, want done", got)
+	}
+	if got := frontmatterField(t, archived, "verdict"); got != "passed" {
+		t.Fatalf("archived verdict=%q, want passed", got)
+	}
+	if got := frontmatterField(t, archived, "mod-block"); got != "" {
+		t.Fatalf("archived mod-block should be cleared, got %q", got)
+	}
+}
+
+// TestMergeGuardBlockedOnPR (AC-3): with pr set, the verb signals blocked/await-pr,
+// leaves mod-block + pr + non-terminal status intact, and does not archive.
+func TestMergeGuardBlockedOnPR(t *testing.T) {
+	root, out, errOut, code := driveMergeGuard(t, "merge-pr-workflow", "070-pr-pending", "--verdict", "passed")
+	if code != 0 {
+		t.Fatalf("blocked should exit 0, got %d (stderr=%q)", code, errOut)
+	}
+	if !strings.Contains(out, "blocked") {
+		t.Fatalf("stdout should signal blocked, got %q", out)
+	}
+	entity := filepath.Join(root, "070-pr-pending.md")
+	if got := frontmatterField(t, entity, "mod-block"); got != "merge:local-merge" {
+		t.Fatalf("blocked must leave mod-block intact, got %q", got)
+	}
+	if got := frontmatterField(t, entity, "pr"); got != "#42" {
+		t.Fatalf("blocked must leave pr intact, got %q", got)
+	}
+	if got := frontmatterField(t, entity, "status"); got != "implementation" {
+		t.Fatalf("blocked must NOT terminalize, status=%q", got)
+	}
+	if fileExists(filepath.Join(root, "_archive", "070-pr-pending.md")) {
+		t.Fatal("blocked must NOT archive")
+	}
+}
+
+// TestMergeGuardVerdictOmissionUnreachable (AC-4): `merge guard` without --verdict
+// exits non-zero BEFORE any terminal write — a verdict-less finalize is unreachable.
+func TestMergeGuardVerdictOmissionUnreachable(t *testing.T) {
+	root, out, errOut, code := driveMergeGuard(t, "merge-local-workflow", "020-no-sentinel")
+	if code == 0 {
+		t.Fatalf("verdict-less guard must exit non-zero, got 0 (stdout=%q)", out)
+	}
+	if !strings.Contains(errOut, "verdict") {
+		t.Fatalf("stderr should name the missing verdict, got %q", errOut)
+	}
+	// No terminal write: the entity is untouched (no mod-block armed either, since
+	// the verdict gate fires before resolving the workflow).
+	if got := frontmatterField(t, filepath.Join(root, "020-no-sentinel.md"), "status"); got != "implementation" {
+		t.Fatalf("verdict-less guard must not mutate, status=%q", got)
+	}
+}
+
+// TestMergeGuardRejectsBadVerdict (AC-4 companion): a --verdict value other than
+// passed/rejected is a usage error, before any mutation.
+func TestMergeGuardRejectsBadVerdict(t *testing.T) {
+	_, out, errOut, code := driveMergeGuard(t, "merge-local-workflow", "020-no-sentinel", "--verdict", "maybe")
+	if code != 1 {
+		t.Fatalf("bad verdict must exit 1, got %d (stdout=%q)", code, out)
+	}
+	if !strings.Contains(errOut, "passed") || !strings.Contains(errOut, "rejected") {
+		t.Fatalf("stderr should name the valid verdicts, got %q", errOut)
+	}
+}
+
+// TestMergeGuardPrNoSentinelRefuses (AC-5): under default merge: pr with a
+// registered hook, a --verdict passed finalize on an entity with no pr and no
+// mod-block propagates the merge-hook guard's `cannot advance to terminal` refusal
+// (exit 1) verbatim, leaves the entity unchanged, and never passes --force.
+func TestMergeGuardPrNoSentinelRefuses(t *testing.T) {
+	root, out, errOut, code := driveMergeGuard(t, "merge-pr-workflow", "020-no-sentinel", "--verdict", "passed")
+	if code != 1 {
+		t.Fatalf("merge: pr no-sentinel finalize must refuse (exit 1), got %d", code)
+	}
+	if !strings.Contains(errOut, "cannot advance to terminal") {
+		t.Fatalf("stderr should propagate the merge-hook refusal verbatim, got %q", errOut)
+	}
+	if strings.Contains(out, "finalized") {
+		t.Fatalf("stdout must not claim finalized on a refusal, got %q", out)
+	}
+	entity := filepath.Join(root, "020-no-sentinel.md")
+	if got := frontmatterField(t, entity, "status"); got != "implementation" {
+		t.Fatalf("refused entity must be unchanged, status=%q", got)
+	}
+	if fileExists(filepath.Join(root, "_archive", "020-no-sentinel.md")) {
+		t.Fatal("refused entity must NOT archive")
+	}
+}
+
+// TestMergeGuardRejectedFinalizesNoPR (AC-6a): --verdict rejected finalizes an
+// entity with empty pr to terminal+rejected+archived without --force.
+func TestMergeGuardRejectedFinalizesNoPR(t *testing.T) {
+	root, out, errOut, code := driveMergeGuard(t, "merge-pr-workflow", "040-rejected", "--verdict", "rejected")
+	if code != 0 {
+		t.Fatalf("rejected finalize should exit 0, got %d (stderr=%q)", code, errOut)
+	}
+	if !strings.Contains(out, "finalized") {
+		t.Fatalf("stdout should signal finalized, got %q", out)
+	}
+	archived := filepath.Join(root, "_archive", "040-rejected.md")
+	if got := frontmatterField(t, archived, "status"); got != "done" {
+		t.Fatalf("archived status=%q, want done", got)
+	}
+	if got := frontmatterField(t, archived, "verdict"); got != "rejected" {
+		t.Fatalf("archived verdict=%q, want rejected", got)
+	}
+}
+
+// TestMergeGuardRejectedClearsModBlockFirst (AC-6b): --verdict rejected on an
+// entity with an in-flight mod-block clears the block in its own --set FIRST, then
+// terminalizes+archives — the combined-clear-with-terminal guard never trips
+// because the verb separates the steps.
+func TestMergeGuardRejectedClearsModBlockFirst(t *testing.T) {
+	root, out, errOut, code := driveMergeGuard(t, "merge-pr-workflow", "050-rejected-pending", "--verdict", "rejected")
+	if code != 0 {
+		t.Fatalf("rejected-with-mod-block finalize should exit 0, got %d (stderr=%q)", code, errOut)
+	}
+	if !strings.Contains(out, "finalized") {
+		t.Fatalf("stdout should signal finalized, got %q", out)
+	}
+	if strings.Contains(errOut, "combined mod-block clear with terminal transition") {
+		t.Fatalf("verb must separate the clear from the terminalize, not trip the combined guard: %q", errOut)
+	}
+	archived := filepath.Join(root, "_archive", "050-rejected-pending.md")
+	if got := frontmatterField(t, archived, "status"); got != "done" {
+		t.Fatalf("archived status=%q, want done", got)
+	}
+	if got := frontmatterField(t, archived, "verdict"); got != "rejected" {
+		t.Fatalf("archived verdict=%q, want rejected", got)
+	}
+	if got := frontmatterField(t, archived, "mod-block"); got != "" {
+		t.Fatalf("archived mod-block should be cleared, got %q", got)
+	}
+}
+
+// TestMergeGuardRequiresSlug (usage): a guard call with no slug is a usage error.
+func TestMergeGuardRequiresSlug(t *testing.T) {
+	root := stageFixture(t, "merge-local-workflow")
+	var out, errBuf bytes.Buffer
+	code := MergeGuard([]string{"--workflow-dir", root, "--verdict", "passed"}, root, &out, &errBuf)
+	if code != 1 {
+		t.Fatalf("missing slug must exit 1, got %d", code)
+	}
+	if !strings.Contains(errBuf.String(), "slug") {
+		t.Fatalf("stderr should name the missing slug, got %q", errBuf.String())
+	}
+}

--- a/internal/status/testdata/merge-pr-workflow/070-pr-pending.md
+++ b/internal/status/testdata/merge-pr-workflow/070-pr-pending.md
@@ -1,0 +1,16 @@
+---
+id: "070"
+title: Entity with an open PR and an in-flight mod-block
+status: implementation
+mod-block: merge:local-merge
+score: "0.50"
+source: roadmap
+pr: "#42"
+---
+# Entity with an open PR and an in-flight mod-block
+
+The merge hook ran and BLOCKED on an open PR (`pr: #42`), leaving the `mod-block`
+in flight. This is the Phase B blocked-by-state-delta case: `merge guard` must
+detect the set `pr`, signal `blocked`/`await-pr`, leave the `mod-block` intact,
+and NOT terminalize or archive. The entity stays at its non-terminal status until
+the PR lands and the FO re-runs the ceremony.


### PR DESCRIPTION
Make the terminal merge ceremony a single binary the FO calls, so the mod-block→clear→terminalize ordering can't be reordered, collapsed, or skip the verdict.

## What changed
- Add `spacedock merge guard <slug>`: arm mod-block (`merge: local` only) → detect completion by state delta → standalone mod-block clear → atomic terminalize → archive.
- Write `status` + `verdict` + `completed` in ONE `--set` (the structural fix for verdict-omission).
- Propagate the underlying `--set`/`--archive` guard refusals verbatim — never `--force` past them.
- Surface `merge`/`guard` in grouped help and bash/zsh completion.

## Evidence
- `internal/status` (9 handler) + `internal/cli` (routing/help/completion) tests cover the 7 ACs against the real binary; full `go test ./...` green on the rebased tree.
- Detached adversarial audit: five claim-breaking edits (combined clear, policy-blind arm, `--force` injection, dropped verdict-gate, split status/verdict) each caught by a distinct test; the `merge: local`-vs-`pr` arm inversion is pinned by a load-bearing test, mutation-proven.

---
[mz](/spacedock-dev/spacedock/blob/e606a064207ac0ea86c1dc71598108035db49b0c/merge-finalize.md)
