### PR TITLE
prose-function restructure: re-express the FO cores as «fn» invocations

### DIFF
--- a/internal/cli/prose_function_routing_test.go
+++ b/internal/cli/prose_function_routing_test.go
@@ -1,0 +1,242 @@
+// ABOUTME: AC-1/AC-4 — bind each prose-function core's notation to the binary's command
+// ABOUTME: routing: shipped backtick verbs route, un-shipped guillemet targets are rejected.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// proseFunctionCores are the restructured FO contract cores carrying the «fn» prose-function
+// declarations. The walk reads them by repo-relative path (the same filesystem-oracle idiom
+// boot_resident_closure_test.go uses), so the check drives the on-disk contract, not a copy.
+var proseFunctionCores = []string{
+	filepath.Join("skills", "first-officer", "references", "first-officer-shared-core.md"),
+	filepath.Join("skills", "first-officer", "references", "fo-dispatch-core.md"),
+	filepath.Join("skills", "first-officer", "references", "fo-merge-core.md"),
+}
+
+// migrationTargetRe matches a prose-function declaration's `→` migration-target line and
+// captures (1) the notation word — `shipped` (a backtick, a live verb) or `prose` (a
+// guillemet, hand-followed) — and (2) the FIRST backticked `spacedock …` verb token on the
+// line, if any. A `→ **shipped**: ` `spacedock state ready` `` line yields ("shipped",
+// "spacedock state ready"); a `→ **prose**, becomes ` `spacedock dispatch next-action` ``
+// line yields ("prose", "spacedock dispatch next-action"); a bare `→ **prose**` line with no
+// `spacedock …` token (the `«feedback.route»` skill-is-the-body form) yields ("prose", "").
+var migrationTargetRe = regexp.MustCompile("→ \\*\\*(shipped|prose)\\*\\*[^\\n]*?`(spacedock [^`]+)`")
+
+// migrationBareRe matches a `→ **shipped**` / `→ **prose**` line that carries NO backticked
+// `spacedock …` token, so a declaration whose notation says "shipped" but names no verb is
+// caught as a malformed shipped-target rather than silently skipped.
+var migrationBareRe = regexp.MustCompile("→ \\*\\*(shipped|prose)\\*\\*")
+
+// verbBinding is one extracted migration target: the verb argv the contract names, the
+// notation (shipped → must route; prose → must be un-routed when a target is named), and the
+// source line for a useful failure message.
+type verbBinding struct {
+	notation string   // "shipped" or "prose"
+	argv     []string // the verb tokens after "spacedock", e.g. {"state","ready"}
+	verb     string   // the full `spacedock …` token, for messages
+	line     string   // the source line
+}
+
+// extractVerbBindings parses one core's text and returns every prose-function migration-target
+// binding it declares. It scopes extraction to the `→` migration-target LINES of the
+// declaration blocks — NOT every inline backtick in the prose — so the deterministic extract
+// sub-calls a judgment body names (`status --read --checklist`) and the negated mention of a
+// never-shipping binary do not masquerade as migration targets. A `shipped` line MUST carry a
+// verb token (malformed otherwise); a `prose` line carries one only when it names a future
+// `becomes` target (the pure-judgment bodies name none).
+func extractVerbBindings(body string) ([]verbBinding, error) {
+	var out []verbBinding
+	for _, line := range strings.Split(body, "\n") {
+		if !migrationBareRe.MatchString(line) {
+			continue
+		}
+		m := migrationTargetRe.FindStringSubmatch(line)
+		if m == nil {
+			// A `→` line with a notation word but no `spacedock …` token: legitimate for a
+			// pure-judgment `prose` body (the skill is the body); a `shipped` line that names
+			// no verb is malformed.
+			if strings.Contains(line, "**shipped**") {
+				return out, malformedShippedLine(line)
+			}
+			continue
+		}
+		notation, verb := m[1], m[2]
+		fields := strings.Fields(verb)
+		out = append(out, verbBinding{
+			notation: notation,
+			argv:     fields[1:], // drop the leading "spacedock"
+			verb:     verb,
+			line:     strings.TrimSpace(line),
+		})
+	}
+	return out, nil
+}
+
+// malformedShippedLine is returned when a `→ **shipped**` line carries no `spacedock …` verb
+// token, so the parser surfaces the defect instead of silently passing.
+type malformedShippedLine string
+
+func (m malformedShippedLine) Error() string {
+	return "→ **shipped** line names no `spacedock …` verb token: " + string(m)
+}
+
+// verbRejected is the routing ORACLE: it invokes the verb's argv against the compiled root
+// (run → newRootCommand) from a workflow-free tempdir and reports whether the routing REJECTED
+// it. Rejection is recognized across ALL THREE marker forms at their three distinct sites:
+// `unknown command: {cmd}` at the cobra root (an absent top-level command, e.g. `gate`);
+// `unknown subcommand` at a parent's `switch args[0]` (e.g. `merge teleport`, `state warp`);
+// and `unknown dispatch subcommand` from dispatch's own handler. A shipped verb routes into its
+// handler (which may then complain about a missing flag/arg — that is acceptance, not
+// rejection). This is the function the production check AND the RED control both drive, so
+// mutating it (stubbing it to never reject) reds the control — what makes the control
+// load-bearing rather than a re-implementation.
+func verbRejected(t *testing.T, argv []string) bool {
+	t.Helper()
+	env := []string{"PATH=" + os.Getenv("PATH")}
+	var out, errBuf bytes.Buffer
+	run(context.Background(), argv, env, t.TempDir(), strings.NewReader(""), &out, &errBuf, &status.NativeRunner{}, nil)
+	combined := out.String() + errBuf.String()
+	for _, marker := range []string{"unknown command:", "unknown subcommand", "unknown dispatch subcommand"} {
+		if strings.Contains(combined, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestProseFunctionNotationBindsToRouting (AC-1/AC-4) is the verb-notation ↔ command-routing
+// binding. For every prose-function declaration in the restructured cores it extracts the
+// migration target and asserts: a SHIPPED (backtick) verb is ACCEPTED by the compiled root
+// (none of the three rejection markers), and a PROSE (guillemet) target that names a future
+// `becomes` verb is REJECTED (one of the three markers). The binary's routing switch — not the
+// contract prose — is the expected value: a contract that backticks a verb the binary does not
+// route fails, and a guillemet whose named target now routes fails as should-have-flipped. The
+// empty-walk guard keeps it from passing vacuously.
+func TestProseFunctionNotationBindsToRouting(t *testing.T) {
+	root := repoRootFromPkg(t)
+	totalShipped, totalProse := 0, 0
+	for _, rel := range proseFunctionCores {
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read prose-function core %s: %v", rel, err)
+		}
+		bindings, err := extractVerbBindings(string(data))
+		if err != nil {
+			t.Fatalf("%s: %v", rel, err)
+		}
+		for _, b := range bindings {
+			rejected := verbRejected(t, b.argv)
+			switch b.notation {
+			case "shipped":
+				totalShipped++
+				if rejected {
+					t.Errorf("%s: backtick (shipped) verb %q is REJECTED by the binary routing — a backtick must name a routed command (line: %s)", rel, b.verb, b.line)
+				}
+			case "prose":
+				totalProse++
+				if !rejected {
+					t.Errorf("%s: guillemet (prose) target %q is ACCEPTED by the binary routing — it should have flipped to a backtick (line: %s)", rel, b.verb, b.line)
+				}
+			}
+		}
+	}
+	if totalShipped == 0 {
+		t.Fatal("extracted zero shipped (backtick) verb bindings from the restructured cores — extraction bug; the binding check would pass vacuously")
+	}
+	if totalProse == 0 {
+		t.Fatal("extracted zero prose (guillemet) targets from the restructured cores — extraction bug; the should-have-flipped half is never exercised")
+	}
+}
+
+// TestProseFunctionRoutingGuardFailsOnViolation is the AC-1 RED control (mirroring
+// boot_resident_closure_test.go's …GuardFailsOnDanglingTarget): it plants the two violation
+// shapes against a fixture and proves the binding logic goes RED for each. (a) A backtick verb
+// the binary does NOT route (`spacedock merge teleport`) — the shipped-must-route half reds.
+// (b) A guillemet whose `→` target IS routed (`spacedock merge guard`) — the should-have-flipped
+// half reds. It drives the same extractVerbBindings + verbRejected the real guard uses, so the
+// control exercises the real code path rather than re-implementing it.
+func TestProseFunctionRoutingGuardFailsOnViolation(t *testing.T) {
+	fixture := "## «merge.phantom»(slug): a planted un-routed backtick\n" +
+		"- → **shipped** (this sprint): `spacedock merge teleport` — invoke it directly.\n" +
+		"## «merge.shouldflip»(slug): a planted routed guillemet target\n" +
+		"- → **prose**, becomes `spacedock merge guard <slug>` (later) — hand-follow for now.\n"
+	bindings, err := extractVerbBindings(fixture)
+	if err != nil {
+		t.Fatalf("control fixture failed to parse: %v", err)
+	}
+	if len(bindings) != 2 {
+		t.Fatalf("control fixture extracted %d bindings, want 2 — the violation cases are not both exercised", len(bindings))
+	}
+
+	var sawPhantomRed, sawShouldFlipRed bool
+	for _, b := range bindings {
+		rejected := verbRejected(t, b.argv)
+		switch {
+		case b.notation == "shipped" && strings.Contains(b.verb, "teleport"):
+			// shipped-must-route: an un-routed backtick is REJECTED, so the real guard's
+			// shipped-branch would red here.
+			if rejected {
+				sawPhantomRed = true
+			} else {
+				t.Errorf("control: planted un-routed backtick %q was unexpectedly ACCEPTED — the shipped-must-route half cannot fail", b.verb)
+			}
+		case b.notation == "prose" && strings.Contains(b.verb, "merge guard"):
+			// should-have-flipped: a routed guillemet target is ACCEPTED, so the real guard's
+			// prose-branch would red here.
+			if !rejected {
+				sawShouldFlipRed = true
+			} else {
+				t.Errorf("control: planted routed guillemet target %q was unexpectedly REJECTED — the should-have-flipped half cannot fail", b.verb)
+			}
+		}
+	}
+	if !sawPhantomRed {
+		t.Fatal("control: the un-routed-backtick violation was not exercised — the shipped-must-route guard cannot fail")
+	}
+	if !sawShouldFlipRed {
+		t.Fatal("control: the routed-guillemet-target violation was not exercised — the should-have-flipped guard cannot fail")
+	}
+}
+
+// TestProseFunctionRoutingOracleDiscriminates is the non-vacuity discriminator for the routing
+// ORACLE: it proves verbRejected returns false for a representative SHIPPED verb and true for a
+// representative UN-SHIPPED target at EACH of the three marker sites — so the oracle genuinely
+// distinguishes shipped from un-shipped and the binding check cannot pass vacuously (e.g. by an
+// oracle that always returns one value). Stubbing verbRejected to a constant reds this control.
+func TestProseFunctionRoutingOracleDiscriminates(t *testing.T) {
+	shipped := [][]string{{"merge", "guard"}, {"state", "commit"}, {"status", "--boot", "--json"}}
+	for _, argv := range shipped {
+		if verbRejected(t, argv) {
+			t.Errorf("oracle: shipped verb %v wrongly reported REJECTED", argv)
+		}
+	}
+	// One per marker site: root (`gate`), parent switch (`merge teleport`), dispatch handler.
+	unshipped := [][]string{{"gate", "assemble-verdict"}, {"merge", "teleport"}, {"dispatch", "next-action"}}
+	for _, argv := range unshipped {
+		if !verbRejected(t, argv) {
+			t.Errorf("oracle: un-shipped target %v wrongly reported ACCEPTED — a marker site is unhandled", argv)
+		}
+	}
+}
+
+// repoRootFromPkg returns the repository root, derived from this package's source dir
+// (internal/cli), so the contract-file walk is independent of the test's working directory.
+// go test runs with cwd = the package source dir, so the root is two levels up.
+func repoRootFromPkg(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", ".."))
+}

--- a/internal/contractlint/prose_function_backstop_test.go
+++ b/internal/contractlint/prose_function_backstop_test.go
@@ -1,0 +1,87 @@
+// ABOUTME: AC-2c catastrophe backstop — the two highest-stakes rule clusters survive the
+// ABOUTME: prose-function restructure: the rebase-halt prohibition anchors + the verbatim reuse diagnostic.
+package contractlint
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// catastropheClause is one load-bearing string whose silent loss in the prose-function
+// restructure would be catastrophic AND whose exact wording is itself load-bearing — the
+// reuse diagnostic is contractually pinned ("must appear verbatim"); the rebase-halt
+// prohibition clauses are the no-data-loss safety nets. `path` is the restructured core that
+// must still carry `want`.
+type catastropheClause struct {
+	path string
+	want string
+}
+
+// catastropheClauses is DELIBERATELY narrow — only the two clusters where a silent drop is
+// catastrophic and the wording is load-bearing. It is NOT extended to the rest of the rule
+// set: presence-grepping every rule would re-introduce the banned prose-grep tautology (the
+// matched text is authored by the same restructuring implementer). The real preservation
+// guard is the validator's detached original-vs-restructured audit (AC-2b); this is a cheap
+// tripwire subordinate to it.
+var catastropheClauses = []catastropheClause{
+	// Rebase-conflict-halt prohibition anchors (shared-core State Management). The 4-step HALT
+	// relocates under the restructured «state.ensure-ready» / «state.commit» bodies' referenced
+	// rebase-conflict halt; these two prohibition clauses must survive the relocation.
+	{
+		path: filepath.Join("skills", "first-officer", "references", "first-officer-shared-core.md"),
+		want: "must NOT `--force` / `--force-with-lease` push",
+	},
+	{
+		path: filepath.Join("skills", "first-officer", "references", "first-officer-shared-core.md"),
+		want: "must NOT auto-resolve (`-X ours/theirs`",
+	},
+	// The verbatim reuse diagnostic (dispatch-core Reuse and Fresh Dispatch). Contractually
+	// pinned to appear character-for-character.
+	{
+		path: filepath.Join("skills", "first-officer", "references", "fo-dispatch-core.md"),
+		want: "does not match next stage effective_model",
+	},
+}
+
+// TestProseFunctionCatastropheClausesSurvive (AC-2c) asserts each of the two highest-stakes
+// clusters' load-bearing strings survives somewhere in its restructured core. A content-presence
+// assertion is the right shape here precisely because the wording itself is contractual (a
+// paraphrase of the verbatim diagnostic would BREAK the contract, so presence — not the usual
+// "a paraphrase must pass" — is what we want). This is the only place that holds: it is
+// subordinate to and does not replace AC-2b's detached audit.
+func TestProseFunctionCatastropheClausesSurvive(t *testing.T) {
+	root := repoRoot(t)
+	if len(catastropheClauses) == 0 {
+		t.Fatal("no catastrophe clauses declared — the backstop would pass vacuously")
+	}
+	for _, c := range catastropheClauses {
+		data, err := os.ReadFile(filepath.Join(root, c.path))
+		if err != nil {
+			t.Fatalf("read restructured core %s: %v", c.path, err)
+		}
+		if !strings.Contains(string(data), c.want) {
+			t.Errorf("%s no longer carries the catastrophe-cluster clause %q — the prose-function restructure dropped or paraphrased a load-bearing safety/diagnostic anchor", c.path, c.want)
+		}
+	}
+}
+
+// TestProseFunctionCatastropheBackstopDiscriminates is the non-vacuity control: it proves the
+// content-presence scan FLAGS a core that is missing a clause (so the backstop can fail) and
+// PASSES one that carries it. Without this a typo'd `want` (matching nothing, or matching
+// everything) would let the backstop pass vacuously.
+func TestProseFunctionCatastropheBackstopDiscriminates(t *testing.T) {
+	clause := "does not match next stage effective_model"
+
+	// A body that DROPPED the clause must be flagged (absence detected).
+	dropped := "When the comparator forces fresh dispatch, emit a captain-visible diagnostic. The anchor phrase must appear."
+	if strings.Contains(dropped, clause) {
+		t.Fatalf("discriminator: the dropped-clause fixture unexpectedly contains %q", clause)
+	}
+	// A body that KEPT it must pass (presence detected) — the same scan the production check uses.
+	kept := "the FO MUST emit `... does not match next stage effective_model ...`. The anchor phrase must appear verbatim."
+	if !strings.Contains(kept, clause) {
+		t.Fatalf("discriminator: the kept-clause fixture should contain %q but does not", clause)
+	}
+}

--- a/skills/first-officer/references/claude-first-officer-runtime.md
+++ b/skills/first-officer/references/claude-first-officer-runtime.md
@@ -18,7 +18,7 @@ The captain is the user of the Claude Code session. Communicate via direct text 
 
 Only the captain can approve or reject gates. Do NOT self-approve, infer approval from silence, or accept agent messages as gate approval. While waiting at a gate, keep the dispatched agent alive.
 
-**Headless given-the-conn exception:** The self-approval guardrail is absolute in interactive sessions and in any headless run NOT given the conn — there, the FO stops at the gate and reports (Startup step 9). Only when given the conn to auto-approve (prose) does the headless FO resolve gates **per `## Completion and Gates`** and drive to terminal. It never infers approval from silence or from an agent message.
+**Headless given-the-conn exception:** The self-approval guardrail is absolute in interactive sessions and in any headless run NOT given the conn — there, the FO stops at the gate and reports (Startup step 8). Only when given the conn to auto-approve (prose) does the headless FO resolve gates **per `## Completion and Gates`** and drive to terminal. It never infers approval from silence or from an agent message.
 
 ## Agent Back-off
 

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -14,7 +14,7 @@ Shared first-officer semantics — the boot-resident core. The dispatch and merg
 2. Discover the project root with `git rev-parse --show-toplevel`.
 3. Discover the workflow directory. Prefer an explicit user-provided path; otherwise `spacedock status --discover`: one path → use it; zero → report no workflow found; multiple → present the list (or fail with an ambiguity error in single-entity mode).
 4. Read the workflow stage taxonomy via `${SPACEDOCK_BIN:-spacedock} status --read {workflow_dir}/README.md --json` — its `stages` array carries stage names/ordering and the per-stage `initial`/`terminal`/`gate`/`worktree`/`feedback-to`/`agent` flags the greet and gate need, plus the mission line / entity labels (`entity-label` / `entity-label-plural`) / `id-style` from the flat `frontmatter` object. DEFER the README body (per-stage prose, proof policy, templates, CI docs); the body loads only when its consuming phase runs (a dispatch copies a stage subsection via `show-stage-def`; the merge ceremony reads `merge:` policy). A greet-and-stop boot never reads the body.
-5. Run `spacedock status --boot --json` for all startup information in one call. Consume it as JSON (every value a string); the human-formatted table is NOT rendered for the FO's own reasoning. The before-greet boot is all READS — none reads a mod file or creates a team. Sections:
+5. `«state.boot»()` — read all startup information in one call. Consume it as JSON (every value a string); the human-formatted table is NOT rendered for the FO's own reasoning. The before-greet boot is all READS — none reads a mod file or creates a team. Sections:
    - **MODS** (MODS-REPORT) — the `mods` map names which hooks are registered at which lifecycle point (startup, idle, merge). Reading the map does NOT open any mod file; it lets the greet *report* a registered hook (a pending merge-PR advancement, a comm-officer spawn) without opening the mod. Startup hooks (RUN-STARTUP-HOOKS) run deferred: the comm-officer spawn defers to first dispatch (it needs a live team); the pr-merge startup-hook advancement runs before-greet at the Merged-PR sweep below, gated on an actually-merged PR.
    - **ID_STYLE** — `sequential`, `sd-b32`, or `slug`.
    - **NEXT_ID** — strategy-dependent ID candidate (not a reservation for `sd-b32`; `n/a (id-style: slug)` for `slug`).
@@ -24,10 +24,9 @@ Shared first-officer semantics — the boot-resident core. The dispatch and merg
    - **DISPATCHABLE** — entities ready for dispatch (same as `--next`).
    - **TEAM_STATE** — whether a team is already present; the greet reports it but does NOT create one.
    - **STATE_BACKEND** — `split-root` or `single-root`, the resolved entity dir, and whether it is present. The split-root halt-gate below keys off this.
-6. **Split-root state halt-gate.** If `state_backend == split-root` AND `entity_dir_present == false`, the state checkout is NOT initialized (orphan branch on origin without a linked worktree — fresh clone or removed worktree). The boot table would render EMPTY and `--validate` VALID — a silent failure. HALT dispatch, report "state not initialized," and run (or prompt the captain to run) `spacedock state init` (manual fallback: `git fetch origin <state-branch> && git worktree add <state-path> <state-branch>`). Re-read `--boot` and proceed only after `entity_dir_present == true`.
-7. **Split-root pull-on-boot.** Before the greet, `git -C <state-path> pull --rebase origin <state-branch>` to integrate peers' state (one pull at boot, NOT per-read). On CONFLICT, follow the rebase-conflict halt in **State Management** below: HALT, `git rebase --abort`, surface the conflict, and stop — do not dispatch against an unmerged state tree.
-8. **Merged-PR sweep (before-greet).** For each `pr_state` entry whose `state == "MERGED"` and whose entity status is non-terminal, read `_mods/pr-merge.md` and run its startup-hook advancement (clear `mod-block`, terminalize `verdict=PASSED`, archive, remove the worktree). Skip this step when no such entry exists — the common boot reads zero mod files. When `pr_state.status == "gh not available"`, the merge state is unknowable: skip the sweep (per the pr-merge mod's "warn the captain and skip PR state checks") and treat merge status as UNKNOWN in the greet, not as stale or absent. This is the one mod-file read correctness-bound to the greet: a boot that greets and stops never enters the event loop, so a merged PR would be reported off live `pr_state` but never advanced unless advanced here.
-9. **Interactive vs headless.** Headless = a non-interactive launch (`-p` / `exec`); otherwise interactive. Compose the state summary (boot JSON + README frontmatter) as today, including `gh`-absent UNKNOWN PR status.
+6. `«state.ensure-ready»()` — converge the split-root checkout to linked-and-integrated before any dispatch (the halt-gate + the pull-on-boot). A single-root workflow is a no-op. See its declaration under **State Management** below.
+7. `«state.sweep-merged»()` — advance every merged-PR entity to terminal at boot, before the greet. The common boot (no merged PR) reads zero mod files. See its declaration under **State Management** below.
+8. **Interactive vs headless.** Headless = a non-interactive launch (`-p` / `exec`); otherwise interactive. Compose the state summary (boot JSON + README frontmatter) as today, including `gh`-absent UNKNOWN PR status.
    - **Interactive:** present the summary (and any ready `gate: true` gate as captain-facing text), then STOP for input; do NOT auto-dispatch. The expensive deferrals stay past the greet, reached on the captain's first direction.
    - **Headless:** do NOT greet-stop — drive every dispatchable entity through the event loop to its first `gate: true` stage or to terminal/blocked, then EXIT reporting each entity's stop reason. Stop AT gates (a gate is human-owned); do not resolve them. **When the stop reason is a `gate: true` stage, the FO MUST author the FULL gate review at that stop, for EACH gate it stops on, BEFORE exiting** — invoke `Skill(skill="spacedock:present-gate")` and render its complete template (the `Gate review:` heading, the chosen-direction prose, the checklist roll-up, and the `Decision:` prompt) per `## Completion and Gates`, exactly as the interactive path does. A terse stop-reason line is NOT sufficient: the human who picks up the headless transcript decides from the authored gate content, so the reviewable `Gate review:` … `Decision:` presentation is the deliverable of a headless gate-stop, not an optional flourish. The FO still does NOT resolve the gate headless (no verdict, no terminalize) — it presents and stops; only "given the conn" (below) resolves.
    - **Headless + given the conn to auto-approve (prose):** additionally resolve gates **per `## Completion and Gates`** and drive to terminal. (E.g. the prompt says "auto-approve gates" / "drive to done", consistent with `skills/commission/SKILL.md`'s skip-confirmation cue.)
@@ -83,7 +82,7 @@ A `--next-id` candidate (SD-B32 `NEXT_ID` from `--boot` / `--next-id`) is a prev
 
 ## Single-Entity Scope
 
-A headless run scoped to one named entity — not a distinct mode. Startup step 9's headless rule governs; scoping only narrows it: resolve the named reference (slug/title/id), stop on ambiguity; drive that entity only; gates and stop conditions per step 9 (and `## Completion and Gates` when given the conn). If the README defines `## Output Format`, use it; otherwise report status, verdict, and entity ID.
+A headless run scoped to one named entity — not a distinct mode. Startup step 8's headless rule governs; scoping only narrows it: resolve the named reference (slug/title/id), stop on ambiguity; drive that entity only; gates and stop conditions per step 8 (and `## Completion and Gates` when given the conn). If the README defines `## Output Format`, use it; otherwise report status, verdict, and entity ID.
 
 ## Working Directory
 
@@ -114,13 +113,28 @@ If not gated: terminal → merge; else decide reuse-or-fresh.
 
 **Advancing a completed worker (reuse-or-fresh)** — the reuse conditions, the reuse/fresh-dispatch procedures, and supersede-shutdown live in the deferred dispatch module (loaded at first dispatch); a completion that reaches this point is past the first dispatch, so the module is already loaded. Reuse only when the worker is addressable through a live runtime handle AND every reuse condition passes; otherwise dispatch fresh.
 
-If the stage is gated:
+If the stage is gated, `«gate.assemble-verdict»(slug, stage)` — assemble the captain-facing gate review and route the verdict:
 - never self-approve
 - present the stage report by invoking `Skill(skill="spacedock:present-gate")` and following its template + assembly rules
 - keep the worker alive while waiting at the gate
-- on a feedback gate recommending `REJECTED`, invoke `Skill(skill="spacedock:feedback-rejection-flow")` and follow it instead of waiting for manual review
-- on captain reject at a `feedback-to` stage, invoke `Skill(skill="spacedock:feedback-rejection-flow")` and follow it (priority over generic rejection)
+- on a feedback gate recommending `REJECTED`, `«feedback.route»(slug, stage)` instead of waiting for manual review
+- on captain reject at a `feedback-to` stage, `«feedback.route»(slug, stage)` (priority over generic rejection)
 - on captain approve to a non-terminal next stage, apply the reuse conditions. On reuse: keep the agent and SendMessage the next stage. On fresh: shut down the agent and any kept-alive `feedback-to` target the next stage does not need.
+
+## «gate.assemble-verdict»(slug, stage): assemble the gate review, route the verdict to the decider
+
+- **effect — extract (deterministic).** Roll up the gate's structured inputs from the entity via the shipped extract modes: the stage-report checklist accounting (`status --read <ref> --checklist`) and the AC coverage scan (`status --read <ref> --ac-scan`). These feed the verdict; they do not make it.
+- **effect — decide (judgment).** The verdict (approve/reject, is-this-AC-satisfied, is-this-chosen-direction-sound) is irreducible JUDGMENT. Route it: a level-2-only FO escalates the decision to a level-3 judge; a capable FO renders its own `Recommend` line. Either way the captain-facing presentation is `present-gate`'s template (the `Gate review:` heading, the chosen-direction prose, the checklist roll-up, the `Decision:` prompt), assembled per its template + assembly rules.
+- **done-when:** the gate review is presented to the captain and the FO is waiting on the captain's decision (the worker kept alive).
+- **block:** never self-approve; never resolve a gate the contract reserves to the captain.
+- → **prose** — the verdict is judgment; no `` `spacedock gate assemble-verdict` `` binary ships (RATIFIED keep-prose). The deterministic extract sub-calls the `effect — extract` bullet names are `6re`'s shipped `status --read --checklist` / `--ac-scan`; the decision routes to L3 or the FO's own `present-gate` `Recommend` line.
+
+## «feedback.route»(slug, stage): route a rejection back to its feedback-to target and re-gate
+
+- **effect:** invoke `Skill(skill="spacedock:feedback-rejection-flow")` and follow it — read the `feedback-to` target, track `### Feedback Cycles`, escalate on cycle 3, consult the budget probe, route findings back to the target stage, re-run the reviewer, re-enter the gate flow.
+- **done-when:** the rejection has been routed to its `feedback-to` target stage and re-gated (or escalated at cycle 3).
+- **block:** the routing decision is judgment-adjacent — the skill, not a binary, owns it.
+- → **prose**; the `feedback-rejection-flow` skill is the body.
 
 ## Merge and Cleanup (deferred module)
 
@@ -132,7 +146,39 @@ The terminal merge-and-cleanup ceremony — the set→invoke→clear mod-block s
 - Assign entity IDs through `id-style`; validate active plus archived entities before trusting status output.
 - Commit state changes at dispatch and merge boundaries.
 
-The worktree-ownership rules (which active state lives in the worktree copy vs. `main`, and the split-root deliverable-isolation contract) travel with the deferred dispatch module — they matter only once a worktree stage dispatches. The concurrency-safe commit / multi-writer sync / rebase-conflict-halt rules below stay boot-resident; the Startup pull-on-boot step fires before any dispatch.
+The worktree-ownership rules (which active state lives in the worktree copy vs. `main`, and the split-root deliverable-isolation contract) travel with the deferred dispatch module — they matter only once a worktree stage dispatches. The concurrency-safe commit / multi-writer sync / rebase-conflict-halt rules below stay boot-resident; the Startup `«state.ensure-ready»()` step fires before any dispatch.
+
+The FO declares intent against the state repo by invoking the prose-functions below; their bodies own the mechanics, so the Startup flow reads as intention. Each is idempotent — re-invoking checks its `done-when` and is a no-op if already satisfied — so the boot sequence (`«state.boot»()`, `«state.ensure-ready»()`, `«state.sweep-merged»()`, greet) converges rather than runs as a script, and each can become a binary independently without touching the flow. Every state write is one call: `«state.commit»(slug)`.
+
+## «state.boot»(): read all startup state in one call
+
+- **effect:** yield the boot record — the MODS / ID_STYLE / NEXT_ID / MIN_PREFIX / ORPHANS / PR_STATE / DISPATCHABLE / TEAM_STATE / STATE_BACKEND sections (Startup step 5), consumed as JSON, all reads, no mod-file open, no team creation.
+- **done-when:** the boot record is in hand for the greet.
+- → **shipped**: `` `spacedock status --boot --json` `` — already a binary; invoke it directly.
+
+## «state.ensure-ready»(): the split-root checkout is linked and integrated with peers before any dispatch
+
+- **guard:** `state_backend == split-root` (a single-root workflow is a no-op).
+- **effect — halt-gate.** If `entity_dir_present == false`, the state checkout is NOT initialized (orphan branch on origin without a linked worktree — fresh clone or removed worktree). The boot table would render EMPTY and `--validate` VALID — a silent failure. HALT dispatch, report "state not initialized," and run (or prompt the captain to run) `spacedock state init` (manual fallback: `git fetch origin <state-branch> && git worktree add <state-path> <state-branch>`). Re-invoke `«state.boot»()` and proceed only after `entity_dir_present == true`.
+- **effect — pull-on-boot.** Before the greet, `git -C <state-path> pull --rebase origin <state-branch>` to integrate peers' state (one pull at boot, NOT per-read).
+- **done-when:** `entity_dir_present == true` and the boot rebase is clean.
+- **block:** on `pull --rebase` CONFLICT, follow the **rebase-conflict halt** below: HALT, `git rebase --abort`, surface the conflict, and stop — do not dispatch against an unmerged state tree.
+- → **shipped** (this sprint): `` `spacedock state ready` `` — invoke it directly.
+
+## «state.sweep-merged»(): merged PRs reach their terminal stage at boot, before the greet
+
+- **guard:** `pr_state` has an entry whose `state == "MERGED"` and whose entity status is non-terminal.
+- **effect:** for each such entry, read `_mods/pr-merge.md` and run its startup-hook advancement (clear `mod-block`, terminalize `verdict=PASSED`, archive, remove the worktree). Skip when no such entry exists — the common boot reads zero mod files. This is the one mod-file read correctness-bound to the greet: a boot that greets and stops never enters the event loop, so a merged PR would be reported off live `pr_state` but never advanced unless advanced here.
+- **done-when:** no `MERGED` + non-terminal entity remains.
+- **block:** when `pr_state.status == "gh not available"`, the merge state is unknowable — skip the sweep (per the pr-merge mod's "warn the captain and skip PR state checks") and treat merge status as UNKNOWN in the greet, not as stale or absent.
+- → **shipped** (this sprint): `` `spacedock state sweep` `` — invoke it directly.
+
+## «state.commit»(slug): record one entity's change durably and concurrency-safe
+
+- **effect:** path-scoped commit + sync per **Split-Root State Sync** below — `git -C {state_checkout} add {entity_path} && git -C {state_checkout} commit -m "…" -- {entity_path}`, never a bare `git add -A` / `git commit`; then push; on push rejection `pull --rebase` then re-push; retry on `index.lock` contention after ~2s.
+- **done-when:** the entity's change is committed (and pushed to `origin` when one exists).
+- **block:** rebase conflict on sync → halt per the **rebase-conflict halt** below.
+- → **shipped** (this sprint): `` `spacedock state commit <slug>` `` — invoke it directly.
 
 ### Split-Root State Sync
 

--- a/skills/first-officer/references/fo-dispatch-core.md
+++ b/skills/first-officer/references/fo-dispatch-core.md
@@ -110,14 +110,19 @@ Whether a dispatch blocks until worker completion or returns a handle to await l
 
 ## Event Loop
 
-After each agent completion:
+After each agent completion, `«dispatch.next-action»()` — pick the next thing to do, or end the iteration. Its body is the skeleton below.
 
 These are FO-internal scheduling reads — parse them as JSON, not the padded human table. Each read below uses `--json` so the FO consumes a compact, byte-stable document (one rule: every value is a string) instead of scraping column padding that a token proxy can mangle. `--fields` narrows the read to the keys the FO needs. The `--json` envelopes are: `status`/`--where` → `{"command":"status","entities":[…]}`; `--next` → `{"command":"next","dispatchable":[{"id","slug","current","next","worktree"},…]}`. The captain-facing state display (shared-core) still forwards the human table verbatim — JSON is for the machine, the table is for the human.
+
+## «dispatch.next-action»(): pick the next event-loop action — dispatch a ready entity, resume a block, or end the iteration
 
 The runtime adapter may insert a host step 0 (a roster-reconcile sweep) before step 1; a host with no roster source omits it. The skeleton is:
 
 1. **Check mod-blocked entities** — Run `status --where "mod-block !=" --json --fields id,slug,mod-block`. For each entity in `entities`, re-read the blocking mod and resume its pending action (e.g., re-present the PR summary). Do not dispatch new work for a mod-blocked entity.
 2. **Run `status --next --json --fields id,slug`** — Dispatch any newly ready entity in `dispatchable` (each row carries the fixed `id,slug,current,next,worktree` plus the named frontmatter keys; `--fields` is additive over the fixed five, since the computed dispatch columns are not projectable).
 3. **If nothing is dispatchable** — Fire `idle` hooks, re-run the host's step-0 reconcile sweep when the adapter declares one, then re-run `status --next`. Dispatch anything newly unblocked; otherwise end the iteration.
+
+- **done-when:** a ready entity is dispatched, a mod-block's pending action is resumed, or nothing is dispatchable and the iteration ends.
+- → **prose**, becomes `` `spacedock dispatch next-action` `` (0222) — the driver binary is descoped to roadmap 0222; until it ships the FO hand-follows the skeleton above.
 
 Repeat from step 1 after each agent completion until the captain ends the session or, in single-entity mode, until the target entity is resolved.

--- a/skills/first-officer/references/fo-merge-core.md
+++ b/skills/first-officer/references/fo-merge-core.md
@@ -4,6 +4,15 @@ The terminal merge-and-cleanup ceremony, the mod-block enforcement that guards i
 
 ## Merge and Cleanup
 
+When an entity reaches its terminal stage, `«merge.guard»(slug)` runs the atomic merge-finalize ceremony — the mod-block set→invoke→clear→terminalize sequence below, as one call.
+
+## «merge.guard»(slug): atomically set→invoke→clear the merge mod-block, then terminalize
+
+- **effect:** run the terminal merge-finalize ceremony for the entity — set `mod-block=merge:{mod_name}`, invoke the registered merge hook, detect completion, clear the mod-block in its own call, default-merge if no hook handled it, terminalize (`completed verdict={verdict} worktree=`), and archive. The mechanism-level enforcement in **Mod-Block Enforcement** below guards every step (the guard refuses a terminal transition while `mod-block` is non-empty, refuses combining `mod-block=` with terminal fields, and refuses terminalizing with merge hooks registered while `pr` and `mod-block` are both empty — all without `--force`).
+- **done-when:** the entity is archived terminal with its mod-block cleared and `pr`/sentinel recorded (or the hook left the entity blocked, in which case `mod-block` stays set and the pending state is reported).
+- **block:** if the hook blocks (`pr` set, captain approval pending, or an external wait), leave `mod-block` set and do not local-merge. `--force` is never part of the happy path — if the guard refuses, a step was skipped, not a flag forgotten.
+- → **shipped** (this sprint): `` `spacedock merge guard <slug>` `` — invoke it directly. The hand-followed sequence it automates is the steps below.
+
 When an entity reaches its terminal stage:
 
 1. If merge hooks are registered, set the mod-block before invoking:


### PR DESCRIPTION
Re-express the FO contract cores as prose-function `«fn»` invocations — the migration substrate, so a future verb landing is a one-body notation flip rather than a contract rewrite.

## What changed
- Re-express five cores as `«fn»` invocations: shipped verbs become backticks (`«state.boot»`, `«state.commit»`/`«state.ensure-ready»`/`«state.sweep-merged»`, `«merge.guard»`); un-shipped stay guillemets with a `→` migration target (`«dispatch.next-action»`→0222, `«gate.assemble-verdict»` and `«feedback.route»` stay judgment-prose).
- Add an `internal/cli` routing-oracle check binding each backtick verb to a routed command and each guillemet `→` target to an un-routed one (recognizing all three rejection-marker sites), with a mutation-proven RED control.
- Add a narrow `contractlint` content backstop for the two catastrophe clusters only.

## Evidence
- Behavior-PRESERVING: an independent detached rule-by-rule audit diffed all six load-bearing rule clusters against the pre-restructure SHA `c049d1ee` — every one byte-identical in force (zero dropped/weakened).
- The `internal/cli` routing check (5 accept / 2 reject, RED control, mutation-proven both directions) + the contractlint backstop + the boot-resident/ceremony/layering suites are green; full `go test ./...` green.
- Detached adversarial audit caught all 5 claim-breaking edits; a non-catastrophe clause dropped under a still-present heading was caught *only* by the detached diff — proving the two-layer guard.

---
[czw](/spacedock-dev/spacedock/blob/d62660a5df033214b38ae65e1dc785ab4fc6f72d/prose-function-restructure.md)
