### PR TITLE
strip deferred-72 tier vocabulary from «gate.assemble-verdict» (pre-cut fix)

### DIFF
--- a/internal/contractlint/deferred_tier_absence_test.go
+++ b/internal/contractlint/deferred_tier_absence_test.go
@@ -1,0 +1,113 @@
+// ABOUTME: Structural-absence guard keeping the DEFERRED-72 (fo-tier-delegation) tier
+// ABOUTME: vocabulary out of the shipped FO contract cores until member 72 un-defers.
+package contractlint
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// foContractCores are the shipped FO contract cores the gate-verdict body lives in —
+// the boot-resident shared core and the two host-neutral cores it names, plus each
+// host runtime adapter. Every host loads the shared core at boot, so a deferred-tier
+// token anywhere here reaches a booting FO as an instruction to escalate a verdict to
+// a mechanism that does not ship (member 72 — fo-tier-delegation — is DEFERRED).
+var foContractCores = []string{
+	filepath.Join("first-officer", "references", "first-officer-shared-core.md"),
+	filepath.Join("first-officer", "references", "fo-dispatch-core.md"),
+	filepath.Join("first-officer", "references", "fo-merge-core.md"),
+	filepath.Join("first-officer", "references", "claude-first-officer-runtime.md"),
+	filepath.Join("first-officer", "references", "codex-first-officer-runtime.md"),
+	filepath.Join("first-officer", "references", "pi-first-officer-runtime.md"),
+	filepath.Join("first-officer", "references", "claude-fo-dispatch.md"),
+}
+
+// deferredTierLiteralTokens are the LITERAL deferred-72 tier-vocabulary tokens that must
+// NOT appear in a shipped FO contract core. They are member 72's (fo-tier-delegation)
+// tier/level-3-judge mechanism — DEFERRED — so nothing in the shipped contract defines
+// an FO "level" or a "level-3 judge". Their presence IS the defect (structural-absence,
+// same family as claudeModelTokens / claudeTeamDispatchTokens), not a paraphrasable
+// meaning: a mechanism-neutral statement that the FO renders its own `Recommend` line
+// carries none of these tokens and passes. The tier mechanism re-enters WITH member 72
+// (and its own `«fo.tier»` source) when 72 un-defers, not before.
+var deferredTierLiteralTokens = []string{
+	"level-2-only",
+	"level-3 judge",
+	"«fo.tier»",
+}
+
+// bareL3RouteRe matches the bare `L3` route framing as a word (`routes to L3`), not an
+// incidental `L3` inside a hash or path. The leak shape was "the decision routes to L3
+// or the FO's own present-gate Recommend line"; a word-bounded match flags that framing
+// while leaving an unrelated `L3` substring alone.
+var bareL3RouteRe = regexp.MustCompile(`\bL3\b`)
+
+// lineLeaksDeferredTierToken reports whether a line carries any deferred-72 tier-vocabulary
+// token. This is the single scanner the absence check and its discriminator control both
+// drive, so defeating it reds both callers.
+func lineLeaksDeferredTierToken(line string) bool {
+	for _, tok := range deferredTierLiteralTokens {
+		if strings.Contains(line, tok) {
+			return true
+		}
+	}
+	return bareL3RouteRe.MatchString(line)
+}
+
+// TestFOContractCoresHaveNoDeferredTierToken is a structural-ABSENCE check: no shipped FO
+// contract core may carry a deferred-72 tier-vocabulary token (`level-2-only`,
+// `level-3 judge`, `«fo.tier»`, the bare `L3` route framing). The leak was in
+// `«gate.assemble-verdict»`'s decide-effect body, but the whole file set is scanned so a
+// re-introduction at any site fails. The expected value comes from the rule (member 72 is
+// DEFERRED, so its tier vocabulary must not ship), not the file's own prose, so a
+// mechanism-neutral phrasing (the FO renders its own `Recommend` line) passes and a
+// re-introduced tier escalation fails — same family as TestDispatchCoreHasNoClaudeModelToken.
+// The paired discriminator control keeps this non-vacuous.
+func TestFOContractCoresHaveNoDeferredTierToken(t *testing.T) {
+	root := skillsRoot(t)
+	for _, rel := range foContractCores {
+		path := filepath.Join(root, rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read FO contract core %s: %v", path, err)
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			if lineLeaksDeferredTierToken(line) {
+				t.Errorf("%s:%d carries a deferred-72 tier-vocabulary token in a shipped FO contract core (member 72 fo-tier-delegation is DEFERRED — the verdict is the FO's own `Recommend` line): %q", path, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+}
+
+// TestDeferredTierTokenScannerDiscriminates is the DISCRIMINATOR control for the
+// deferred-tier absence check: it proves the scanner flags the genuine pre-strip leak
+// shapes and passes the mechanism-neutral phrasings the strip produces — so
+// TestFOContractCoresHaveNoDeferredTierToken can never pass vacuously (e.g. by a typo'd
+// token never matching anything).
+func TestDeferredTierTokenScannerDiscriminates(t *testing.T) {
+	// Genuine pre-strip leak shapes — each MUST flag.
+	mustFlag := []string{
+		"a level-2-only FO escalates the decision to a level-3 judge; a capable FO renders its own `Recommend` line",
+		"the decision routes to L3 or the FO's own `present-gate` `Recommend` line",
+		"the tier mechanism rides member 72 WITH its «fo.tier» source",
+	}
+	for _, line := range mustFlag {
+		if !lineLeaksDeferredTierToken(line) {
+			t.Errorf("discriminator control: a genuine deferred-tier leak line was NOT flagged (the scanner would pass vacuously): %q", line)
+		}
+	}
+
+	// Mechanism-neutral phrasings the strip produces — each MUST pass.
+	mustPass := []string{
+		"The verdict is irreducible JUDGMENT. The FO renders its own `Recommend` line.",
+		"the decision is the FO's own `present-gate` `Recommend` line",
+	}
+	for _, line := range mustPass {
+		if lineLeaksDeferredTierToken(line) {
+			t.Errorf("discriminator control: a mechanism-neutral phrasing was wrongly flagged: %q", line)
+		}
+	}
+}

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -124,10 +124,10 @@ If the stage is gated, `«gate.assemble-verdict»(slug, stage)` — assemble the
 ## «gate.assemble-verdict»(slug, stage): assemble the gate review, route the verdict to the decider
 
 - **effect — extract (deterministic).** Roll up the gate's structured inputs from the entity via the shipped extract modes: the stage-report checklist accounting (`status --read <ref> --checklist`) and the AC coverage scan (`status --read <ref> --ac-scan`). These feed the verdict; they do not make it.
-- **effect — decide (judgment).** The verdict (approve/reject, is-this-AC-satisfied, is-this-chosen-direction-sound) is irreducible JUDGMENT. Route it: a level-2-only FO escalates the decision to a level-3 judge; a capable FO renders its own `Recommend` line. Either way the captain-facing presentation is `present-gate`'s template (the `Gate review:` heading, the chosen-direction prose, the checklist roll-up, the `Decision:` prompt), assembled per its template + assembly rules.
+- **effect — decide (judgment).** The verdict (approve/reject, is-this-AC-satisfied, is-this-chosen-direction-sound) is irreducible JUDGMENT. The FO renders its own `Recommend` line. The captain-facing presentation is `present-gate`'s template (the `Gate review:` heading, the chosen-direction prose, the checklist roll-up, the `Decision:` prompt), assembled per its template + assembly rules.
 - **done-when:** the gate review is presented to the captain and the FO is waiting on the captain's decision (the worker kept alive).
 - **block:** never self-approve; never resolve a gate the contract reserves to the captain.
-- → **prose** — the verdict is judgment; no `` `spacedock gate assemble-verdict` `` binary ships (RATIFIED keep-prose). The deterministic extract sub-calls the `effect — extract` bullet names are `6re`'s shipped `status --read --checklist` / `--ac-scan`; the decision routes to L3 or the FO's own `present-gate` `Recommend` line.
+- → **prose** — the verdict is judgment; no `` `spacedock gate assemble-verdict` `` binary ships (RATIFIED keep-prose). The deterministic extract sub-calls the `effect — extract` bullet names are `6re`'s shipped `status --read --checklist` / `--ac-scan`; the decision is the FO's own `present-gate` `Recommend` line.
 
 ## «feedback.route»(slug, stage): route a rejection back to its feedback-to target and re-gate
 

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -113,7 +113,7 @@ If not gated: terminal → merge; else decide reuse-or-fresh.
 
 **Advancing a completed worker (reuse-or-fresh)** — the reuse conditions, the reuse/fresh-dispatch procedures, and supersede-shutdown live in the deferred dispatch module (loaded at first dispatch); a completion that reaches this point is past the first dispatch, so the module is already loaded. Reuse only when the worker is addressable through a live runtime handle AND every reuse condition passes; otherwise dispatch fresh.
 
-If the stage is gated, `«gate.assemble-verdict»(slug, stage)` — assemble the captain-facing gate review and route the verdict:
+If the stage is gated, `«gate.assemble-verdict»(slug, stage)` — assemble the captain-facing gate review and render the verdict:
 - never self-approve
 - present the stage report by invoking `Skill(skill="spacedock:present-gate")` and following its template + assembly rules
 - keep the worker alive while waiting at the gate
@@ -121,7 +121,7 @@ If the stage is gated, `«gate.assemble-verdict»(slug, stage)` — assemble the
 - on captain reject at a `feedback-to` stage, `«feedback.route»(slug, stage)` (priority over generic rejection)
 - on captain approve to a non-terminal next stage, apply the reuse conditions. On reuse: keep the agent and SendMessage the next stage. On fresh: shut down the agent and any kept-alive `feedback-to` target the next stage does not need.
 
-## «gate.assemble-verdict»(slug, stage): assemble the gate review, route the verdict to the decider
+## «gate.assemble-verdict»(slug, stage): assemble the gate review and render the verdict
 
 - **effect — extract (deterministic).** Roll up the gate's structured inputs from the entity via the shipped extract modes: the stage-report checklist accounting (`status --read <ref> --checklist`) and the AC coverage scan (`status --read <ref> --ac-scan`). These feed the verdict; they do not make it.
 - **effect — decide (judgment).** The verdict (approve/reject, is-this-AC-satisfied, is-this-chosen-direction-sound) is irreducible JUDGMENT. The FO renders its own `Recommend` line. The captain-facing presentation is `present-gate`'s template (the `Gate review:` heading, the chosen-direction prose, the checklist roll-up, the `Decision:` prompt), assembled per its template + assembly rules.


### PR DESCRIPTION
Strip a dangling reference to the deferred tier mechanism that leaked into the prose-function restructure (#402), caught by the pre-cut antipattern audit.

## What changed
- Revert the `«gate.assemble-verdict»` body to mechanism-neutral phrasing — the FO assembles the gate review and renders its own `Recommend` line — removing the undefined "level-3 judge" / "level-2-only FO" / "the decider" references (that vocabulary belongs to the deferred `fo-tier-delegation` member, which will define it when it ships).
- Add a `contractlint` structural-absence guard (with a mutation-proven discriminator) so deferred-member tier vocabulary cannot re-leak into the shipped contract until its member lands.

## Evidence
- `grep` for `level-2-only` / `level-3` / `judge` / `«fo.tier»` / `L3` / `decider` across the FO contract cores → **zero**.
- The absence-guard is proven load-bearing by mutation (planting a tier token reds the absence check; stubbing the scanner reds the discriminator); full `go test ./...` green.
- Surgical: 4 prose lines + one new test; czw's `«fn»` notation, routing oracle, and the six behavioral clusters are untouched.

---
[ga](/spacedock-dev/spacedock/blob/aa7a9e04de9a389ef4d43761f6c1961ac1b55891/strip-deferred-tier-vocabulary.md)
