### PR TITLE
pi-fo-runtime: stamp parent live model on null dispatch + declare Pi model space

### DIFF
--- a/skills/first-officer/references/pi-first-officer-runtime.md
+++ b/skills/first-officer/references/pi-first-officer-runtime.md
@@ -25,6 +25,24 @@ For Spacedock stage dispatches through `pi-subagents`, do not use the `subagent(
 
 For the core's standing-injection call: `pi-subagents` has no standing surface (no-op); `pi-agent-teams` MAY map injection to `member_spawn` per the adapter's lifecycle mapping.
 
+### Model Resolution (Pi-specific — overrides core null handling)
+
+The dispatch core (`fo-dispatch-core.md` step 4) instructs ALL adapters: when `dispatch build` emits `output.model` as null, OMIT the model argument entirely (default-inheritance applies only when the argument is absent). **On Pi this OMIT-on-null behavior is WRONG and this adapter overrides it.** pi-subagents resolves an omitted/null model to `settings.json`'s `defaultModel` (e.g. `~openai/gpt-mini-latest`), NOT the parent FO session's live model. That is a silent tier/provider drift: the ensign runs on the settings default while the FO session is on a different model, and reuse-condition-4's model-match comparator then compares against a meaningless stamped value. Confirmed in run `0637e2ed` meta: `model: ~openai/gpt-mini-latest` while the FO session was `z-ai/glm-5.2`.
+
+**Null case — stamp the parent's live model.** When `dispatch build` emits `model: null` (the common case — `stages.defaults` declares no model), before calling `subagent(...)`, read the FO's own live model via `intercom({action:"list"})`. The "Current session" entry carries the live model in parentheses, e.g. `subagent-chat-019ee0d6 (b4c9b23b) — /Users/.../spacedock-v1 (z-ai/glm-5.2) [same cwd, tool:subagent]`. Pass that model explicitly on the spawn call: `subagent(... model: "<live model>")`. `intercom` is always connected for the boot-resident FO, so this is a single reliable programmatic read — no disk-grep, no session-file inference.
+
+**Stage-declared model wins (override preserved).** When `dispatch build` emits a non-null `output.model` (the stage or `stages.defaults` declares a model), pass that value on the `subagent(... model: "<declared model>")` call unchanged. The stage-declared model overrides the parent's live model — the override path is the same as on other hosts. Stage-declared models on Pi MUST use Pi-valid model strings (see the model-space declaration below), not the Claude-centric enum.
+
+**Q13 contradiction window — intentional and temporary.** This adapter's "stamp the parent's live model when null" directly contradicts the core's "OMIT the model argument entirely when null" (`fo-dispatch-core.md` step 4). The contradiction is intentional and temporary: this task ships the Pi-specific resolution; the capstone (`pi-back-channel-dispatch`, sprint `0223-pi-dispatch-contract` member 3) generalizes the override into a named `model-resolution` rule under the `worker-identity-capture` capability ("when `dispatch build` emits null, the adapter resolves the model per its host's rule — Pi stamps the parent's live model via `intercom list`; Claude inherits the team's model; Codex inherits the thread's model"). Do NOT edit `fo-dispatch-core.md` to resolve the contradiction here — that is the capstone's job (Deliverable A). A Commander reading both documents during the transition window should see a planned override, not a bug.
+
+### Canonical Model Space (Pi — for reuse-condition-4)
+
+The dispatch core's reuse-condition-4 (`fo-dispatch-core.md` condition 4) says a member stamped with a captain-session fallback value — one outside the host's canonical model enum — never matches an enum value and forces a one-time fresh dispatch. The core's enum assumption is Claude-centric (`sonnet`/`opus`/`haiku`). **Pi has no such enum.** On Pi, any provider/model string is a valid model: `z-ai/glm-5.2`, `~openai/gpt-mini-latest`, `anthropic/claude-sonnet-4`, `google/gemini-2.5-pro`, etc. There is no Claude-centric `sonnet`/`opus`/`haiku` enum on Pi.
+
+This adapter DECLARES the Pi canonical model space as: all valid pi-subagents model strings (provider-qualified or `~`-prefixed provider-relative strings). Reuse-condition-4's model-match comparator MUST operate on these Pi-native strings, not the Claude enum. Otherwise every Pi reuse would be a "captain-session fallback value outside the enum" and force fresh dispatch — defeating reuse entirely. The stamped model from the Model Resolution rule above is a Pi-native string in this declared space, so reuse-condition-4's comparator has a meaningful value to match against `next_stage.effective_model`.
+
+This model-space declaration is the `worker-identity-capture` capability's model-space field (OWNER: this task). The capstone (`pi-back-channel-dispatch`) REFERENCES it but does not re-declare it — see the entity body's composition section.
+
 ## Awaiting Completion
 
 For `pi-subagents`, the completion signal is the subagent result returned to the parent. After the result arrives, read the entity file and verify the stage report exactly as the shared core requires. Do not advance state based only on a cheerful worker summary.


### PR DESCRIPTION
## Why

A Pi first-officer dispatch that omits an explicit model (the common case — `spacedock dispatch build` emits `model: null` for stages with no declared model) silently ran the ensign on `settings.json`'s `defaultModel` (`~openai/gpt-mini-latest`), not the parent FO session's live model. Confirmed in run `0637e2ed`: the worker ran on gpt-mini while the FO was on `z-ai/glm-5.2`. "Default-inheritance" on pi-subagents means "use the configured default," not "inherit the parent." The dispatch core's reuse-condition-4 model-match comparator then operated on a meaningless stamped value, and the FO had to remember to pass `model:` explicitly on every dispatch to avoid silent tier/provider drift.

This is sprint `0223-pi-dispatch-contract` member 2 (`bdt`). It ships the Pi-specific resolution; the capstone (`pi-back-channel-dispatch`) generalizes it into a named `model-resolution` rule.

## What changed

Prose-only edit (+18 lines, 1 file) to `skills/first-officer/references/pi-first-officer-runtime.md` — two new Dispatch subsections:

- **`### Model Resolution (Pi-specific — overrides core null handling)`** — when `dispatch build` emits `model: null`, the FO reads its live model via `intercom({action:"list"})` (the "Current session" entry's parenthesized model) and passes it explicitly on the `subagent(...)` call. Stage-declared models still win (override preserved). Documents the **Q13 contradiction window** as intentional/temporary (the core says "OMIT on null"; the Pi adapter says "stamp live model") — the capstone generalizes it.
- **`### Canonical Model Space (Pi — for reuse-condition-4)`** — declares the Pi canonical model space as all valid pi-subagents model strings (no Claude-centric `sonnet`/`opus`/`haiku` enum on Pi), so reuse-condition-4's comparator doesn't force fresh dispatch on every Pi reuse.

`fo-dispatch-core.md` was NOT edited (the capstone owns that — no scope breach).

## Evidence

- **AC-1 (live):** FO parent-level null-model probe dispatch (run `ba6a11f3`) stamped `z-ai/glm-5.2`; the probe self-reported `PROBE_MODEL=z-ai/glm-5.2` via `intercom list` — the inverse of the `0637e2ed` drift (gpt-mini on a glm-5.2 session). The drift was observed live in a sibling session (`subagent-chat-019ee267` on `~openai/gpt-mini-latest`).
- **AC-2/AC-3 (structural):** validator grep-confirmed both subsections + the override + the Q13 note present; `fo-dispatch-core.md` not in the commit; commit is prose-only (1 file, +18).
- **Non-regression:** `go test ./internal/cli/... ./internal/contractlint/...` green; only the pre-existing unrelated `internal/status` `TestMigrationCheckFixturesParseConsistently` fails (verified on base `5bf98e1e`, identical message — not a regression).

No live CI lane required — prose-only skill-file change (no code, no host-runtime surface).

---

Sprint: `0223-pi-dispatch-contract` (member 2). Validator: PASSED (run `aa24686d`). State audit: `bdt` entity @ `spacedock-state/dev`.
