### PR TITLE
pi: install-managed skill placement — ship Spacedock as a pi package

### DIFF
--- a/.pi/extensions/spacedock.ts
+++ b/.pi/extensions/spacedock.ts
@@ -1,0 +1,27 @@
+// Spacedock pi extension — parent-session skill discovery.
+//
+// Once `spacedock install --host pi` (or the dev `pi install ./local/path`)
+// registers the Spacedock package in ~/.pi/agent/settings.json `packages`, the
+// main pi session loads this extension. It implements `resources_discover` so
+// the parent session discovers the Spacedock skills (first-officer, ensign, ...)
+// from the package's own `skills/` directory — resolved relative to this
+// extension's location, exactly like the obra/superpowers reference.
+//
+// This replaces the launcher's retired `--skill <repo>/skills/{first-officer,ensign}`
+// flags. Child pi-subagents sessions discover the same skills independently via
+// the package-root scan reading `package.json` `pi.skills` — no cwd dependency.
+
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+
+export default function registerSpacedockExtension(pi: {
+	on(event: "resources_discover", handler: (event: { type: "resources_discover"; cwd: string; reason: string }) => { skillPaths?: string[] } | void): void;
+}): void {
+	pi.on("resources_discover", () => {
+		const extDir = path.dirname(fileURLToPath(import.meta.url));
+		// .pi/extensions/ -> ../.. -> repo root -> skills/
+		const repoRoot = path.resolve(extDir, "..", "..");
+		const skillsDir = path.join(repoRoot, "skills");
+		return { skillPaths: [skillsDir] };
+	});
+}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -88,8 +88,10 @@ Usage:
   spacedock pi [task] [--plugin-dir <checkout>] [-- pi-flags]
 
 Start Pi as your Spacedock first officer by loading the Pi-native pi-subagents
-extension/skill and the Spacedock first-officer/ensign skills. The optional task
-is appended to the launch prompt; everything after -- forwards verbatim to pi.
+extension/skill. The Spacedock first-officer/ensign skills are discovered from
+the installed Spacedock package (run: spacedock install --host pi); the optional
+--plugin-dir loads a local checkout as a dev override. The optional task is
+appended to the launch prompt; everything after -- forwards verbatim to pi.
 
 Flags:
 `)

--- a/internal/cli/launch_banner_wording_test.go
+++ b/internal/cli/launch_banner_wording_test.go
@@ -179,8 +179,9 @@ func TestPiBannerEmittedBeforeLaunch(t *testing.T) {
 	pkg := t.TempDir()
 	writePiSubagentsFixtures(t, pkg)
 	ops := &fakePiRuntimeOps{
-		lookPath: piHealthyPathFixtures(),
-		statOK:   statOKForPiResources(repo, pkg),
+		lookPath:      piHealthyPathFixtures(),
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: healthyPiPackageStatus(),
 	}
 	var stdout, stderr bytes.Buffer
 

--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -2,11 +2,14 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -16,10 +19,38 @@ import (
 
 const piBootstrapPrompt = "Use $spacedock:first-officer for this whole Pi session."
 
+// piSpacedockPackageSource is the published install source for the Spacedock
+// package. `spacedock install --host pi` runs `pi install <source>`, which
+// registers the package in ~/.pi/agent/settings.json `packages` and places the
+// repo in pi's package store. The dev override (--plugin-dir) replaces this with
+// a local checkout path so in-tree edits are picked up without reinstall.
+const piSpacedockPackageSource = "git:github.com/spacedock-dev/spacedock"
+
 type piRuntimeOps interface {
 	LookPath(name string) (string, error)
 	Stat(path string) error
 	Launch(argv []string) error
+	// PiInstall runs `pi install <source>` and returns its combined output. The
+	// real implementation execs `pi`; tests record the source and return canned
+	// output. This is the install seam that retires Pi's check-only status.
+	PiInstall(source string) (string, error)
+	// SpacedockPackageStatus reports whether the Spacedock package is registered
+	// in ~/.pi/agent/settings.json `packages` and whether the ensign (and
+	// first-officer) skills are discoverable via the package-root skill scan —
+	// the same mechanism pi-subagents' collectSettingsPackageSkillPaths uses.
+	// agentDir is the pi agent directory (~/.pi/agent or PI_CODING_AGENT_DIR);
+	// home is used to resolve ~ entries.
+	SpacedockPackageStatus(agentDir, home string) piPackageStatus
+}
+
+// piPackageStatus is the result of the package-registration + skill-discovery
+// check that replaces the retired repo-path Stat skill checks.
+type piPackageStatus struct {
+	registered               bool
+	ensignDiscoverable       bool
+	firstOfficerDiscoverable bool
+	source                   string // the settings.json packages entry for spacedock
+	packageRoot              string // the resolved package root
 }
 
 type execPiRuntimeOps struct{}
@@ -28,17 +59,26 @@ func (execPiRuntimeOps) LookPath(name string) (string, error) { return exec.Look
 func (execPiRuntimeOps) Stat(path string) error               { _, err := os.Stat(path); return err }
 func (execPiRuntimeOps) Launch(argv []string) error           { return execHost{}.Launch(argv, os.Environ()) }
 
+func (execPiRuntimeOps) PiInstall(source string) (string, error) {
+	out, err := exec.Command("pi", "install", source).CombinedOutput()
+	return string(out), err
+}
+
+func (execPiRuntimeOps) SpacedockPackageStatus(agentDir, home string) piPackageStatus {
+	return piSpacedockPackageStatus(agentDir, home)
+}
+
 type piRuntimeConfig struct {
-	repoRoot              string
+	repoRoot              string // dev-override only: --plugin-dir / SPACEDOCK_REPO_ROOT
 	packageRoot           string
 	intercomPackageRoot   string
 	extensionPath         string
 	subagentsSkill        string
-	firstOfficer          string
-	ensign                string
 	authPath              string
 	openAIAPIKey          string
 	sessionDir            string
+	agentDir              string
+	home                  string
 	pluginDirSource       string
 	packageRootSource     string
 	intercomPackageSource string
@@ -55,8 +95,8 @@ type piCheckResult struct {
 	subagentsIntercomBridgeOK bool
 	intercomPackageOK         bool
 	intercomSkillOK           bool
-	firstOfficerOK            bool
-	ensignOK                  bool
+	spacedockPackageOK        bool
+	packageStatus             piPackageStatus
 	packageRoot               string
 	intercomPackageRoot       string
 	repoRoot                  string
@@ -81,12 +121,15 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 
 	launchBanner("pi", dir, safehouse.Present(dir), ops.LookPath, stderr)
 
+	// The Spacedock first-officer/ensign skills are no longer passed as --skill
+	// flags: the installed package's .pi/extensions/spacedock.ts extension
+	// discovers them for the parent session via resources_discover, and
+	// pi-subagents children discover them via the package-root scan. Only the
+	// pi-subagents extension + skill are passed explicitly here.
 	argv := []string{
 		"pi",
 		"--extension", cfg.extensionPath,
 		"--skill", cfg.subagentsSkill,
-		"--skill", cfg.firstOfficerDir(),
-		"--skill", cfg.ensignDir(),
 	}
 	argv = append(argv, fd.passthrough...)
 	argv = append(argv, launchPrompt(piBootstrapPrompt, fd))
@@ -103,7 +146,27 @@ func runInitWithPi(ctx context.Context, args []string, hostOps hostOps, piOps pi
 		return code
 	}
 	if host != "pi" {
+		// --plugin-dir is the pi dev-override install source; it is not supported
+		// for claude/codex install (which use the host plugin marketplace).
+		if pluginDir != "" {
+			fmt.Fprintln(stderr, "spacedock install: --plugin-dir is not supported; use SPACEDOCK_REPO_ROOT or run from the Spacedock checkout")
+			return 2
+		}
 		return runInit(ctx, args, hostOps, stdout, stderr)
+	}
+	if !checkOnly {
+		source := piSpacedockPackageSource
+		if pluginDir != "" {
+			source = pluginDir
+		}
+		out, err := piOps.PiInstall(source)
+		if strings.TrimSpace(out) != "" {
+			fmt.Fprint(stdout, out)
+		}
+		if err != nil {
+			fmt.Fprintf(stderr, "spacedock install: pi install %q failed: %v\n", source, err)
+			return 1
+		}
 	}
 	cfg := piRuntimeConfigFromEnv(env, cwd(), pluginDir)
 	check := checkPiRuntime(piOps, cfg)
@@ -111,20 +174,21 @@ func runInitWithPi(ctx context.Context, args []string, hostOps hostOps, piOps pi
 		printPiDoctorReport(stdout, check)
 		return piDoctorExit(check)
 	}
+	printPiDoctorReport(stdout, check)
 	if piRuntimeLaunchReady(check) {
-		fmt.Fprintf(stdout, "Pi runtime ready.\n  pi-subagents: %s\n  pi-intercom: %s\n  Spacedock skills: %s\n", check.packageRoot, check.intercomPackageRoot, check.repoRoot)
+		fmt.Fprintf(stdout, "Pi runtime ready.\n  pi-subagents: %s\n  pi-intercom: %s\n  Spacedock package: %s\n", check.packageRoot, check.intercomPackageRoot, check.packageStatus.source)
 		printPiSupervisorTalkbackBoundary(stdout)
 		return 0
 	}
-	fmt.Fprintf(stdout,
-		"Pi runtime setup incomplete.\n\n"+
-			"Required next steps:\n"+
-			"  1. Install Pi and authenticate so %s exists.\n"+
-			"  2. Install the subagent substrate, for example: pi install npm:pi-subagents\n"+
-			"  3. Install the supervisor-talkback substrate, for example: pi install npm:pi-intercom or npm install pi-intercom into the Pi npm root.\n"+
-			"  4. If pi-subagents or pi-intercom are installed outside the default locations, set PI_SUBAGENTS_PACKAGE_ROOT and PI_INTERCOM_PACKAGE_ROOT.\n"+
-			"  5. Re-run: spacedock doctor --host pi\n\n", check.authPath)
-	printPiDoctorReport(stdout, check)
+	fmt.Fprintf(stdout, "Pi runtime setup incomplete.\n\n"+
+		"Required next steps:\n"+
+		"  1. Install Pi and authenticate so %s exists.\n"+
+		"  2. Install the subagent substrate, for example: pi install npm:pi-subagents\n"+
+		"  3. Install the supervisor-talkback substrate, for example: pi install npm:pi-intercom or npm install pi-intercom into the Pi npm root.\n"+
+		"  4. Install the Spacedock package: spacedock install --host pi\n"+
+		"  5. If pi-subagents or pi-intercom are installed outside the default locations, set PI_SUBAGENTS_PACKAGE_ROOT and PI_INTERCOM_PACKAGE_ROOT.\n"+
+		"  6. Re-run: spacedock doctor --host pi\n\n", check.authPath)
+	printPiSupervisorTalkbackBoundary(stdout)
 	return 0
 }
 
@@ -193,10 +257,9 @@ func parsePiSetupArgs(command string, args []string, stderr io.Writer) (host str
 			}
 			i++
 		case "--plugin-dir":
-			if command == "install" {
-				fmt.Fprintln(stderr, "spacedock install: --plugin-dir is not supported; use SPACEDOCK_REPO_ROOT or run from the Spacedock checkout")
-				return "", false, "", 2
-			}
+			// Accepted for both install (pi dev-override source) and doctor.
+			// Non-pi install rejects it in runInitWithPi; non-pi doctor rejects
+			// it via the re-parse in runDoctor.
 			if i+1 >= len(args) {
 				fmt.Fprintf(stderr, "spacedock %s: --plugin-dir requires a path\n", command)
 				return "", false, "", 2
@@ -212,20 +275,21 @@ func parsePiSetupArgs(command string, args []string, stderr io.Writer) (host str
 }
 
 func piRuntimeConfigFromEnv(env []string, dir, pluginDir string) piRuntimeConfig {
+	_ = dir
 	envMap := envMap(env)
 	home := envMap["HOME"]
 	if home == "" {
 		home = os.Getenv("HOME")
 	}
+	// repoRoot is the dev-override path only (--plugin-dir / SPACEDOCK_REPO_ROOT).
+	// The cwd fallback is removed (D5c): the installed package is discovered via
+	// the package-root scan regardless of cwd, and repoRoot is no longer needed
+	// for skill discovery (the retired --skill flags were its only consumer).
 	repo := pluginDir
 	pluginDirSource := "--plugin-dir"
 	if repo == "" {
 		repo = envMap["SPACEDOCK_REPO_ROOT"]
 		pluginDirSource = "SPACEDOCK_REPO_ROOT"
-	}
-	if repo == "" {
-		repo = dir
-		pluginDirSource = "working directory"
 	}
 	pkg := envMap["PI_SUBAGENTS_PACKAGE_ROOT"]
 	pkgSource := "PI_SUBAGENTS_PACKAGE_ROOT"
@@ -239,15 +303,13 @@ func piRuntimeConfigFromEnv(env []string, dir, pluginDir string) piRuntimeConfig
 		intercomPkg = filepath.Join(home, ".pi", "agent", "npm", "node_modules", "pi-intercom")
 		intercomPkgSource = "default ~/.pi/agent/npm/node_modules/pi-intercom"
 	}
-	authRoot := envMap["PI_CODING_AGENT_DIR"]
-	authPath := ""
+	agentDir := envMap["PI_CODING_AGENT_DIR"]
 	authPathSource := "PI_CODING_AGENT_DIR"
-	if authRoot != "" {
-		authPath = filepath.Join(authRoot, "auth.json")
-	} else {
-		authPath = filepath.Join(home, ".pi", "agent", "auth.json")
-		authPathSource = "default ~/.pi/agent/auth.json"
+	if agentDir == "" {
+		agentDir = filepath.Join(home, ".pi", "agent")
+		authPathSource = "default ~/.pi/agent"
 	}
+	authPath := filepath.Join(agentDir, "auth.json")
 	sessionDir := envMap["PI_CODING_AGENT_SESSION_DIR"]
 	sessionDirSource := "PI_CODING_AGENT_SESSION_DIR"
 	if sessionDir == "" {
@@ -260,11 +322,11 @@ func piRuntimeConfigFromEnv(env []string, dir, pluginDir string) piRuntimeConfig
 		intercomPackageRoot:   intercomPkg,
 		extensionPath:         filepath.Join(pkg, "src", "extension", "index.ts"),
 		subagentsSkill:        filepath.Join(pkg, "skills", "pi-subagents"),
-		firstOfficer:          filepath.Join(repo, "skills", "first-officer", "SKILL.md"),
-		ensign:                filepath.Join(repo, "skills", "ensign", "SKILL.md"),
 		authPath:              authPath,
 		openAIAPIKey:          envMap["OPENAI_API_KEY"],
 		sessionDir:            sessionDir,
+		agentDir:              agentDir,
+		home:                  home,
 		pluginDirSource:       pluginDirSource,
 		packageRootSource:     pkgSource,
 		intercomPackageSource: intercomPkgSource,
@@ -290,13 +352,18 @@ func checkPiRuntime(ops piRuntimeOps, cfg piRuntimeConfig) piCheckResult {
 	res.subagentsIntercomBridgeOK = ops.Stat(filepath.Join(cfg.packageRoot, "src", "intercom", "intercom-bridge.ts")) == nil
 	res.intercomPackageOK = ops.Stat(cfg.intercomPackageRoot) == nil
 	res.intercomSkillOK = ops.Stat(filepath.Join(cfg.intercomPackageRoot, "skills", "pi-intercom", "SKILL.md")) == nil
-	res.firstOfficerOK = ops.Stat(cfg.firstOfficer) == nil
-	res.ensignOK = ops.Stat(cfg.ensign) == nil
+	// The retired repo-path Stat checks (firstOfficerOK/ensignOK) are replaced by
+	// spacedockPackageOK: the package is registered AND ensign is discoverable via
+	// the package-root skill scan — the real discovery contract, not a filesystem
+	// coincidence at a cwd-derived path.
+	status := ops.SpacedockPackageStatus(cfg.agentDir, cfg.home)
+	res.packageStatus = status
+	res.spacedockPackageOK = status.registered && status.ensignDiscoverable
 	return res
 }
 
 func piRuntimeLaunchReady(c piCheckResult) bool {
-	return c.piBinOK && c.extensionOK && c.subagentsSkillOK && c.subagentsIntercomBridgeOK && c.intercomPackageOK && c.intercomSkillOK && c.firstOfficerOK && c.ensignOK
+	return c.piBinOK && c.extensionOK && c.subagentsSkillOK && c.subagentsIntercomBridgeOK && c.intercomPackageOK && c.intercomSkillOK && c.spacedockPackageOK
 }
 
 func piDoctorHealthy(c piCheckResult) bool {
@@ -321,9 +388,18 @@ func printPiDoctorReport(w io.Writer, c piCheckResult) {
 	printPiCheck(w, c.subagentsIntercomBridgeOK, "pi-subagents intercom bridge", filepath.Join(c.packageRoot, "src", "intercom", "intercom-bridge.ts"), "install/update pi-subagents or set PI_SUBAGENTS_PACKAGE_ROOT to a package root containing the intercom bridge")
 	printPiCheck(w, c.intercomPackageOK, "pi-intercom package root", c.intercomPackageRoot, "set PI_INTERCOM_PACKAGE_ROOT to the installed pi-intercom package root")
 	printPiCheck(w, c.intercomSkillOK, "pi-intercom skill", filepath.Join(c.intercomPackageRoot, "skills", "pi-intercom"), "install pi-intercom or set PI_INTERCOM_PACKAGE_ROOT to a package root containing skills/pi-intercom/SKILL.md")
-	printPiCheck(w, c.firstOfficerOK, "Spacedock first-officer skill", filepath.Join(c.repoRoot, "skills", "first-officer"), "pass --plugin-dir <spacedock checkout> or set SPACEDOCK_REPO_ROOT")
-	printPiCheck(w, c.ensignOK, "Spacedock ensign skill", filepath.Join(c.repoRoot, "skills", "ensign"), "pass --plugin-dir <spacedock checkout> or set SPACEDOCK_REPO_ROOT")
+	printPiCheck(w, c.spacedockPackageOK, "Spacedock package", piPackageReportPath(c.packageStatus), "run `spacedock install --host pi` to install the Spacedock package (or `spacedock install --host pi --plugin-dir <checkout>` for a dev override)")
 	printPiSupervisorTalkbackBoundary(w)
+}
+
+func piPackageReportPath(s piPackageStatus) string {
+	if s.packageRoot != "" {
+		return s.packageRoot
+	}
+	if s.source != "" {
+		return s.source
+	}
+	return ""
 }
 
 func printPiSupervisorTalkbackBoundary(w io.Writer) {
@@ -346,9 +422,6 @@ func printPiCheck(w io.Writer, ok bool, label, path, remedy string) {
 	}
 }
 
-func (c piRuntimeConfig) firstOfficerDir() string { return filepath.Dir(c.firstOfficer) }
-func (c piRuntimeConfig) ensignDir() string       { return filepath.Dir(c.ensign) }
-
 func lastString(v []string) string {
 	if len(v) == 0 {
 		return ""
@@ -365,4 +438,207 @@ func envMap(env []string) map[string]string {
 		}
 	}
 	return m
+}
+
+// piSpacedockPackageStatus replicates the package-registration + skill-discovery
+// contract that pi-subagents' collectSettingsPackageSkillPaths uses: it reads
+// ~/.pi/agent/settings.json `packages`, resolves each entry's package root (via
+// resolveSettingsPackageRoot), reads the package's package.json, and confirms a
+// package named "spacedock" is registered with ensign discoverable under its
+// pi.skills paths. This is the real discovery check — not a Stat of a cwd-derived
+// path — so it holds from a non-repo cwd once the package is installed.
+func piSpacedockPackageStatus(agentDir, home string) piPackageStatus {
+	if agentDir == "" {
+		return piPackageStatus{}
+	}
+	data, err := os.ReadFile(filepath.Join(agentDir, "settings.json"))
+	if err != nil {
+		return piPackageStatus{}
+	}
+	var settings struct {
+		Packages []json.RawMessage `json:"packages"`
+	}
+	if json.Unmarshal(data, &settings) != nil {
+		return piPackageStatus{}
+	}
+	for _, raw := range settings.Packages {
+		src := piPackageSourceFromEntry(raw)
+		if src == "" {
+			continue
+		}
+		root := resolveSettingsPackageRoot(src, agentDir, home)
+		if root == "" {
+			continue
+		}
+		name, skillPaths := readPackagePiSkills(root)
+		if name != "spacedock" {
+			continue
+		}
+		st := piPackageStatus{registered: true, source: src, packageRoot: root}
+		for _, sp := range skillPaths {
+			dir := filepath.Join(root, sp)
+			if piSkillFileExists(dir, "ensign") {
+				st.ensignDiscoverable = true
+			}
+			if piSkillFileExists(dir, "first-officer") {
+				st.firstOfficerDiscoverable = true
+			}
+		}
+		return st
+	}
+	return piPackageStatus{}
+}
+
+func piPackageSourceFromEntry(raw json.RawMessage) string {
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var obj struct {
+		Source string `json:"source"`
+	}
+	if json.Unmarshal(raw, &obj) == nil {
+		return obj.Source
+	}
+	return ""
+}
+
+func readPackagePiSkills(root string) (name string, skills []string) {
+	data, err := os.ReadFile(filepath.Join(root, "package.json"))
+	if err != nil {
+		return "", nil
+	}
+	var pkg struct {
+		Name string `json:"name"`
+		Pi   struct {
+			Skills []string `json:"skills"`
+		} `json:"pi"`
+	}
+	if json.Unmarshal(data, &pkg) != nil {
+		return "", nil
+	}
+	return pkg.Name, pkg.Pi.Skills
+}
+
+func piSkillFileExists(dir, skill string) bool {
+	_, err := os.Stat(filepath.Join(dir, skill, "SKILL.md"))
+	return err == nil
+}
+
+// resolveSettingsPackageRoot replicates pi-subagents' resolveSettingsPackageRoot:
+// it resolves a settings.json `packages` entry to a filesystem package root,
+// handling git:, npm:, file:, ~, absolute, and relative path sources.
+func resolveSettingsPackageRoot(source, baseDir, home string) string {
+	s := strings.TrimSpace(source)
+	if s == "" {
+		return ""
+	}
+	if strings.HasPrefix(s, "git:") {
+		host, repoPath := parseGitPackagePath(strings.TrimSpace(strings.TrimPrefix(s, "git:")))
+		if host == "" || repoPath == "" {
+			return ""
+		}
+		return filepath.Join(baseDir, "git", host, repoPath)
+	}
+	if strings.HasPrefix(s, "npm:") {
+		name := parseNpmPackageName(strings.TrimSpace(strings.TrimPrefix(s, "npm:")))
+		if name == "" {
+			return ""
+		}
+		return filepath.Join(baseDir, "npm", "node_modules", name)
+	}
+	norm := strings.TrimPrefix(s, "file:")
+	if norm == "~" {
+		return home
+	}
+	if strings.HasPrefix(norm, "~/") {
+		return filepath.Join(home, norm[2:])
+	}
+	if filepath.IsAbs(norm) {
+		return norm
+	}
+	if norm == "." || norm == ".." || strings.HasPrefix(norm, "./") || strings.HasPrefix(norm, "../") {
+		return filepath.Join(baseDir, norm)
+	}
+	return ""
+}
+
+var scpGitRe = regexp.MustCompile(`^git@([^:]+):(.+)$`)
+
+// parseGitPackagePath replicates pi-subagents' parseGitPackagePath, returning the
+// host and normalized repo path for a git: package source.
+func parseGitPackagePath(spec string) (host, repoPath string) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return "", ""
+	}
+	if m := scpGitRe.FindStringSubmatch(spec); m != nil {
+		host = m[1]
+		repoPath = m[2]
+	} else if u, err := url.Parse(spec); err == nil && u.IsAbs() && u.Host != "" {
+		host = u.Hostname()
+		repoPath = strings.TrimPrefix(u.Path, "/")
+	} else if i := strings.Index(spec, "/"); i > 0 {
+		host = spec[:i]
+		repoPath = spec[i+1:]
+	} else {
+		return "", ""
+	}
+	repoPath = stripGitRef(repoPath)
+	repoPath = strings.TrimSuffix(repoPath, ".git")
+	repoPath = strings.TrimPrefix(repoPath, "/")
+	if !isSafePackagePath(host) || !isSafePackagePath(repoPath) || len(strings.Split(repoPath, "/")) < 2 {
+		return "", ""
+	}
+	return host, repoPath
+}
+
+// parseNpmPackageName replicates pi-subagents' parseNpmPackageName: it extracts
+// the package name (without @version) from an npm: source.
+func parseNpmPackageName(spec string) string {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return ""
+	}
+	re := regexp.MustCompile(`^(@?[^@]+(?:/[^@]+)?)(?:@(.+))?$`)
+	m := re.FindStringSubmatch(spec)
+	name := spec
+	if m != nil && m[1] != "" {
+		name = m[1]
+	}
+	if !isSafePackagePath(name) {
+		return ""
+	}
+	return name
+}
+
+// stripGitRef replicates pi-subagents' stripGitRef: it strips a @ref or #ref
+// suffix (the first @ or #, whichever comes first) from a repo path.
+func stripGitRef(repoPath string) string {
+	at := strings.Index(repoPath, "@")
+	hash := strings.Index(repoPath, "#")
+	var idx int = -1
+	if at >= 0 && (hash < 0 || at < hash) {
+		idx = at
+	} else if hash >= 0 {
+		idx = hash
+	}
+	if idx < 0 {
+		return repoPath
+	}
+	return repoPath[:idx]
+}
+
+// isSafePackagePath replicates pi-subagents' isSafePackagePath: a path is safe
+// when it is non-empty, not absolute, and has no "." or ".." segments.
+func isSafePackagePath(value string) bool {
+	if value == "" || filepath.IsAbs(value) {
+		return false
+	}
+	for _, part := range strings.Split(value, string(filepath.Separator)) {
+		if part == "" || part == "." || part == ".." {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cli/pi_frontdoor_test.go
+++ b/internal/cli/pi_frontdoor_test.go
@@ -12,9 +12,13 @@ import (
 )
 
 type fakePiRuntimeOps struct {
-	lookPath map[string]string
-	statOK   map[string]bool
-	launched []string
+	lookPath      map[string]string
+	statOK        map[string]bool
+	launched      []string
+	piInstalls    []string // sources captured by PiInstall
+	piInstallOut  string
+	piInstallErr  error
+	packageStatus piPackageStatus
 }
 
 func (f *fakePiRuntimeOps) LookPath(name string) (string, error) {
@@ -34,6 +38,27 @@ func (f *fakePiRuntimeOps) Stat(path string) error {
 func (f *fakePiRuntimeOps) Launch(argv []string) error {
 	f.launched = append([]string(nil), argv...)
 	return nil
+}
+
+func (f *fakePiRuntimeOps) PiInstall(source string) (string, error) {
+	f.piInstalls = append(f.piInstalls, source)
+	return f.piInstallOut, f.piInstallErr
+}
+
+func (f *fakePiRuntimeOps) SpacedockPackageStatus(agentDir, home string) piPackageStatus {
+	return f.packageStatus
+}
+
+// healthyPiPackageStatus is the canned status for a registered, discoverable
+// Spacedock package — the state `spacedock install --host pi` produces.
+func healthyPiPackageStatus() piPackageStatus {
+	return piPackageStatus{
+		registered:               true,
+		ensignDiscoverable:       true,
+		firstOfficerDiscoverable: true,
+		source:                   "git:github.com/spacedock-dev/spacedock",
+		packageRoot:              "/pkg-store/spacedock",
+	}
 }
 
 func TestPiCommandRegisteredInTopLevelHelp(t *testing.T) {
@@ -61,8 +86,9 @@ func TestPiFrontDoorLaunchesWithNativeResourcePaths(t *testing.T) {
 	pkg := t.TempDir()
 	writePiSubagentsFixtures(t, pkg)
 	ops := &fakePiRuntimeOps{
-		lookPath: piHealthyPathFixtures(),
-		statOK:   statOKForPiResources(repo, pkg),
+		lookPath:      piHealthyPathFixtures(),
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: healthyPiPackageStatus(),
 	}
 	var stdout, stderr bytes.Buffer
 
@@ -70,12 +96,13 @@ func TestPiFrontDoorLaunchesWithNativeResourcePaths(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
+	// The retired --skill <repo>/skills/{first-officer,ensign} flags are absent;
+	// only the pi-subagents skill is passed. The Spacedock skills are discovered
+	// from the installed package's extension (resources_discover), not the flags.
 	wantPrefix := []string{
 		"pi",
 		"--extension", filepath.Join(pkg, "src", "extension", "index.ts"),
 		"--skill", filepath.Join(pkg, "skills", "pi-subagents"),
-		"--skill", filepath.Join(repo, "skills", "first-officer"),
-		"--skill", filepath.Join(repo, "skills", "ensign"),
 		"--model", "google/gemini",
 	}
 	if len(ops.launched) < len(wantPrefix)+1 {
@@ -92,49 +119,72 @@ func TestPiFrontDoorLaunchesWithNativeResourcePaths(t *testing.T) {
 			t.Fatalf("pi launch argv contains banned runtime token %q: %v", banned, ops.launched)
 		}
 	}
+	// Exactly one --skill flag (pi-subagents); the retired first-officer/ensign
+	// skill flags must not appear.
+	if got := strings.Count(joined, "--skill"); got != 1 {
+		t.Fatalf("expected exactly 1 --skill flag (pi-subagents only), got %d: %v", got, ops.launched)
+	}
+	if strings.Contains(joined, filepath.Join(repo, "skills", "first-officer")) || strings.Contains(joined, filepath.Join(repo, "skills", "ensign")) {
+		t.Fatalf("pi launch argv must not pass retired repo skill flags: %v", ops.launched)
+	}
 	prompt := ops.launched[len(ops.launched)-1]
 	if !strings.Contains(prompt, "Use $spacedock:first-officer") || !strings.Contains(prompt, "review this") {
 		t.Fatalf("pi prompt missing FO skill or task: %q", prompt)
 	}
 }
 
-func TestPiInstallRejectsPluginDir(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	ops := &fakeHost{}
-	piOps := &fakePiRuntimeOps{}
-
-	code := runInitWithPi(context.Background(), []string{"--host", "pi", "--plugin-dir", "/checkout"}, ops, piOps, nil, &stdout, &stderr)
-	if code != 2 {
-		t.Fatalf("exit=%d want 2; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "--plugin-dir is not supported") {
-		t.Fatalf("stderr should clearly reject install --plugin-dir, got %q", stderr.String())
-	}
-	if len(ops.installCmds) != 0 {
-		t.Fatalf("install seam called despite rejected --plugin-dir: %v", ops.installCmds)
-	}
-}
-
-func TestPiInstallAcceptedAndDoesNotUsePluginCommands(t *testing.T) {
+func TestPiInstallAcceptsPluginDirAsDevOverride(t *testing.T) {
 	repo := t.TempDir()
 	writePiSkillFixtures(t, repo)
 	pkg := t.TempDir()
 	writePiSubagentsFixtures(t, pkg)
 	ops := &fakeHost{}
+	piOps := &fakePiRuntimeOps{
+		lookPath:      piHealthyPathFixtures(),
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: healthyPiPackageStatus(),
+	}
 	var stdout, stderr bytes.Buffer
 
-	code := runInitWithPi(context.Background(), []string{"--host", "pi"}, ops, &fakePiRuntimeOps{
-		lookPath: piHealthyPathFixtures(),
-		statOK:   statOKForPiResources(repo, pkg),
-	}, append(piTestEnv(pkg, t.TempDir()), "SPACEDOCK_REPO_ROOT="+repo), &stdout, &stderr)
+	code := runInitWithPi(context.Background(), []string{"--host", "pi", "--plugin-dir", "/checkout"}, ops, piOps, piTestEnv(pkg, t.TempDir()), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	// --plugin-dir is the dev-override install source: pi install <path>.
+	if len(piOps.piInstalls) != 1 || piOps.piInstalls[0] != "/checkout" {
+		t.Fatalf("expected pi install /checkout, got %v", piOps.piInstalls)
+	}
+	if len(ops.installCmds) != 0 {
+		t.Fatalf("install --host pi must not call the host plugin install seam: %v", ops.installCmds)
+	}
+}
+
+func TestPiInstallRunsPiInstallAndDoesNotUsePluginCommands(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	ops := &fakeHost{}
+	piOps := &fakePiRuntimeOps{
+		lookPath:      piHealthyPathFixtures(),
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: healthyPiPackageStatus(),
+	}
+	var stdout, stderr bytes.Buffer
+
+	code := runInitWithPi(context.Background(), []string{"--host", "pi"}, ops, piOps, append(piTestEnv(pkg, t.TempDir()), "SPACEDOCK_REPO_ROOT="+repo), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	// install --host pi runs `pi install <published source>`, not the host plugin seam.
+	if len(piOps.piInstalls) != 1 || piOps.piInstalls[0] != piSpacedockPackageSource {
+		t.Fatalf("expected pi install %q, got %v", piSpacedockPackageSource, piOps.piInstalls)
 	}
 	if len(ops.installCmds) != 0 {
 		t.Fatalf("install --host pi called host plugin install seam: %v", ops.installCmds)
 	}
 	out := stdout.String()
-	for _, want := range []string{"Pi runtime ready", "pi-subagents", "pi-intercom", pkg, repo, "necessary supervisor-talkback setup prerequisites only"} {
+	for _, want := range []string{"Pi runtime ready", "pi-subagents", "pi-intercom", pkg, "Spacedock package", "necessary supervisor-talkback setup prerequisites only"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("install --host pi output missing %q:\n%s", want, out)
 		}
@@ -307,6 +357,94 @@ func TestPiRuntimeConfigDefaultsIntercomAndAuthPathsUnderHome(t *testing.T) {
 	assertEqual(t, cfg.intercomPackageRoot, filepath.Join(home, ".pi", "agent", "npm", "node_modules", "pi-intercom"))
 	assertEqual(t, cfg.authPath, filepath.Join(home, ".pi", "agent", "auth.json"))
 	assertEqual(t, cfg.sessionDir, filepath.Join(home, ".pi", "agent", "sessions"))
+	assertEqual(t, cfg.agentDir, filepath.Join(home, ".pi", "agent"))
+}
+
+// TestPiRuntimeConfigRetiresSkillFlagsAndCwdFallback is the AC-3 behavior test: the
+// launcher's --skill first-officer/ensign flags and the cwd fallback are retired,
+// the doctor gates on spacedockPackageOK (package registered + ensign discoverable
+// as user-package), and the doctor reports OK from a non-repo cwd when installed.
+func TestPiRuntimeConfigRetiresSkillFlagsAndCwdFallback(t *testing.T) {
+	t.Run("cwd fallback removed", func(t *testing.T) {
+		// No --plugin-dir, no SPACEDOCK_REPO_ROOT: repoRoot is empty (NOT the cwd),
+		// even from a non-repo cwd. The cwd fallback is removed, not demoted.
+		cfg := piRuntimeConfigFromEnv([]string{"HOME=/h"}, "/some/non-repo/cwd", "")
+		assertEqual(t, cfg.repoRoot, "")
+		assertEqual(t, cfg.pluginDirSource, "SPACEDOCK_REPO_ROOT")
+	})
+
+	t.Run("dev override retained", func(t *testing.T) {
+		cfg := piRuntimeConfigFromEnv([]string{"HOME=/h"}, "/cwd", "/checkout")
+		assertEqual(t, cfg.repoRoot, "/checkout")
+		assertEqual(t, cfg.pluginDirSource, "--plugin-dir")
+		cfg2 := piRuntimeConfigFromEnv([]string{"HOME=/h", "SPACEDOCK_REPO_ROOT=/env-repo"}, "/cwd", "")
+		assertEqual(t, cfg2.repoRoot, "/env-repo")
+	})
+
+	t.Run("launch args have no retired skill flags", func(t *testing.T) {
+		repo := t.TempDir()
+		writePiSkillFixtures(t, repo)
+		pkg := t.TempDir()
+		writePiSubagentsFixtures(t, pkg)
+		ops := &fakePiRuntimeOps{
+			lookPath:      piHealthyPathFixtures(),
+			statOK:        statOKForPiResources(repo, pkg),
+			packageStatus: healthyPiPackageStatus(),
+		}
+		var stdout, stderr bytes.Buffer
+		code := runPi(context.Background(), []string{"--plugin-dir", repo}, "/tmp", piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+		}
+		joined := strings.Join(ops.launched, " ")
+		if got := strings.Count(joined, "--skill"); got != 1 {
+			t.Fatalf("expected exactly 1 --skill flag (pi-subagents only), got %d: %v", got, ops.launched)
+		}
+		for _, banned := range []string{filepath.Join(repo, "skills", "first-officer"), filepath.Join(repo, "skills", "ensign")} {
+			if strings.Contains(joined, banned) {
+				t.Fatalf("retired repo skill flag present in launch args: %v", ops.launched)
+			}
+		}
+	})
+
+	t.Run("doctor gates on spacedockPackageOK from non-repo cwd", func(t *testing.T) {
+		pkg := t.TempDir()
+		writePiSubagentsFixtures(t, pkg)
+		home := t.TempDir()
+		auth := filepath.Join(home, ".pi", "agent", "auth.json")
+		statOK := statOKForPiResources(t.TempDir(), pkg)
+		statOK[auth] = true
+
+		// Not installed: packageStatus zero -> spacedockPackageOK false -> not ready,
+		// reported from a non-repo cwd (/tmp). This is the inverse of the old
+		// cwd-fallback false-positive.
+		var stdout, stderr bytes.Buffer
+		code := runDoctorWithPi(context.Background(), []string{"--host", "pi"}, &fakeHost{}, &fakePiRuntimeOps{
+			lookPath: piHealthyPathFixtures(),
+			statOK:   statOK,
+		}, piTestEnv(pkg, home), &stdout, &stderr)
+		if code == 0 {
+			t.Fatalf("doctor should be non-zero when package not installed; stdout=%q", stdout.String())
+		}
+		if !strings.Contains(stdout.String(), "MISSING Spacedock package") {
+			t.Fatalf("doctor should report MISSING Spacedock package when not installed:\n%s", stdout.String())
+		}
+
+		// Installed: packageStatus healthy -> spacedockPackageOK true -> ready,
+		// still from a non-repo cwd (/tmp). No --plugin-dir, no SPACEDOCK_REPO_ROOT.
+		var stdout2, stderr2 bytes.Buffer
+		code2 := runDoctorWithPi(context.Background(), []string{"--host", "pi"}, &fakeHost{}, &fakePiRuntimeOps{
+			lookPath:      piHealthyPathFixtures(),
+			statOK:        statOK,
+			packageStatus: healthyPiPackageStatus(),
+		}, piTestEnv(pkg, home), &stdout2, &stderr2)
+		if code2 != 0 {
+			t.Fatalf("doctor should be zero when package installed from non-repo cwd; exit=%d stdout=%q", code2, stdout2.String())
+		}
+		if !strings.Contains(stdout2.String(), "OK Spacedock package") {
+			t.Fatalf("doctor should report OK Spacedock package when installed:\n%s", stdout2.String())
+		}
+	})
 }
 
 func TestRuntimeSupportDocsKeepPiDoctorVsLiveTalkbackBoundary(t *testing.T) {
@@ -358,8 +496,9 @@ func TestPiDoctorReportsMissingAndHealthyRuntime(t *testing.T) {
 	t.Run("openai-api-key-auth", func(t *testing.T) {
 		var stdout, stderr bytes.Buffer
 		code := runDoctorWithPi(context.Background(), []string{"--host", "pi", "--plugin-dir", repo}, &fakeHost{}, &fakePiRuntimeOps{
-			lookPath: piHealthyPathFixtures(),
-			statOK:   statOKForPiResources(repo, pkg),
+			lookPath:      piHealthyPathFixtures(),
+			statOK:        statOKForPiResources(repo, pkg),
+			packageStatus: healthyPiPackageStatus(),
 		}, append(piTestEnv(pkg, home), "OPENAI_API_KEY=test-key"), &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
@@ -374,16 +513,23 @@ func TestPiDoctorReportsMissingAndHealthyRuntime(t *testing.T) {
 		statOK := statOKForPiResources(repo, pkg)
 		statOK[auth] = true
 		code := runDoctorWithPi(context.Background(), []string{"--host", "pi", "--plugin-dir", repo}, &fakeHost{}, &fakePiRuntimeOps{
-			lookPath: piHealthyPathFixtures(),
-			statOK:   statOK,
+			lookPath:      piHealthyPathFixtures(),
+			statOK:        statOK,
+			packageStatus: healthyPiPackageStatus(),
 		}, piTestEnv(pkg, home), &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 		}
 		out := stdout.String()
-		for _, want := range []string{"OK pi CLI", "OK Pi auth", "OK pi-subagents extension", "OK pi-subagents intercom bridge", "OK pi-intercom package root", "OK pi-intercom skill", "OK Spacedock first-officer skill", "OK Spacedock ensign skill", "live child talkback", "durable marker probe"} {
+		for _, want := range []string{"OK pi CLI", "OK Pi auth", "OK pi-subagents extension", "OK pi-subagents intercom bridge", "OK pi-intercom package root", "OK pi-intercom skill", "OK Spacedock package", "live child talkback", "durable marker probe"} {
 			if !strings.Contains(out, want) {
 				t.Fatalf("healthy doctor output missing %q:\n%s", want, out)
+			}
+		}
+		// The retired repo-path skill checks must not appear.
+		for _, notWant := range []string{"OK Spacedock first-officer skill", "OK Spacedock ensign skill"} {
+			if strings.Contains(out, notWant) {
+				t.Fatalf("healthy doctor output should not print retired skill check %q:\n%s", notWant, out)
 			}
 		}
 	})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "spacedock",
+  "type": "module",
+  "private": true,
+  "pi": {
+    "extensions": [
+      "./.pi/extensions/spacedock.ts"
+    ],
+    "skills": [
+      "./skills"
+    ]
+  }
+}


### PR DESCRIPTION
## Why

`spacedock install --host pi` was check-only — it printed a report and wrote nothing. The parent pi session found the Spacedock skills only because `spacedock pi` passed `--skill <repo>/skills/{first-officer,ensign}/SKILL.md` flags (with `repo` resolved as `--plugin-dir` → `SPACEDOCK_REPO_ROOT` → **cwd** fallback). But pi-subagents **children** don't inherit those flags — they use their own `discoverAvailableSkills(cwd)` scan, which doesn't include the repo's `skills/`. So `skill:["ensign"]` on a dispatched child emitted "Skills not found: ensign" and the worker ran as a bare `worker` (implementation-biased) regardless of stage. This is the parent/child discovery split born of install being check-only — Pi was the one host where install wrote nothing.

This is sprint `0223-pi-dispatch-contract` member 1 (`eq`). It retires the `--skill` flags + cwd fallback and the doctor's repo-path `Stat` checks in favor of install-managed package placement, so both parent and child discover skills with no clone/cwd/symlink dependency.

## What changed

Ship Spacedock as a pi package (6 files, +538/-73):

- **`package.json`** (new) — `name: spacedock`, `pi.extensions: ["./.pi/extensions/spacedock.ts"]`, `pi.skills: ["./skills"]`.
- **`.pi/extensions/spacedock.ts`** (new) — `resources_discover` extension returning the repo `skills/` dir (resolved relative to own location); parent-session discovery replacing the retired `--skill` flags.
- **`internal/cli/pi.go`** — `runInitWithPi` runs `pi install` (published `git:github.com/spacedock-dev/spacedock` or local `--plugin-dir` dev override); `piRuntimeConfigFromEnv` retires the `--skill cfg.firstOfficerDir()`/`--skill cfg.ensignDir()` flags + removes the cwd fallback (repoRoot is dev-override only); `checkPiRuntime` retires `firstOfficerOK`/`ensignOK` `Stat` checks → `spacedockPackageOK` (replicates `collectSettingsPackageSkillPaths`: package registered in `settings.json packages` + `ensign` discoverable as `user-package`); `piRuntimeLaunchReady` gates on it; `piRuntimeOps` gained `PiInstall` + `SpacedockPackageStatus`; `parsePiSetupArgs` accepts `--plugin-dir` for install (non-pi still rejects).
- **`internal/cli/help.go`** — pi help text updated for install-managed discovery.
- **`internal/cli/pi_frontdoor_test.go`** + **`launch_banner_wording_test.go`** — frontdoor tests updated to the new contract + new AC-3 behavior test `TestPiRuntimeConfigRetiresSkillFlagsAndCwdFallback`.

## Evidence

- **AC-1 (live):** `spacedock install --host pi --plugin-dir <worktree>` ran `pi install` → "Installed"; `~/.pi/agent/settings.json` `packages` contains the Spacedock entry; built binary `spacedock doctor --host pi` from `/tmp` (non-repo cwd) → `OK Spacedock package` + exit 0.
- **AC-2 (live):** `discoverAvailableSkills("/tmp")` lists `ensign` + `first-officer` as `user-package` (no cwd/symlink dependency); `skillsWarning("/tmp", ["ensign"])` = `undefined` (control `["nonexistent"]` produces the warning) — the precise inverse of run `0637e2ed`. (AC-2b nested-probe run-meta left to FO parent-level — child has no `subagent(...)` tool; the `skillsWarning` precondition is proven.)
- **AC-3 (behavior-tested):** `TestPiRuntimeConfigRetiresSkillFlagsAndCwdFallback` 4 subtests PASS (cwd fallback removed; dev-override retained; exactly one `--skill` [pi-subagents only]; `spacedockPackageOK` replaces Stat checks; doctor gates on it).
- **AC-4 (live):** dev-override live edit — marker skill appears/disappears in `discoverAvailableSkills("/tmp")` without reinstall.
- **Non-regression:** `go test ./internal/cli/ ./internal/piruntime/ -race` green; `go test ./...` green except pre-existing `internal/status` fixture (verified on baseline). gofmt clean.
- **Region discipline:** touches only `eq`'s owned `pi.go` regions (`runInitWithPi`/`piRuntimeConfigFromEnv`/`checkPiRuntime`/`parsePiSetupArgs`/`printPiDoctorReport` + new `PiInstall`/`SpacedockPackageStatus`); does NOT touch `qn`'s `parsePiFrontDoorArgs`/`runPi`-wrap/`setPiHelp`.

CI: `pi-live` lane required (touches `internal/cli/pi.go` + `help.go` — pi-only front-door surfaces). No claude/codex live lanes needed (no `frontdoor.go`/`safehouse`/`contractlint`/`hostneutrality` changes).

---

Sprint: `0223-pi-dispatch-contract` (member 1). Validator: PASSED (run `4333f38b`). State audit: `eq` entity @ `spacedock-state/dev`.
