### PR TITLE
pi front door: register --safehouse-* flags + safehouse wrapping (parity with claude/codex)

### DIFF
--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -78,14 +78,23 @@ Examples:
 }
 
 // setPiHelp installs the Pi-specific launch help. Pi loads explicit skills and
-// extensions instead of a Claude/Codex plugin manifest.
+// extensions instead of a Claude/Codex plugin manifest. The safehouse subset
+// mirrors the claude/codex help (same flag names) so operator muscle memory
+// transfers across hosts; --skip-contract-check / --no-install are NOT declared
+// because pi has no contract gate. The flags are declared on the command only so
+// FlagUsages renders them (the pi command is DisableFlagParsing, exactly like
+// claude/codex); parsePiFrontDoorArgs owns the real parsing.
 func setPiHelp(cmd *cobra.Command, w io.Writer) {
-	cmd.Flags().String("plugin-dir", "", "Load a local Spacedock skill checkout")
+	cmd.Flags().StringArray("plugin-dir", nil, "Load a local Spacedock skill checkout")
+	cmd.Flags().Bool("safehouse", false, "Force the safehouse sandbox wrap even without a .safehouse profile in the directory")
+	cmd.Flags().StringArray("safehouse-enable", nil, "Enable a safehouse capability (KEY[,KEY]); repeatable; e.g. --safehouse-enable ssh,docker")
+	cmd.Flags().StringArray("safehouse-add-dirs", nil, "Grant safehouse read-write access to a directory; repeatable")
+	cmd.Flags().StringArray("safehouse-add-dirs-ro", nil, "Grant safehouse read-only access to a directory; repeatable")
 	cmd.SetHelpFunc(func(c *cobra.Command, _ []string) {
 		fmt.Fprint(w, tagline+`
 
 Usage:
-  spacedock pi [task] [--plugin-dir <checkout>] [-- pi-flags]
+  spacedock pi [task] [--plugin-dir <checkout>] [--safehouse-* knobs] [-- pi-flags]
 
 Start Pi as your Spacedock first officer by loading the Pi-native pi-subagents
 extension/skill. The Spacedock first-officer/ensign skills are discovered from
@@ -93,17 +102,25 @@ the installed Spacedock package (run: spacedock install --host pi); the optional
 --plugin-dir loads a local checkout as a dev override. The optional task is
 appended to the launch prompt; everything after -- forwards verbatim to pi.
 
+When any --safehouse-* knob (or a .safehouse profile, or the bare --safehouse) is
+present, the launch is wrapped as `+"`"+`safehouse --trust-workdir-config [extra] -- pi …`+"`"+`
+so a sandboxed session can grant additional directory access. No inner
+permission flag is added — pi's posture is its --tools/--exclude-tools passthrough
+and the safehouse isolation itself.
+
 Flags:
 `)
 		fmt.Fprint(w, c.Flags().FlagUsages())
 		fmt.Fprint(w, `
 Forwarding:
-  Tokens before -- are spacedock's (the task + --plugin-dir). Tokens after --
-  forward verbatim to pi, e.g. --model, --print, or --session-dir.
+  Tokens before -- are spacedock's (the task + --plugin-dir + the --safehouse-*
+  knobs). Tokens after -- forward verbatim to pi, e.g. --model, --print, or
+  --session-dir.
 
 Examples:
   spacedock pi --plugin-dir ./checkout
   spacedock pi "drive the workflow" --plugin-dir ./checkout -- --model google/gemini
+  spacedock pi --safehouse-add-dirs ~/scratch -- --model google/gemini
 `)
 	})
 }

--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -119,13 +119,33 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 		return 1
 	}
 
-	launchBanner("pi", dir, safehouse.Present(dir), ops.LookPath, stderr)
+	// Translate the de-prefixed safehouse knobs into the safehouse `extra` slot
+	// (the same function claude/codex use) and compute the wrap decision identically:
+	// a `.safehouse` profile in dir, the bare `--safehouse` flag, or any knob. An
+	// unknown key is a hard error (no Launch), mirroring the claude/codex gate. Per
+	// PI-SPECIFIC DECISION 2, the wrap arm uses safehouse.Wrap(inner, extra) with NO
+	// launcherBinEnvPassFlags() and NO launchEnv threading — runPi/execPiRuntimeOps
+	// never forward SPACEDOCK_BIN today (Launch takes no env), so the minimal wrap
+	// introduces no regression.
+	extra, err := safehouse.TranslateFlags(fd.safehouseFlags)
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock pi: %v\n", err)
+		return 1
+	}
+	wrap := safehouse.Present(dir) || fd.forceSafehouse || len(fd.safehouseFlags) > 0
+
+	launchBanner("pi", dir, wrap, ops.LookPath, stderr)
 
 	// The Spacedock first-officer/ensign skills are no longer passed as --skill
 	// flags: the installed package's .pi/extensions/spacedock.ts extension
 	// discovers them for the parent session via resources_discover, and
 	// pi-subagents children discover them via the package-root scan. Only the
 	// pi-subagents extension + skill are passed explicitly here.
+
+	// The inner argv is byte-identical wrapped or not (PI-SPECIFIC DECISION 1): pi
+	// has no per-action permission-prompting flag to suppress, so NO inner
+	// permission-mode flag is added on the wrap arm — safehouse isolation alone is
+	// the boundary, and the operator's --tools/--exclude-tools passthrough wins.
 	argv := []string{
 		"pi",
 		"--extension", cfg.extensionPath,
@@ -133,6 +153,13 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 	}
 	argv = append(argv, fd.passthrough...)
 	argv = append(argv, launchPrompt(piBootstrapPrompt, fd))
+	if wrap {
+		if ok, hint := safehouse.Available(ops.LookPath); !ok {
+			fmt.Fprintln(stderr, hint)
+			return 1
+		}
+		argv = safehouse.Wrap(argv, extra)
+	}
 	if err := ops.Launch(argv); err != nil {
 		fmt.Fprintf(stderr, "spacedock pi: launch failed: %v\n", err)
 		return 1
@@ -210,8 +237,25 @@ func parsePiFrontDoorArgs(args []string) (fd frontDoorArgs, pluginDirs []string,
 	fs := pflag.NewFlagSet("spacedock-pi", pflag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	pluginDir := fs.StringArray("plugin-dir", nil, "Load local Spacedock skill checkout")
+	// The safehouse subset mirrors bindFrontDoorFlags' safehouse flags (same names
+	// for operator muscle-memory transfer across hosts). --skip-contract-check / --no-install
+	// are NOT registered: pi has no contract gate, so advertising them would mislead.
+	forceSafehouse := fs.Bool("safehouse", false, "Force the safehouse sandbox wrap even without a .safehouse profile in the directory")
+	enable := fs.StringArray("safehouse-enable", nil, "Enable a safehouse capability (KEY[,KEY]); repeatable; e.g. --safehouse-enable ssh,docker")
+	addDirs := fs.StringArray("safehouse-add-dirs", nil, "Grant safehouse read-write access to a directory; repeatable")
+	addDirsRO := fs.StringArray("safehouse-add-dirs-ro", nil, "Grant safehouse read-only access to a directory; repeatable")
 	if err := fs.Parse(args); err != nil {
 		return frontDoorArgs{}, nil, err
+	}
+	fd.forceSafehouse = *forceSafehouse
+	for _, v := range *enable {
+		fd.safehouseFlags = append(fd.safehouseFlags, "enable="+v)
+	}
+	for _, v := range *addDirs {
+		fd.safehouseFlags = append(fd.safehouseFlags, "add-dirs="+v)
+	}
+	for _, v := range *addDirsRO {
+		fd.safehouseFlags = append(fd.safehouseFlags, "add-dirs-ro="+v)
 	}
 	positionals := fs.Args()
 	dash := fs.ArgsLenAtDash()

--- a/internal/cli/pi_frontdoor_test.go
+++ b/internal/cli/pi_frontdoor_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/safehouse"
 )
 
 type fakePiRuntimeOps struct {
@@ -672,7 +674,8 @@ func statOKForPiResources(repo, pkg string) map[string]bool {
 
 func piHealthyPathFixtures() map[string]string {
 	return map[string]string{
-		"pi": "/bin/pi",
+		"pi":        "/bin/pi",
+		"safehouse": "/bin/safehouse",
 	}
 }
 
@@ -681,5 +684,266 @@ func piTestEnv(pkg, home string) []string {
 		"PI_SUBAGENTS_PACKAGE_ROOT=" + pkg,
 		"PI_INTERCOM_PACKAGE_ROOT=" + pkg + "-intercom",
 		"HOME=" + home,
+	}
+}
+
+// piSafehouseReadyOps builds a fakePiRuntimeOps with the healthy path fixtures
+// (pi + safehouse resolvable) and the stat set for the repo/pkg resources, so a
+// safehouse-wrapped runPi reaches the launch seam.
+func piSafehouseReadyOps(repo, pkg string) *fakePiRuntimeOps {
+	return &fakePiRuntimeOps{
+		lookPath:      piHealthyPathFixtures(),
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: healthyPiPackageStatus(),
+	}
+}
+
+// piSafehouseInnerArgv returns the inner pi argv (after the safehouse `--`
+// separator) from a wrapped launch argv, or argv unchanged when unwrapped.
+func piSafehouseInnerArgv(argv []string) []string {
+	if len(argv) == 0 || argv[0] != "safehouse" {
+		return argv
+	}
+	for i, tok := range argv {
+		if tok == "--" {
+			return argv[i+1:]
+		}
+	}
+	return nil
+}
+
+// piSafehouseExtra returns the safehouse `extra` slot (tokens between
+// --trust-workdir-config and the `--` separator) from a wrapped launch argv.
+func piSafehouseExtra(argv []string) []string {
+	if len(argv) < 2 || argv[0] != "safehouse" || argv[1] != "--trust-workdir-config" {
+		return nil
+	}
+	for i := 2; i < len(argv); i++ {
+		if argv[i] == "--" {
+			return argv[2:i]
+		}
+	}
+	return nil
+}
+
+// TestPiFrontDoorAcceptsSafehouseFlags pins AC-1: parsePiFrontDoorArgs accepts the
+// four --safehouse-* flags (space/= /repeatable) without error and populates
+// fd.forceSafehouse + fd.safehouseFlags with the re-prefixed tokens. Today pflag
+// rejects these with exit 2.
+func TestPiFrontDoorAcceptsSafehouseFlags(t *testing.T) {
+	cases := []struct {
+		name           string
+		args           []string
+		forceSafehouse bool
+		safehouseFlags []string
+	}{
+		{"bare-safehouse", []string{"--safehouse"}, true, nil},
+		{"enable-equals", []string{"--safehouse-enable=ssh"}, false, []string{"enable=ssh"}},
+		{"enable-space", []string{"--safehouse-enable", "ssh"}, false, []string{"enable=ssh"}},
+		{"enable-comma", []string{"--safehouse-enable=ssh,docker"}, false, []string{"enable=ssh,docker"}},
+		{"add-dirs-equals", []string{"--safehouse-add-dirs=~/scratch"}, false, []string{"add-dirs=~/scratch"}},
+		{"add-dirs-space", []string{"--safehouse-add-dirs", "~/scratch"}, false, []string{"add-dirs=~/scratch"}},
+		{"add-dirs-repeat", []string{"--safehouse-add-dirs", "/a", "--safehouse-add-dirs", "/b"}, false, []string{"add-dirs=/a", "add-dirs=/b"}},
+		{"add-dirs-ro-equals", []string{"--safehouse-add-dirs-ro=~/ro"}, false, []string{"add-dirs-ro=~/ro"}},
+		{"add-dirs-ro-space", []string{"--safehouse-add-dirs-ro", "~/ro"}, false, []string{"add-dirs-ro=~/ro"}},
+		{"all-knobs", []string{"--safehouse", "--safehouse-enable", "ssh", "--safehouse-add-dirs", "~/scratch", "--safehouse-add-dirs-ro", "~/ro"}, true, []string{"enable=ssh", "add-dirs=~/scratch", "add-dirs-ro=~/ro"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fd, _, err := parsePiFrontDoorArgs(tc.args)
+			if err != nil {
+				t.Fatalf("parsePiFrontDoorArgs(%v) err = %v (today pflag rejects these with exit 2)", tc.args, err)
+			}
+			if fd.forceSafehouse != tc.forceSafehouse {
+				t.Errorf("forceSafehouse = %v, want %v", fd.forceSafehouse, tc.forceSafehouse)
+			}
+			if !equalArgv(fd.safehouseFlags, tc.safehouseFlags) {
+				t.Errorf("safehouseFlags = %v, want %v", fd.safehouseFlags, tc.safehouseFlags)
+			}
+		})
+	}
+}
+
+// TestPiFrontDoorWrapsWhenKnobPresent pins AC-2: with a knob present and a
+// resolvable safehouse binary, runPi produces safehouse --trust-workdir-config
+// <TranslateFlags-extra> -- pi …, where extra matches safehouse.TranslateFlags'
+// output (the same function claude/codex use).
+func TestPiFrontDoorWrapsWhenKnobPresent(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	ops := piSafehouseReadyOps(repo, pkg)
+	var stdout, stderr bytes.Buffer
+
+	code := runPi(context.Background(), []string{"--plugin-dir", repo, "--safehouse-add-dirs=/a"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if len(ops.launched) == 0 || ops.launched[0] != "safehouse" {
+		t.Fatalf("expected safehouse-wrapped argv, got %v", ops.launched)
+	}
+	wantExtra, err := safehouse.TranslateFlags([]string{"add-dirs=/a"})
+	if err != nil {
+		t.Fatalf("TranslateFlags err = %v", err)
+	}
+	if !equalArgv(piSafehouseExtra(ops.launched), wantExtra) {
+		t.Fatalf("extra = %v, want TranslateFlags output %v\nargv=%v", piSafehouseExtra(ops.launched), wantExtra, ops.launched)
+	}
+	inner := piSafehouseInnerArgv(ops.launched)
+	// The retired --skill <repo>/skills/{first-officer,ensign} flags are absent
+	// (eq's install-managed merge: the installed package's extension discovers
+	// the Spacedock skills via resources_discover); only the pi-subagents skill is
+	// passed, matching TestPiFrontDoorLaunchesWithNativeResourcePaths.
+	wantPrefix := []string{
+		"pi",
+		"--extension", filepath.Join(pkg, "src", "extension", "index.ts"),
+		"--skill", filepath.Join(pkg, "skills", "pi-subagents"),
+	}
+	if len(inner) < len(wantPrefix)+1 {
+		t.Fatalf("wrapped inner argv too short: %v", inner)
+	}
+	for i, want := range wantPrefix {
+		if inner[i] != want {
+			t.Fatalf("wrapped inner[%d]=%q want %q\ninner=%v", i, inner[i], want, inner)
+		}
+	}
+}
+
+// TestPiFrontDoorPlainWhenNoTrigger pins AC-2: with no knob, no --safehouse, and
+// no .safehouse profile, runPi produces the plain pi argv (no safehouse prefix).
+func TestPiFrontDoorPlainWhenNoTrigger(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	ops := piSafehouseReadyOps(repo, pkg)
+	var stdout, stderr bytes.Buffer
+
+	code := runPi(context.Background(), []string{"--plugin-dir", repo}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr.String())
+	}
+	if len(ops.launched) == 0 || ops.launched[0] != "pi" {
+		t.Fatalf("expected plain pi argv (no safehouse prefix), got %v", ops.launched)
+	}
+}
+
+// TestPiFrontDoorWrapsWhenSafehouseProfileAlone pins AC-2: a .safehouse profile
+// alone (no flags) also triggers the wrap; the extra slot is empty.
+func TestPiFrontDoorWrapsWhenSafehouseProfileAlone(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	dir := safehouseFixtureDir(t)
+	ops := piSafehouseReadyOps(repo, pkg)
+	var stdout, stderr bytes.Buffer
+
+	code := runPi(context.Background(), []string{"--plugin-dir", repo}, dir, piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr.String())
+	}
+	if len(ops.launched) == 0 || ops.launched[0] != "safehouse" {
+		t.Fatalf("expected safehouse-wrapped argv for .safehouse profile alone, got %v", ops.launched)
+	}
+	if !equalArgv(piSafehouseExtra(ops.launched), nil) {
+		t.Fatalf("extra should be empty for profile-alone wrap, got %v", piSafehouseExtra(ops.launched))
+	}
+}
+
+// TestPiFrontDoorUnknownSafehouseKeyErrors pins AC-2: an unknown --safehouse-* key
+// exits non-zero with no Launch, mirroring TestUnknownSafehouseKeyErrors.
+func TestPiFrontDoorUnknownSafehouseKeyErrors(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	ops := piSafehouseReadyOps(repo, pkg)
+	var stdout, stderr bytes.Buffer
+
+	code := runPi(context.Background(), []string{"--safehouse-bogus=x"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("exit=0 want non-zero for unknown --safehouse-* key")
+	}
+	if ops.launched != nil {
+		t.Fatalf("Launch invoked on unknown --safehouse-* key: %v", ops.launched)
+	}
+	if !strings.Contains(stderr.String(), "--safehouse-bogus") {
+		t.Fatalf("error does not name the knob --safehouse-bogus: %q", stderr.String())
+	}
+}
+
+// TestPiFrontDoorWrapInnerEqualsUnwrapped pins AC-3 (PI-SPECIFIC DECISION 1): the
+// wrapped inner argv (tokens after safehouse --trust-workdir-config [extra] --) is
+// byte-identical to the unwrapped pi argv. No --dangerously-skip-permissions-
+// equivalent and no --tools/--exclude-tools default is injected by the wrap; the
+// wrap prefix is the only difference.
+func TestPiFrontDoorWrapInnerEqualsUnwrapped(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+
+	// Unwrapped: no knob, no --safehouse, no .safehouse profile.
+	plainOps := piSafehouseReadyOps(repo, pkg)
+	var stdout, stderr bytes.Buffer
+	if code := runPi(context.Background(), []string{"--plugin-dir", repo}, t.TempDir(), piTestEnv(pkg, t.TempDir()), plainOps, &stdout, &stderr); code != 0 {
+		t.Fatalf("plain exit=%d stderr=%q", code, stderr.String())
+	}
+	unwrapped := plainOps.launched
+
+	// Wrapped: a knob triggers the wrap, no .safehouse profile.
+	wrapOps := piSafehouseReadyOps(repo, pkg)
+	var wout, werr bytes.Buffer
+	if code := runPi(context.Background(), []string{"--plugin-dir", repo, "--safehouse-add-dirs=/tmp/probe"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), wrapOps, &wout, &werr); code != 0 {
+		t.Fatalf("wrapped exit=%d stderr=%q", code, werr.String())
+	}
+	wrapped := wrapOps.launched
+	if len(wrapped) == 0 || wrapped[0] != "safehouse" {
+		t.Fatalf("expected safehouse-wrapped argv, got %v", wrapped)
+	}
+	inner := piSafehouseInnerArgv(wrapped)
+	if !equalArgv(inner, unwrapped) {
+		t.Fatalf("wrapped inner argv != unwrapped pi argv:\n wrapped inner=%v\n unwrapped    =%v", inner, unwrapped)
+	}
+	for _, banned := range []string{"--dangerously-skip-permissions", "--dangerously-bypass-approvals-and-sandbox"} {
+		for _, tok := range inner {
+			if tok == banned || strings.HasPrefix(tok, banned+"=") {
+				t.Fatalf("wrap injected a permission-mode flag %q into the inner argv: %v", banned, inner)
+			}
+		}
+	}
+}
+
+// TestPiHelpCarriesSafehouseDetail pins AC-4: `spacedock pi --help` (exit 0)
+// carries the four --safehouse-* usages + the --safehouse-add-dirs ~/scratch
+// example + the -- forwarding note, and does NOT declare --skip-contract-check / --no-install
+// (pi has no contract gate).
+func TestPiHelpCarriesSafehouseDetail(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"pi", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"--safehouse",
+		"--safehouse-enable",
+		"--safehouse-add-dirs",
+		"--safehouse-add-dirs-ro",
+		"--plugin-dir",
+		"--safehouse-add-dirs ~/scratch",
+		"forward verbatim",
+		"Examples:",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("pi --help missing %q:\n%s", want, out)
+		}
+	}
+	for _, notWant := range []string{"--skip-contract-check", "--no-install"} {
+		if strings.Contains(out, notWant) {
+			t.Errorf("pi --help should not declare %q:\n%s", notWant, out)
+		}
 	}
 }


### PR DESCRIPTION
## Why

The pi front door (`spacedock pi`) was the only Spacedock front door that rejected `--safehouse-*` flags and never wrapped the launch in safehouse — claude/codex do (`frontdoor.go`). So a Commander on a sandboxed pi session could not grant additional directory access (e.g. `~/.pi/agent` for pi-install writes) through the launcher; the only path was an external `safehouse --add-dirs X -- spacedock pi ...` wrap. This is sprint `0223-pi-dispatch-contract` member 3 (`qn`), retiring the Q14 break-glass workaround.

## What changed

Brings `internal/cli/pi.go` + `internal/cli/help.go` to safehouse parity with the claude/codex pattern (3 files, +328/-7), reusing `internal/safehouse` UNCHANGED:

- **D1** `parsePiFrontDoorArgs` registers `--safehouse` (Bool → `fd.forceSafehouse`) + `--safehouse-enable`/`--safehouse-add-dirs`/`--safehouse-add-dirs-ro` (StringArray, repeatable → re-prefixed `enable=`/`add-dirs=`/`add-dirs-ro=` tokens on `fd.safehouseFlags`). `--skip-contract-check`/`--no-install` NOT registered (pi has no contract gate).
- **D2** `runPi` calls `safehouse.TranslateFlags(fd.safehouseFlags)` (the same function claude/codex use), computes `wrap := safehouse.Present(dir) || fd.forceSafehouse || len(fd.safehouseFlags) > 0`, and when `wrap` gates on `safehouse.Available(ops.LookPath)` then `argv = safehouse.Wrap(argv, extra)`. Unknown key → exit 1, no Launch (mirrors claude/codex); unknown-flag parse path still exit 2.
- **D3** `setPiHelp` declares the safehouse subset + the `~/scratch` example + the forwarding note.

Both captain-concurred pi-specific decisions implemented:
- **Decision 1 (AC-3):** NO inner permission-mode flag — the wrapped inner argv is byte-identical to the unwrapped pi argv (safehouse isolation alone is the boundary).
- **Decision 2 (out of scope):** NO `SPACEDOCK_BIN`/`launchEnv` threading — `runPi` never forwarded it; minimal wrap is no regression. Full launcher-binary-through-sandbox parity is a separate follow-up.

## Merge-time integration fix (vs base `5bf98e1e`)

This branch was rebased onto `origin/main` after `eq` (PR #406) landed. `eq` raised `piRuntimeLaunchReady` to require `spacedockPackageOK`; `qn`'s 4 safehouse-wrap tests built a fake pi env with no Spacedock package, so the new gate bailed before reaching the wrap path. Test-only fix: `piSafehouseReadyOps` now sets `packageStatus: healthyPiPackageStatus()` (reusing `eq`'s helper) so `spacedockPackageOK = true` and the launcher proceeds to the wrap path under test. The `pi.go` change in this PR is the mechanical rebase conflict resolution preserving qn's D1/D2 + eq's retired-skill argv shape — no new production logic.

## Evidence

- **AC-1..AC-4 (Go tests, independently re-run):** `TestPiFrontDoorAcceptsSafehouseFlags` (9 subtests), the AC-2 wrap family (`WrapsWhenKnobPresent` with `extra` matching real `safehouse.TranslateFlags`, `PlainWhenNoTrigger`, `WrapsWhenSafehouseProfileAlone`, `UnknownSafehouseKeyErrors`), `TestPiFrontDoorWrapInnerEqualsUnwrapped` (Decision 1 — wrapped inner == unwrapped inner), `TestPiHelpCarriesSafehouseDetail` — all PASS post-merge-fix.
- **Race + gofmt:** `go test ./internal/cli/... -race` green; `gofmt -l` clean on the 3 files.
- **Region discipline:** touches only `qn`'s owned regions (`parsePiFrontDoorArgs`/`runPi`-wrap-assembly/`setPiHelp`); `internal/safehouse` reused unchanged; `eq`'s `runInitWithPi`/`piRuntimeConfigFromEnv`/`checkPiRuntime` untouched.
- **pi-live lane (live write-grant proof, from validation):** built binary drove `spacedock pi --safehouse-add-dirs /tmp/qn-probe -- ...` → banner `Sandbox: enabled (safehouse)`; `safehouse --add-dirs=/tmp/qn-probe -- /bin/sh -c 'echo HELLO > /tmp/qn-probe/sh-marker.txt'` → exit 0, file written (the wrap arm grants access correctly).
- **Non-regression:** `go test ./...` green (incl. `internal/status` — the pre-existing debrief-fixture failure was fixed separately on main).

CI: `pi-live` lane required (pi-only front-door surfaces). No claude/codex live lanes (no `frontdoor.go`/`safehouse`/`contractlint`/`hostneutrality` changes).

### Out-of-scope follow-up (does not block this merge)

The inner *pi* process (a node CLI shim) fails to start inside safehouse with `Cannot find module` — a safehouse×node env-sanitization runtime interaction, reproduced with direct `safehouse … -- pi …`. Orthogonal to the wrap arm (pinned by the green Go tests + the live grant proof); pi never launched under safehouse before this task, so not a regression. Filed as a safehouse-runtime follow-up so the full `spacedock pi --safehouse-*` live round-trip runs green in CI.

---

Sprint: `0223-pi-dispatch-contract` (member 3). Validator: PASSED (run `c1eae5b2`); merge-fix applied (run `b3dfc1dd`). State audit: `qn` entity @ `spacedock-state/dev`.
