### PR TITLE
pi: honor --plugin-dir/SPACEDOCK_REPO_ROOT dev override in package-OK gate

### DIFF
--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -359,6 +359,24 @@ func checkPiRuntime(ops piRuntimeOps, cfg piRuntimeConfig) piCheckResult {
 	status := ops.SpacedockPackageStatus(cfg.agentDir, cfg.home)
 	res.packageStatus = status
 	res.spacedockPackageOK = status.registered && status.ensignDiscoverable
+	// Dev override: --plugin-dir / SPACEDOCK_REPO_ROOT points at a local
+	// Spacedock checkout. When the package is not registered in settings.json
+	// (e.g. a fresh pi-home), the dev-override checkout satisfies the gate if
+	// it contains the ensign skill (skills/ensign/SKILL.md). This restores the
+	// documented dev-override launch path that the package-OK gate
+	// inadvertently broke. When repoRoot is empty, spacedockPackageOK still
+	// requires the registered package (the install-managed contract).
+	if !res.spacedockPackageOK && cfg.repoRoot != "" &&
+		ops.Stat(filepath.Join(cfg.repoRoot, "skills", "ensign", "SKILL.md")) == nil {
+		res.spacedockPackageOK = true
+		res.packageStatus = piPackageStatus{
+			registered:               true,
+			ensignDiscoverable:       true,
+			firstOfficerDiscoverable: ops.Stat(filepath.Join(cfg.repoRoot, "skills", "first-officer", "SKILL.md")) == nil,
+			source:                   cfg.repoRoot + " (dev override)",
+			packageRoot:              cfg.repoRoot,
+		}
+	}
 	return res
 }
 

--- a/internal/cli/pi_frontdoor_test.go
+++ b/internal/cli/pi_frontdoor_test.go
@@ -535,6 +535,102 @@ func TestPiDoctorReportsMissingAndHealthyRuntime(t *testing.T) {
 	})
 }
 
+// TestPiRuntimeDevOverrideSatisfiesPackageGate verifies the regression fix for
+// the --plugin-dir / SPACEDOCK_REPO_ROOT dev-override launch path: when the
+// Spacedock package is NOT registered in settings.json (fresh pi-home), a
+// dev-override repoRoot that contains skills/ensign/SKILL.md satisfies the
+// package gate so the launch path reaches the ensign. The inverse (no
+// repoRoot, no package) still fails the gate — the install-managed contract.
+func TestPiRuntimeDevOverrideSatisfiesPackageGate(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+
+	t.Run("dev override satisfies gate without installed package", func(t *testing.T) {
+		home := t.TempDir()
+		cfg := piRuntimeConfigFromEnv(append(piTestEnv(pkg, home), "SPACEDOCK_REPO_ROOT="+repo), "/non-repo-cwd", "")
+		if cfg.repoRoot != repo {
+			t.Fatalf("cfg.repoRoot=%q want %q", cfg.repoRoot, repo)
+		}
+		check := checkPiRuntime(&fakePiRuntimeOps{
+			lookPath: piHealthyPathFixtures(),
+			statOK:   statOKForPiResources(repo, pkg),
+			// No package registered in settings.json.
+			packageStatus: piPackageStatus{},
+		}, cfg)
+		if !check.spacedockPackageOK {
+			t.Fatalf("dev override should satisfy spacedockPackageOK; packageStatus=%+v", check.packageStatus)
+		}
+		if !piRuntimeLaunchReady(check) {
+			t.Fatalf("dev override should make runtime launch-ready; check=%+v", check)
+		}
+		if check.packageStatus.source != repo+" (dev override)" {
+			t.Fatalf("packageStatus.source=%q want %q", check.packageStatus.source, repo+" (dev override)")
+		}
+		if check.packageStatus.packageRoot != repo {
+			t.Fatalf("packageStatus.packageRoot=%q want %q", check.packageStatus.packageRoot, repo)
+		}
+	})
+
+	t.Run("runPi launches with dev override and no installed package", func(t *testing.T) {
+		home := t.TempDir()
+		var stdout, stderr bytes.Buffer
+		code := runPi(context.Background(), []string{"do work", "--plugin-dir", repo, "--", "--print"}, "/non-repo-cwd",
+			append(piTestEnv(pkg, home)), &fakePiRuntimeOps{
+				lookPath:      piHealthyPathFixtures(),
+				statOK:        statOKForPiResources(repo, pkg),
+				packageStatus: piPackageStatus{}, // not installed
+			}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("runPi exit=%d want 0; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+		}
+		if strings.Contains(stdout.String(), "MISSING Spacedock package") {
+			t.Fatalf("dev override must not report MISSING Spacedock package:\n%s", stdout.String())
+		}
+	})
+
+	t.Run("no repoRoot and no package fails gate", func(t *testing.T) {
+		home := t.TempDir()
+		cfg := piRuntimeConfigFromEnv(piTestEnv(pkg, home), "/non-repo-cwd", "")
+		if cfg.repoRoot != "" {
+			t.Fatalf("cfg.repoRoot=%q want empty", cfg.repoRoot)
+		}
+		check := checkPiRuntime(&fakePiRuntimeOps{
+			lookPath:      piHealthyPathFixtures(),
+			statOK:        statOKForPiResources(t.TempDir(), pkg),
+			packageStatus: piPackageStatus{},
+		}, cfg)
+		if check.spacedockPackageOK {
+			t.Fatalf("without repoRoot or installed package, spacedockPackageOK should be false")
+		}
+		if piRuntimeLaunchReady(check) {
+			t.Fatalf("without repoRoot or installed package, runtime should not be launch-ready")
+		}
+	})
+
+	t.Run("dev override without ensign skill does not satisfy gate", func(t *testing.T) {
+		bareRepo := t.TempDir() // no skills/ensign/SKILL.md
+		home := t.TempDir()
+		statOK := map[string]bool{
+			filepath.Join(pkg, "src", "extension", "index.ts"):          true,
+			filepath.Join(pkg, "skills", "pi-subagents", "SKILL.md"):    true,
+			filepath.Join(pkg, "src", "intercom", "intercom-bridge.ts"): true,
+			pkg + "-intercom": true,
+			filepath.Join(pkg+"-intercom", "skills", "pi-intercom", "SKILL.md"): true,
+		}
+		cfg := piRuntimeConfigFromEnv(append(piTestEnv(pkg, home), "SPACEDOCK_REPO_ROOT="+bareRepo), "/non-repo-cwd", "")
+		check := checkPiRuntime(&fakePiRuntimeOps{
+			lookPath:      piHealthyPathFixtures(),
+			statOK:        statOK,
+			packageStatus: piPackageStatus{},
+		}, cfg)
+		if check.spacedockPackageOK {
+			t.Fatalf("dev override without ensign skill must not satisfy spacedockPackageOK")
+		}
+	})
+}
+
 func assertEqual(t *testing.T, got, want string) {
 	t.Helper()
 	if got != want {


### PR DESCRIPTION
## Why

Regression fix on `main` (post-`eq` #406). `eq`'s D5b `spacedockPackageOK` gate computed readiness only from `settings.json` `packages`, ignoring the `--plugin-dir`/`SPACEDOCK_REPO_ROOT` dev override. So a dev-override launch (`spacedock pi ... --plugin-dir <repo>`) against a fresh pi-home with no installed package reported `MISSING Spacedock package` → `piRuntimeLaunchReady` false → `runPi` bailed with "Pi runtime is not ready" before reaching the ensign.

This broke the `pi-live` lane on `qn` PR #407: `TestLivePiFrontDoorSmoke` runs `binary pi <prompt> --plugin-dir <repo> -- --print ...` against a temp pi-home with no install, and post-`eq` the gate bailed. `eq`'s unit tests didn't catch it (they stub `spacedockPackageOK` via the fake); the live lane did — exactly its purpose. `--plugin-dir` is the documented dev-override escape hatch (`piRuntimeConfigFromEnv`: "repoRoot is the dev-override path only"); the gate must honor it.

## What changed

`internal/cli/pi.go` `checkPiRuntime`: after computing `status := ops.SpacedockPackageStatus(...)`, when `!spacedockPackageOK && cfg.repoRoot != "" && ops.Stat(filepath.Join(cfg.repoRoot, "skills", "ensign", "SKILL.md")) == nil`, treat the gate as satisfied by the dev override — set `spacedockPackageOK = true` and record the override in `packageStatus` (`source: <repoRoot> (dev override)`, `packageRoot: repoRoot`) so the doctor report shows it instead of `MISSING`. When `repoRoot` is empty, `spacedockPackageOK` still requires the registered package — the install-managed contract is unchanged.

## Evidence

- **New test** `TestPiRuntimeDevOverrideSatisfiesPackageGate` (4 subtests, independently re-run PASS): (1) dev override satisfies gate without installed package; (2) `runPi` launches with dev override + no package (exit 0, no MISSING); (3) no repoRoot + no package fails the gate (unchanged); (4) dev override **without** the ensign skill does NOT satisfy the gate (negative — the `Stat` guard is real).
- **Regression test** `TestPiRuntimeConfigRetiresSkillFlagsAndCwdFallback` still PASS (eq's retirement intact).
- `go test ./internal/cli/ ./internal/ensigncycle/ -race` green; `go test ./...` all ok; `gofmt -l` clean on touched files.
- Scoped: `internal/cli/pi.go` (the fix) + `internal/cli/pi_frontdoor_test.go` (the test). No other files.

CI: `pi-live` lane is the live proof — this fix restores the `--plugin-dir` launch path so `TestLivePiFrontDoorSmoke` reaches the ensign. Unblocks `qn` #407.

---

Sprint: `0223-pi-dispatch-contract` (regression fix on `eq`'s D5b, surfaced by `qn` #407's `pi-live` lane). State audit: `pi-devoverride-package-ok` entity @ `spacedock-state/dev`.
