### PR TITLE
spacedock claude exports CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 so FO sessions get the worker back-channel

### DIFF
--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -54,11 +54,11 @@ var executablePath = os.Executable
 
 const spacedockBinEnv = "SPACEDOCK_BIN"
 
-// agentTeamsEnv gates claude's worker↔FO back-channel (SendMessage/TeamCreate).
-// It is OFF by default in claude, so a first-officer session launched without it
-// can spawn named background agents but cannot address them. The `spacedock
-// claude` launcher enables it by construction so the FO contract's back-channel
-// assumption holds.
+// agentTeamsEnv is the env flag associated with claude's worker↔FO back-channel
+// (SendMessage/TeamCreate). The authoritative enabler is ~/.claude/settings.json
+// (env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 + teammateMode:auto), which re-applies
+// the flag to every child regardless of shell env; the launcher export below does
+// NOT independently enable the feature.
 const agentTeamsEnv = "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"
 
 func launchEnv(parent []string) []string {
@@ -69,9 +69,11 @@ func launchEnv(parent []string) []string {
 	return env
 }
 
-// withAgentTeams enables the claude back-channel in the launched child env unless
-// the parent already set agentTeamsEnv — an explicit operator value (even =0) is
-// preserved. Claude-only: codex/pi launch paths do not call this.
+// withAgentTeams sets agentTeamsEnv=1 in the launched child env unless the parent
+// already set it — an explicit operator value (even =0) is preserved. This is a
+// best-effort export for users without the authoritative settings.json enabler
+// (see agentTeamsEnv) and a no-op when settings already enable it; it does NOT
+// independently enable the back-channel. Claude-only: codex/pi do not call this.
 func withAgentTeams(env []string) []string {
 	if hasEnv(env, agentTeamsEnv) {
 		return env

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -54,12 +54,39 @@ var executablePath = os.Executable
 
 const spacedockBinEnv = "SPACEDOCK_BIN"
 
+// agentTeamsEnv gates claude's worker↔FO back-channel (SendMessage/TeamCreate).
+// It is OFF by default in claude, so a first-officer session launched without it
+// can spawn named background agents but cannot address them. The `spacedock
+// claude` launcher enables it by construction so the FO contract's back-channel
+// assumption holds.
+const agentTeamsEnv = "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"
+
 func launchEnv(parent []string) []string {
 	env := withoutEnv(parent, spacedockBinEnv)
 	if bin, ok := resolvedLauncherBin(); ok {
 		env = append(env, spacedockBinEnv+"="+bin)
 	}
 	return env
+}
+
+// withAgentTeams enables the claude back-channel in the launched child env unless
+// the parent already set agentTeamsEnv — an explicit operator value (even =0) is
+// preserved. Claude-only: codex/pi launch paths do not call this.
+func withAgentTeams(env []string) []string {
+	if hasEnv(env, agentTeamsEnv) {
+		return env
+	}
+	return append(env, agentTeamsEnv+"=1")
+}
+
+func hasEnv(env []string, key string) bool {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // launcherBinEnvPassFlags returns the `--env-pass SPACEDOCK_BIN` safehouse flags
@@ -345,7 +372,7 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 		argv = safehouse.Wrap(inner, append(launcherBinEnvPassFlags(), extra...))
 	}
 
-	if err := ops.Launch(argv, launchEnv(os.Environ())); err != nil {
+	if err := ops.Launch(argv, withAgentTeams(launchEnv(os.Environ()))); err != nil {
 		fmt.Fprintf(stderr, "spacedock claude: launch failed: %v\n", err)
 		return 1
 	}

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -243,6 +243,46 @@ func TestClaudeFrontDoorLaunchEnvResolvesSymlink(t *testing.T) {
 	}
 }
 
+// TestClaudeFrontDoorEnablesAgentTeamsWhenParentUnset (AC-1): with no parent
+// value for CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, the launched claude child env
+// carries it set to 1 — the worker↔FO back-channel is reliable by construction
+// rather than ambient-env-dependent.
+func TestClaudeFrontDoorEnablesAgentTeamsWhenParentUnset(t *testing.T) {
+	t.Setenv(agentTeamsEnv, "") // register restore-on-cleanup, then unset for real
+	os.Unsetenv(agentTeamsEnv)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	got, ok := envValue(fake.launchedEnv, agentTeamsEnv)
+	if !ok || got != "1" {
+		t.Fatalf("%s in launch env = %q, %v; want %q, true (env=%v)", agentTeamsEnv, got, ok, "1", fake.launchedEnv)
+	}
+}
+
+// TestClaudeFrontDoorPreservesExplicitAgentTeams (AC-2): an explicit parent value
+// for CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS is preserved, not overridden — an
+// operator who set =0 keeps =0. The launcher respects the override either way.
+func TestClaudeFrontDoorPreservesExplicitAgentTeams(t *testing.T) {
+	t.Setenv(agentTeamsEnv, "0")
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	got, ok := envValue(fake.launchedEnv, agentTeamsEnv)
+	if !ok || got != "0" {
+		t.Fatalf("%s in launch env = %q, %v; want %q, true (env=%v)", agentTeamsEnv, got, ok, "0", fake.launchedEnv)
+	}
+}
+
 // TestClaudeFrontDoorFailFastOnMismatch (AC-2): a real version mismatch still
 // fails fast even without --no-install — auto-install must NOT paper over an
 // incompatibility. The verdict reaches runClaude's mismatch branch, not the
@@ -613,6 +653,24 @@ func TestCodexFrontDoorInjectsLauncherBinThroughSafehouseResume(t *testing.T) {
 	got, ok := envValue(fake.launchedEnv, spacedockBinEnv)
 	if !ok || got != bin {
 		t.Fatalf("%s in launch env = %q, %v; want %q, true (env=%v)", spacedockBinEnv, got, ok, bin, fake.launchedEnv)
+	}
+}
+
+// TestCodexFrontDoorDoesNotEnableAgentTeams: the agent-teams flag is a
+// claude-only concern; the codex launch path must NOT inject it (scope guard).
+func TestCodexFrontDoorDoesNotEnableAgentTeams(t *testing.T) {
+	t.Setenv(agentTeamsEnv, "") // register restore-on-cleanup, then unset for real
+	os.Unsetenv(agentTeamsEnv)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runCodex(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if got, ok := envValue(fake.launchedEnv, agentTeamsEnv); ok {
+		t.Fatalf("%s in codex launch env = %q, want omitted", agentTeamsEnv, got)
 	}
 }
 

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -245,8 +245,8 @@ func TestClaudeFrontDoorLaunchEnvResolvesSymlink(t *testing.T) {
 
 // TestClaudeFrontDoorEnablesAgentTeamsWhenParentUnset (AC-1): with no parent
 // value for CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, the launched claude child env
-// carries it set to 1 — the worker↔FO back-channel is reliable by construction
-// rather than ambient-env-dependent.
+// carries it set to 1 — a best-effort export, not the authoritative enabler (the
+// authoritative enabler is ~/.claude/settings.json; see agentTeamsEnv).
 func TestClaudeFrontDoorEnablesAgentTeamsWhenParentUnset(t *testing.T) {
 	t.Setenv(agentTeamsEnv, "") // register restore-on-cleanup, then unset for real
 	os.Unsetenv(agentTeamsEnv)


### PR DESCRIPTION
spacedock claude sets CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in the launched claude child env (preserving an explicit override) — best-effort toward the worker back-channel.

## What changed
- Add `withAgentTeams`: inject `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` into the claude child env when the parent is unset.
- Preserve an explicit parent value (even `=0`); scoped to the claude launch path (codex/pi untouched).

## Evidence
- `go test ./internal/cli/`: AgentTeams 3/3 passed (set-when-unset, preserve-explicit, codex scope-guard); AC-1 mutation-verified load-bearing.
- Local exec-path check: a stub `claude` child reports the flag in its received env.

## Review guidance
- The authoritative enabler is `~/.claude/settings.json` (`env` flag + `teammateMode: auto`); this launcher export is best-effort and a no-op when settings already enable it — it does not independently enable the feature.

---
[66](/spacedock-dev/spacedock/blob/51c783c2/docs/dev/.spacedock-state/claude-launch-agent-teams-flag.md)
