### PR TITLE
status --validate non-deterministic on untracked entity files (root cause of escaped blank-id)

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -221,7 +221,7 @@ Validation pilots should use these when verifying implementation work:
 | Clean log + `-json` archive from one run | `gotestsum --jsonfile detail.jsonl --format pkgname -- ./pkg` | The live-CI test-output shape: a clean step log (per-package progress + an `=== Failed` recap with `file:line`) plus a full `-json` archive, from a single run, with the `go test` exit preserved. Locally: `go install gotest.tools/gotestsum@v1.13.0` (the version CI pins), or run `.github/scripts/install-gotestsum.sh` for the same sha256-verified prebuilt. Inspect the archive with `grep '"Action":"fail"' detail.jsonl` or a `go tool test2json`-aware reader. |
 | Launcher help smoke test | `go run ./cmd/spacedock --help` | Basic command entrypoint behavior |
 | Launcher version smoke test | `go run ./cmd/spacedock --version` | Basic version output behavior |
-| Status validator | `spacedock status --workflow-dir docs/dev --validate` | Spacedock entity-contract validation |
+| Status validator | `spacedock status --workflow-dir docs/dev --validate` from the repo root, or pass an absolute workflow definition dir | Spacedock entity-contract validation; fails closed if `--workflow-dir` does not resolve to a commissioned workflow |
 | Status table | `spacedock status --workflow-dir docs/dev` | Status enumeration output |
 | State behavior extension | `docs/specs/state-behavior-extension.md` | Split-root state semantics and external tracker bridge principles |
 | Bootstrap roadmap | `docs/roadmap/bootstrap-roadmap.md` | Stage-specific required tests |

--- a/internal/status/native_runner.go
+++ b/internal/status/native_runner.go
@@ -178,6 +178,11 @@ func dispatch(probe claudeteam.TeamStateProbe, args []string, dir string, e env,
 			return errExit(stderr, "this is a state checkout; point --workflow-dir at the definition dir (the one whose README declares state:): "+defDir)
 		}
 	}
+	if showValidate {
+		if rc := validateRootsOrExit(roots, rootPath, stderr); rc != 0 {
+			return rc
+		}
+	}
 
 	// --new atomic create.
 	if newSlug != "" {

--- a/internal/status/roots.go
+++ b/internal/status/roots.go
@@ -4,6 +4,8 @@ package status
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -62,6 +64,34 @@ func resolveRoots(workflowDir, baseDir string) (roots, error) {
 	r.entityDir = filepath.Join(abs, relPath)
 	r.entityDirSpelling = PyJoin(spellingOr(workflowDir, abs), relPath)
 	return r, nil
+}
+
+// validateRootsOrExit makes the explicit --validate surface fail closed: it must
+// certify a commissioned workflow definition dir and, for split-root workflows,
+// an existing state entity dir. The default table path intentionally keeps its
+// historical empty-dir compatibility and does not call this guard.
+func validateRootsOrExit(roots roots, rootPath string, stderr io.Writer) int {
+	if rootPath != "" {
+		return 0
+	}
+	readme := filepath.Join(roots.definitionDir, "README.md")
+	if !(isRegularFile(readme) && len(parseStagesBlock(readme)) > 0) {
+		if defDir, ok := stateCheckoutParent(roots.definitionDir); ok {
+			return errExit(stderr, "this is a state checkout; point --workflow-dir at the definition dir (the one whose README declares state:): "+defDir)
+		}
+		return errExit(stderr, "--validate requires --workflow-dir to resolve to a commissioned Spacedock workflow: "+roots.definitionDir)
+	}
+	mode, relPath, err := ClassifyState(ParseFrontmatter(readme)["state"])
+	if err != nil {
+		return errExit(stderr, err.Error())
+	}
+	if mode == StateSplitRoot {
+		info, statErr := os.Stat(roots.entityDir)
+		if statErr != nil || !info.IsDir() {
+			return errExit(stderr, "--validate requires state checkout directory declared by README state: "+relPath+" at "+roots.entityDir)
+		}
+	}
+	return 0
 }
 
 // mergePolicy is a workflow's declared merge policy, read from the README's

--- a/internal/status/validate_roots_test.go
+++ b/internal/status/validate_roots_test.go
@@ -1,0 +1,157 @@
+package status
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func splitRootValidationFixture(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	def := filepath.Join(root, "docs", "dev")
+	state := filepath.Join(def, ".spacedock-state")
+	writeFile(t, filepath.Join(def, "README.md"), `---
+commissioned-by: spacedock@test
+entity-type: task
+id-style: sequential
+state: .spacedock-state
+stages:
+  states:
+    - name: backlog
+      initial: true
+    - name: done
+      terminal: true
+---
+
+# Dev Workflow
+`)
+	if err := os.MkdirAll(state, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitInit(t, root)
+	return def, state
+}
+
+func hookEnv(t *testing.T, base []string, state string) []string {
+	t.Helper()
+	gitDir := filepath.Join(state, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	index := filepath.Join(t.TempDir(), "index")
+	return append(append([]string{}, base...),
+		"GIT_DIR="+gitDir,
+		"GIT_INDEX_FILE="+index,
+	)
+}
+
+func commitAll(t *testing.T, dir, msg string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"-c", "user.email=t@t", "-c", "user.name=t", "add", "-A"},
+		{"-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", msg},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+func TestValidateFailsClosedForMisresolvedSplitRoot(t *testing.T) {
+	def, state := splitRootValidationFixture(t)
+	baseEnv := pinnedEnv(t)
+	envs := map[string][]string{
+		"clean": baseEnv,
+		"hook":  hookEnv(t, baseEnv, state),
+	}
+	cases := map[string]string{
+		"state-cwd":      state,
+		"definition-cwd": def,
+	}
+
+	for envName, env := range envs {
+		for cwdName, cwd := range cases {
+			t.Run(envName+"/"+cwdName, func(t *testing.T) {
+				out, errOut, code := runNative(t, cwd, env, "--workflow-dir", "docs/dev", "--validate")
+				if code == 0 {
+					t.Fatalf("wrong root returned success: stdout=%q stderr=%q", out, errOut)
+				}
+				if strings.Contains(out, "VALID") {
+					t.Fatalf("wrong root must not print VALID, stdout=%q", out)
+				}
+				if !strings.Contains(errOut, "--validate requires --workflow-dir to resolve to a commissioned Spacedock workflow") {
+					t.Fatalf("stderr missing root-resolution error, got %q", errOut)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateReportsUntrackedBlankIDFlatAndFolderEntities(t *testing.T) {
+	def, state := splitRootValidationFixture(t)
+	writeFile(t, filepath.Join(state, "blank-flat.md"), "---\nid:\ntitle: Flat\nstatus: backlog\n---\n# Flat\n")
+	writeFile(t, filepath.Join(state, "blank-folder", "index.md"), "---\nid:\ntitle: Folder\nstatus: backlog\n---\n# Folder\n")
+	baseEnv := pinnedEnv(t)
+	envs := map[string][]string{
+		"clean": baseEnv,
+		"hook":  hookEnv(t, baseEnv, state),
+	}
+
+	for envName, env := range envs {
+		t.Run(envName, func(t *testing.T) {
+			for i := 0; i < 5; i++ {
+				out, errOut, code := runNative(t, state, env, "--workflow-dir", def, "--validate")
+				if code == 0 {
+					t.Fatalf("run %d returned success: stdout=%q stderr=%q", i, out, errOut)
+				}
+				if strings.Contains(out, "VALID") {
+					t.Fatalf("run %d must not print VALID, stdout=%q", i, out)
+				}
+				for _, want := range []string{
+					"Error: missing required id:",
+					"slug=blank-flat",
+					"slug=blank-folder",
+				} {
+					if !strings.Contains(errOut, want) {
+						t.Fatalf("run %d stderr missing %q, got %q", i, want, errOut)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestValidateKeepsTrackedStagedCommittedEntitiesWhileFailingBadUntracked(t *testing.T) {
+	def, state := splitRootValidationFixture(t)
+	writeFile(t, filepath.Join(state, "committed.md"), ent(`"001"`, "backlog"))
+	commitAll(t, filepath.Dir(filepath.Dir(def)), "committed state entity")
+	writeFile(t, filepath.Join(state, "staged.md"), ent(`"002"`, "backlog"))
+	cmd := exec.Command("git", "-C", filepath.Dir(filepath.Dir(def)), "add", filepath.Join(state, "staged.md"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add staged entity: %v\n%s", err, out)
+	}
+	writeFile(t, filepath.Join(state, "untracked-good.md"), ent(`"003"`, "done"))
+	writeFile(t, filepath.Join(state, "bad-untracked.md"), "---\nid:\ntitle: Bad\nstatus: backlog\n---\n# Bad\n")
+
+	out, errOut, code := runNative(t, state, pinnedEnv(t), "--workflow-dir", def, "--validate")
+	if code == 0 {
+		t.Fatalf("bad untracked sibling should fail validation: stdout=%q stderr=%q", out, errOut)
+	}
+	if strings.Contains(out, "VALID") {
+		t.Fatalf("validation failure must not print VALID, stdout=%q", out)
+	}
+	for _, want := range []string{"slug=bad-untracked", "Error: missing required id:"} {
+		if !strings.Contains(errOut, want) {
+			t.Fatalf("stderr missing %q, got %q", want, errOut)
+		}
+	}
+	for _, notWant := range []string{"slug=committed", "slug=staged", "slug=untracked-good"} {
+		if strings.Contains(errOut, notWant) {
+			t.Fatalf("valid tracked/staged/committed entity reported as invalid: %q", errOut)
+		}
+	}
+}


### PR DESCRIPTION
Validation now fails closed for bad workflow roots while still scanning real split-root entity files.

## What changed

- Reject misresolved validation roots before entity validation.
- Preserve default status output compatibility.
- Add blank-id flat and folder entity regression tests.
- Document repo-root or absolute-dir validation usage.

## Evidence

- `go test ./...`: 1642/1642 passed.
- `go test ./... -race`: 1642/1642 passed.
- Adversarial audit made the wrong-root test fail before restoring the guard.

---

[a1](/spacedock-dev/spacedock/blob/5ac2de8df0932ceada9bca6a87e264c409df414a/status-validate-determinism/index.md)
