### PR TITLE
pi: resolve fnm multishell race + workspace-rooted safehouse grant (env-forwarding)

### DIFF
--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -59,6 +59,36 @@ func (execPiRuntimeOps) LookPath(name string) (string, error) { return exec.Look
 func (execPiRuntimeOps) Stat(path string) error               { _, err := os.Stat(path); return err }
 func (execPiRuntimeOps) Launch(argv []string) error           { return execHost{}.Launch(argv, os.Environ()) }
 
+// resolveFnmMultishellPi resolves a looked-up `pi` path that lives under fnm's
+// per-shell multishell symlink farm to its stable node-installation bin, so the
+// launched argv[0] points at a path fnm never tears down. fnm creates
+// `~/.local/state/fnm_multishells/<pid>_<ts>/bin` per shell and unlinks the
+// `<pid>_<ts>` symlink on shell exit; between Go's LookPath and the child Node's
+// Module._resolveFilename (milliseconds later) a sibling shell exiting can
+// ENOENT the multishell path. The stable install bin's parent
+// (`~/.local/share/fnm/node-versions/<ver>/installation/bin`) is a real dir fnm
+// never tears down. lookedUp is the result of ops.LookPath("pi"). On any miss,
+// resolution failure, or when lookedUp is already the stable path, it returns
+// ("", false) so runPi leaves argv[0] untouched (no regression).
+func resolveFnmMultishellPi(lookedUp string) (stable string, ok bool) {
+	if !strings.Contains(lookedUp, "/fnm_multishells/") {
+		return "", false
+	}
+	binDir := filepath.Dir(lookedUp)
+	stableDir, err := filepath.EvalSymlinks(binDir)
+	if err != nil {
+		return "", false
+	}
+	stable = filepath.Join(stableDir, "pi")
+	if _, err := os.Lstat(stable); err != nil {
+		return "", false
+	}
+	if stable == lookedUp {
+		return "", false
+	}
+	return stable, true
+}
+
 func (execPiRuntimeOps) PiInstall(source string) (string, error) {
 	out, err := exec.Command("pi", "install", source).CombinedOutput()
 	return string(out), err
@@ -159,6 +189,15 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 			return 1
 		}
 		argv = safehouse.Wrap(argv, extra)
+	}
+	// Resolve the fnm per-shell multishell symlink to its stable node-installation
+	// bin so execHost.Launch's stdlib exec.LookPath(<absolute>) hands Node a script
+	// path fnm never tears down. On any miss/failure argv[0] stays "pi" (current
+	// behavior, no regression on non-fnm setups or direct installs).
+	if lp, err := ops.LookPath("pi"); err == nil {
+		if stable, ok := resolveFnmMultishellPi(lp); ok {
+			argv[0] = stable
+		}
 	}
 	if err := ops.Launch(argv); err != nil {
 		fmt.Fprintf(stderr, "spacedock pi: launch failed: %v\n", err)

--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -29,7 +29,7 @@ const piSpacedockPackageSource = "git:github.com/spacedock-dev/spacedock"
 type piRuntimeOps interface {
 	LookPath(name string) (string, error)
 	Stat(path string) error
-	Launch(argv []string) error
+	Launch(argv []string, env []string) error
 	// PiInstall runs `pi install <source>` and returns its combined output. The
 	// real implementation execs `pi`; tests record the source and return canned
 	// output. This is the install seam that retires Pi's check-only status.
@@ -57,7 +57,9 @@ type execPiRuntimeOps struct{}
 
 func (execPiRuntimeOps) LookPath(name string) (string, error) { return exec.LookPath(name) }
 func (execPiRuntimeOps) Stat(path string) error               { _, err := os.Stat(path); return err }
-func (execPiRuntimeOps) Launch(argv []string) error           { return execHost{}.Launch(argv, os.Environ()) }
+func (execPiRuntimeOps) Launch(argv []string, env []string) error {
+	return execHost{}.Launch(argv, env)
+}
 
 // resolveFnmMultishellPi resolves a looked-up `pi` path that lives under fnm's
 // per-shell multishell symlink farm to its stable node-installation bin, so the
@@ -87,6 +89,66 @@ func resolveFnmMultishellPi(lookedUp string) (stable string, ok bool) {
 		return "", false
 	}
 	return stable, true
+}
+
+// fnmStableSandboxDir computes the safehouse --add-dirs grant that makes the
+// sandbox see the stable `pi` Node is handed under wrap, so the sandboxed launch
+// resolves and loads the script + its hoisted deps (feedback cycle 2). The
+// stable `pi` is a symlink chain: installation/bin/pi ->
+// installation/lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js,
+// and in a dev-link (npm link) install @earendil-works/pi-coding-agent is ITSELF
+// a symlink out to a monorepo (e.g. ~/git/pi-mono/packages/coding-agent). So the
+// real script escapes the fnm installation, and granting just the bin dir (or
+// the installation) is insufficient — Node must traverse the chain AND require
+// the package's runtime deps, which are hoisted to a workspace/dep root's
+// node_modules. realScript is filepath.EvalSymlinks(stable) (the real cli.js).
+// Walk up from its dir; grant the first ancestor that (a) contains a node_modules
+// dir AND (b) is a workspace root (package.json with a `workspaces` key) — that
+// is the dep-hoist root for the script. If no workspace root is found, grant the
+// HIGHEST ancestor containing node_modules (the top of the node_modules-bearing
+// subtree — the normal `npm i -g` case lands on installation/lib, which covers
+// the pi package + all its deps). Returns "" on failure so runPi omits the grant
+// (never blocks the launch). Targeted — grants pi's actual code+dep tree, not
+// the whole filesystem.
+func fnmStableSandboxDir(stable string) string {
+	realScript, err := filepath.EvalSymlinks(stable)
+	if err != nil || realScript == "" {
+		return ""
+	}
+	dir := filepath.Dir(realScript)
+	var highestNodeModules string
+	for {
+		if info, err := os.Stat(filepath.Join(dir, "node_modules")); err == nil && info.IsDir() {
+			if isWorkspaceRoot(dir) {
+				return dir
+			}
+			highestNodeModules = dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return highestNodeModules
+}
+
+// isWorkspaceRoot reports whether dir carries a package.json with a `workspaces`
+// key (the monorepo/workspace root signal). A missing or null workspaces entry
+// does not count.
+func isWorkspaceRoot(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return false
+	}
+	var pkg struct {
+		Workspaces json.RawMessage `json:"workspaces"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false
+	}
+	ws := strings.TrimSpace(string(pkg.Workspaces))
+	return ws != "" && ws != "null"
 }
 
 func (execPiRuntimeOps) PiInstall(source string) (string, error) {
@@ -152,11 +214,12 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 	// Translate the de-prefixed safehouse knobs into the safehouse `extra` slot
 	// (the same function claude/codex use) and compute the wrap decision identically:
 	// a `.safehouse` profile in dir, the bare `--safehouse` flag, or any knob. An
-	// unknown key is a hard error (no Launch), mirroring the claude/codex gate. Per
-	// PI-SPECIFIC DECISION 2, the wrap arm uses safehouse.Wrap(inner, extra) with NO
-	// launcherBinEnvPassFlags() and NO launchEnv threading — runPi/execPiRuntimeOps
-	// never forward SPACEDOCK_BIN today (Launch takes no env), so the minimal wrap
-	// introduces no regression.
+	// unknown key is a hard error (no Launch), mirroring the claude/codex gate. The
+	// wrap arm mirrors claude/codex's env-forwarding plumbing (frontdoor.go:345):
+	// launcherBinEnvPassFlags() carries SPACEDOCK_BIN through the sandbox via
+	// --env-pass and Launch is called with launchEnv(os.Environ()); the pi-specific
+	// load-bearing addition is --safehouse-add-dirs <fnm-install-bin-dir> (see the
+	// resolution block below) so the sandbox can see the stable `pi` it is handed.
 	extra, err := safehouse.TranslateFlags(fd.safehouseFlags)
 	if err != nil {
 		fmt.Fprintf(stderr, "spacedock pi: %v\n", err)
@@ -186,28 +249,35 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 	// Resolve the fnm per-shell multishell symlink to its stable node-installation
 	// bin so execHost.Launch's stdlib exec.LookPath(<absolute>) hands Node a script
 	// path fnm never tears down. On any miss/failure argv[0] stays "pi" (current
-	// behavior, no regression on non-fnm setups or direct installs). This resolution
-	// is GATED to the non-wrap path only: under safehouse the inner command execs
-	// INSIDE the sandbox, whose filesystem view does not include
-	// ~/.local/share/fnm/node-versions/... (not the workdir, not added via
-	// --safehouse-add-dirs), so handing safehouse the stable ABSOLUTE path as the
-	// inner token makes Node's Module._resolveFilename fail with MODULE_NOT_FOUND
-	// (manual pi-live smoke, feedback cycle 1 revised). Instead, under wrap we
-	// leave argv[0]="pi" and let safehouse exec the BARE name, which resolves via
-	// the sandbox's PATH — mirroring claude/codex (frontdoor.go:315,498 pass the
-	// bare name as inner[0] even when wrapped). The fnm-multishell race then
-	// re-exists under safehouse (safehouse may exec a tearing-down multishell
-	// `pi`); this is NO WORSE than claude/codex today and is a rare shared surface,
-	// recorded as a known limitation. The unsandboxed launch keeps the race fix
-	// (the stable path is visible, no teardown). The real fix for the sandboxed
-	// case is env/PATH forwarding into the sandbox (the qn-deferred Decision 2,
-	// SPACEDOCK_BIN-through-sandbox, requires a Launch(argv, env) signature
-	// change) — deferred, out of scope here.
-	if !wrap {
-		if lp, err := ops.LookPath("pi"); err == nil {
-			if stable, ok := resolveFnmMultishellPi(lp); ok {
-				argv[0] = stable
-			}
+	// behavior, no regression on non-fnm setups or direct installs). The resolution
+	// applies ALWAYS — wrap or not (feedback cycle 2). The prior cycles each did
+	// only half: cycle-1 reorder resolved the stable ABSOLUTE path under wrap, but
+	// the sandbox's filesystem view does not include ~/.local/share/fnm/
+	// node-versions/... (not the workdir, not added) → Node's
+	// Module._resolveFilename failed with MODULE_NOT_FOUND on the stable path;
+	// cycle-1-revised gated the resolution to !wrap and left the bare "pi" under
+	// wrap, but the sandbox PRESERVES the inherited PATH, which carried a stale
+	// (tearing-down) fnm_multishells/<pid>_<ts> dir → MODULE_NOT_FOUND on the
+	// multishell path. The coupled fix (feedback cycle 2, captain-approved reframe):
+	// resolve the stable path ALWAYS, AND under wrap grant the sandbox visibility
+	// of pi's ACTUAL code + hoisted deps via --safehouse-add-dirs <grant>. The
+	// root cause under safehouse is filesystem VISIBILITY, not only the multishell
+	// teardown: the stable `pi` is a symlink chain that escapes the fnm
+	// installation (in a dev-link install, out to a monorepo like ~/git/pi-mono),
+	// and the .safehouse profile grants only the workdir, so the sandbox sees
+	// neither the multishell dir, the installation, nor the dev-link target. The
+	// grant is computed by fnmStableSandboxDir from the FULLY RESOLVED real script
+	// — the workspace root (package.json with `workspaces`) whose node_modules
+	// holds the hoisted runtime deps, or the highest node_modules-bearing ancestor
+	// (the normal npm-i-g install lands on installation/lib). Under !wrap the
+	// stable path is visible (no sandbox) → deterministic; under wrap the grant
+	// makes the resolved code+deps visible → deterministic. The race/visibility
+	// gap is closed for both.
+	fnmSandboxDir := ""
+	if lp, err := ops.LookPath("pi"); err == nil {
+		if stable, ok := resolveFnmMultishellPi(lp); ok {
+			argv[0] = stable
+			fnmSandboxDir = fnmStableSandboxDir(stable)
 		}
 	}
 	if wrap {
@@ -215,9 +285,22 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 			fmt.Fprintln(stderr, hint)
 			return 1
 		}
-		argv = safehouse.Wrap(argv, extra)
+		// Mirror claude/codex's wrap plumbing (frontdoor.go:345):
+		// launcherBinEnvPassFlags() forwards SPACEDOCK_BIN through the sandbox via
+		// --env-pass (launchEnv sets it on the safehouse process; the flag carries
+		// it through) so the launcher the helper calls resolve survives the
+		// boundary. The pi-specific load-bearing addition is
+		// --safehouse-add-dirs <fnmSandboxDir>: the dir whose node_modules holds
+		// the stable `pi`'s real script + hoisted deps (computed by
+		// fnmStableSandboxDir), which the sandbox cannot see by default. Targeted —
+		// grants pi's actual code+dep tree, not the whole filesystem.
+		piExtra := append(launcherBinEnvPassFlags(), extra...)
+		if fnmSandboxDir != "" {
+			piExtra = append(piExtra, "--add-dirs="+fnmSandboxDir)
+		}
+		argv = safehouse.Wrap(argv, piExtra)
 	}
-	if err := ops.Launch(argv); err != nil {
+	if err := ops.Launch(argv, launchEnv(os.Environ())); err != nil {
 		fmt.Fprintf(stderr, "spacedock pi: launch failed: %v\n", err)
 		return 1
 	}

--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -183,21 +183,39 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 	}
 	argv = append(argv, fd.passthrough...)
 	argv = append(argv, launchPrompt(piBootstrapPrompt, fd))
+	// Resolve the fnm per-shell multishell symlink to its stable node-installation
+	// bin so execHost.Launch's stdlib exec.LookPath(<absolute>) hands Node a script
+	// path fnm never tears down. On any miss/failure argv[0] stays "pi" (current
+	// behavior, no regression on non-fnm setups or direct installs). This resolution
+	// is GATED to the non-wrap path only: under safehouse the inner command execs
+	// INSIDE the sandbox, whose filesystem view does not include
+	// ~/.local/share/fnm/node-versions/... (not the workdir, not added via
+	// --safehouse-add-dirs), so handing safehouse the stable ABSOLUTE path as the
+	// inner token makes Node's Module._resolveFilename fail with MODULE_NOT_FOUND
+	// (manual pi-live smoke, feedback cycle 1 revised). Instead, under wrap we
+	// leave argv[0]="pi" and let safehouse exec the BARE name, which resolves via
+	// the sandbox's PATH — mirroring claude/codex (frontdoor.go:315,498 pass the
+	// bare name as inner[0] even when wrapped). The fnm-multishell race then
+	// re-exists under safehouse (safehouse may exec a tearing-down multishell
+	// `pi`); this is NO WORSE than claude/codex today and is a rare shared surface,
+	// recorded as a known limitation. The unsandboxed launch keeps the race fix
+	// (the stable path is visible, no teardown). The real fix for the sandboxed
+	// case is env/PATH forwarding into the sandbox (the qn-deferred Decision 2,
+	// SPACEDOCK_BIN-through-sandbox, requires a Launch(argv, env) signature
+	// change) — deferred, out of scope here.
+	if !wrap {
+		if lp, err := ops.LookPath("pi"); err == nil {
+			if stable, ok := resolveFnmMultishellPi(lp); ok {
+				argv[0] = stable
+			}
+		}
+	}
 	if wrap {
 		if ok, hint := safehouse.Available(ops.LookPath); !ok {
 			fmt.Fprintln(stderr, hint)
 			return 1
 		}
 		argv = safehouse.Wrap(argv, extra)
-	}
-	// Resolve the fnm per-shell multishell symlink to its stable node-installation
-	// bin so execHost.Launch's stdlib exec.LookPath(<absolute>) hands Node a script
-	// path fnm never tears down. On any miss/failure argv[0] stays "pi" (current
-	// behavior, no regression on non-fnm setups or direct installs).
-	if lp, err := ops.LookPath("pi"); err == nil {
-		if stable, ok := resolveFnmMultishellPi(lp); ok {
-			argv[0] = stable
-		}
 	}
 	if err := ops.Launch(argv); err != nil {
 		fmt.Fprintf(stderr, "spacedock pi: launch failed: %v\n", err)

--- a/internal/cli/pi_frontdoor_test.go
+++ b/internal/cli/pi_frontdoor_test.go
@@ -17,6 +17,7 @@ type fakePiRuntimeOps struct {
 	lookPath      map[string]string
 	statOK        map[string]bool
 	launched      []string
+	launchedEnv   []string
 	piInstalls    []string // sources captured by PiInstall
 	piInstallOut  string
 	piInstallErr  error
@@ -37,8 +38,9 @@ func (f *fakePiRuntimeOps) Stat(path string) error {
 	return errors.New("missing")
 }
 
-func (f *fakePiRuntimeOps) Launch(argv []string) error {
+func (f *fakePiRuntimeOps) Launch(argv []string, env []string) error {
 	f.launched = append([]string(nil), argv...)
+	f.launchedEnv = append([]string(nil), env...)
 	return nil
 }
 
@@ -787,8 +789,13 @@ func TestPiFrontDoorWrapsWhenKnobPresent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TranslateFlags err = %v", err)
 	}
+	// Feedback cycle 2: pi now mirrors claude/codex's wrap plumbing —
+	// launcherBinEnvPassFlags() prefixes the safehouse extra with --env-pass
+	// SPACEDOCK_BIN (AC-4) so the launcher the helper calls resolve survives the
+	// sandbox boundary. The operator's add-dirs follows.
+	wantExtra = append(launcherBinEnvPassFlags(), wantExtra...)
 	if !equalArgv(piSafehouseExtra(ops.launched), wantExtra) {
-		t.Fatalf("extra = %v, want TranslateFlags output %v\nargv=%v", piSafehouseExtra(ops.launched), wantExtra, ops.launched)
+		t.Fatalf("extra = %v, want TranslateFlags output prefixed by launcherBinEnvPassFlags %v\nargv=%v", piSafehouseExtra(ops.launched), wantExtra, ops.launched)
 	}
 	inner := piSafehouseInnerArgv(ops.launched)
 	// The retired --skill <repo>/skills/{first-officer,ensign} flags are absent
@@ -830,7 +837,8 @@ func TestPiFrontDoorPlainWhenNoTrigger(t *testing.T) {
 }
 
 // TestPiFrontDoorWrapsWhenSafehouseProfileAlone pins AC-2: a .safehouse profile
-// alone (no flags) also triggers the wrap; the extra slot is empty.
+// alone (no flags) also triggers the wrap; the extra slot carries only the
+// env-pass prefix (launcherBinEnvPassFlags, AC-4) — no operator add-dirs/enables.
 func TestPiFrontDoorWrapsWhenSafehouseProfileAlone(t *testing.T) {
 	repo := t.TempDir()
 	writePiSkillFixtures(t, repo)
@@ -847,8 +855,8 @@ func TestPiFrontDoorWrapsWhenSafehouseProfileAlone(t *testing.T) {
 	if len(ops.launched) == 0 || ops.launched[0] != "safehouse" {
 		t.Fatalf("expected safehouse-wrapped argv for .safehouse profile alone, got %v", ops.launched)
 	}
-	if !equalArgv(piSafehouseExtra(ops.launched), nil) {
-		t.Fatalf("extra should be empty for profile-alone wrap, got %v", piSafehouseExtra(ops.launched))
+	if !equalArgv(piSafehouseExtra(ops.launched), launcherBinEnvPassFlags()) {
+		t.Fatalf("extra should be just launcherBinEnvPassFlags for profile-alone wrap, got %v", piSafehouseExtra(ops.launched))
 	}
 }
 

--- a/internal/cli/pi_launch_test.go
+++ b/internal/cli/pi_launch_test.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildFnmMultishellTree builds a synthetic fnm tree in a temp dir mirroring
+// the live fnm layout: a per-shell `fnm_multishells/<pid>_<ts>` symlink to a
+// stable `node-versions/<ver>/installation` dir, with `…/installation/bin/pi`
+// as a relative symlink to `../lib/node_modules/pkg/dist/cli.js` (the target
+// file is created). It returns the multishell looked-up pi path and the stable
+// install bin path. The stable install bin's parent is a REAL directory (not a
+// symlink), matching fnm — fnm only ever unlinks the per-shell `<pid>_<ts>`
+// symlink, never the shared installation tree.
+func buildFnmMultishellTree(t *testing.T) (multishellPi, stablePi string) {
+	t.Helper()
+	root := t.TempDir()
+	installation := filepath.Join(root, "stable-versions", "v1.2.3", "installation")
+	binDir := filepath.Join(installation, "bin")
+	libTarget := filepath.Join(installation, "lib", "node_modules", "pkg", "dist", "cli.js")
+	writeFileWithDirs(t, libTarget, "#!/usr/bin/env node\n")
+	// bin/pi is a relative symlink to ../lib/node_modules/pkg/dist/cli.js, exactly
+	// as fnm's installed pi bin is.
+	piLink := filepath.Join(binDir, "pi")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../lib/node_modules/pkg/dist/cli.js", piLink); err != nil {
+		t.Fatal(err)
+	}
+	// Per-shell multishell dir: fnm_multishells/<pid>_<ts> is a symlink to the
+	// stable installation dir.
+	multishellParent := filepath.Join(root, "fnm_multishells")
+	if err := os.MkdirAll(multishellParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	multishellLink := filepath.Join(multishellParent, "123_456")
+	if err := os.Symlink(installation, multishellLink); err != nil {
+		t.Fatal(err)
+	}
+	multishellPi = filepath.Join(multishellLink, "bin", "pi")
+	// Compute the expected stable path the same way the helper does:
+	// EvalSymlinks of the bin dir (resolves any OS-level /var -> /private/var
+	// symlink on macOS) then Join(..., "pi").
+	stableBinDir, err := filepath.EvalSymlinks(binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stablePi = filepath.Join(stableBinDir, "pi")
+	return multishellPi, stablePi
+}
+
+// TestResolveFnmMultishellPi_StableChosen pins AC-1: when lookedUp is a path
+// under */fnm_multishells/*/bin/pi, the helper resolves through the per-shell
+// symlink to the stable node-installation bin (NOT under fnm_multishells/).
+func TestResolveFnmMultishellPi_StableChosen(t *testing.T) {
+	multishellPi, stablePi := buildFnmMultishellTree(t)
+
+	got, ok := resolveFnmMultishellPi(multishellPi)
+	if !ok {
+		t.Fatalf("resolveFnmMultishellPi(%q) ok=false, want true", multishellPi)
+	}
+	if got != stablePi {
+		t.Fatalf("resolveFnmMultishellPi(%q) = %q, want stable %q", multishellPi, got, stablePi)
+	}
+	if strings.Contains(got, "/fnm_multishells/") {
+		t.Fatalf("stable path still under fnm_multishells: %q", got)
+	}
+}
+
+// TestResolveFnmMultishellPi_NonMultishell_Unchanged pins AC-2: a non-multishell
+// lookedUp path returns ("", false) so runPi leaves argv[0]="pi" unchanged.
+func TestResolveFnmMultishellPi_NonMultishell_Unchanged(t *testing.T) {
+	for _, lookedUp := range []string{"/usr/local/bin/pi", "/opt/bin/pi"} {
+		if got, ok := resolveFnmMultishellPi(lookedUp); ok || got != "" {
+			t.Fatalf("resolveFnmMultishellPi(%q) = (%q, %v), want (\"\", false)", lookedUp, got, ok)
+		}
+	}
+}
+
+// TestResolveFnmMultishellPi_TornDownParent_Fallback pins the fall-back
+// guarantee: when the multishell parent symlink has been torn down (a sibling
+// shell exited), EvalSymlinks errors and the helper returns ("", false) — runPi
+// leaves argv[0]="pi" rather than blocking the launch.
+func TestResolveFnmMultishellPi_TornDownParent_Fallback(t *testing.T) {
+	multishellPi, _ := buildFnmMultishellTree(t)
+	// Simulate fnm tearing down the per-shell multishell dir.
+	multishellLink := filepath.Dir(filepath.Dir(multishellPi))
+	if err := os.Remove(multishellLink); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := resolveFnmMultishellPi(multishellPi); ok || got != "" {
+		t.Fatalf("resolveFnmMultishellPi after teardown = (%q, %v), want (\"\", false)", got, ok)
+	}
+}
+
+// TestRunPi_LaunchArgv0_StableForMultishell pins AC-1 end-to-end at the runPi
+// seam: when ops.LookPath("pi") returns a multishell path, the launched argv[0]
+// is the stable install bin (NOT under fnm_multishells/).
+func TestRunPi_LaunchArgv0_StableForMultishell(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	multishellPi, stablePi := buildFnmMultishellTree(t)
+
+	ops := &fakePiRuntimeOps{
+		lookPath: map[string]string{
+			"pi":        multishellPi,
+			"safehouse": "/bin/safehouse",
+		},
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: healthyPiPackageStatus(),
+	}
+	var stdout, stderr bytes.Buffer
+
+	code := runPi(context.Background(), []string{"--plugin-dir", repo, "--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runPi exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if len(ops.launched) == 0 {
+		t.Fatalf("Launch was not invoked")
+	}
+	if got := ops.launched[0]; got != stablePi {
+		t.Fatalf("launched argv[0]=%q, want stable %q\nargv=%v", got, stablePi, ops.launched)
+	}
+	if strings.Contains(ops.launched[0], "/fnm_multishells/") {
+		t.Fatalf("launched argv[0] is still a multishell path: %q", ops.launched[0])
+	}
+}
+
+// TestRunPi_LaunchArgv0_UnchangedForDirect pins AC-2: when ops.LookPath("pi")
+// returns a non-multishell path, the launched argv[0] is the literal "pi"
+// exactly as today.
+func TestRunPi_LaunchArgv0_UnchangedForDirect(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+
+	ops := &fakePiRuntimeOps{
+		lookPath: map[string]string{
+			"pi":        "/usr/local/bin/pi",
+			"safehouse": "/bin/safehouse",
+		},
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: healthyPiPackageStatus(),
+	}
+	var stdout, stderr bytes.Buffer
+
+	code := runPi(context.Background(), []string{"--plugin-dir", repo, "--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runPi exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if len(ops.launched) == 0 {
+		t.Fatalf("Launch was not invoked")
+	}
+	if got := ops.launched[0]; got != "pi" {
+		t.Fatalf("launched argv[0]=%q, want \"pi\" (unchanged)\nargv=%v", got, ops.launched)
+	}
+}

--- a/internal/cli/pi_launch_test.go
+++ b/internal/cli/pi_launch_test.go
@@ -99,6 +99,79 @@ func TestResolveFnmMultishellPi_TornDownParent_Fallback(t *testing.T) {
 	}
 }
 
+// TestFnmStableSandboxDir_NormalInstall pins the normal `npm i -g` walk
+// (feedback cycle 2): the stable `pi` is a symlink to a real script under
+// installation/lib/node_modules/... with NO workspace root, so the walk grants
+// the highest node_modules-bearing ancestor = installation/lib (covers the pi
+// package + all its deps).
+func TestFnmStableSandboxDir_NormalInstall(t *testing.T) {
+	_, stablePi := buildFnmMultishellTree(t)
+	installation := filepath.Dir(filepath.Dir(stablePi)) // .../installation/bin/pi -> installation
+	want := filepath.Join(installation, "lib")
+
+	got := fnmStableSandboxDir(stablePi)
+	if got != want {
+		t.Fatalf("fnmStableSandboxDir(%q) = %q, want %q (installation/lib, the node_modules root)", stablePi, got, want)
+	}
+}
+
+// TestFnmStableSandboxDir_DevLinkWorkspaces pins the dev-link (npm link) walk
+// (feedback cycle 2, the captain's actual env): the stable `pi` symlink chain
+// escapes the fnm installation out to a monorepo workspace root whose
+// node_modules holds the HOISTED runtime deps. The walk must stop at the
+// workspace root (package.json with `workspaces`), NOT the package's own
+// node_modules (which holds only dev/test deps). Mirrors the live env where
+// cross-spawn is hoisted to pi-mono/node_modules, not coding-agent/node_modules.
+func TestFnmStableSandboxDir_DevLinkWorkspaces(t *testing.T) {
+	root := t.TempDir()
+	// Workspace root: package.json with `workspaces`, node_modules with the
+	// hoisted runtime dep (cross-spawn), and a packages/<pkg> workspace.
+	ws := filepath.Join(root, "pi-mono")
+	writeFileWithDirs(t, filepath.Join(ws, "package.json"), `{"name":"pi-mono","workspaces":["packages/*"]}`+"\n")
+	if err := os.MkdirAll(filepath.Join(ws, "node_modules", "cross-spawn"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pkg := filepath.Join(ws, "packages", "coding-agent")
+	// The package's OWN node_modules holds only dev/test deps (NOT cross-spawn),
+	// exactly as the captain verified for the live env.
+	if err := os.MkdirAll(filepath.Join(pkg, "node_modules", "chai"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realScript := filepath.Join(pkg, "dist", "cli.js")
+	writeFileWithDirs(t, realScript, "#!/usr/bin/env node\n")
+
+	// fnm installation: bin/pi -> lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js,
+	// and @earendil-works/pi-coding-agent is a symlink out to the workspace pkg
+	// (the npm link). EvalSymlinks(installation/bin/pi) resolves to ws pkg cli.js.
+	installation := filepath.Join(root, "node-versions", "v24", "installation")
+	binDir := filepath.Join(installation, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nmPkg := filepath.Join(installation, "lib", "node_modules", "@earendil-works", "pi-coding-agent")
+	if err := os.MkdirAll(filepath.Dir(nmPkg), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(pkg, nmPkg); err != nil { // npm link: package -> workspace pkg
+		t.Fatal(err)
+	}
+	stable := filepath.Join(binDir, "pi")
+	if err := os.Symlink(filepath.Join("..", "lib", "node_modules", "@earendil-works", "pi-coding-agent", "dist", "cli.js"), stable); err != nil {
+		t.Fatal(err)
+	}
+
+	got := fnmStableSandboxDir(stable)
+	// EvalSymlinks walks the real (resolved) path, which on macOS resolves the
+	// temp dir's /var -> /private/var symlink, so compare against the resolved ws.
+	wantWS, err := filepath.EvalSymlinks(ws)
+	if err != nil {
+		wantWS = ws
+	}
+	if got != wantWS {
+		t.Fatalf("fnmStableSandboxDir dev-link = %q, want workspace root %q\n(must stop at the workspaces root whose node_modules holds the hoisted deps, not the package's own node_modules)", got, wantWS)
+	}
+}
+
 // TestRunPi_LaunchArgv0_StableForMultishell pins AC-1 end-to-end at the runPi
 // seam: when ops.LookPath("pi") returns a multishell path, the launched argv[0]
 // is the stable install bin (NOT under fnm_multishells/).
@@ -134,27 +207,36 @@ func TestRunPi_LaunchArgv0_StableForMultishell(t *testing.T) {
 	}
 }
 
-// TestRunPi_LaunchArgv0_BarePiUnderWrap pins the feedback-cycle-1 REVISED
-// regression: when BOTH the safehouse wrap is triggered AND ops.LookPath("pi")
-// returns a fnm multishell path, the fnm resolution must be SUPPRESSED under
-// wrap. The launched argv[0] must be "safehouse" and the inner token after the
-// safehouse "--" separator must be the bare "pi" (NOT the stable install bin
-// path). Rationale: safehouse execs the inner command INSIDE the sandbox, whose
-// filesystem view does not include ~/.local/share/fnm/node-versions/... (not
-// the workdir, not added via --safehouse-add-dirs), so handing safehouse the
-// stable ABSOLUTE path as the inner token makes Node's Module._resolveFilename
-// fail with MODULE_NOT_FOUND (manual pi-live smoke, feedback cycle 1 revised).
-// Under wrap we leave argv[0]="pi" (parity with claude/codex, which pass the
-// bare name as inner[0] even when wrapped — frontdoor.go:315,498); the race is
-// accepted as a known shared limitation under safehouse. This test REDs on the
-// cycle-1 reorder code (which set inner=stable even under wrap) and GREENs after
-// the !wrap gate lands.
-func TestRunPi_LaunchArgv0_BarePiUnderWrap(t *testing.T) {
+// TestRunPi_LaunchArgv0_StableUnderWrapWithAddDirs pins the feedback-cycle-2 fix:
+// when BOTH the safehouse wrap is triggered AND ops.LookPath("pi") returns a fnm
+// multishell path, the fnm resolution is NO LONGER suppressed under wrap. The
+// launched argv[0] must be "safehouse" and the inner token after the safehouse
+// "--" separator must be the STABLE install bin path (NOT bare "pi", NOT the
+// multishell path), AND the safehouse extra/argv must contain
+// --add-dirs=<stable-bin-dir> so the sandbox can see the stable path. Rationale
+// (feedback cycle 2): cycle-1-revised gated the resolution to !wrap and left bare
+// "pi" under wrap, but the sandbox PRESERVES the inherited PATH, which carried a
+// stale (tearing-down) fnm_multishells/<pid>_<ts> dir → MODULE_NOT_FOUND on the
+// multishell path. The coupled fix resolves the stable path ALWAYS and grants
+// the stable bin's parent dir to the sandbox via --safehouse-add-dirs (a REAL dir
+// fnm never tears down) so Node's Module._resolveFilename sees it. Adversarial:
+// (a) drop the add-dirs grant under wrap → this test REDs on the missing
+// --add-dirs token (the sandbox would have no visibility). (b) re-gate the
+// resolution to !wrap → this test REDs with inner argv[0]=="pi" (stable path
+// suppressed under wrap).
+func TestRunPi_LaunchArgv0_StableUnderWrapWithAddDirs(t *testing.T) {
 	repo := t.TempDir()
 	writePiSkillFixtures(t, repo)
 	pkg := t.TempDir()
 	writePiSubagentsFixtures(t, pkg)
 	multishellPi, stablePi := buildFnmMultishellTree(t)
+	// The synthetic tree is the normal-install shape (no workspaces), so
+	// fnmStableSandboxDir walks up from the resolved real script and lands on the
+	// highest node_modules-bearing ancestor = installation/lib (covers the pi
+	// package + its deps). Dev-link workspaces path is covered by
+	// TestFnmStableSandboxDir_DevLinkWorkspaces below.
+	installation := filepath.Dir(filepath.Dir(stablePi)) // .../installation/bin/pi -> installation
+	wantGrant := filepath.Join(installation, "lib")
 
 	ops := &fakePiRuntimeOps{
 		lookPath: map[string]string{
@@ -166,29 +248,108 @@ func TestRunPi_LaunchArgv0_BarePiUnderWrap(t *testing.T) {
 	}
 	var stdout, stderr bytes.Buffer
 
-	// A --safehouse-* knob triggers the wrap (no .safehouse profile needed);
-	// safehouse.Available passes because the fake resolves "safehouse".
-	code := runPi(context.Background(), []string{"--plugin-dir", repo, "--safehouse-add-dirs=/a", "--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	// --safehouse-enable triggers the wrap (no .safehouse profile, no operator
+	// add-dirs that would confound the fnm add-dirs assertion); safehouse.Available
+	// passes because the fake resolves "safehouse".
+	code := runPi(context.Background(), []string{"--plugin-dir", repo, "--safehouse-enable=ssh", "--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("runPi exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
 	if len(ops.launched) == 0 {
 		t.Fatalf("Launch was not invoked")
 	}
-	// argv[0] must be "safehouse" — the fnm resolution must not clobber the wrap.
+	// argv[0] must be "safehouse" — the wrap fired.
 	if got := ops.launched[0]; got != "safehouse" {
 		t.Fatalf("launched argv[0]=%q, want safehouse\nargv=%v", got, ops.launched)
 	}
 	// The inner pi token (right after the safehouse "--" separator) must be the
-	// BARE "pi", NOT the stable install bin path and NOT the multishell path.
-	// Handing safehouse the stable absolute path makes Node's
-	// Module._resolveFilename fail with MODULE_NOT_FOUND inside the sandbox.
+	// STABLE install bin path — NOT bare "pi" and NOT the multishell path. The
+	// resolution now applies under wrap too (feedback cycle 2).
 	inner := piSafehouseInnerArgv(ops.launched)
 	if len(inner) == 0 {
 		t.Fatalf("no inner argv after safehouse -- separator: %v", ops.launched)
 	}
-	if got := inner[0]; got != "pi" {
-		t.Fatalf("inner argv[0]=%q, want bare %q (fnm resolution must be suppressed under wrap; stable path %q is not visible in the sandbox)\ninner=%v", got, "pi", stablePi, inner)
+	if got := inner[0]; got != stablePi {
+		t.Fatalf("inner argv[0]=%q, want stable %q (resolution must apply under wrap)\ninner=%v", got, stablePi, inner)
+	}
+	if strings.Contains(inner[0], "/fnm_multishells/") {
+		t.Fatalf("inner argv[0] is still a multishell path: %q", inner[0])
+	}
+	// The safehouse extra (before the "--" separator) must grant the dir whose
+	// node_modules holds the stable `pi`'s real script + hoisted deps, computed
+	// by fnmStableSandboxDir. For the synthetic normal-install tree that is
+	// installation/lib. The token is --add-dirs=<grant>.
+	wantAddDirs := "--add-dirs=" + wantGrant
+	sep := -1
+	for i, tok := range ops.launched {
+		if tok == "--" {
+			sep = i
+			break
+		}
+	}
+	if sep < 0 {
+		t.Fatalf("no -- separator in wrapped argv: %v", ops.launched)
+	}
+	extra := ops.launched[:sep]
+	found := false
+	for _, tok := range extra {
+		if tok == wantAddDirs {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("safehouse extra missing %q (sandbox would not see the stable bin)\nextra=%v", wantAddDirs, extra)
+	}
+}
+
+// TestRunPi_LaunchEnvForwarding pins AC-4: the Launch(argv, env) signature
+// change lands and env is threaded into the launch (mirroring claude/codex's
+// launchEnv plumbing, frontdoor.go:348). runPi must call ops.Launch(argv,
+// launchEnv(os.Environ())) — the env reaches the fake, and launchEnv sets
+// SPACEDOCK_BIN from the resolved launcher binary so the sandbox --env-pass
+// forwarding carries it through. This test fails to compile (and REDs) if the
+// piRuntimeOps.Launch signature regresses to (argv []string) — the fake's
+// method no longer satisfies the interface.
+func TestRunPi_LaunchEnvForwarding(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+
+	ops := &fakePiRuntimeOps{
+		lookPath: map[string]string{
+			"pi":        "/usr/local/bin/pi",
+			"safehouse": "/bin/safehouse",
+		},
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: healthyPiPackageStatus(),
+	}
+	var stdout, stderr bytes.Buffer
+
+	code := runPi(context.Background(), []string{"--plugin-dir", repo, "--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runPi exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if len(ops.launchedEnv) == 0 {
+		t.Fatalf("Launch was invoked with no env; env must be threaded (Launch(argv, env))")
+	}
+	// launchEnv sets SPACEDOCK_BIN from the resolved launcher binary (the test
+	// binary under `go test`); it must reach the launched env so the sandbox
+	// --env-pass forwarding carries it through, exactly as claude/codex do.
+	var spacedockBin string
+	found := false
+	for _, kv := range ops.launchedEnv {
+		if k, v, ok := strings.Cut(kv, "="); ok && k == spacedockBinEnv {
+			spacedockBin = v
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("%s not in launched env (launchEnv must set it): %v", spacedockBinEnv, ops.launchedEnv)
+	}
+	if spacedockBin == "" {
+		t.Fatalf("%s in launched env is empty: %v", spacedockBinEnv, ops.launchedEnv)
 	}
 }
 

--- a/internal/cli/pi_launch_test.go
+++ b/internal/cli/pi_launch_test.go
@@ -134,6 +134,64 @@ func TestRunPi_LaunchArgv0_StableForMultishell(t *testing.T) {
 	}
 }
 
+// TestRunPi_LaunchArgv0_BarePiUnderWrap pins the feedback-cycle-1 REVISED
+// regression: when BOTH the safehouse wrap is triggered AND ops.LookPath("pi")
+// returns a fnm multishell path, the fnm resolution must be SUPPRESSED under
+// wrap. The launched argv[0] must be "safehouse" and the inner token after the
+// safehouse "--" separator must be the bare "pi" (NOT the stable install bin
+// path). Rationale: safehouse execs the inner command INSIDE the sandbox, whose
+// filesystem view does not include ~/.local/share/fnm/node-versions/... (not
+// the workdir, not added via --safehouse-add-dirs), so handing safehouse the
+// stable ABSOLUTE path as the inner token makes Node's Module._resolveFilename
+// fail with MODULE_NOT_FOUND (manual pi-live smoke, feedback cycle 1 revised).
+// Under wrap we leave argv[0]="pi" (parity with claude/codex, which pass the
+// bare name as inner[0] even when wrapped — frontdoor.go:315,498); the race is
+// accepted as a known shared limitation under safehouse. This test REDs on the
+// cycle-1 reorder code (which set inner=stable even under wrap) and GREENs after
+// the !wrap gate lands.
+func TestRunPi_LaunchArgv0_BarePiUnderWrap(t *testing.T) {
+	repo := t.TempDir()
+	writePiSkillFixtures(t, repo)
+	pkg := t.TempDir()
+	writePiSubagentsFixtures(t, pkg)
+	multishellPi, stablePi := buildFnmMultishellTree(t)
+
+	ops := &fakePiRuntimeOps{
+		lookPath: map[string]string{
+			"pi":        multishellPi,
+			"safehouse": "/bin/safehouse",
+		},
+		statOK:        statOKForPiResources(repo, pkg),
+		packageStatus: healthyPiPackageStatus(),
+	}
+	var stdout, stderr bytes.Buffer
+
+	// A --safehouse-* knob triggers the wrap (no .safehouse profile needed);
+	// safehouse.Available passes because the fake resolves "safehouse".
+	code := runPi(context.Background(), []string{"--plugin-dir", repo, "--safehouse-add-dirs=/a", "--", "--version"}, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runPi exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if len(ops.launched) == 0 {
+		t.Fatalf("Launch was not invoked")
+	}
+	// argv[0] must be "safehouse" — the fnm resolution must not clobber the wrap.
+	if got := ops.launched[0]; got != "safehouse" {
+		t.Fatalf("launched argv[0]=%q, want safehouse\nargv=%v", got, ops.launched)
+	}
+	// The inner pi token (right after the safehouse "--" separator) must be the
+	// BARE "pi", NOT the stable install bin path and NOT the multishell path.
+	// Handing safehouse the stable absolute path makes Node's
+	// Module._resolveFilename fail with MODULE_NOT_FOUND inside the sandbox.
+	inner := piSafehouseInnerArgv(ops.launched)
+	if len(inner) == 0 {
+		t.Fatalf("no inner argv after safehouse -- separator: %v", ops.launched)
+	}
+	if got := inner[0]; got != "pi" {
+		t.Fatalf("inner argv[0]=%q, want bare %q (fnm resolution must be suppressed under wrap; stable path %q is not visible in the sandbox)\ninner=%v", got, "pi", stablePi, inner)
+	}
+}
+
 // TestRunPi_LaunchArgv0_UnchangedForDirect pins AC-2: when ops.LookPath("pi")
 // returns a non-multishell path, the launched argv[0] is the literal "pi"
 // exactly as today.


### PR DESCRIPTION
## What

Resolves the fnm-multishell launch race under safehouse+fnm (`pi-launch-fnm-multishell-race`, feedback cycle 2). The captain's manual smoke (`spacedock pi --plugin-dir . -- --model z-ai/glm-5.2 --thinking xhigh`) now launches cleanly where cycles 1 and 1-revised both failed with MODULE_NOT_FOUND.

## The coupled fix (commit `a1690b5c`)

- **A** — resolve the stable node-installation bin ALWAYS (`resolveFnmMultishellPi`), not gated to `!wrap`. `argv[0]=stable` before the safehouse wrap, wrap or not.
- **B** — under wrap, grant the sandbox pi's actual code+dep tree via `--safehouse-add-dirs <fnmStableSandboxDir>`. `fnmStableSandboxDir` walks up from `filepath.EvalSymlinks(stable)` to the WORKSPACE ROOT (`package.json` `workspaces` key) — Node's dep-hoist boundary. Dev-link lands on the monorepo root (e.g. `~/git/pi-mono`); normal `npm i -g` lands on `installation/lib`. (Captain-corrected: the first `node_modules` ancestor stops one level too early — the package's own `node_modules` has only dev/test deps, runtime deps are hoisted.)
- **C** — `Launch(argv, env)` signature change mirroring claude/codex (`frontdoor.go:345`): `launchEnv` + `launcherBinEnvPassFlags()` (`--env-pass SPACEDOCK_BIN`). Un-defers `qn`'s Decision 2 (SPACEDOCK_BIN-through-sandbox forwarding).

## Reframe

Under safehouse the real issue is filesystem VISIBILITY of pi's actual code+deps, not only the multishell teardown. The stable `pi` is a symlink chain that escapes the fnm installation (npm link → monorepo); the `.safehouse` profile grants only the workdir. The grant lands on the workspace root so the sandbox sees the script + hoisted deps.

## Tests

- `TestRunPi_LaunchArgv0_StableUnderWrapWithAddDirs` (replaces `BarePiUnderWrap`) — wrap=true, multishell → safehouse argv[0], inner=stable, `--add-dirs=<grant>` present.
- `TestRunPi_LaunchEnvForwarding` — `Launch(argv, env)` + `SPACEDOCK_BIN` threaded.
- `TestFnmStableSandboxDir_{NormalInstall,DevLinkWorkspaces}` — pin the walk for both install shapes.
- Adversarial: drop grant → RED; re-gate `!wrap` → RED; first-ancestor walk → RED.

## Gates

`go test ./...` ok; `go test ./... -race` ok; gofmt clean on task files.

## Validation

Fresh validator: all 4 ACs PASSED; adversarial audit caught every mutation; live smoke (captain's env) clean. Gate-approved by captain.