### PR TITLE
Trim state commit contract prose

### DIFF
--- a/docs/runtime-support.md
+++ b/docs/runtime-support.md
@@ -16,6 +16,8 @@ Keep runtime tool names in runtime binding sections. Host-neutral core text and 
 
 Treat probes as the source of runtime truth. Do not file a `v2` or host-variant runtime solely because a version label changed; first probe the live tool surface and update the binding map when the lifecycle capability is the same. A separate runtime file is justified only when the lifecycle semantics differ enough that the shared capability contract would become misleading.
 
+Prefer pseudo-code contracts over narrative instructions. Shared and runtime contracts should look like callable bodies keyed by capability names, with compact fields such as `guard`, `effect`, `done-when`, `block`, and `→` binding/status lines. Use prose only for fuzzy judgment, host quirks proven by probes, or rationale that cannot be encoded as an executable-shaped obligation.
+
 ### Runtime binding-block shape
 
 A first-officer runtime adapter should default to a bindings block, not lifecycle prose. The shared core owns when capabilities are invoked; the runtime file owns how the host realizes them.

--- a/internal/cli/prose_function_routing_test.go
+++ b/internal/cli/prose_function_routing_test.go
@@ -26,8 +26,8 @@ var proseFunctionCores = []string{
 // migrationTargetRe matches a prose-function declaration's `→` migration-target line and
 // captures (1) the notation word — `shipped` (a backtick, a live verb) or `prose` (a
 // guillemet, hand-followed) — and (2) the FIRST backticked `spacedock …` verb token on the
-// line, if any. A `→ **shipped**: ` `spacedock state ready` `` line yields ("shipped",
-// "spacedock state ready"); a `→ **prose**, becomes ` `spacedock dispatch next-action` ``
+// line, if any. A shipped line naming `spacedock state ready` yields ("shipped",
+// "spacedock state ready"); a prose line naming `spacedock dispatch next-action`
 // line yields ("prose", "spacedock dispatch next-action"); a bare `→ **prose**` line with no
 // `spacedock …` token (the `«feedback.route»` skill-is-the-body form) yields ("prose", "").
 var migrationTargetRe = regexp.MustCompile("→ \\*\\*(shipped|prose)\\*\\*[^\\n]*?`(spacedock [^`]+)`")

--- a/internal/contractlint/prose_function_backstop_test.go
+++ b/internal/contractlint/prose_function_backstop_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: AC-2c catastrophe backstop — the two highest-stakes rule clusters survive the
-// ABOUTME: prose-function restructure: the rebase-halt prohibition anchors + the verbatim reuse diagnostic.
+// ABOUTME: AC-2c catastrophe backstop — the highest-stakes rule clusters survive the
+// ABOUTME: prose-function restructure: the compact rebase-halt anchor + the verbatim reuse diagnostic.
 package contractlint
 
 import (
@@ -11,31 +11,27 @@ import (
 
 // catastropheClause is one load-bearing string whose silent loss in the prose-function
 // restructure would be catastrophic AND whose exact wording is itself load-bearing — the
-// reuse diagnostic is contractually pinned ("must appear verbatim"); the rebase-halt
-// prohibition clauses are the no-data-loss safety nets. `path` is the restructured core that
+// reuse diagnostic is contractually pinned ("must appear verbatim"); the compact rebase-halt
+// prohibition anchor is the no-data-loss safety net. `path` is the restructured core that
 // must still carry `want`.
 type catastropheClause struct {
 	path string
 	want string
 }
 
-// catastropheClauses is DELIBERATELY narrow — only the two clusters where a silent drop is
+// catastropheClauses is DELIBERATELY narrow — only the clusters where a silent drop is
 // catastrophic and the wording is load-bearing. It is NOT extended to the rest of the rule
 // set: presence-grepping every rule would re-introduce the banned prose-grep tautology (the
 // matched text is authored by the same restructuring implementer). The real preservation
 // guard is the validator's detached original-vs-restructured audit (AC-2b); this is a cheap
 // tripwire subordinate to it.
 var catastropheClauses = []catastropheClause{
-	// Rebase-conflict-halt prohibition anchors (shared-core State Management). The 4-step HALT
-	// relocates under the restructured «state.ensure-ready» / «state.commit» bodies' referenced
-	// rebase-conflict halt; these two prohibition clauses must survive the relocation.
+	// Rebase-conflict-halt prohibition anchor (shared-core State Management). The compact
+	// «state.commit» body must still preserve the FO's no-data-loss halt obligation without
+	// pinning the old multi-step git recipe.
 	{
 		path: filepath.Join("skills", "first-officer", "references", "first-officer-shared-core.md"),
-		want: "must NOT `--force` / `--force-with-lease` push",
-	},
-	{
-		path: filepath.Join("skills", "first-officer", "references", "first-officer-shared-core.md"),
-		want: "must NOT auto-resolve (`-X ours/theirs`",
+		want: "do not force-push or auto-resolve",
 	},
 	// The verbatim reuse diagnostic (dispatch-core Reuse and Fresh Dispatch). Contractually
 	// pinned to appear character-for-character.
@@ -45,7 +41,7 @@ var catastropheClauses = []catastropheClause{
 	},
 }
 
-// TestProseFunctionCatastropheClausesSurvive (AC-2c) asserts each of the two highest-stakes
+// TestProseFunctionCatastropheClausesSurvive (AC-2c) asserts each highest-stakes
 // clusters' load-bearing strings survives somewhere in its restructured core. A content-presence
 // assertion is the right shape here precisely because the wording itself is contractual (a
 // paraphrase of the verbatim diagnostic would BREAK the contract, so presence — not the usual

--- a/internal/ensigncycle/haiku_loop_spike_live_test.go
+++ b/internal/ensigncycle/haiku_loop_spike_live_test.go
@@ -221,7 +221,7 @@ func haikuLoopPrompt(fx haikuLoopFixture) string {
 // narration.
 type haikuLoopGrade struct {
 	// Durable end-state (read from disk after the drive).
-	entityLocated bool
+	entityLocated  bool
 	entityArchived bool
 	statusDone     bool
 	completedSet   bool
@@ -236,8 +236,8 @@ type haikuLoopGrade struct {
 	integrationTransitionCommitted bool
 
 	// Stream-derived facts (parsed from the captured tool-call stream).
-	dispatchBuildCalled   bool // a `spacedock dispatch build` Bash call appeared
-	noStrongerModelAgent  bool // NO Agent(model=opus|sonnet) tool_use appeared anywhere
+	dispatchBuildCalled  bool // a `spacedock dispatch build` Bash call appeared
+	noStrongerModelAgent bool // NO Agent(model=opus|sonnet) tool_use appeared anywhere
 }
 
 // driveHaikuLoopOnce runs ONE bare-`claude --model haiku -p` mechanical-loop drive

--- a/internal/ensigncycle/shared_reviewer_reuse_table_test.go
+++ b/internal/ensigncycle/shared_reviewer_reuse_table_test.go
@@ -188,7 +188,9 @@ func TestAssertCodexReviewerReuse(t *testing.T) {
 	sendInputToFresh := `{"type":"item.started","item":{"type":"collab_tool_call","tool":"send_input","receiver_thread_ids":["` + vThread2 + `"],"prompt":"Re-run validation for rejection-task as cycle 2."}}`
 	freshDispatch := spawnValidation + "\n" + spawnImpl + "\n" + feedbackToImpl + "\n" + freshCycle2Spawn + "\n" + sendInputToFresh
 	noAddressableSurface := `{"type":"item.completed","item":{"type":"agent_message","text":"The live Codex tool surface has spawn_agent and wait_agent, but no followup_task/send_message reuse route exposed here."}}`
+	currentNoAddressableSurface := `{"type":"item.completed","item":{"type":"agent_message","text":"Codex has no turn-starting follow-up route for a completed worker, so there is no completed-worker follow-up route for validation reuse."}}`
 	absentTwoFresh := noAddressableSurface + "\n" + spawnValidation + "\n" + spawnImpl + "\n" + freshCycle2Spawn
+	currentAbsentTwoFresh := currentNoAddressableSurface + "\n" + spawnValidation + "\n" + spawnImpl + "\n" + freshCycle2Spawn
 	absentOnlyOneValidation := noAddressableSurface + "\n" + spawnValidation + "\n" + spawnImpl
 	absentButReuseTool := noAddressableSurface + "\n" + realReuseV2
 
@@ -201,6 +203,7 @@ func TestAssertCodexReviewerReuse(t *testing.T) {
 		{"real followup_task to the validation reviewer thread", realReuseV2, false},
 		{"fresh cycle-2 spawn_agent + send_input must RED", freshDispatch, true},
 		{"addressable-worker absent: two fresh validation spawns", absentTwoFresh, false},
+		{"addressable-worker absent: current live wording plus two fresh validation spawns", currentAbsentTwoFresh, false},
 		{"addressable-worker absent: missing second fresh validation spawn must RED", absentOnlyOneValidation, true},
 		{"addressable-worker absent: reuse tool contradicts absent classification", absentButReuseTool, true},
 		{

--- a/internal/ensigncycle/shared_reviewer_reuse_test.go
+++ b/internal/ensigncycle/shared_reviewer_reuse_test.go
@@ -313,6 +313,8 @@ func codexAddressableWorkerAbsent(jsonl string) bool {
 	lower := strings.ToLower(jsonl)
 	return strings.Contains(lower, "no followup_task/send_message reuse route exposed") ||
 		strings.Contains(lower, "followup_task/message reuse is unavailable") ||
+		strings.Contains(lower, "no turn-starting follow-up route for a completed worker") ||
+		strings.Contains(lower, "no completed-worker follow-up route") ||
 		strings.Contains(lower, "reviewer reuse is not available in this host")
 }
 

--- a/internal/status/section_read.go
+++ b/internal/status/section_read.go
@@ -190,7 +190,7 @@ func formatReadText(path string, sr sectionRead) string {
 
 // codeFenceMarker returns the fence marker (``` ``` ``` or `~~~`) when line opens
 // or closes a fenced code block, else "". A fence is a line whose first
-// non-whitespace run is three or more `` ` `` or `~`; the returned marker is the
+// non-whitespace run is three or more backticks or `~`; the returned marker is the
 // three-char prefix so a closing fence is matched by the same opening marker.
 func codeFenceMarker(line string) string {
 	trimmed := strings.TrimSpace(line)

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -146,7 +146,7 @@ The terminal merge-and-cleanup ceremony — the `«merge.guard»` envelope, the 
 - Assign entity IDs through `id-style`; validate active plus archived entities before trusting status output.
 - Commit state changes at dispatch and merge boundaries.
 
-The worktree-ownership rules (which active state lives in the worktree copy vs. `main`, and the split-root deliverable-isolation contract) travel with the deferred dispatch module — they matter only once a worktree stage dispatches. The concurrency-safe commit / multi-writer sync / rebase-conflict-halt rules below stay boot-resident; the Startup `«state.ensure-ready»()` step fires before any dispatch.
+The worktree-ownership rules (which active state lives in the worktree copy vs. `main`, and the split-root deliverable-isolation contract) travel with the deferred dispatch module — they matter only once a worktree stage dispatches. The compact state-commit obligation stays boot-resident; the Startup `«state.ensure-ready»()` step fires before any dispatch.
 
 The FO declares intent against the state repo by invoking the prose-functions below; their bodies own the mechanics, so the Startup flow reads as intention. Each is idempotent — re-invoking checks its `done-when` and is a no-op if already satisfied — so the boot sequence (`«state.boot»()`, `«state.ensure-ready»()`, `«state.sweep-merged»()`, greet) converges rather than runs as a script, and each can become a binary independently without touching the flow. Every state write is one call: `«state.commit»(slug)`.
 
@@ -175,25 +175,10 @@ The FO declares intent against the state repo by invoking the prose-functions be
 
 ## «state.commit»(slug): record one entity's change durably and concurrency-safe
 
-- **effect:** `spacedock state commit <slug>` path-scoped-commits the entity and runs the full sync (push; on push rejection `pull --rebase` then re-push) per **Split-Root State Sync** below.
-- **done-when:** the entity's change is committed (and pushed to `origin` when one exists).
-- **block:** rebase conflict on sync → halt per the **rebase-conflict halt** below.
-- → **shipped** (this sprint): `` `spacedock state commit <slug>` `` — invoke it directly.
-
-### Split-Root State Sync
-
-When the workflow is split-root (README declares `state:` checkout, e.g. `state: .spacedock-state`), the state branch is shared via `origin`. `spacedock state commit <slug>` owns the whole concurrency-safe write: it resolves the entity path under the state checkout, path-scoped-commits it (never a bare `git add -A`, which would sweep up a sibling writer's staged entity), and runs the full sync — push, and on a non-fast-forward rejection `pull --rebase` then re-push. The FO invokes the verb; it does not hand-roll the git sequence. The boot `pull --rebase` (the Startup pull-on-boot step, `«state.ensure-ready»()`) integrates peers' state once at boot, not per-read.
-
-**No-origin carve-out.** When the state checkout has no `origin` remote, the verb commits locally only: boot reports `STATE_BACKEND: … remote: none — state not remotely synced` (and `state_remote: none` in `--boot --json`), the dispatch omits the push/pull reminder, and state stays local-only until an `origin` is configured. Surface that to the captain rather than treating the missing remote as a sync failure.
-
-**Rebase-conflict halt.** If `pull --rebase` CONFLICTS (two writers editing the SAME entity's frontmatter concurrently), the FO MUST:
-
-1. **HALT** the dispatch. Do not proceed against an unmerged state tree.
-2. **Abort the rebase**: `git -C {state_checkout} rebase --abort`.
-3. **Surface** the conflicting entity path(s) and peer commit to the captain, and stop. Manual intervention required.
-4. The FO must NOT `--force` / `--force-with-lease` push; must NOT auto-resolve (`-X ours/theirs` — discarding either side silently loses a peer's frontmatter edit).
-
-This matches the escalate-rather-than-guess discipline. A full lock model is out of scope; the halt is the boundary behavior.
+- **effect:** invoke `spacedock state commit <slug>` after each state mutation. The command resolves the split-root entity, commits only that entity path, syncs with `origin` when present, and reports local-only/no-op as needed.
+- **done-when:** the command exits 0 with the entity committed, and pushed when an origin exists.
+- **block:** exit 3 means a same-entity rebase conflict was aborted by `spacedock state commit`; HALT, surface the named conflicting path(s) to the captain, and do not force-push or auto-resolve.
+- → **shipped**: `` `spacedock state commit <slug>` `` — invoke it directly.
 
 ## FO Write Scope
 


### PR DESCRIPTION
## Summary
- trim the shared-core state.commit contract into a compact pseudo-code block
- document pseudo-code capability-body principles in runtime support guidance

## Verification
- dispatched ensign validation running
