### PR TITLE
fix(release): edge cask installs `spacedock` command, conflicts_with stable

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -117,6 +117,13 @@ homebrew_casks:
     skip_upload: auto
     ids:
       - spacedock-stable
+    # Both channels install the same `spacedock` command from the bare `spacedock`
+    # archive file, so only one may be linked at a time. Declaring the edge cask a
+    # conflict makes brew refuse to install both at once — the channel-switch model
+    # (uninstall one, install the other). The stable cask keeps the default binary
+    # stanza: its cask name already equals the archive file.
+    conflicts:
+      - cask: spacedock@next
     repository:
       owner: spacedock-dev
       name: homebrew-tap
@@ -158,6 +165,16 @@ homebrew_casks:
     skip_upload: false
     ids:
       - spacedock-edge
+    # The archive ships the binary as `spacedock`, so the edge command is also
+    # `spacedock` — pin the binary stanza explicitly because the default would be
+    # the cask name `spacedock@next`, which has no matching file in the archive.
+    # Both channels install the same `spacedock` command, so the edge cask declares
+    # the stable cask a conflict: brew installs one channel at a time (uninstall to
+    # switch).
+    binaries:
+      - spacedock
+    conflicts:
+      - cask: spacedock
     repository:
       owner: spacedock-dev
       name: homebrew-tap


### PR DESCRIPTION
## Root cause

goreleaser v2.16 defaults a cask's `binary` stanza to the cask **name** when no binary is configured. The edge cask `spacedock@next` therefore generated `binary "spacedock@next"` — but every release archive ships a bare `spacedock` binary (the cross-channel archive contract; both builds set `binary: spacedock`). brew's symlink source `spacedock@next` did not exist in the archive, so `brew install spacedock-dev/tap/spacedock@next` failed:

```
Error: It seems the symlink source '…/Caskroom/spacedock@next/0.23.0-pre.2/spacedock@next' is not there.
```

Latent since the edge cask first shipped (pre.1 / pre.2). The stable cask was never affected because its cask name already equals the archive file (`spacedock`).

## Fix — Option B (channel-switch via `conflicts_with`)

Both channels install the same `spacedock` command; a user runs one channel at a time and uninstalls to switch. No `target:` rename trick.

- **Edge cask**: `binaries: ["spacedock"]` (pin the stanza to the real archive file, overriding the cask-name default) + `conflicts: [cask: spacedock]`.
- **Stable cask**: keeps its default `binary "spacedock"` + `conflicts: [cask: spacedock@next]`.

Emitted via goreleaser's **first-class `conflicts` field** (`HomebrewCask.conflicts`, `[]{cask, formula}`) — not `custom_block`, not a template hack.

## Snapshot evidence (`goreleaser release --snapshot --clean`)

- edge `dist/homebrew/Casks/spacedock@next.rb`: `binary "spacedock"` + `conflicts_with cask: ["spacedock"]`
- stable `dist/homebrew/Casks/spacedock.rb`: `binary "spacedock"` + `conflicts_with cask: ["spacedock@next"]`
- `goreleaser check` → `1 configuration file(s) validated`.

## Live tap already hotfixed

The published pre.2 edge cask was hand-corrected to this exact shape so users can install pre.2 today (tap commits `1005da3` → `9f7ec64`). This PR makes the **generator** reproduce that shape, so the next cut (stable v0.23.0) emits it without a hand edit.

## Interim sharp edge

The live stable `0.22.0` cask predates this change and carries no `conflicts_with`. While stable 0.22.0 is installed, switching to edge needs a manual `brew uninstall --cask spacedock` first (and edge→stable needs `brew uninstall --cask spacedock@next` first) to avoid a `spacedock` symlink collision. The two-way `conflicts_with` fully engages once stable v0.23.0 is cut from this generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)