### PR TITLE
roadmap: commission 0230 — stable v0.23.0 finalization (lean cut)

### DIFF
--- a/docs/roadmap/0230-stable-finalization/dispatch-sprint-execution.md
+++ b/docs/roadmap/0230-stable-finalization/dispatch-sprint-execution.md
@@ -1,0 +1,244 @@
+# 0230 (v0.23.0) — stable finalization (lean cut) — Commander dispatch (cold-boot)
+
+> **Self-contained cold-boot package.** A Commander session boots `spacedock:first-officer`,
+> reads this file + the sprint `index.md`, and drives the members to a tagged stable
+> `v0.23.0`. The Shaping FO's work is done; this is the handoff to the drive phase. This
+> package is runnable from a COLD BOOT — everything load-bearing is here.
+
+## Boot
+
+Sprint = the entities matching `sprint: 0230-stable-finalization` (query, not a list).
+Drivable set:
+`spacedock status --workflow-dir docs/dev --where sprint=0230-stable-finalization --where 'sprint-readiness != defer'`
+
+Boot the first officer (`spacedock claude`), run `status --boot`, and read each member body
+for its design + ACs. Goal/DoD + the VALUE GATE: `index.md`. Foundation: this cut rides the
+`v0.22.0` stable floor; `main` is at `b7ecd04a` (the `#420` cask fix). The plugin manifests
+read `0.22.0` (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`).
+
+> **Query caveat.** Two of member 4's reconciliation targets still carry
+> `sprint: 0201-post-flip-release-model` and will NOT appear in the 0230 query
+> (`stamp-then-tag-release-ritual` `ezn308z0chwc2zvmyny9ry8w`,
+> `steady-state-stable-release-runbook` `qpfmdxy6438fsndp9nw4c89e`). They are folded into
+> member 4 by reference — see member 4 below.
+
+## Deliverable & DoD — begin with the end
+
+**`v0.23.0`** = a LEAN stable release cut from `main`. The token clawback is the WHY the
+stable was held; it is the deliverable's gate, not side polish. Done when the VALUE GATE is
+met AND the tag fires on an e2e-green commit AND a fresh `brew install` launches.
+
+### THE VALUE GATE (the DoD; begin-with-the-end STOP)
+
+**The `v0.23.0` tag does NOT fire until this gate is met.** Stop here and check it BEFORE
+doing release-cut work. A green `go test`, a clean pre-cut audit, and finished members do
+NOT authorize the tag if the byte counts still exceed the baseline.
+
+Measured `wc -c` on the boot-resident contract files MUST be `≤` the `v0.22.0` baseline for
+EVERY runtime:
+
+```
+first-officer-shared-core.md   ≤ 28586   (30640 at the commission HEAD, +2054 owed)
+fo-dispatch-core.md            ≤ 17488   (22929 at HEAD, +5441 owed — the big one)
+fo-merge-core.md               ≤ 8059    (8597 at HEAD, +538 owed)
+claude-first-officer-runtime.md ≤ 4575   (4575 — met at the line)
+codex-first-officer-runtime.md  ≤ 6004   (6043 at HEAD, +39 owed)
+pi-first-officer-runtime.md     ≤ 3754   (3754 — already met; #418 over-delivered)
+```
+
+Files live under `skills/first-officer/references/`. Re-measure with `wc -c` on these exact
+paths against the assembled `main` tip immediately before the cut. **The release is NOT cut
+while ANY byte count exceeds its `v0.22.0` number.** If any file is over, the tag does not
+fire — bounce back to the owning member (1 owns the shared-core + adapter clawback; 2 owns
+`fo-dispatch-core.md` + the merge-core overage).
+
+## The members (riskiest-first)
+
+| # | slug | id | deliverable |
+| --- | --- | --- | --- |
+| 1 | `fo-contract-token-cut` | `y2r7ew51xqs6q3avsb6mcaka` | Boot-resident clawback: rebase the `fo-contract-token-cleanup.md` proposal (#418 landed → just a rebase + the remaining cuts), apply the verified cuts to `first-officer-shared-core.md` + the runtime adapters, fold in the zero-discover "no filesystem sweep" prohibition. Leads the value-measurement de-risk. |
+| 2 | `trim-dispatch-adapter-prose` | `adk755xqeb4a9dxhhgtjwawh` | The `+5441 B` dispatch/merge-core half. SB2-class: premature-reap ban + idle guardrail + reuse/await semantics stay BYTE-INTACT; AC gates on a NEGATIVE cumulative line delta; `contractlint`-guarded. Lands AFTER member 1. |
+| 3 | `#420` cask channel-switch | merged `b7ecd04a` | ALREADY MERGED. In the tag because goreleaser regenerates both casks. No drive. |
+| 4 | `docs/releasing.md` reconciliation | `7yd3mbsy2am5qggc17sxvz2v` + `ezn308z0chwc2zvmyny9ry8w` + `qpfmdxy6438fsndp9nw4c89e` | ONE serialized pass folding three colliding entities. Fixes the stale step-3 manual pre-stamp that blocks the cutter at the exact-SHA e2e-gate. |
+| 5 | `spacedock-marketplace-source-env` | `z2tjv3570ahjxewv1c309rbc` | Codex EDGE install via channel-via-marketplace-name: edge installs as `spacedock@spacedock-edge` from a distinct `spacedock-edge` MARKETPLACE NAME so codex's entry-name == `plugin.json`-name check passes. Carries the marketplace restructure to expose that name. (The standalone-marketplace decouple is a SHIPPED PREREQUISITE, PR #352 — not a member.) |
+
+## Drive order
+
+1. **Member 1 (`fo-contract-token-cut`) FIRST** — it leads the value-measurement de-risk
+   (pin the `wc -c` baseline + the measurement command) AND owns the boot-resident
+   clawback. Run the no-guidance-control micro-test on the cut clauses, apply the cuts,
+   re-test the keeps (the control can overturn a keep), then verify the 4 live shared
+   scenarios green on Claude AND Codex.
+2. **Member 2 (`trim-dispatch-adapter-prose`) AFTER member 1** — they both touch resident
+   contract prose; serialize. AC gates on a negative cumulative line delta;
+   `contractlint` green is the merge condition. The premature-reap ban + idle guardrail +
+   reuse/await semantics must remain byte-intact.
+3. **Member 3 (`#420`) is already merged** — confirm `b7ecd04a` is in `main`'s log; no drive.
+4. **(Parallel) Member 5 (codex-edge)** — independent of 1/2/4; drive whenever.
+5. **VALUE-GATE CHECK** — re-measure all six resident byte counts vs `v0.22.0`; if any
+   exceeds, the tag does NOT fire — bounce back to the owning member.
+6. **Member 4 (`docs/releasing.md` reconciliation)** — one serialized pass over the three
+   colliding entities; land before the cut so the cutter follows a doc that tags the
+   e2e-green commit, not a freshly-stamped one.
+7. **Pre-cut antipattern audit** — independent reviewer (tag not yet fired).
+8. **Write the `v0.23.0` release notes** — MUST cover `pre.1`/`pre.2` content + the clawback.
+9. **Cut.**
+
+## Drive procedure (per member)
+
+For each drivable member (1, 2, 4, 5), the Commander runs the standard FO dispatch cycle:
+
+1. **Advance `→ implementation`** (worktree stage). `status --set {slug} status=implementation
+   worktree=.worktrees/spacedock-ensign-{slug} started`. Commit the state transition
+   path-scoped, push.
+2. **Create the worktree** on first dispatch.
+3. **Build the dispatch** via `spacedock dispatch build` with a checklist file (≤3 items —
+   the dispatch-core cap).
+4. **Dispatch** the worker (the FO follows its runtime adapter's dispatch capability).
+5. **On completion, verify the stage report** against the entity file (`status --read {ref}
+   --json` → last `## Stage Report` → `Read(offset,limit)`). Never advance on a cheerful
+   summary alone.
+6. **Advance `→ validation`** (fresh validator; `feedback-to: implementation`; `gate: true`).
+7. **At the validation gate**, present it (`present-gate`); the captain decides. Approve →
+   terminal ceremony (PR-merge mod). Reject → `feedback-rejection-flow`.
+8. **Detached adversarial audit at validation** for the high-stakes surfaces — the shipped
+   FO-contract trims (members 1, 2) and the release machinery (member 4). For the contract
+   trims, the audit refutes that the diff dropped a load-bearing FO-safety guarantee while
+   the byte count dropped.
+
+## In-drive gates (captain-owned)
+
+- **Validation gates: captain decides.** The Commander presents each (`present-gate`); never
+  self-approve.
+- **Merge gate:** each member merges to `main` via the `pr-merge` mod; the mod-block
+  enforcement runs at terminalization.
+- **VALUE-GATE CHECK (the DoD funnel):** after members merge and before the pre-cut audit,
+  re-measure the six resident byte counts vs `v0.22.0`. If any exceeds → the tag does NOT
+  fire; bounce back. This is the begin-with-the-end stop.
+- **Pre-cut antipattern audit:** with all members merged and the tag NOT yet fired, dispatch
+  an INDEPENDENT reviewer (staff-eng persona; not the Commander, not the implementers) over
+  the assembled sprint. The contract trims are the highest-stakes surface: confirm no
+  load-bearing FO guarantee was dropped to make the byte count. Ship-blockers fixed before
+  the cut; non-blockers seeded.
+- **Release cut:** `go test ./...` green from the root, then `docs/releasing.md`. Captain
+  authorizes the cut.
+
+## Per-member build notes
+
+### Member 1 — `fo-contract-token-cut` · boot-resident clawback (the WHY) · leads the de-risk
+
+`#418` already landed, so the proposal (`docs/dev/_proposals/fo-contract-token-cleanup.md`)
+is just a rebase + the remaining cuts to `first-officer-shared-core.md` and the runtime
+adapters. The proposal carries the per-clause `safe-cut` / `cut-with-care` / `keep` verdicts
+and the no-guidance-control micro-test method. The drive: validate the control on the
+sample clauses spanning the verdict space (e.g. a `keep`, a `cut-with-care`, a `safe-cut`),
+apply the default-path cuts, RE-TEST the remaining keeps (the control can overturn a keep),
+then confirm the four live shared scenarios (`gate-guardrail`, `rejection-flow`,
+`feedback-3-cycle-escalation`, `merge-hook-guardrail`) stay green on Claude AND Codex.
+Folds in the zero-discover "no filesystem sweep" prohibition. The contract files are
+shipped scaffolding (`skills/` is product, not FO-direct-editable) — edits ship through a
+dispatched worker in a worktree under test. **This member also pins the value-gate
+measurement** (the exact `wc -c` paths + baseline numbers from `index.md`) so the gate is
+checked against a fixed oracle.
+
+### Member 2 — `trim-dispatch-adapter-prose` · the +5441 B half · SB2-class · lands after 1
+
+The single largest delta on the gate (`fo-dispatch-core.md`, +5441 B; plus the merge-core
++538 B overage). SB2-class risk: the trim MUST keep these BYTE-INTACT — the premature-reap
+ban, the dispatch idle guardrail, and the reuse/await semantics. These are the FO-safety
+guarantees the `fo-contract-token-cleanup.md` keep-list protects (the premature-teardown
+ban and the DISPATCH IDLE GUARDRAIL are named keeps). The AC gates on a NEGATIVE cumulative
+line delta and is `contractlint`-guarded (the notation↔command-tree binding, not a grep).
+Lands after member 1 to avoid a resident-prose collision.
+
+### Member 3 — `#420` cask channel-switch · ALREADY MERGED · no drive
+
+Squash `b7ecd04a` on `main`. The edge cask installs the `spacedock` binary and declares
+`conflicts_with` stable, so a user switching between the `spacedock` stable cask and the
+`spacedock@next` edge cask gets the right binary. Listed because the stable tag regenerates
+BOTH casks via goreleaser — it needed to be in before the tag. Verified by the post-cut
+fresh-install check.
+
+### Member 4 — `docs/releasing.md` reconciliation · ONE serialized pass · before the cut
+
+Three entities collide on `docs/releasing.md` — serialize them into a single pass, do NOT
+dispatch in parallel:
+- `releasing-doc-pre-stamp-drift` (`7yd3mbsy2am5qggc17sxvz2v`) — step 3 today does a manual
+  `stamp-version` → commit, creating a fresh SHA the e2e-gate has never run green on.
+- `stamp-then-tag-release-ritual` (`ezn308z0chwc2zvmyny9ry8w`, on `sprint: 0201` — by
+  reference) — the tagged commit's manifest must match its tag.
+- `steady-state-stable-release-runbook` (`qpfmdxy6438fsndp9nw4c89e`, on `sprint: 0201` — by
+  reference) — advance `main` from a green `next` tip; reconcile `docs/releasing.md`.
+
+The bug they collectively fix: `docs/releasing.md`'s `## What the Tag Push Does` already
+says goreleaser "publishes only after the `e2e-gate` job confirms the tagged commit has a
+green Runtime Live E2E run (or a recorded `SPACEDOCK_E2E_GATE_WAIVER`)" — but the cut steps
+(step 3) tell the cutter to make a fresh manual pre-stamp commit, which the e2e-gate has
+never exercised. A cutter following the doc verbatim tags a commit the gate will block.
+The reconciliation makes the doc tag the GREEN e2e commit.
+
+### Member 5 — `spacedock-marketplace-source-env` (z2) · codex EDGE install · independent
+
+The standalone-marketplace decouple is a SHIPPED PREREQUISITE (PR #352 — the standalone
+`spacedock-dev/marketplace` repo with the `spacedock`/`spacedock-edge` entries already
+exists, per `docs/releasing.md`). It is NOT a live 0230 member; reference it only as
+already-shipped groundwork. z2 carries the remaining codex-edge fix:
+channel-via-marketplace-name. Today the standalone marketplace is ONE marketplace NAMED
+`spacedock` carrying two ENTRIES (`spacedock` stable, `spacedock-edge` edge); codex's
+entry-name == `plugin.json`-name check REJECTS the `spacedock-edge` entry, so edge cannot
+install. z2's fix exposes a distinct `spacedock-edge` MARKETPLACE NAME so edge installs as
+`spacedock@spacedock-edge` and the name-match passes — that marketplace restructure is
+within z2's scope. Independent of members 1/2/4 — drive in parallel.
+
+## Release-cut recipe (the finalization sequence — DoD path)
+
+1. **Members 1, 2, 4, 5 merged to `main`** via PR-merge; member 3 already in (`b7ecd04a`).
+2. **VALUE-GATE CHECK** — re-measure all six resident byte counts (`wc -c` on the
+   `skills/first-officer/references/` paths) vs `v0.22.0`. **If any exceeds, the tag does
+   NOT fire — bounce back to the owning member.** This is the begin-with-the-end stop.
+3. **Pre-cut antipattern audit** — independent reviewer over the assembled sprint, tag NOT
+   yet fired. The contract trims are the highest-stakes surface (refute that a load-bearing
+   FO guarantee was dropped to make the byte count). Ship-blockers fixed before the cut.
+4. **Write the `v0.23.0` release notes** — MUST cover the `pre.1`/`pre.2` content AND the
+   token clawback, so a stable user upgrading from `0.22.0` sees the whole story.
+5. **`go test ./...` green** from the root.
+6. **Cut** per the (now-reconciled) `docs/releasing.md`:
+   - Stamp `0.23.0` into the plugin manifests (`.claude-plugin/plugin.json`,
+     `.codex-plugin/plugin.json` — currently `0.22.0`) via `go run ./cmd/spacedock-release
+     stamp-version 0.23.0 ...`.
+   - Tag the e2e-GREEN commit `v0.23.0` (annotated, the release notes as the changelog).
+   - Push to fire goreleaser — it regenerates BOTH casks (with `#420`'s fix), publishes the
+     GitHub Release, and stamps the manifests.
+   - The standalone `spacedock-dev/marketplace` stable `spacedock` entry is repointed to the
+     released tag (a commit in that repo, NOT a manifest stamp on `main`).
+7. **Verify** the tagged commit's manifest reads `0.23.0` AND a fresh `brew install` of the
+   released cask launches (the postflight strips `com.apple.quarantine` → Gatekeeper-clean).
+8. **Cut from `main`** (NOT `next` — `next` is the dev/edge line).
+
+   *Captain authorizes the cut.*
+
+## Escalation (Commander → captain)
+
+Escalate only on: a 3rd feedback cycle on any member, a budget blowout, an irrecoverable
+block, or a genuine scope fork. Specific triggers for THIS sprint:
+
+- **The value gate cannot be met without dropping a load-bearing FO guarantee** — if a trim
+  cannot reach the byte target without touching a named keep (premature-reap ban, idle
+  guardrail, reuse/await semantics), escalate; do not ship a leaner-but-unsafe contract.
+- **The e2e-gate blocks the tag** — if the tagged commit lacks a green Runtime Live E2E run
+  and no waiver applies, escalate (this is member 4's bug surfacing live).
+- **A fresh `brew install` does not launch** post-cut — escalate; the `#420`/postflight
+  chain is the first-launch guarantee and a failure there blocks the deliverable's promise.
+
+Otherwise the Commander drives to the DoD and presents the validation gates + the value-gate
+check + the pre-cut audit + the release cut for captain authorization.
+
+## Close (Shaping FO, post-drive)
+
+- Seed the next sprint — fold the pre-cut audit's non-blockers + the deferred set
+  (`notarize-macos-release`, `gate-on-end-value`, `fo-self-evidence-bar`,
+  `next-independent-release-line`, `live-test-stream-tee-ci-stdout-noise` → 0203) into the
+  next backlog.
+- Light post-cut release verification — some release-machinery issues only manifest when the
+  tag actually fires (the cask regeneration, the marketplace repoint, the fresh-install
+  launch).

--- a/docs/roadmap/0230-stable-finalization/dispatch-sprint-execution.md
+++ b/docs/roadmap/0230-stable-finalization/dispatch-sprint-execution.md
@@ -16,11 +16,12 @@ for its design + ACs. Goal/DoD + the VALUE GATE: `index.md`. Foundation: this cu
 `v0.22.0` stable floor; `main` is at `b7ecd04a` (the `#420` cask fix). The plugin manifests
 read `0.22.0` (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`).
 
-> **Query caveat.** Two of member 4's reconciliation targets still carry
-> `sprint: 0201-post-flip-release-model` and will NOT appear in the 0230 query
-> (`stamp-then-tag-release-ritual` `ezn308z0chwc2zvmyny9ry8w`,
-> `steady-state-stable-release-runbook` `qpfmdxy6438fsndp9nw4c89e`). They are folded into
-> member 4 by reference — see member 4 below.
+> **Member 4 is ONE pass over three query members.** All six members carry
+> `sprint: 0230-stable-finalization` (state commit `5b0dcbc8`) and DO appear in the query.
+> Member 4's three targets — `releasing-doc-pre-stamp-drift` (`7yd3mbsy2am5qggc17sxvz2v`),
+> `stamp-then-tag-release-ritual` (`ezn308z0chwc2zvmyny9ry8w`), and
+> `steady-state-stable-release-runbook` (`qpfmdxy6438fsndp9nw4c89e`) — collide on
+> `docs/releasing.md`, so reconcile all three in ONE serialized pass — see member 4 below.
 
 ## Deliverable & DoD — begin with the end
 
@@ -161,14 +162,14 @@ fresh-install check.
 
 ### Member 4 — `docs/releasing.md` reconciliation · ONE serialized pass · before the cut
 
-Three entities collide on `docs/releasing.md` — serialize them into a single pass, do NOT
-dispatch in parallel:
+Three entities (all `sprint: 0230-stable-finalization`) collide on `docs/releasing.md` —
+serialize them into a single pass, do NOT dispatch in parallel:
 - `releasing-doc-pre-stamp-drift` (`7yd3mbsy2am5qggc17sxvz2v`) — step 3 today does a manual
   `stamp-version` → commit, creating a fresh SHA the e2e-gate has never run green on.
-- `stamp-then-tag-release-ritual` (`ezn308z0chwc2zvmyny9ry8w`, on `sprint: 0201` — by
-  reference) — the tagged commit's manifest must match its tag.
-- `steady-state-stable-release-runbook` (`qpfmdxy6438fsndp9nw4c89e`, on `sprint: 0201` — by
-  reference) — advance `main` from a green `next` tip; reconcile `docs/releasing.md`.
+- `stamp-then-tag-release-ritual` (`ezn308z0chwc2zvmyny9ry8w`) — the tagged commit's
+  manifest must match its tag.
+- `steady-state-stable-release-runbook` (`qpfmdxy6438fsndp9nw4c89e`) — advance `main` from a
+  green `next` tip; reconcile `docs/releasing.md`.
 
 The bug they collectively fix: `docs/releasing.md`'s `## What the Tag Push Does` already
 says goreleaser "publishes only after the `e2e-gate` job confirms the tagged commit has a

--- a/docs/roadmap/0230-stable-finalization/index.md
+++ b/docs/roadmap/0230-stable-finalization/index.md
@@ -20,13 +20,14 @@ spacedock status --workflow-dir docs/dev --where sprint=0230-stable-finalization
 spacedock status --workflow-dir docs/dev --where sprint=0230-stable-finalization --where 'sprint-readiness != defer'
 ```
 
-> **Query caveat (load-bearing for the Commander).** Two of member 4's reconciliation
-> targets — `stamp-then-tag-release-ritual` (`ezn308z0chwc2zvmyny9ry8w`) and
-> `steady-state-stable-release-runbook` (`qpfmdxy6438fsndp9nw4c89e`) — still carry
-> `sprint: 0201-post-flip-release-model` frontmatter, so the `--where sprint=0230` query
-> will NOT surface them. They are folded into member 4 BY REFERENCE (they collide on the
-> same file, `docs/releasing.md`). The Commander reconciles all three in one pass; do not
-> treat the query result as the complete reconciliation scope for member 4.
+> **Member 4 is ONE consolidated pass over three query members.** All six members carry
+> `sprint: 0230-stable-finalization` (state commit `5b0dcbc8`) and DO surface in the query.
+> Member 4's three reconciliation targets — `releasing-doc-pre-stamp-drift`
+> (`7yd3mbsy2am5qggc17sxvz2v`), `stamp-then-tag-release-ritual` (`ezn308z0chwc2zvmyny9ry8w`),
+> and `steady-state-stable-release-runbook` (`qpfmdxy6438fsndp9nw4c89e`) — all collide on
+> the same file (`docs/releasing.md`), so the Commander reconciles all three in ONE
+> serialized pass rather than three parallel dispatches. The query returns them as three
+> entities; member 4 is the single consolidated unit of work over them.
 
 ## Goal (success criterion)
 

--- a/docs/roadmap/0230-stable-finalization/index.md
+++ b/docs/roadmap/0230-stable-finalization/index.md
@@ -1,0 +1,208 @@
+# 0230 — stable v0.23.0 finalization (lean cut)
+
+> **Commissioned 2026-06-20 (Shaping FO).** The first sprint whose deliverable is a
+> STABLE release, not a feature. `v0.22.0` is the last stable tag; two pre-releases
+> (`v0.23.0-pre.1`, `v0.23.0-pre.2`) shipped edge content but accumulated boot-resident
+> FO-contract bloat. Stable was held precisely because that bloat must be clawed back
+> before it ships to every stable user. This sprint cuts a lean `v0.23.0` from `main`.
+
+## Theme
+
+Cut a LEAN stable `v0.23.0` whose boot-resident FO contract is back at or below the
+`v0.22.0` baseline — recovering the token bloat that accreted through `pre.1`/`pre.2` —
+with the `#420` cask channel-switch fix in, a fresh `brew install` surviving first
+launch, and release notes covering everything the two pre-releases shipped.
+
+## Membership is the query, never a hard-coded list
+
+```bash
+spacedock status --workflow-dir docs/dev --where sprint=0230-stable-finalization
+spacedock status --workflow-dir docs/dev --where sprint=0230-stable-finalization --where 'sprint-readiness != defer'
+```
+
+> **Query caveat (load-bearing for the Commander).** Two of member 4's reconciliation
+> targets — `stamp-then-tag-release-ritual` (`ezn308z0chwc2zvmyny9ry8w`) and
+> `steady-state-stable-release-runbook` (`qpfmdxy6438fsndp9nw4c89e`) — still carry
+> `sprint: 0201-post-flip-release-model` frontmatter, so the `--where sprint=0230` query
+> will NOT surface them. They are folded into member 4 BY REFERENCE (they collide on the
+> same file, `docs/releasing.md`). The Commander reconciles all three in one pass; do not
+> treat the query result as the complete reconciliation scope for member 4.
+
+## Goal (success criterion)
+
+A stable `v0.23.0` is tagged from `main` and a fresh `brew install` of it launches, where:
+
+1. **The boot-resident FO contract is lean** — every resident contract file is measured
+   `wc -c` at or below its `v0.22.0` baseline (the VALUE GATE below). This is the WHY the
+   stable was held; it is the deliverable's gate, not side polish.
+2. **The `#420` cask channel-switch fix is in** — a user who switches between the stable
+   `spacedock` cask and the `spacedock@next` edge cask gets the right binary, with the two
+   casks declaring `conflicts_with` each other. (Already merged; in because the tag
+   regenerates both casks via goreleaser.)
+3. **A fresh `brew install` survives first launch** — the cask postflight strips
+   `com.apple.quarantine`, so a Gatekeeper-clean first run works without Developer-ID
+   notarization (which is deferred — it needs an Apple cert).
+4. **Release notes cover everything shipped** — the `v0.23.0` changelog names the `pre.1`
+   and `pre.2` content PLUS the token clawback, so a stable user upgrading from `0.22.0`
+   sees the whole story in one set of notes.
+
+## The VALUE GATE — the definition of done (begin-with-the-end)
+
+**The `v0.23.0` tag does NOT fire until this gate is met.** This is the WHY the stable
+release was held: the token clawback is the deliverable. Stop at this gate and check it
+BEFORE doing release-cut work — a green test suite and a clean audit do not authorize the
+tag if the byte counts still exceed the baseline.
+
+Measured `wc -c` on the boot-resident contract files MUST be `≤` the `v0.22.0` baseline
+for EVERY runtime:
+
+| resident file | v0.22.0 baseline (B) | HEAD at commission (B) | delta | met? |
+| --- | ---: | ---: | ---: | --- |
+| `skills/first-officer/references/first-officer-shared-core.md` | 28586 | 30640 | +2054 | NO — clawback owed |
+| `skills/first-officer/references/fo-dispatch-core.md` | 17488 | 22929 | +5441 | NO — clawback owed |
+| `skills/first-officer/references/fo-merge-core.md` | 8059 | 8597 | +538 | NO — clawback owed |
+| `skills/first-officer/references/claude-first-officer-runtime.md` | 4575 | 4575 | 0 | met (at the line) |
+| `skills/first-officer/references/codex-first-officer-runtime.md` | 6004 | 6043 | +39 | NO — small clawback owed |
+| `skills/first-officer/references/pi-first-officer-runtime.md` | 3754 | 3754 | 0 | met (#418 over-delivered) |
+
+The release is NOT cut while ANY byte count exceeds its `v0.22.0` number. Re-measure with
+`wc -c` against the assembled `main` tip immediately before the cut; if any file is over,
+the tag does not fire — bounce back to the owning member.
+
+> **Measurement de-risk (riskiest-first).** The byte counts above are the gate's authority.
+> Before any cut is applied, pin the baseline numbers and the measurement command (`wc -c`
+> on the exact file paths) so the gate is checked against a fixed, agreed oracle, not a
+> re-derived estimate. Member 1 leads this de-risk (it owns the boot-resident clawback and
+> the no-guidance-control micro-test that proves a cut preserves FO behavior).
+
+## Members (riskiest-first)
+
+| # | slug | id | deliverable | the WHY |
+| --- | --- | --- | --- | --- |
+| 1 | `fo-contract-token-cut` | `y2r7ew51xqs6q3avsb6mcaka` | Boot-resident clawback: apply the verified cuts (`first-officer-shared-core.md` + the runtime adapters) from the `fo-contract-token-cleanup.md` proposal; fold in the zero-discover "no filesystem sweep" prohibition. #418 already landed → this is a rebase + the remaining cuts. | The gate's core; recovers the resident-contract bloat. |
+| 2 | `trim-dispatch-adapter-prose` | `adk755xqeb4a9dxhhgtjwawh` | The `+5441 B` dispatch/merge-core half: trim `fo-dispatch-core.md` (and the merge-core overage) to capability bindings. SB2-class risk. | The single largest delta on the gate. |
+| 3 | `#420` cask channel-switch fix | — (merged: `b7ecd04a`) | Edge cask installs the `spacedock` binary, declares `conflicts_with` stable. | In the tag because goreleaser regenerates both casks at cut time. |
+| 4 | `docs/releasing.md` reconciliation (consolidated) | `7yd3mbsy2am5qggc17sxvz2v` + `ezn308z0chwc2zvmyny9ry8w` + `qpfmdxy6438fsndp9nw4c89e` | ONE pass folding `releasing-doc-pre-stamp-drift` + `stamp-then-tag-release-ritual` + `steady-state-stable-release-runbook`. Fixes the stale step-3 manual pre-stamp that would block a cutter at the exact-SHA e2e-gate. | All three collide on `docs/releasing.md`; serialize them. |
+| 5 | `spacedock-marketplace-source-env` | `z2tjv3570ahjxewv1c309rbc` | Codex EDGE install fix: channel-via-marketplace-name. Edge installs as `spacedock@spacedock-edge` from a distinct `spacedock-edge` MARKETPLACE NAME so codex's entry-name == `plugin.json`-name check passes. Carries the marketplace restructure to expose that distinct name. | Codex edge install is rejected without it. |
+
+### Riskiest-first rationale
+
+Members 1 and 2 carry the value-gate clawback and the SB2-class risk that the trim drops
+a load-bearing guarantee — they go first. Member 3 is already merged. Members 4 and 5 are
+release-machinery and install-path correctness that must be in before the tag but do not
+threaten the gate.
+
+### Member 1 — `fo-contract-token-cut` (the WHY, boot-resident)
+
+The boot-resident clawback. `#418` already landed (the pi adapter over-delivered → the pi
+gate is already met). What remains: rebase the `fo-contract-token-cleanup.md` proposal and
+apply the verified cuts to `first-officer-shared-core.md` and the runtime adapters, and
+fold in the zero-discover "no filesystem sweep" prohibition. Leads the value-measurement
+de-risk: pin the `wc -c` baseline numbers and run the no-guidance-control micro-test on the
+cut clauses before applying, then re-test the keeps (the control can overturn a keep).
+
+### Member 2 — `trim-dispatch-adapter-prose` (the +5441 B half)
+
+The largest single delta on the gate. SB2-class risk: the cuts MUST keep the
+premature-reap ban, the dispatch idle guardrail, and the reuse/await semantics
+**byte-intact** — those are load-bearing FO-safety guarantees. The acceptance criterion
+gates on a NEGATIVE cumulative line delta and is `contractlint`-guarded. Lands AFTER
+member 1 (they both touch resident contract prose; serialize to avoid a collision).
+
+### Member 3 — `#420` cask channel-switch (ALREADY MERGED)
+
+Squash `b7ecd04a` on `main` (`fix(release): edge cask installs spacedock command,
+conflicts_with stable`). Listed as a member because the stable tag regenerates BOTH casks
+via goreleaser — it just needed to be in before the tag fires. No drive work; verified by
+the post-cut fresh-install check.
+
+### Member 4 — `docs/releasing.md` reconciliation (consolidated, serialize)
+
+ONE pass folding three entities that collide on `docs/releasing.md`. The bug: step 3
+today does a manual pre-stamp commit (`stamp-version` → commit), creating a fresh SHA
+the e2e-gate has never exercised green — so a cutter who follows the doc verbatim tags a
+commit the `e2e-gate` job will block (it publishes only after confirming the tagged commit
+has a green Runtime Live E2E or a recorded waiver). The reconciliation makes the doc tag
+the GREEN e2e commit, not a freshly-stamped one. Because all three entities edit the same
+file, they MUST be serialized into a single pass; do not dispatch them in parallel.
+
+### Member 5 — `spacedock-marketplace-source-env` (z2)
+
+Codex EDGE install fix. The standalone-marketplace decouple is a SHIPPED PREREQUISITE (PR
+#352 — the standalone `spacedock-dev/marketplace` repo with the `spacedock`/`spacedock-edge`
+entries already exists), NOT a live member. z2 carries the remaining codex-edge fix:
+channel-via-marketplace-name. Today the standalone marketplace is one marketplace NAMED
+`spacedock` carrying two ENTRIES (`spacedock` stable, `spacedock-edge` edge); codex's
+entry-name == `plugin.json`-name check REJECTS the `spacedock-edge` entry. z2's fix exposes
+a distinct `spacedock-edge` MARKETPLACE NAME so edge installs as `spacedock@spacedock-edge`
+and the name-match passes. That marketplace restructure is within z2's scope.
+
+## Deferred (NOT in 0230) — and why
+
+| deferred | why it is out of 0230 |
+| --- | --- |
+| `notarize-macos-release` | The cask postflight already strips `com.apple.quarantine`, so fresh installs launch. Developer-ID notarization needs an Apple cert — out of scope for a leanness cut. |
+| `gate-on-end-value` | Adds resident tokens during a leanness sprint — directly opposes the value gate. |
+| `fo-self-evidence-bar` | Adds contract text — same opposition to the gate. |
+| `next-independent-release-line` | Edge versioning, not the stable cut. |
+| `live-test-stream-tee-ci-stdout-noise` | CI log hygiene → belongs to `0203`. |
+
+## Dependencies & sequencing
+
+- **Member 1 leads** (boot-resident clawback + the value-measurement de-risk). Member 2
+  lands AFTER member 1 (both touch resident contract prose — serialize).
+- **Member 3 is already merged** — no drive; it is in the tree.
+- **Member 4 is a single serialized pass** over `docs/releasing.md` (three colliding
+  entities).
+- **Member 5** (codex-edge install) is independent of 1/2/4 and can run in parallel.
+- **The value gate is the funnel** — every member feeds the cut, but the cut does not fire
+  until the gate's byte counts are all met, re-measured against the assembled `main` tip.
+
+## Definition of Done
+
+`v0.23.0` is cut from `main` when:
+
+- **The VALUE GATE is met** — every resident contract file is `wc -c` `≤` its `v0.22.0`
+  baseline (the table above), re-measured against the assembled `main` tip.
+- Members 1, 2, 4, 5 merged to `main`; member 3 already in.
+- The pre-cut antipattern audit (independent reviewer, tag not yet fired) is clean —
+  ship-blockers fixed, non-blockers seeded.
+- `go test ./...` green from the root.
+- The `v0.23.0` release notes cover the `pre.1`/`pre.2` content AND the token clawback.
+- The plugin manifests (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
+  currently `0.22.0`) are stamped `0.23.0` on the tagged commit, the tag is on an
+  e2e-green commit, and the tagged commit's manifest reads `0.23.0`.
+- The tag push fires goreleaser (regenerating both casks with `#420`'s fix), and a fresh
+  `brew install` of the released cask launches.
+
+## Sprint lifecycle checklist (owner-tagged)
+
+**Shape — Shaping FO (this session)**
+- [x] **Scope-lock** with the captain — members in / deferred ✓
+- [x] **Carve** — members stamped `sprint: 0230-stable-finalization` (member 1, 2, and the
+  releasing-doc-pre-stamp-drift entity); write this `index.md` ✓
+- [ ] **Ideate** any gated member that is not already designed (the token-cut + trim cuts
+  carry their proposals; the releasing reconciliation + codex-edge fix carry their entity
+  bodies)
+- [ ] **⚠️ Preflight staff review (sprint-wide)** — independent reviewer refutes the sprint
+  as a whole → `staff-review.md`
+- [ ] **Package** — `dispatch-sprint-execution.md` (the cold-boot Commander package — below) ✓
+
+**Drive — Commander (a separate, cold-booted session)**
+- [ ] Implementation → validation → done per member; detached adversarial audit at
+  validation for the high-stakes surfaces (the shipped FO contract trims; the release
+  machinery)
+- [ ] Merge each to `main` (PR-merge); state commits concurrency-safe
+- [ ] **VALUE-GATE CHECK** — re-measure all resident byte counts vs `v0.22.0`; if any
+  exceeds, the tag does NOT fire — bounce back
+- [ ] **⚠️ Pre-cut antipattern audit** — independent reviewer over the assembled sprint
+  before the tag fires
+- [ ] **Cut the release** — `go test ./...` green, stamp `0.23.0`, tag the e2e-green
+  commit, push to fire goreleaser, verify the tagged manifest reads `0.23.0` + fresh
+  install launches *(captain authorizes)*
+
+**Close — Shaping FO**
+- [ ] Seed the next sprint — fold the pre-cut audit's non-blockers + the deferred set
+  (notarize, gate-on-end-value, fo-self-evidence-bar, next-independent-release-line,
+  live-test-stream-tee → 0203) into the next backlog + a light post-cut release
+  verification.


### PR DESCRIPTION
Commissions sprint **0230 — stable v0.23.0 finalization (lean cut)** as a self-contained Commander dispatch package, runnable from a cold boot by a separate session.

## Goal
Cut a LEAN stable `v0.23.0` from `main` whose boot-resident FO contract is back at or below the `v0.22.0` baseline (recovering the bloat that accumulated through `pre.1`/`pre.2`), with the `#420` cask channel-switch fix in, a fresh `brew install` surviving first launch, and release notes covering everything the two pre-releases shipped. The token clawback is the WHY stable was held — it is the deliverable's gate, not side polish.

## The VALUE GATE (begin-with-the-end; the DoD)
The `v0.23.0` tag does NOT fire until measured `wc -c` on every boot-resident contract file is `≤` its `v0.22.0` baseline:
- `first-officer-shared-core.md` ≤ 28586 B (30640 at HEAD, +2054 owed)
- `fo-dispatch-core.md` ≤ 17488 B (22929 at HEAD, +5441 owed — the big one)
- `fo-merge-core.md` ≤ 8059 B (8597 at HEAD, +538 owed)
- `claude-first-officer-runtime.md` ≤ 4575 B (met at the line)
- `codex-first-officer-runtime.md` ≤ 6004 B (6043 at HEAD, +39 owed)
- `pi-first-officer-runtime.md` ≤ 3754 B (met — #418 over-delivered)

The release is NOT cut while any byte count exceeds its number — re-measure against the assembled `main` tip and bounce back if any file is over.

## Members (riskiest-first)
1. `fo-contract-token-cut` — boot-resident clawback (the WHY); leads the value-measurement de-risk. #418 landed → rebase + remaining cuts + the zero-discover "no filesystem sweep" prohibition.
2. `trim-dispatch-adapter-prose` — the +5441 B dispatch/merge-core half. SB2-class: premature-reap ban + idle guardrail + reuse/await semantics stay BYTE-INTACT; AC gates on a negative cumulative line delta; contractlint-guarded.
3. `#420` — edge cask channel-switch. ALREADY MERGED (`b7ecd04a`); in because the tag regenerates both casks via goreleaser.
4. Consolidated `docs/releasing.md` reconciliation — one serialized pass folding `releasing-doc-pre-stamp-drift` + `stamp-then-tag-release-ritual` + `steady-state-stable-release-runbook` (they collide on the same file). Fixes the stale step-3 manual pre-stamp that would block a cutter at the exact-SHA e2e-gate.
5. `spacedock-marketplace-source-env` (z2) — codex EDGE install via channel-via-marketplace-name: edge installs as `spacedock@spacedock-edge` from a distinct `spacedock-edge` MARKETPLACE NAME so codex's entry-name == plugin.json-name check passes. The standalone-marketplace decouple is a SHIPPED PREREQUISITE (PR #352), not a member.

## Deferred (NOT in 0230)
`notarize-macos-release` (postflight already strips quarantine; Developer-ID notarization needs an Apple cert), `gate-on-end-value` + `fo-self-evidence-bar` (both add resident tokens during a leanness sprint), `next-independent-release-line` (edge versioning), `live-test-stream-tee-ci-stdout-noise` (CI log hygiene → 0203).

## Files
- `docs/roadmap/0230-stable-finalization/index.md` — sprint strategy (goal, value gate as DoD, members, deferred + why, lifecycle checklist).
- `docs/roadmap/0230-stable-finalization/dispatch-sprint-execution.md` — cold-boot Commander dispatch (boot recipe, value gate as DoD + begin-with-the-end stop, ordered member sequence, finalization/cut recipe, escalation triggers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
