### PR TITLE
Convert ensign runtime adapters to capability binding blocks (t0g ensign-side)

### DIFF
--- a/docs/runtime-support.md
+++ b/docs/runtime-support.md
@@ -37,6 +37,17 @@ Keep residual sections short and factual: live-tool probes, harness isolation, c
 
 If a host-specific rule is load-bearing, first try to attach it to the relevant capability bullet. Add a separate prose section only when the rule spans multiple capabilities or documents a probe/harness concern.
 
+An ensign runtime adapter follows the same default: a `## Runtime implementation` bindings block, not lifecycle prose. The shared ensign core (`ensign-shared-core.md`) owns the discipline (assignment reading, worktree, split-root commit, frontmatter, proof, stage report); the adapter binds only the concerns that differ by host. The ensign block is keyed by the ensign-controlled concern, not the FO's worker-lifecycle capabilities.
+
+Preferred shape:
+
+- `Clarification` -> the host channel for asking the FO a blocking or non-blocking question.
+- `Completion signal` -> the observable signal the ensign emits when done; note that the FO file-verifies the stage report as the gate.
+- `Captain communication` -> the direct-to-captain channel when the stage involves captain interaction (host-only; omit where the host has no such channel).
+- `Shutdown response` -> the cooperative shutdown acknowledgement (host-only; omit where the host has no mailbox shutdown).
+
+Do not re-narrate the shared dispatch, worktree, split-root, frontmatter, path-scoped-commit, or feedback-routing discipline in the ensign adapter — the shared ensign core carries it. Omit a bullet whose concern the host does not have rather than binding it to a negative contrast against another host.
+
 ## Runtime layers
 
 Add support in small layers. Each layer should have its own proof.

--- a/internal/contractlint/pi_runtime_negative_contrast_test.go
+++ b/internal/contractlint/pi_runtime_negative_contrast_test.go
@@ -59,11 +59,13 @@ func TestPiFirstOfficerRuntimeAvoidsNegativeHostContrast(t *testing.T) {
 }
 
 // TestPiEnsignRuntimeAvoidsNegativeHostContrast is the Pi ensign equivalent of
-// TestCodexEnsignRuntimeAvoidsNegativeHostContrast. The Pi ensign adapter has
-// zero legitimate "Claude" mentions (the runtime-support.md sweep removed the
-// lone negative "Do not assume Claude team tools exist in Pi." sentence), so a
-// targeted phrase ban is safe here: it passes today and would have caught the
-// FIX-4 regression if the removed sentence were re-introduced.
+// TestCodexEnsignRuntimeAvoidsNegativeHostContrast. The Pi ensign adapter is a
+// compact binding block keyed by the Pi-specific concerns (clarification,
+// completion signal); the shared ensign core owns the rest. The adapter has zero
+// legitimate "Claude" mentions, so a targeted phrase ban is safe here: it passes
+// today and would catch a re-introduced negative host-contrast sentence. The
+// positive assertions pin the binding-block bullets so the host-specific Pi
+// completion and clarification bindings survive the shared-core duplication trim.
 func TestPiEnsignRuntimeAvoidsNegativeHostContrast(t *testing.T) {
 	root := repoRoot(t)
 	rel := filepath.Join("skills", "ensign", "references", "pi-ensign-runtime.md")
@@ -83,12 +85,17 @@ func TestPiEnsignRuntimeAvoidsNegativeHostContrast(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		// FIX 4 — the positive Pi completion binding retained after the negative
-		// "Do not assume Claude team tools exist in Pi." sentence was dropped.
+		// The completion-signal binding bullet — the Pi-specific completion signal
+		// the shared core does not carry.
+		"- `Completion signal` ->",
 		"Completion is reported by the worker's final result in the Pi turn or by the active Pi adapter's task-completion notification.",
+		// The clarification binding bullet — the Pi-specific contact_supervisor
+		// surface the shared core does not carry.
+		"- `Clarification` ->",
+		"contact_supervisor` with `reason: \"need_decision\"`",
 	} {
 		if !strings.Contains(text, want) {
-			t.Errorf("%s missing positive Pi ensign wording %q", rel, want)
+			t.Errorf("%s missing positive Pi ensign binding wording %q", rel, want)
 		}
 	}
 }

--- a/skills/ensign/references/codex-ensign-runtime.md
+++ b/skills/ensign/references/codex-ensign-runtime.md
@@ -1,48 +1,12 @@
 # Codex Ensign Runtime
 
-How the shared ensign core executes on Codex.
+How the shared ensign core executes on Codex. The shared core owns the ensign discipline (assignment reading, worktree, split-root commit, proof, stage report); this adapter binds only the Codex-specific concerns.
 
-## Agent Surface
+## Runtime implementation
 
-The ensign is dispatched through Codex multi-agent dispatch. The dispatch prompt is authoritative for all assignment fields: entity, stage, stage definition, workflow location, and checklist.
+- `Clarification` -> ask in the Codex worker thread, naming what you understand and what is ambiguous so the FO can route an answer through `«addressable-worker»`.
+- `Completion signal` -> one minimal final message in the Codex worker thread: `Done: {entity title} completed {stage}. Report written to {entity_file_path}.` Plain text, single line; the entity file is the artifact. After sending the completion signal, stop unless the FO routes more work through `«addressable-worker»`.
+- `Captain communication` -> when the stage involves direct captain interaction, communicate via direct Codex conversation text; keep operational signals concise so the FO mailbox notification stays easy to interpret.
+- `Shutdown response` -> on an explicit cooperative shutdown request through `«addressable-worker»`, acknowledge in plain text and stop unless load-bearing in-flight work would be lost, in which case briefly name what must be preserved first.
 
-Codex dispatch build prompts are file pointers. Read the named dispatch file directly and treat its content as the assignment.
-
-`«context-budget»` is unavailable unless a future probe binds it. The FO owns reuse decisions; the ensign follows the assignment.
-
-## Dispatch
-
-Initial dispatch comes from `spacedock dispatch build` with `host: "codex"`. The generated file carries fetch commands, worktree rules, split-root state commit guidance, checklist, and completion-signal wording. Use the generated file as the source of truth.
-
-When `«worker.spawn»` is bound, the FO maps the helper output to the live worker dispatch capability: the helper `prompt` is passed unchanged as the worker message, while unsupported helper fields are not passed to the live spawn tool. The helper `name` remains the `«worker-identity»` source, even when the live task name is sanitized to lowercase digits and underscores.
-
-## Awaiting Completion
-
-The FO observes completion through the async final-status notification in the FO mailbox. After sending the completion signal, stop unless the FO routes more work through `«addressable-worker»`.
-
-## Clarification
-
-If requirements are unclear, ask in the Codex worker thread. Describe what you understand and what is ambiguous so the FO can route a non-triggering note or turn-starting work through `«addressable-worker»`.
-
-## Captain Communication
-
-When dispatched for a stage that involves direct interaction with the captain, communicate via direct Codex conversation text. Keep operational completion signals concise so the FO mailbox notification stays easy to interpret.
-
-## Completion Signal
-
-When your work is done, send one minimal final message in the Codex worker
-thread:
-
-```text
-Done: {entity title} completed {stage}. Report written to {entity_file_path}.
-```
-
-The entity file is the artifact. Keep the completion signal plain text and limited to the single line above.
-
-## Feedback Interaction
-
-For feedback stages, when `«addressable-worker»` is bound, the FO routes turn-starting feedback through it. Apply the feedback, update the stage report if needed, and send the same completion signal when finished.
-
-## Shutdown Response Protocol
-
-If the FO sends an explicit cooperative shutdown request through `«addressable-worker»`, acknowledge in plain text and stop unless load-bearing in-flight work would be lost. In that case, briefly name what must be preserved before shutdown. Codex `«worker.shutdown»` remains unresolved until probed; do not assume live interruption is a safe shutdown instruction.
+`«context-budget»` is unavailable unless a future probe binds it. The FO owns reuse decisions. Codex dispatch build prompts are file pointers carrying fetch commands, worktree rules, split-root commit guidance, checklist, and completion-signal wording. Use the generated file as the source of truth.

--- a/skills/ensign/references/pi-ensign-runtime.md
+++ b/skills/ensign/references/pi-ensign-runtime.md
@@ -1,36 +1,8 @@
 # Pi Ensign Runtime
 
-This file defines how the shared ensign core executes on Pi.
+How the shared ensign core executes on Pi. The shared core owns the ensign discipline (assignment reading, worktree, split-root commit, frontmatter, proof, stage report); this adapter binds only the Pi-specific concerns.
 
-## Agent Surface
+## Runtime implementation
 
-A Pi ensign receives a bounded assignment from a Pi-native substrate such as `pi-subagents` or, through an adapter, `pi-agent-teams`. The assignment content is authoritative: entity path, workflow directory, target stage, stage definition fetch command, worktree path when present, and completion checklist.
-
-Completion is reported by the worker's final result in the Pi turn or by the active Pi adapter's task-completion notification.
-
-## Pi-Specific Rules
-
-- If the dispatch prompt is a read-dispatch-file pointer, read that file first and treat its content as the assignment.
-- If no worktree path is provided, stay on the repo root/main-branch checkout named by the assignment.
-- If a worktree path is provided, keep code reads, writes, tests, and code commits under that worktree.
-- In split-root workflows, the entity body and stage report stay at the state-checkout entity path provided by the dispatch; do not invent a worktree copy of the entity.
-- Do not modify YAML frontmatter in the entity file.
-- Commit the entity body/stage report path-scoped in the state checkout when the assignment asks for a state commit.
-- Treat each follow-up assignment as a fresh cycle; never assume a previous completion still satisfies the current assignment.
-
-## Clarification
-
-If requirements are unclear or ambiguous, ask for clarification via `contact_supervisor` with `reason: "need_decision"` rather than guessing. Describe what you understand and what's ambiguous so the FO can route a quick answer. The FO replies via `intercom({action:"reply", message:"..."})`; after receiving the reply, resume working. `need_decision` blocks with a 10-minute timeout — ask only when genuinely blocked, and surface enough context for a one-shot answer.
-
-For non-blocking plan-changing discoveries (a riskier mechanism panning out, a scope boundary discovered, an unexpected dependency), send `contact_supervisor` with `reason: "progress_update"` — the FO reads and acknowledges; no reply is required and you continue working without waiting.
-
-## Completion
-
-When done, return one concise final result that names:
-
-- the entity and stage completed;
-- the entity file containing the stage report;
-- the commit or durable evidence produced;
-- any residual risk or blocker.
-
-The final result (the subagent return) is the primary completion signal; an optional done-advisory sent via `intercom send` (NOT `contact_supervisor`, which offers no completion reason) may precede the subagent return as a heads-up; the FO file-verifies the stage report either way. After sending that completion result, stop. Do not idle waiting for another message unless the active Pi substrate explicitly delivers one or the FO routes follow-up through the back-channel.
+- `Clarification` -> `contact_supervisor` with `reason: "need_decision"` when genuinely blocked, naming what you understand and what is ambiguous for a one-shot answer; the FO replies via `intercom({action:"reply", message:"..."})` and you resume. `need_decision` blocks with a 10-minute timeout. For non-blocking plan-changing discoveries, use `reason: "progress_update"` — the FO acknowledges, no reply required, and you continue.
+- `Completion signal` -> return one concise final result naming the entity and stage completed, the entity file containing the stage report, the commit or durable evidence produced, and any residual risk. Completion is reported by the worker's final result in the Pi turn or by the active Pi adapter's task-completion notification. The subagent return is the primary signal and the FO file-verifies the stage report; an optional `intercom send` done-advisory may precede the return as a heads-up. After returning, stop unless the active Pi substrate delivers another message or the FO routes follow-up through the back-channel.


### PR DESCRIPTION
Shrink the Codex and Pi ensign runtime adapters to host-specific binding blocks, cutting ~70-80% duplication of the ensign shared core.

## What changed
- Reduce codex-ensign-runtime.md to a compact host-binding block (2847→1522 B).
- Reduce pi-ensign-runtime.md likewise (2838→1333 B).
- Re-target the #417 pi-ensign contractlint guard to the binding bullets.
- Document the ensign binding-block shape in docs/runtime-support.md.

## Evidence
- Byte gates met: codex 1522 ≤ 2390, pi 1333 ≤ 1768; shared-core + claude-ensign byte-unchanged.
- `go test ./...` + contractlint green; detached audit reproduced on a throwaway checkout.

---
[x1](/spacedock-dev/spacedock/blob/012aee734f66ef72268088876ca7852d7b14d6ef/ensign-runtime-binding-block-cleanup/index.md)
