### PR TITLE
Codex edge channel install — marketplace-name channels, programmatic install, source override

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -409,6 +409,76 @@ jobs:
             exit 1
           fi
 
+      # AC-1: the EDGE channel install end-to-end on the real codex CLI. Codex
+      # enforces that a marketplace entry's name equals the plugin's own plugin.json
+      # `name` (`spacedock`). The OLD channel encoding put the channel in the ENTRY
+      # name (`spacedock-edge`), so `codex plugin add spacedock-edge@spacedock` was
+      # rejected — the failing-today baseline. The fix puts the channel in the
+      # marketplace NAME (`spacedock-edge`) with the entry still `spacedock`, so
+      # `codex plugin add spacedock@spacedock-edge` passes. This step proves BOTH on
+      # the live host: the old shape still fails (baseline moves the wrong way) and
+      # the new shape succeeds (the fix flips it).
+      - name: Codex edge channel install (name-match baseline → fix)
+        run: |
+          # Baseline: the OLD shape — entry named `spacedock-edge` in a marketplace
+          # named `spacedock` — must FAIL codex's entry-name vs plugin.json name
+          # check. (The plugin's own plugin.json name is `spacedock`.)
+          oldmkt="$RUNNER_TEMP/spacedock-codex-oldshape"
+          mkdir -p "$oldmkt/.agents/plugins" "$oldmkt/plugins"
+          ln -s "$GITHUB_WORKSPACE" "$oldmkt/plugins/spacedock"
+          cat > "$oldmkt/.agents/plugins/marketplace.json" <<'JSON'
+          {
+            "name": "spacedock",
+            "plugins": [
+              {
+                "name": "spacedock-edge",
+                "source": { "source": "local", "path": "./plugins/spacedock" },
+                "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+                "category": "workflow"
+              }
+            ]
+          }
+          JSON
+          codex plugin marketplace add "$oldmkt"
+          if codex plugin add spacedock-edge@spacedock 2> "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-baseline-err.txt"; then
+            echo "BASELINE REGRESSION: codex accepted the old entry-name shape spacedock-edge@spacedock; the name-match constraint this AC depends on no longer holds." >&2
+            cat "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-baseline-err.txt" >&2
+            exit 1
+          fi
+          echo "Baseline confirmed: codex rejects spacedock-edge@spacedock (entry name != plugin.json name)." | tee -a "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-baseline-err.txt"
+
+          # Fix: the NEW shape — entry still `spacedock`, marketplace named
+          # `spacedock-edge` — must SUCCEED. This is the channelMarketplace fix the
+          # binary now emits (spacedock@spacedock-edge).
+          edgemkt="$RUNNER_TEMP/spacedock-codex-edge-marketplace"
+          mkdir -p "$edgemkt/.agents/plugins" "$edgemkt/plugins"
+          ln -s "$GITHUB_WORKSPACE" "$edgemkt/plugins/spacedock"
+          cat > "$edgemkt/.agents/plugins/marketplace.json" <<'JSON'
+          {
+            "name": "spacedock-edge",
+            "plugins": [
+              {
+                "name": "spacedock",
+                "source": { "source": "local", "path": "./plugins/spacedock" },
+                "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+                "category": "workflow"
+              }
+            ]
+          }
+          JSON
+          codex plugin marketplace add "$edgemkt"
+          codex plugin add spacedock@spacedock-edge
+          codex plugin list | tee "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-plugin-list.txt"
+          if ! grep -Fq "spacedock@spacedock-edge" "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-plugin-list.txt"; then
+            echo "codex-live edge install did not list spacedock@spacedock-edge after a successful add." >&2
+            exit 1
+          fi
+          if ! grep -Fq "$edgemkt/plugins/spacedock" "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-plugin-list.txt"; then
+            echo "codex-live edge install did not list the current checkout plugin path." >&2
+            exit 1
+          fi
+          echo "Fix confirmed: codex installed spacedock@spacedock-edge from the spacedock-edge marketplace name."
+
       - name: Verify Codex resolver against installed plugin
         run: go test ./internal/cli -run TestCodexResolveManifestAgainstInstalledHost
 

--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -422,11 +422,21 @@ jobs:
         run: |
           # Baseline: the OLD shape — entry named `spacedock-edge` in a marketplace
           # named `spacedock` — must FAIL codex's entry-name vs plugin.json name
-          # check. (The plugin's own plugin.json name is `spacedock`.)
-          oldmkt="$RUNNER_TEMP/spacedock-codex-oldshape"
-          mkdir -p "$oldmkt/.agents/plugins" "$oldmkt/plugins"
-          ln -s "$GITHUB_WORKSPACE" "$oldmkt/plugins/spacedock"
-          cat > "$oldmkt/.agents/plugins/marketplace.json" <<'JSON'
+          # check. (The plugin's own plugin.json name is `spacedock`.) The baseline's
+          # marketplace is ALSO named `spacedock`, which collides with the real
+          # `spacedock` marketplace this job already registered ("marketplace
+          # 'spacedock' is already added from a different source"). Run the baseline
+          # under its OWN isolated CODEX_HOME (a subshell export, scoped to these
+          # commands) so the old-shape add can't collide; the fix portion below runs
+          # in the job's default CODEX_HOME and integrates with the rest of the job.
+          (
+            baseline_home="$RUNNER_TEMP/spacedock-codex-baseline-home"
+            mkdir -p "$baseline_home"
+            export CODEX_HOME="$baseline_home"
+            oldmkt="$RUNNER_TEMP/spacedock-codex-oldshape"
+            mkdir -p "$oldmkt/.agents/plugins" "$oldmkt/plugins"
+            ln -s "$GITHUB_WORKSPACE" "$oldmkt/plugins/spacedock"
+            cat > "$oldmkt/.agents/plugins/marketplace.json" <<'JSON'
           {
             "name": "spacedock",
             "plugins": [
@@ -439,17 +449,25 @@ jobs:
             ]
           }
           JSON
-          codex plugin marketplace add "$oldmkt"
-          if codex plugin add spacedock-edge@spacedock 2> "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-baseline-err.txt"; then
-            echo "BASELINE REGRESSION: codex accepted the old entry-name shape spacedock-edge@spacedock; the name-match constraint this AC depends on no longer holds." >&2
-            cat "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-baseline-err.txt" >&2
-            exit 1
-          fi
-          echo "Baseline confirmed: codex rejects spacedock-edge@spacedock (entry name != plugin.json name)." | tee -a "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-baseline-err.txt"
+            codex plugin marketplace add "$oldmkt"
+            if codex plugin add spacedock-edge@spacedock 2> "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-baseline-err.txt"; then
+              echo "BASELINE REGRESSION: codex accepted the old entry-name shape spacedock-edge@spacedock; the name-match constraint this AC depends on no longer holds." >&2
+              cat "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-baseline-err.txt" >&2
+              exit 1
+            fi
+            if ! grep -Fq "does not match" "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-baseline-err.txt"; then
+              echo "BASELINE add failed, but NOT with the expected name-mismatch error (e.g. a marketplace collision); the baseline must fail for the name-match reason." >&2
+              cat "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-baseline-err.txt" >&2
+              exit 1
+            fi
+            echo "Baseline confirmed: codex rejects spacedock-edge@spacedock (entry name != plugin.json name)." | tee -a "$SPACEDOCK_LIVE_ARTIFACT_DIR/codex-edge-baseline-err.txt"
+          )
 
           # Fix: the NEW shape — entry still `spacedock`, marketplace named
           # `spacedock-edge` — must SUCCEED. This is the channelMarketplace fix the
-          # binary now emits (spacedock@spacedock-edge).
+          # binary now emits (spacedock@spacedock-edge). It runs in the job's default
+          # CODEX_HOME; the `spacedock-edge` marketplace name is distinct from the
+          # already-registered `spacedock`, so no collision.
           edgemkt="$RUNNER_TEMP/spacedock-codex-edge-marketplace"
           mkdir -p "$edgemkt/.agents/plugins" "$edgemkt/plugins"
           ln -s "$GITHUB_WORKSPACE" "$edgemkt/plugins/spacedock"

--- a/docs/site/get-started/install.md
+++ b/docs/site/get-started/install.md
@@ -43,9 +43,29 @@ Replace `claude` with `codex` or `pi` for the respective coding agents.
 Spacedock installs the relevant skills on launch. To install them manually:
 
 ```bash
+# Stable (default channel) — marketplace named `spacedock`, entry `spacedock`
 claude plugin marketplace add spacedock-dev/marketplace
 claude plugin install spacedock@spacedock
+
+# Edge (tracks next) — marketplace named `spacedock-edge`, entry still `spacedock`
+claude plugin install spacedock@spacedock-edge
 ```
+
+The channel is the marketplace name; the entry name stays `spacedock` on both
+channels (it equals the plugin's own `name`, so the host's entry-name vs
+plugin-name check passes). Codex installs the same way with `codex plugin add`.
+
+Set `SPACEDOCK_MARKETPLACE_SOURCE` to install from a local or alternate
+marketplace instead of the default `spacedock-dev/marketplace` — useful for
+dogfooding a marketplace change before it reaches the production marketplace:
+
+```bash
+SPACEDOCK_MARKETPLACE_SOURCE=/path/to/local/marketplace spacedock install --host codex
+```
+
+Launching with `--plugin-dir` loads a local plugin checkout directly and bypasses
+installed-plugin resolution, but it does not wrap the launch in the safehouse
+sandbox — use it for plugin development, not as an install substitute.
 
 ## Sandboxing
 

--- a/internal/cli/channel_aware_resolver_test.go
+++ b/internal/cli/channel_aware_resolver_test.go
@@ -1,0 +1,118 @@
+// ABOUTME: AC-4 channel-aware resolvers — an edge binary recognizes/refreshes an
+// ABOUTME: installed edge plugin (spacedock@spacedock-edge), not the hardcoded stable id.
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestCodexCacheManifestResolvesEdgeChannel locks AC-4 for the codex cache tail:
+// an edge binary (devBranch=next) resolves the EDGE plugin's cached manifest under
+// the channel marketplace's cache dir (cache/spacedock-edge/spacedock/<ver>/…), not
+// the hardcoded stable cache/spacedock/spacedock path. A stable-only resolver would
+// return "" here and the edge front door would never launch a present edge plugin.
+func TestCodexCacheManifestResolvesEdgeChannel(t *testing.T) {
+	saved := devBranch
+	devBranch = "next"
+	defer func() { devBranch = saved }()
+
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	// The edge plugin's cache layout: the marketplace name is the channel
+	// (spacedock-edge), the entry is spacedock.
+	manifest := filepath.Join(home, "plugins", "cache", "spacedock-edge", "spacedock", "0.13.0", ".codex-plugin", "plugin.json")
+	if err := os.MkdirAll(filepath.Dir(manifest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifest, []byte(`{"name":"spacedock"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := codexCacheManifest()
+	if err != nil {
+		t.Fatalf("codexCacheManifest errored: %v", err)
+	}
+	if got != manifest {
+		t.Fatalf("codexCacheManifest (edge) = %q, want %q (edge resolves under the spacedock-edge marketplace cache)", got, manifest)
+	}
+}
+
+// TestCodexCacheManifestStableUnchanged guards that the stable channel still
+// resolves under cache/spacedock/spacedock — the channel-aware change must not
+// regress the stable path.
+func TestCodexCacheManifestStableUnchanged(t *testing.T) {
+	saved := devBranch
+	devBranch = "main"
+	defer func() { devBranch = saved }()
+
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	manifest := filepath.Join(home, "plugins", "cache", "spacedock", "spacedock", "0.13.0", ".codex-plugin", "plugin.json")
+	if err := os.MkdirAll(filepath.Dir(manifest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifest, []byte(`{"name":"spacedock"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := codexCacheManifest()
+	if err != nil {
+		t.Fatalf("codexCacheManifest errored: %v", err)
+	}
+	if got != manifest {
+		t.Fatalf("codexCacheManifest (stable) = %q, want %q", got, manifest)
+	}
+}
+
+// TestResolveClaudeManifestMatchesEdgeChannel locks AC-4 for the claude resolver:
+// with an edge binary (devBranch=next), resolveClaudeManifest must match the EDGE
+// plugin id (spacedock@spacedock-edge) in the host listing, not only the stable
+// spacedock@spacedock. A PATH-stub `claude` emits the listing JSON so the test runs
+// with no real claude CLI.
+func TestResolveClaudeManifestMatchesEdgeChannel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub script uses /bin/sh; not portable to Windows")
+	}
+	saved := devBranch
+	devBranch = "next"
+	defer func() { devBranch = saved }()
+
+	installPath := t.TempDir()
+	listing := `[{"id":"spacedock@spacedock-edge","installPath":"` + installPath + `","enabled":true}]`
+	dir := writePluginListStub(t, "claude", listing)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	got, err := execHost{}.resolveClaudeManifest("claude")
+	if err != nil {
+		t.Fatalf("resolveClaudeManifest errored: %v", err)
+	}
+	want := filepath.Join(installPath, manifestSubpath("claude"))
+	if got != want {
+		t.Fatalf("resolveClaudeManifest (edge) = %q, want %q (edge binary must recognize the spacedock@spacedock-edge install)", got, want)
+	}
+}
+
+// writePluginListStub writes a host CLI stub that prints the given JSON listing on
+// `plugin list --json` (and empty otherwise), for resolver tests that need the
+// host's `plugin list` output without a real CLI.
+func writePluginListStub(t *testing.T, binName, listingJSON string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, binName)
+	body := `#!/bin/sh
+case "$*" in
+"plugin list --json")
+  cat <<'JSON'
+` + listingJSON + `
+JSON
+  ;;
+esac
+`
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write plugin-list stub: %v", err)
+	}
+	return dir
+}

--- a/internal/cli/channel_marketplace_name_test.go
+++ b/internal/cli/channel_marketplace_name_test.go
@@ -1,0 +1,67 @@
+// ABOUTME: AC-2 channel-in-marketplace-name — the entry stays `spacedock` (== manifest
+// ABOUTME: name, so the host name-match passes); the channel lives in the marketplace NAME.
+package cli
+
+import "testing"
+
+// TestChannelEntryIsAlwaysManifestName locks the name-match-safe shape: the
+// marketplace ENTRY name is always `spacedock`, equal to the plugin's own
+// plugin.json `name`, on BOTH channels. Codex (and claude) reject an entry whose
+// name differs from the manifest name, so encoding the channel in the entry name
+// (the old `spacedock-edge` entry) made `codex plugin add` fail. The entry must be
+// channel-invariant.
+func TestChannelEntryIsAlwaysManifestName(t *testing.T) {
+	for _, devBranch := range []string{"main", "next", "anything-else"} {
+		if got := channelEntry(devBranch); got != "spacedock" {
+			t.Errorf("channelEntry(%q) = %q, want spacedock (entry name must equal manifest name on every channel)", devBranch, got)
+		}
+	}
+}
+
+// TestChannelMarketplaceCarriesTheChannel locks the inverted model: the channel is
+// the marketplace NAME. A stable binary (devBranch=main) resolves the `spacedock`
+// marketplace; an edge binary (any other devBranch) resolves `spacedock-edge`.
+func TestChannelMarketplaceCarriesTheChannel(t *testing.T) {
+	cases := []struct {
+		channel       string
+		devBranch     string
+		wantMarketplace string
+	}{
+		{channel: "stable", devBranch: "main", wantMarketplace: "spacedock"},
+		{channel: "edge", devBranch: "next", wantMarketplace: "spacedock-edge"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.channel, func(t *testing.T) {
+			if got := channelMarketplace(tc.devBranch); got != tc.wantMarketplace {
+				t.Errorf("channelMarketplace(%q) = %q, want %q (the %s channel marketplace name)", tc.devBranch, got, tc.wantMarketplace, tc.channel)
+			}
+		})
+	}
+}
+
+// TestChannelPluginIDIsEntryAtMarketplace locks the resolved id under the inverted
+// model: `<entry>@<marketplace>` = `spacedock@spacedock` (stable) and
+// `spacedock@spacedock-edge` (edge). The OLD broken shape `spacedock-edge@spacedock`
+// (channel in the entry) must NOT appear — it is the id that fails the host
+// name-match.
+func TestChannelPluginIDIsEntryAtMarketplace(t *testing.T) {
+	cases := []struct {
+		channel   string
+		devBranch string
+		wantID    string
+	}{
+		{channel: "stable", devBranch: "main", wantID: "spacedock@spacedock"},
+		{channel: "edge", devBranch: "next", wantID: "spacedock@spacedock-edge"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.channel, func(t *testing.T) {
+			got := channelPluginID(tc.devBranch)
+			if got != tc.wantID {
+				t.Errorf("channelPluginID(%q) = %q, want %q", tc.devBranch, got, tc.wantID)
+			}
+			if got == "spacedock-edge@spacedock" {
+				t.Errorf("channelPluginID(%q) = %q — the channel must be the marketplace name, not the entry name (this id fails the host name-match)", tc.devBranch, got)
+			}
+		})
+	}
+}

--- a/internal/cli/channel_marketplace_name_test.go
+++ b/internal/cli/channel_marketplace_name_test.go
@@ -23,8 +23,8 @@ func TestChannelEntryIsAlwaysManifestName(t *testing.T) {
 // marketplace; an edge binary (any other devBranch) resolves `spacedock-edge`.
 func TestChannelMarketplaceCarriesTheChannel(t *testing.T) {
 	cases := []struct {
-		channel       string
-		devBranch     string
+		channel         string
+		devBranch       string
 		wantMarketplace string
 	}{
 		{channel: "stable", devBranch: "main", wantMarketplace: "spacedock"},

--- a/internal/cli/channel_selection_test.go
+++ b/internal/cli/channel_selection_test.go
@@ -186,7 +186,7 @@ func sequenceInstallsID(steps []installStep, id string) bool {
 // drives the real runCodex no-plugin auto-install with devBranch set per channel
 // and OBSERVES the seam values, then reconstructs the production codex install
 // argv from them — the channel-correct entry id (`spacedock@spacedock` stable /
-// `spacedock-edge@spacedock` edge) must be the `plugin add` target. The values are
+// `spacedock@spacedock-edge` edge) must be the `plugin add` target. The values are
 // read off the recorded seam, never grepped from a constant.
 func TestCodexNoPluginAutoInstallSelectsChannelEntry(t *testing.T) {
 	saved := devBranch

--- a/internal/cli/channel_selection_test.go
+++ b/internal/cli/channel_selection_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: AC-3 channel-resolution seam — devBranch selects the marketplace ENTRY
-// ABOUTME: NAME (spacedock vs spacedock-edge) from the marketplace repo, no @ref shorthand.
+// ABOUTME: AC-3 channel-resolution seam — devBranch selects the marketplace NAME
+// ABOUTME: (spacedock vs spacedock-edge); the entry stays spacedock, no @ref shorthand.
 package cli
 
 import (
@@ -10,25 +10,29 @@ import (
 	"testing"
 )
 
-// TestChannelEntryFromDevBranch locks the channel-selection rule under Model B:
-// the binary's devBranch stamp selects the marketplace ENTRY NAME, not a git ref
-// pinned into the plugin repo. A stable binary (devBranch=main) resolves the
-// `spacedock` entry; an edge binary (devBranch=next) resolves `spacedock-edge`.
-// The tag pin lives in the marketplace manifest, so the channel is the entry, not
-// an @branch shorthand on the install command.
-func TestChannelEntryFromDevBranch(t *testing.T) {
+// TestChannelMarketplaceFromDevBranch locks the channel-selection rule: the
+// binary's devBranch stamp selects the marketplace NAME, not a git ref pinned into
+// the plugin repo. A stable binary (devBranch=main) resolves the `spacedock`
+// marketplace; an edge binary (devBranch=next) resolves `spacedock-edge`. The tag
+// pin lives in the marketplace manifest, so the channel is the marketplace name,
+// not an @branch shorthand on the install command. The entry name stays `spacedock`
+// on both channels (== manifest name, so the host name-match passes).
+func TestChannelMarketplaceFromDevBranch(t *testing.T) {
 	cases := []struct {
-		channel   string
-		devBranch string
-		wantEntry string
+		channel         string
+		devBranch       string
+		wantMarketplace string
 	}{
-		{channel: "stable", devBranch: "main", wantEntry: "spacedock"},
-		{channel: "edge", devBranch: "next", wantEntry: "spacedock-edge"},
+		{channel: "stable", devBranch: "main", wantMarketplace: "spacedock"},
+		{channel: "edge", devBranch: "next", wantMarketplace: "spacedock-edge"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.channel, func(t *testing.T) {
-			if got := channelEntry(tc.devBranch); got != tc.wantEntry {
-				t.Errorf("channelEntry(%q) = %q, want %q (the %s channel)", tc.devBranch, got, tc.wantEntry, tc.channel)
+			if got := channelMarketplace(tc.devBranch); got != tc.wantMarketplace {
+				t.Errorf("channelMarketplace(%q) = %q, want %q (the %s channel)", tc.devBranch, got, tc.wantMarketplace, tc.channel)
+			}
+			if got := channelEntry(tc.devBranch); got != "spacedock" {
+				t.Errorf("channelEntry(%q) = %q, want spacedock (entry stays the manifest name on every channel)", tc.devBranch, got)
 			}
 		})
 	}
@@ -36,24 +40,26 @@ func TestChannelEntryFromDevBranch(t *testing.T) {
 
 // TestClaudeChannelInstallArgvSequence is AC-3's claude half: with marketplaceSource
 // repointed to the marketplace repo and devBranch set per channel, the issued
-// claude install argv installs the channel-correct ENTRY id (`spacedock@spacedock`
-// stable / `spacedock-edge@spacedock` edge) and the marketplace add carries the
-// BARE marketplace-repo source — no `@<branch>` shorthand. The plugin id (`@spacedock`
-// suffix) is the marketplace NAME; the entry before the `@` is the channel.
+// claude install argv installs the channel-correct id (`spacedock@spacedock` stable
+// / `spacedock@spacedock-edge` edge) and the marketplace add carries the BARE
+// marketplace-repo source — no `@<branch>` shorthand. The plugin id suffix is the
+// marketplace NAME (the channel); the entry before the `@` is always `spacedock`.
+// The marketplace-remove cleanup targets the channel's marketplace name.
 func TestClaudeChannelInstallArgvSequence(t *testing.T) {
 	cases := []struct {
-		channel   string
-		devBranch string
-		wantID    string
+		channel         string
+		devBranch       string
+		wantID          string
+		wantMarketplace string
 	}{
-		{channel: "stable", devBranch: "main", wantID: "spacedock@spacedock"},
-		{channel: "edge", devBranch: "next", wantID: "spacedock-edge@spacedock"},
+		{channel: "stable", devBranch: "main", wantID: "spacedock@spacedock", wantMarketplace: "spacedock"},
+		{channel: "edge", devBranch: "next", wantID: "spacedock@spacedock-edge", wantMarketplace: "spacedock-edge"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.channel, func(t *testing.T) {
 			want := []installStep{
 				{argv: []string{"plugin", "uninstall", tc.wantID}, tolerateExit: true},
-				{argv: []string{"plugin", "marketplace", "remove", "spacedock"}, tolerateExit: true},
+				{argv: []string{"plugin", "marketplace", "remove", tc.wantMarketplace}, tolerateExit: true},
 				{argv: []string{"plugin", "marketplace", "add", "spacedock-dev/marketplace"}},
 				{argv: []string{"plugin", "install", tc.wantID}},
 			}
@@ -74,22 +80,24 @@ func TestClaudeChannelInstallArgvSequence(t *testing.T) {
 }
 
 // TestCodexChannelInstallArgvSequence is AC-3's codex half: the codex install argv
-// adds the BARE marketplace-repo source (no `--ref`, since the channel is the entry
-// name, not a branch ref) and adds the channel-correct entry id.
+// adds the BARE marketplace-repo source (no `--ref`, since the channel is the
+// marketplace name, not a branch ref) and adds the channel-correct id. The
+// marketplace-remove cleanup targets the channel's marketplace name.
 func TestCodexChannelInstallArgvSequence(t *testing.T) {
 	cases := []struct {
-		channel   string
-		devBranch string
-		wantID    string
+		channel         string
+		devBranch       string
+		wantID          string
+		wantMarketplace string
 	}{
-		{channel: "stable", devBranch: "main", wantID: "spacedock@spacedock"},
-		{channel: "edge", devBranch: "next", wantID: "spacedock-edge@spacedock"},
+		{channel: "stable", devBranch: "main", wantID: "spacedock@spacedock", wantMarketplace: "spacedock"},
+		{channel: "edge", devBranch: "next", wantID: "spacedock@spacedock-edge", wantMarketplace: "spacedock-edge"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.channel, func(t *testing.T) {
 			want := []installStep{
 				{argv: []string{"plugin", "remove", tc.wantID}, tolerateExit: true},
-				{argv: []string{"plugin", "marketplace", "remove", "spacedock"}, tolerateExit: true},
+				{argv: []string{"plugin", "marketplace", "remove", tc.wantMarketplace}, tolerateExit: true},
 				{argv: []string{"plugin", "marketplace", "add", "spacedock-dev/marketplace"}},
 				{argv: []string{"plugin", "add", tc.wantID}},
 			}
@@ -125,7 +133,7 @@ func TestClaudeNoPluginAutoInstallSelectsChannelEntry(t *testing.T) {
 		wantID    string
 	}{
 		{channel: "stable", devBranch: "main", wantID: "spacedock@spacedock"},
-		{channel: "edge", devBranch: "next", wantID: "spacedock-edge@spacedock"},
+		{channel: "edge", devBranch: "next", wantID: "spacedock@spacedock-edge"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.channel, func(t *testing.T) {
@@ -190,7 +198,7 @@ func TestCodexNoPluginAutoInstallSelectsChannelEntry(t *testing.T) {
 		wantID    string
 	}{
 		{channel: "stable", devBranch: "main", wantID: "spacedock@spacedock"},
-		{channel: "edge", devBranch: "next", wantID: "spacedock-edge@spacedock"},
+		{channel: "edge", devBranch: "next", wantID: "spacedock@spacedock-edge"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.channel, func(t *testing.T) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -170,6 +170,7 @@ func newClaudeCommand(ctx context.Context, env []string, dir string, stdout, std
 				return cmd.Help()
 			}
 			applyDevBranchOverride(env)
+			applyMarketplaceSourceOverride(env)
 			if code := runClaude(ctx, args, dir, execHost{}, exec.LookPath, stdout, stderr); code != 0 {
 				return exitCodeError{code}
 			}
@@ -192,6 +193,7 @@ func newCodexCommand(ctx context.Context, env []string, dir string, stdout, stde
 				return cmd.Help()
 			}
 			applyDevBranchOverride(env)
+			applyMarketplaceSourceOverride(env)
 			if code := runCodex(ctx, args, dir, execHost{}, exec.LookPath, stdout, stderr); code != 0 {
 				return exitCodeError{code}
 			}
@@ -240,6 +242,7 @@ func newInstallCommand(ctx context.Context, env []string, stdout, stderr io.Writ
 				return cmd.Help()
 			}
 			applyDevBranchOverride(env)
+			applyMarketplaceSourceOverride(env)
 			if code := runInitWithPi(ctx, args, execHost{}, execPiRuntimeOps{}, env, stdout, stderr); code != 0 {
 				return exitCodeError{code}
 			}
@@ -528,6 +531,20 @@ func applyDevBranchOverride(env []string) {
 	for _, kv := range env {
 		if strings.HasPrefix(kv, "SPACEDOCK_DEV_BRANCH=") {
 			devBranch = strings.TrimPrefix(kv, "SPACEDOCK_DEV_BRANCH=")
+			return
+		}
+	}
+}
+
+// applyMarketplaceSourceOverride lets SPACEDOCK_MARKETPLACE_SOURCE override the
+// default marketplace add source (`spacedock-dev/marketplace`) on the install
+// paths. An UNSET env var leaves the default in place — the released binary keeps
+// installing from the production marketplace — while an explicit value wins,
+// pointing the install at a local/alternate marketplace for dogfooding.
+func applyMarketplaceSourceOverride(env []string) {
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "SPACEDOCK_MARKETPLACE_SOURCE=") {
+			marketplaceSource = strings.TrimPrefix(kv, "SPACEDOCK_MARKETPLACE_SOURCE=")
 			return
 		}
 	}

--- a/internal/cli/codex_name_match_test.go
+++ b/internal/cli/codex_name_match_test.go
@@ -1,0 +1,107 @@
+// ABOUTME: AC-7 backstop — exercises codex's entry-name vs plugin.json name-match
+// ABOUTME: constraint on the real CLI: old entry-name shape fails, new shape passes.
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCodexEntryNameMustMatchPluginName is the AC-7 mechanism backstop for the
+// integration gap that shipped the edge channel without a real `codex plugin add`.
+// Codex enforces that a marketplace entry's name equals the plugin's own
+// plugin.json `name` (`spacedock`). This test runs the REAL codex CLI against an
+// isolated CODEX_HOME and two local marketplaces:
+//
+//   - OLD shape: an entry named `spacedock-edge` in a marketplace named `spacedock`
+//     — `codex plugin add spacedock-edge@spacedock` MUST FAIL with the name-mismatch
+//     error (the failing-today baseline the channel fix flips).
+//   - NEW shape: the entry stays `spacedock`, the marketplace is named
+//     `spacedock-edge` — `codex plugin add spacedock@spacedock-edge` MUST SUCCEED,
+//     and the install lands at the channel cache path the resolver expects
+//     (cache/spacedock-edge/spacedock/<ver>/.codex-plugin/plugin.json).
+//
+// Skips when `codex` is not on PATH; hermetic via CODEX_HOME isolation +
+// local-path marketplaces (offline). This is the unit-level proof that serves AC-1;
+// it does not substitute for AC-1's live-lane `codex plugin add`.
+func TestCodexEntryNameMustMatchPluginName(t *testing.T) {
+	codexBin, err := exec.LookPath("codex")
+	if err != nil {
+		t.Skip("codex not on PATH; name-match backstop requires the host CLI")
+	}
+
+	tmp := t.TempDir()
+	codexHomeDir := filepath.Join(tmp, "codexhome")
+	mustMkdir(t, codexHomeDir)
+	t.Setenv("CODEX_HOME", codexHomeDir)
+
+	// OLD shape: marketplace `spacedock`, entry `spacedock-edge` (!= plugin.json
+	// name `spacedock`) — codex must reject the add.
+	oldMkt := buildCodexNamedMarketplace(t, filepath.Join(tmp, "oldshape"), "spacedock", "spacedock-edge")
+	runHost(t, codexBin, os.Environ(), "plugin", "marketplace", "add", oldMkt)
+	out, err := exec.Command(codexBin, "plugin", "add", "spacedock-edge@spacedock").CombinedOutput()
+	if err == nil {
+		t.Fatalf("BASELINE REGRESSION: codex accepted the old entry-name shape spacedock-edge@spacedock; the name-match constraint this AC depends on no longer holds\n%s", out)
+	}
+	if !strings.Contains(string(out), "does not match") {
+		t.Fatalf("old-shape add failed but not with the expected name-mismatch error:\n%s", out)
+	}
+
+	// NEW shape: marketplace `spacedock-edge`, entry `spacedock` (== plugin.json
+	// name) — codex must accept the add.
+	edgeMkt := buildCodexNamedMarketplace(t, filepath.Join(tmp, "edge"), "spacedock-edge", "spacedock")
+	runHost(t, codexBin, os.Environ(), "plugin", "marketplace", "add", edgeMkt)
+	if out, err := exec.Command(codexBin, "plugin", "add", "spacedock@spacedock-edge").CombinedOutput(); err != nil {
+		t.Fatalf("NEW shape add of spacedock@spacedock-edge failed: %v\n%s", err, out)
+	}
+
+	// The install must land where the channel-aware resolver looks for the edge
+	// channel: cache/spacedock-edge/spacedock/<ver>/.codex-plugin/plugin.json.
+	saved := devBranch
+	devBranch = "next"
+	defer func() { devBranch = saved }()
+	manifest, err := codexCacheManifest()
+	if err != nil {
+		t.Fatalf("codexCacheManifest (edge) after real install: %v", err)
+	}
+	if manifest == "" {
+		t.Fatalf("codexCacheManifest (edge) returned empty after a real spacedock@spacedock-edge install")
+	}
+	if !strings.Contains(manifest, filepath.Join("cache", "spacedock-edge", "spacedock")) {
+		t.Fatalf("edge install resolved to %q, want a path under cache/spacedock-edge/spacedock", manifest)
+	}
+	if _, statErr := os.Stat(manifest); statErr != nil {
+		t.Fatalf("resolved edge manifest %s does not exist: %v", manifest, statErr)
+	}
+}
+
+// buildCodexNamedMarketplace writes a minimal local marketplace under root with the
+// given marketplace name and single-entry name, sourcing the plugin from a colocated
+// checkout whose plugin.json name is always `spacedock`. Returns the marketplace dir.
+// Codex reads the marketplace manifest from .claude-plugin/marketplace.json and the
+// plugin manifest from the plugin's .codex-plugin/plugin.json.
+func buildCodexNamedMarketplace(t *testing.T, root, marketplaceName, entryName string) string {
+	t.Helper()
+	marketplace := filepath.Join(root, "marketplace")
+	plugin := filepath.Join(marketplace, "spacedock")
+	mustMkdir(t, filepath.Join(marketplace, ".claude-plugin"))
+	mustMkdir(t, filepath.Join(plugin, ".codex-plugin"))
+	mustMkdir(t, filepath.Join(plugin, "skills", "demo"))
+
+	mustWrite(t, filepath.Join(marketplace, ".claude-plugin", "marketplace.json"), `{
+  "name": "`+marketplaceName+`",
+  "owner": { "name": "CL Kao" },
+  "plugins": [
+    { "name": "`+entryName+`", "source": "./spacedock", "description": "test", "category": "workflow" }
+  ]
+}
+`)
+	mustWrite(t, filepath.Join(plugin, ".codex-plugin", "plugin.json"),
+		`{ "name": "spacedock", "version": "0.0.0", "requires-contract": ">=1,<2", "skills": "./skills/" }
+`)
+	mustWrite(t, filepath.Join(plugin, "skills", "demo", "SKILL.md"), "---\nname: demo\ndescription: demo skill\n---\ndemo\n")
+	return marketplace
+}

--- a/internal/cli/codex_resolve_test.go
+++ b/internal/cli/codex_resolve_test.go
@@ -21,6 +21,12 @@ func TestCodexResolveManifestAgainstInstalledHost(t *testing.T) {
 	if err != nil {
 		t.Skip("codex not on PATH; codex resolver test requires the host CLI")
 	}
+	// Verify the stable channel resolver against a stable (`spacedock@spacedock`)
+	// install: the resolver reads the package devBranch to pick the channel id, so
+	// pin it to main to match the stable id this test confirms.
+	saved := devBranch
+	devBranch = "main"
+	defer func() { devBranch = saved }()
 
 	listOut, err := exec.Command(codexBin, "plugin", "list").CombinedOutput()
 	if err != nil {

--- a/internal/cli/codex_resolver_unit_test.go
+++ b/internal/cli/codex_resolver_unit_test.go
@@ -177,6 +177,10 @@ func TestCodexEntryInstalledRealFormats(t *testing.T) {
 // predicate fix alone is insufficient: the front door only launches if this
 // cache tail lands on a real manifest.
 func TestCodexCacheManifestResolvesCachedPluginJSON(t *testing.T) {
+	saved := devBranch
+	devBranch = "main" // stable channel resolves under cache/spacedock/spacedock
+	defer func() { devBranch = saved }()
+
 	home := t.TempDir()
 	t.Setenv("CODEX_HOME", home)
 	manifest := filepath.Join(home, "plugins", "cache", "spacedock", "spacedock", "0.12.1", ".codex-plugin", "plugin.json")

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -42,9 +42,12 @@ func (e execHost) ResolveManifest(host string) (string, error) {
 	return e.resolveClaudeManifest(host)
 }
 
-// resolveClaudeManifest shells `claude plugin list --json`, finds the spacedock@
-// spacedock entry, and returns <installPath>/.claude-plugin/plugin.json. Returns
-// "" (no error) when the host reports no matching install or no installPath.
+// resolveClaudeManifest shells `claude plugin list --json`, finds the channel's
+// plugin id (`spacedock@spacedock` stable / `spacedock@spacedock-edge` edge — the
+// binary's devBranch selects it), and returns <installPath>/.claude-plugin/
+// plugin.json. Returns "" (no error) when the host reports no matching install or
+// no installPath. Matching the channel id (not the hardcoded stable id) is what
+// lets an edge binary recognize/refresh an installed edge plugin.
 func (execHost) resolveClaudeManifest(host string) (string, error) {
 	out, err := exec.Command(host, "plugin", "list", "--json").Output()
 	if err != nil {
@@ -54,8 +57,9 @@ func (execHost) resolveClaudeManifest(host string) (string, error) {
 	if err := json.Unmarshal(out, &entries); err != nil {
 		return "", fmt.Errorf("parse %s plugin list --json: %w", host, err)
 	}
+	id := channelPluginID(devBranch)
 	for _, e := range entries {
-		if e.ID == "spacedock@spacedock" {
+		if e.ID == id {
 			if e.InstallPath == "" {
 				return "", nil
 			}
@@ -65,11 +69,12 @@ func (execHost) resolveClaudeManifest(host string) (string, error) {
 	return "", nil
 }
 
-// resolveCodexManifest confirms spacedock@spacedock is installed via the text
-// `codex plugin list` and resolves the manifest under the Codex plugin cache.
-// Codex's listing carries no install path (its `--json` form has one only for
-// the marketplace root, not the cached plugin), so the deterministic cache
-// layout is the resolver. Codex installs land at
+// resolveCodexManifest confirms the channel's plugin id (`spacedock@spacedock`
+// stable / `spacedock@spacedock-edge` edge — the binary's devBranch selects it) is
+// installed via the text `codex plugin list` and resolves the manifest under the
+// Codex plugin cache. Codex's listing carries no install path (its `--json` form
+// has one only for the marketplace root, not the cached plugin), so the
+// deterministic cache layout is the resolver. Codex installs land at
 // <CODEX_HOME>/plugins/cache/<marketplace>/<plugin>/<version>/.codex-plugin/plugin.json.
 // Returns "" (no error) when the plugin is not installed or no cached manifest
 // exists for it yet.
@@ -78,19 +83,21 @@ func (execHost) resolveCodexManifest() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("codex plugin list: %w (%s)", err, strings.TrimSpace(string(out)))
 	}
-	if !codexEntryInstalled(string(out), "spacedock@spacedock") {
+	if !codexEntryInstalled(string(out), channelPluginID(devBranch)) {
 		return "", nil
 	}
 	return codexCacheManifest()
 }
 
-// codexCacheManifest resolves the cached spacedock@spacedock manifest under the
-// Codex plugin cache: <CODEX_HOME>/plugins/cache/spacedock/spacedock/<version>/
-// .codex-plugin/plugin.json. It picks the semver-greatest version dir and
-// returns that manifest path, or "" (no error) when no cached manifest exists
-// yet (absent cache root, no version dir, or the manifest file is missing).
+// codexCacheManifest resolves the channel's cached manifest under the Codex plugin
+// cache: <CODEX_HOME>/plugins/cache/<marketplace>/spacedock/<version>/.codex-plugin/
+// plugin.json, where <marketplace> is the channel marketplace name (`spacedock`
+// stable / `spacedock-edge` edge) and the entry dir is always `spacedock`. It picks
+// the semver-greatest version dir and returns that manifest path, or "" (no error)
+// when no cached manifest exists yet (absent cache root, no version dir, or the
+// manifest file is missing).
 func codexCacheManifest() (string, error) {
-	cacheRoot := filepath.Join(codexHome(), "plugins", "cache", "spacedock", "spacedock")
+	cacheRoot := filepath.Join(codexHome(), "plugins", "cache", channelMarketplace(devBranch), channelEntry(devBranch))
 	versionDir, err := latestVersionDir(cacheRoot)
 	if err != nil || versionDir == "" {
 		return "", nil
@@ -209,26 +216,36 @@ func manifestSubpath(host string) string {
 	return filepath.Join(".claude-plugin", "plugin.json")
 }
 
-// channelEntry maps the binary's devBranch stamp to the marketplace ENTRY name
-// it installs: a stable binary (devBranch=main) installs the `spacedock` entry; an
-// edge binary (any other devBranch, e.g. next) installs `spacedock-edge`. The two
-// entries live in the one marketplace repo and resolve distinct pinned versions
-// (stable pinned to a release tag, edge tracking next HEAD), so the channel is the
-// entry name — the version pin lives in the manifest, not an @ref on the install
-// command.
+// channelEntry is the marketplace ENTRY name the binary installs. It is always
+// `spacedock` — equal to the plugin's own plugin.json `name` — on every channel,
+// because the host (codex confirmed, claude by construction) rejects a marketplace
+// entry whose name differs from the manifest name. The channel is NOT the entry
+// name; it is the marketplace name (see channelMarketplace).
 func channelEntry(devBranch string) string {
+	return "spacedock"
+}
+
+// channelMarketplace maps the binary's devBranch stamp to the marketplace NAME the
+// channel resolves from: a stable binary (devBranch=main) resolves the `spacedock`
+// marketplace; an edge binary (any other devBranch, e.g. next) resolves
+// `spacedock-edge`. The standalone marketplace repo exposes both names as distinct
+// marketplace.json sources, each with the single `spacedock` entry pinned to that
+// channel's version (stable to a release tag, edge tracking next HEAD). Encoding
+// the channel here — not in the entry name — keeps the entry equal to the manifest
+// `name`, so the host name-match passes on both channels.
+func channelMarketplace(devBranch string) string {
 	if devBranch == "main" {
 		return "spacedock"
 	}
 	return "spacedock-edge"
 }
 
-// channelPluginID is the `<entry>@spacedock` plugin id for the channel devBranch
-// selects: `spacedock@spacedock` (stable) or `spacedock-edge@spacedock` (edge).
-// The `@spacedock` suffix is the marketplace NAME (the marketplace.json `name`);
-// the prefix is the channel entry.
+// channelPluginID is the `<entry>@<marketplace>` plugin id for the channel devBranch
+// selects: `spacedock@spacedock` (stable) or `spacedock@spacedock-edge` (edge). The
+// entry (before the `@`) is always `spacedock`; the suffix is the channel
+// marketplace NAME (the marketplace.json `name`).
 func channelPluginID(devBranch string) string {
-	return channelEntry(devBranch) + "@spacedock"
+	return channelEntry(devBranch) + "@" + channelMarketplace(devBranch)
 }
 
 // Launch replaces the current process with argv via execve, so the host CLI
@@ -257,23 +274,25 @@ type installStep struct {
 // uninstall any existing channel plugin first (cause-and-effect — claude
 // tracks an installed plugin via its marketplace record, so the marketplace
 // remove later would orphan a live uninstall), drop the existing marketplace
-// declaration for spacedock (so the next add re-pins the source instead of
-// no-op'ing on "already on disk"), add the marketplace-repo source, then install
-// the channel entry the devBranch selects (`spacedock` stable / `spacedock-edge`
-// edge). The marketplace add carries the BARE marketplace-repo source — the
-// channel and version pin live in the manifest, not an @ref shorthand. The
-// tolerance asymmetry: BOTH cleanup steps (plugin uninstall + marketplace remove)
-// are tolerated as best-effort, because claude exits 1 on the fresh-box cases
-// ("Plugin not found in installed plugins" for uninstall, "Marketplace 'spacedock'
-// not found" for remove) with no way to distinguish those from real failures via
-// stable stderr matching. BOTH pinning steps (marketplace add + plugin install)
-// stay fail-fast — they are the real-failure backstops that surface a broken
-// install (network, contract incompatibility, missing source).
+// declaration for the channel marketplace name (so the next add re-pins the
+// source instead of no-op'ing on "already on disk"), add the marketplace-repo
+// source, then install the channel id the devBranch selects (`spacedock@spacedock`
+// stable / `spacedock@spacedock-edge` edge — the entry is always `spacedock`, the
+// channel is the marketplace name). The marketplace add carries the BARE
+// marketplace-repo source — the channel and version pin live in the marketplace
+// manifest, not an @ref shorthand. The tolerance asymmetry: BOTH cleanup steps
+// (plugin uninstall + marketplace remove) are tolerated as best-effort, because
+// claude exits 1 on the fresh-box cases ("Plugin not found in installed plugins"
+// for uninstall, "Marketplace not found" for remove) with no way to distinguish
+// those from real failures via stable stderr matching. BOTH pinning steps
+// (marketplace add + plugin install) stay fail-fast — they are the real-failure
+// backstops that surface a broken install (network, contract incompatibility,
+// missing source).
 func installArgvSequence(source, devBranch string) []installStep {
 	id := channelPluginID(devBranch)
 	return []installStep{
 		{argv: []string{"plugin", "uninstall", id}, tolerateExit: true},
-		{argv: []string{"plugin", "marketplace", "remove", "spacedock"}, tolerateExit: true},
+		{argv: []string{"plugin", "marketplace", "remove", channelMarketplace(devBranch)}, tolerateExit: true},
 		{argv: []string{"plugin", "marketplace", "add", source}},
 		{argv: []string{"plugin", "install", id}},
 	}
@@ -283,19 +302,19 @@ func installArgvSequence(source, devBranch string) []installStep {
 // 4-command cleanup-then-pin shape, but in codex's verb vocabulary (`plugin
 // remove` / `plugin add`, not claude's `uninstall` / `install`). The marketplace
 // add carries the BARE marketplace-repo source with NO `--ref` — the channel is
-// the entry name (`spacedock` stable / `spacedock-edge` edge) the devBranch
-// selects, and the version pin lives in the manifest, not a branch ref. The
-// tolerance asymmetry matches claude: BOTH cleanup steps (plugin remove +
-// marketplace remove) are tolerated — on a fresh box `plugin remove` exits 0
-// (idempotent) but `marketplace remove` exits 1 ("marketplace `spacedock` is not
-// configured or installed"), and neither is a real failure. BOTH pinning steps
-// (marketplace add + plugin add) stay fail-fast — they are the real-failure
-// backstops.
+// the marketplace name (`spacedock` stable / `spacedock-edge` edge) the devBranch
+// selects, the entry is always `spacedock`, and the version pin lives in the
+// marketplace manifest, not a branch ref. The tolerance asymmetry matches claude:
+// BOTH cleanup steps (plugin remove + marketplace remove) are tolerated — on a
+// fresh box `plugin remove` exits 0 (idempotent) but `marketplace remove` exits 1
+// ("marketplace is not configured or installed"), and neither is a real failure.
+// BOTH pinning steps (marketplace add + plugin add) stay fail-fast — they are the
+// real-failure backstops.
 func codexInstallArgvSequence(source, devBranch string) []installStep {
 	id := channelPluginID(devBranch)
 	return []installStep{
 		{argv: []string{"plugin", "remove", id}, tolerateExit: true},
-		{argv: []string{"plugin", "marketplace", "remove", "spacedock"}, tolerateExit: true},
+		{argv: []string{"plugin", "marketplace", "remove", channelMarketplace(devBranch)}, tolerateExit: true},
 		{argv: []string{"plugin", "marketplace", "add", source}},
 		{argv: []string{"plugin", "add", id}},
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -18,10 +18,10 @@ import (
 // manifest, not an @ref on the install command.
 const marketplaceSource = "spacedock-dev/marketplace"
 
-// runInit installs/updates the per-host plugin (claude) or emits the documented
-// add command pair (codex), then runs doctor. `--check` runs the report without
-// installing. No skill-file copies — install goes through the host plugin
-// mechanism, which is what makes Skill()/--agent spacedock:first-officer resolve.
+// runInit installs/updates the per-host plugin (claude or codex) then runs doctor.
+// `--check` runs the report without installing. Both hosts install programmatically
+// through the host plugin mechanism (claude `install` / codex `add`) — no skill-file
+// copies — which is what makes Skill()/--agent spacedock:first-officer resolve.
 func runInit(ctx context.Context, args []string, ops hostOps, stdout, stderr io.Writer) int {
 	host, check, code := parseInitArgs(args, stderr)
 	if code != 0 {
@@ -42,52 +42,33 @@ func runInit(ctx context.Context, args []string, ops hostOps, stdout, stderr io.
 		}
 		return runDoctor(ctx, []string{"--host", "claude"}, ops, stdout, stderr)
 	case "codex":
-		resolved, err := ops.ResolveManifest("codex")
-		if err != nil {
-			fmt.Fprintf(stderr, "spacedock init: could not resolve the installed codex plugin: %v\n", err)
-			return 1
-		}
 		if check {
-			return contract.RunDoctor(resolved, "codex", Version, stdout, stderr)
-		}
-		if resolved != "" {
-			// An already-present plugin is refreshed on `install` like the claude
-			// arm — drive the install seam, then run doctor. Without this the codex
-			// arm was a doctor-only no-op that left a behind plugin in place.
-			out, err := ops.Install("codex", marketplaceSource, devBranch)
+			resolved, err := ops.ResolveManifest("codex")
 			if err != nil {
-				fmt.Fprintf(stderr, "spacedock install: host install failed: %v\n", err)
+				fmt.Fprintf(stderr, "spacedock init: could not resolve the installed codex plugin: %v\n", err)
 				return 1
 			}
-			if out != "" {
-				fmt.Fprintln(stdout, out)
-			}
-			return runDoctor(ctx, []string{"--host", "codex"}, ops, stdout, stderr)
+			return contract.RunDoctor(resolved, "codex", Version, stdout, stderr)
 		}
-
-		// Codex install is documented prose when no installed plugin resolves: the
-		// host install verb is `add` (NOT `install`), and the channel entry the
-		// binary's devBranch selects is named in the documented `plugin add`.
-		printCodexInstallProse(stdout)
-		return 0
+		// `install --host codex` drives the install seam (marketplace add + plugin
+		// add, re-pinning the source) and runs doctor — the same programmatic path
+		// as the claude arm, whether or not a plugin is already present. A fresh box
+		// installs; a present plugin is refreshed. The install verb is codex's `add`
+		// (supplied by codexInstallArgvSequence), and the channel marketplace the
+		// binary's devBranch selects is the install target.
+		out, err := ops.Install("codex", marketplaceSource, devBranch)
+		if err != nil {
+			fmt.Fprintf(stderr, "spacedock install: host install failed: %v\n", err)
+			return 1
+		}
+		if out != "" {
+			fmt.Fprintln(stdout, out)
+		}
+		return runDoctor(ctx, []string{"--host", "codex"}, ops, stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "spacedock install: unknown host %q (want claude or codex)\n", host)
 		return 2
 	}
-}
-
-// printCodexInstallProse emits the documented Codex install command pair: add the
-// marketplace-repo source, then add the channel entry the binary's devBranch
-// selects (`spacedock@spacedock` stable / `spacedock-edge@spacedock` edge). No
-// `--ref` — the channel is the entry name and the version pin lives in the
-// manifest, not a branch ref.
-func printCodexInstallProse(stdout io.Writer) {
-	fmt.Fprintf(stdout,
-		"Codex has no programmatic plugin install from spacedock. Run these in your shell:\n"+
-			"  codex plugin marketplace add %s\n"+
-			"  codex plugin add %s\n"+
-			"Then use the spacedock:first-officer skill in your Codex session.\n",
-		marketplaceSource, channelPluginID(devBranch))
 }
 
 // runDoctor is the `spacedock doctor` command path. With `--plugin-manifest PATH`

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -11,12 +11,15 @@ import (
 )
 
 // marketplaceSource is the marketplace add source: the standalone marketplace
-// repo (NOT the plugin repo). It holds the one marketplace.json with two entries
-// of one source — `spacedock` (stable, pinned to a release tag) and
-// `spacedock-edge` (edge, tracking next HEAD). The binary's devBranch stamp
-// selects which entry installs (see channelEntry); the version pin lives in the
-// manifest, not an @ref on the install command.
-const marketplaceSource = "spacedock-dev/marketplace"
+// repo (NOT the plugin repo). It exposes the channel marketplaces — `spacedock`
+// (stable, pinned to a release tag) and `spacedock-edge` (edge, tracking next
+// HEAD) — each a marketplace.json with the single `spacedock` entry. The binary's
+// devBranch stamp selects which marketplace installs (see channelMarketplace); the
+// version pin lives in the manifest, not an @ref on the install command. It is a
+// var (not a const) so `SPACEDOCK_MARKETPLACE_SOURCE` can override it — pointing
+// the install at a local/alternate marketplace to dogfood a channel fix before it
+// reaches the production marketplace; tests save/restore it.
+var marketplaceSource = "spacedock-dev/marketplace"
 
 // runInit installs/updates the per-host plugin (claude or codex) then runs doctor.
 // `--check` runs the report without installing. Both hosts install programmatically

--- a/internal/cli/init_codex_programmatic_test.go
+++ b/internal/cli/init_codex_programmatic_test.go
@@ -1,0 +1,44 @@
+// ABOUTME: AC-3 — `spacedock install --host codex` with NO plugin installed drives
+// ABOUTME: the install seam (marketplace add + plugin add), not prose-only.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestInitCodexNotInstalledRunsInstall locks AC-3: `spacedock install --host codex`
+// MUST drive the install seam with {codex, marketplaceSource, devBranch} — running
+// the marketplace add + plugin add and re-pinning the source — instead of printing
+// manual prose and running nothing. The recorded {host, source, branch} call is the
+// source of truth that the install fired. No "Run these in your shell" prose
+// appears, and the post-install doctor (resolving the now-present plugin) reports OK.
+func TestInitCodexNotInstalledRunsInstall(t *testing.T) {
+	saved := devBranch
+	devBranch = "main"
+	defer func() { devBranch = saved }()
+
+	// The plugin is present once the seam runs; the doctor resolve after install
+	// sees the compatible manifest.
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runInit(context.Background(), []string{"--host", "codex"}, fake, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	wantInstall := []string{"codex", marketplaceSource, "main"}
+	if !equalArgv(fake.installCmds, wantInstall) {
+		t.Fatalf("install seam = %v, want %v — codex install must run the seam, not print prose", fake.installCmds, wantInstall)
+	}
+	out := stdout.String()
+	if strings.Contains(out, "Run these in your shell") {
+		t.Fatalf("codex install must not fall back to manual prose:\n%s", out)
+	}
+	// After install, init runs doctor — a compatible report on stdout.
+	if !strings.Contains(out, "OK") {
+		t.Fatalf("codex install should run doctor after install; stdout = %q", out)
+	}
+}

--- a/internal/cli/init_devbranch_test.go
+++ b/internal/cli/init_devbranch_test.go
@@ -41,21 +41,22 @@ func TestInitTargetsNextWhenDevBranchPinned(t *testing.T) {
 // first (claude tracks an installed plugin via its marketplace record, so the
 // marketplace remove later would orphan a live uninstall; tolerated, fresh-box
 // exit 1 with "Plugin not found in installed plugins"), then `plugin marketplace
-// remove spacedock` (tolerated, fresh-box exit 1 with "not found"), then `plugin
-// marketplace add` with the BARE marketplace-repo source (no @ref — the channel
-// is the entry name and the version pin lives in the manifest), then `plugin
-// install <id>`. The id is the channel entry the devBranch selects:
-// `spacedock-edge@spacedock` for the edge binary, `spacedock@spacedock` for
-// stable. The marketplace-remove step is what defeats the "already on disk" no-op
-// in marketplace add when a stale source is declared. The asymmetry: BOTH cleanup
-// steps (uninstall + remove) are tolerated; BOTH pinning steps (add + install)
-// are fail-fast.
+// remove <marketplace>` (tolerated, fresh-box exit 1 with "not found"), then
+// `plugin marketplace add` with the BARE marketplace-repo source (no @ref — the
+// channel is the marketplace name and the version pin lives in the manifest), then
+// `plugin install <id>`. The id is the channel the devBranch selects, with the
+// channel in the marketplace name: `spacedock@spacedock-edge` for the edge binary
+// (marketplace remove targets `spacedock-edge`), `spacedock@spacedock` for stable.
+// The marketplace-remove step is what defeats the "already on disk" no-op in
+// marketplace add when a stale source is declared. The asymmetry: BOTH cleanup
+// steps (uninstall + remove) are tolerated; BOTH pinning steps (add + install) are
+// fail-fast.
 func TestInstallArgvSequence(t *testing.T) {
 	wantEdge := []installStep{
-		{argv: []string{"plugin", "uninstall", "spacedock-edge@spacedock"}, tolerateExit: true},
-		{argv: []string{"plugin", "marketplace", "remove", "spacedock"}, tolerateExit: true},
+		{argv: []string{"plugin", "uninstall", "spacedock@spacedock-edge"}, tolerateExit: true},
+		{argv: []string{"plugin", "marketplace", "remove", "spacedock-edge"}, tolerateExit: true},
 		{argv: []string{"plugin", "marketplace", "add", "spacedock-dev/marketplace"}},
-		{argv: []string{"plugin", "install", "spacedock-edge@spacedock"}},
+		{argv: []string{"plugin", "install", "spacedock@spacedock-edge"}},
 	}
 	if got := installArgvSequence("spacedock-dev/marketplace", "next"); !reflect.DeepEqual(got, wantEdge) {
 		t.Errorf("installArgvSequence(devBranch=next) = %v, want %v", got, wantEdge)

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -41,9 +41,8 @@ func TestInitClaudeIssuesHostPluginCommands(t *testing.T) {
 // marketplace-add target is the standalone marketplace repo
 // `spacedock-dev/marketplace`, NOT the plugin repo `spacedock-dev/spacedock` (the
 // manifest moved out of the plugin branch). Without this, a silent revert of the
-// marketplaceSource constant back to the plugin repo would not fail `go test` —
-// both the claude install seam and the codex add-prose carry the source, so both
-// paths are asserted.
+// marketplaceSource back to the plugin repo would not fail `go test` — both hosts'
+// install seams carry the source, so both paths are asserted.
 func TestInitMarketplaceSourceIsMarketplaceRepo(t *testing.T) {
 	const wantSource = "spacedock-dev/marketplace"
 
@@ -65,8 +64,8 @@ func TestInitMarketplaceSourceIsMarketplaceRepo(t *testing.T) {
 		}
 	})
 
-	t.Run("codex-add-prose", func(t *testing.T) {
-		fake := &fakeHost{}
+	t.Run("codex-install-seam", func(t *testing.T) {
+		fake := &fakeHost{manifest: compatibleManifest(t)}
 		var stdout, stderr bytes.Buffer
 
 		code := runInit(context.Background(), []string{"--host", "codex"}, fake, &stdout, &stderr)
@@ -74,12 +73,11 @@ func TestInitMarketplaceSourceIsMarketplaceRepo(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
-		out := stdout.String()
-		if !strings.Contains(out, "codex plugin marketplace add "+wantSource) {
-			t.Fatalf("codex add-prose marketplace source not %q:\n%s", wantSource, out)
+		if len(fake.installCmds) < 2 {
+			t.Fatalf("codex install seam recorded %v, want at least {host, source}", fake.installCmds)
 		}
-		if strings.Contains(out, "spacedock-dev/spacedock") {
-			t.Fatalf("codex add-prose still names the plugin repo spacedock-dev/spacedock; the manifest moved to the marketplace repo:\n%s", out)
+		if got := fake.installCmds[1]; got != wantSource {
+			t.Fatalf("codex marketplace source = %q, want %q (pre-migration plugin repo must not return)", got, wantSource)
 		}
 	})
 }
@@ -149,9 +147,11 @@ func TestInitCodexInstallReadiness(t *testing.T) {
 		}
 	})
 
+	// not-installed: AC-3 — on a fresh box (no plugin resolves) the codex arm RUNS
+	// the install seam (marketplace add + plugin add, re-pinning the source), like
+	// the claude arm, instead of printing manual prose. The recorded {host, source,
+	// branch} call is the source of truth; no "Run these in your shell" prose.
 	t.Run("not-installed", func(t *testing.T) {
-		// The codex add-prose adds the channel entry the binary's devBranch selects;
-		// pin a stable binary (devBranch=main) so the prose names spacedock@spacedock.
 		saved := devBranch
 		devBranch = "main"
 		defer func() { devBranch = saved }()
@@ -164,23 +164,18 @@ func TestInitCodexInstallReadiness(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
-		out := stdout.String()
-		for _, want := range []string{
-			"codex plugin marketplace add",
-			"codex plugin add spacedock@spacedock",
-		} {
-			if !strings.Contains(out, want) {
-				t.Errorf("codex init prose missing %q:\n%s", want, out)
-			}
+		wantInstall := []string{"codex", marketplaceSource, "main"}
+		if !equalArgv(fake.installCmds, wantInstall) {
+			t.Fatalf("install seam = %v, want %v — fresh-box codex install must run the seam, not print prose", fake.installCmds, wantInstall)
 		}
-		if strings.Contains(out, "codex plugin install") {
-			t.Errorf("codex init prose must not use 'codex plugin install' (verb is add):\n%s", out)
+		if out := stdout.String(); strings.Contains(out, "Run these in your shell") {
+			t.Errorf("fresh-box codex install must not fall back to manual prose:\n%s", out)
 		}
 	})
 
-	// not-installed-edge: an edge binary (devBranch=next) names the edge channel
-	// entry spacedock-edge@spacedock in the add-prose — the channel selection
-	// reaches the documented codex install.
+	// not-installed-edge: an edge binary (devBranch=next) drives the install seam
+	// with devBranch=next, so the channel selection reaches the codex install — the
+	// seam then targets the `spacedock@spacedock-edge` id (the edge marketplace).
 	t.Run("not-installed-edge", func(t *testing.T) {
 		saved := devBranch
 		devBranch = "next"
@@ -194,8 +189,15 @@ func TestInitCodexInstallReadiness(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
-		if got := stdout.String(); !strings.Contains(got, "codex plugin add spacedock-edge@spacedock") {
-			t.Errorf("edge codex init prose missing 'codex plugin add spacedock-edge@spacedock':\n%s", got)
+		wantInstall := []string{"codex", marketplaceSource, "next"}
+		if !equalArgv(fake.installCmds, wantInstall) {
+			t.Fatalf("edge codex install seam = %v, want %v", fake.installCmds, wantInstall)
+		}
+		// The observed seam values reconstruct the production codex install argv: the
+		// edge channel id must be the `plugin add` target.
+		seq := codexInstallArgvSequence(fake.installCmds[1], fake.installCmds[2])
+		if !codexSequenceAddsID(seq, "spacedock@spacedock-edge") {
+			t.Fatalf("edge codex install sequence does not `plugin add spacedock@spacedock-edge`; steps=%v", seq)
 		}
 	})
 

--- a/internal/cli/install_behavior_codex_test.go
+++ b/internal/cli/install_behavior_codex_test.go
@@ -24,6 +24,12 @@ func TestCodexPluginInstallIsHostNative(t *testing.T) {
 	if _, err := exec.LookPath("codex"); err != nil {
 		t.Skip("codex not on PATH; behavioral install test requires the host CLI")
 	}
+	// devBranch=main installs the stable `spacedock` channel and resolves it under
+	// cache/spacedock/spacedock — the resolver reads the package devBranch, so it
+	// must match the channel this test installs.
+	saved := devBranch
+	devBranch = "main"
+	defer func() { devBranch = saved }()
 
 	tmp := t.TempDir()
 	marketplace := buildLocalCodexMarketplace(t, tmp)
@@ -91,6 +97,11 @@ func TestCodexInitRefreshAdvancesBehindPlugin(t *testing.T) {
 	if _, err := exec.LookPath("codex"); err != nil {
 		t.Skip("codex not on PATH; refresh-advances smoke requires the host CLI")
 	}
+	// devBranch=main installs and resolves the stable `spacedock` channel; the
+	// resolver reads the package devBranch, so it must match the seeded channel.
+	saved := devBranch
+	devBranch = "main"
+	defer func() { devBranch = saved }()
 
 	tmp := t.TempDir()
 	behind := buildCodexMarketplaceAtVersion(t, filepath.Join(tmp, "behind"), "0.0.1")

--- a/internal/cli/install_tolerance_codex_test.go
+++ b/internal/cli/install_tolerance_codex_test.go
@@ -13,7 +13,7 @@ import (
 // every step → Install("codex", "spacedock-dev/marketplace", "next") returns nil
 // and the combined output carries all four step markers, including the bare
 // marketplace-repo `plugin marketplace add spacedock-dev/marketplace` (no --ref)
-// and the edge channel's `plugin add spacedock-edge@spacedock`. The stub's echoed
+// and the edge channel's `plugin add spacedock@spacedock-edge`. The stub's echoed
 // argv is the independent source of truth.
 func TestCodexInstallIssuesSequenceInOrder(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -27,10 +27,10 @@ func TestCodexInstallIssuesSequenceInOrder(t *testing.T) {
 		t.Fatalf("Install returned error on all-zero codex stub: %v\nout=%q", err, out)
 	}
 	wantOrder := []string{
-		"stub:plugin remove spacedock-edge@spacedock:exit=0",
-		"stub:plugin marketplace remove spacedock:exit=0",
+		"stub:plugin remove spacedock@spacedock-edge:exit=0",
+		"stub:plugin marketplace remove spacedock-edge:exit=0",
 		"stub:plugin marketplace add spacedock-dev/marketplace:exit=0",
-		"stub:plugin add spacedock-edge@spacedock:exit=0",
+		"stub:plugin add spacedock@spacedock-edge:exit=0",
 	}
 	last := -1
 	for _, want := range wantOrder {
@@ -47,7 +47,7 @@ func TestCodexInstallIssuesSequenceInOrder(t *testing.T) {
 }
 
 // TestCodexInstallToleratesMarketplaceRemoveFailure locks AC-1b: the fresh-box
-// path where `codex plugin marketplace remove spacedock` exits 1 ("is not
+// path where `codex plugin marketplace remove <marketplace>` exits 1 ("is not
 // configured or installed") and every other step exits 0. Install MUST return a
 // nil error and the combined output MUST carry all four step markers — the
 // marketplace remove is a tolerated cleanup step.
@@ -63,10 +63,10 @@ func TestCodexInstallToleratesMarketplaceRemoveFailure(t *testing.T) {
 		t.Fatalf("Install returned error on tolerated marketplace-remove failure: %v\nout=%q", err, out)
 	}
 	for _, want := range []string{
-		"stub:plugin remove spacedock-edge@spacedock:exit=0",
-		"stub:plugin marketplace remove spacedock:exit=1",
+		"stub:plugin remove spacedock@spacedock-edge:exit=0",
+		"stub:plugin marketplace remove spacedock-edge:exit=1",
 		"stub:plugin marketplace add spacedock-dev/marketplace:exit=0",
-		"stub:plugin add spacedock-edge@spacedock:exit=0",
+		"stub:plugin add spacedock@spacedock-edge:exit=0",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("combined output missing %q\nout=%q", want, out)
@@ -91,9 +91,9 @@ func TestCodexInstallToleratesPluginRemoveFailure(t *testing.T) {
 		t.Fatalf("Install returned error on tolerated plugin-remove failure: %v\nout=%q", err, out)
 	}
 	for _, want := range []string{
-		"stub:plugin remove spacedock-edge@spacedock:exit=1",
+		"stub:plugin remove spacedock@spacedock-edge:exit=1",
 		"stub:plugin marketplace add spacedock-dev/marketplace:exit=0",
-		"stub:plugin add spacedock-edge@spacedock:exit=0",
+		"stub:plugin add spacedock@spacedock-edge:exit=0",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("combined output missing %q\nout=%q", want, out)
@@ -137,10 +137,10 @@ func TestCodexInstallFailsFastOnPluginAdd(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Install returned nil error; want plugin-add fail-fast\nout=%q", out)
 	}
-	if !strings.Contains(err.Error(), "plugin add spacedock-edge@spacedock") {
+	if !strings.Contains(err.Error(), "plugin add spacedock@spacedock-edge") {
 		t.Errorf("error %q does not wrap the codex plugin add subcommand argv", err)
 	}
-	if !strings.Contains(out, "stub:plugin add spacedock-edge@spacedock:exit=1") {
+	if !strings.Contains(out, "stub:plugin add spacedock@spacedock-edge:exit=1") {
 		t.Errorf("combined output missing plugin-add stub marker; out=%q", out)
 	}
 }

--- a/internal/cli/install_tolerance_test.go
+++ b/internal/cli/install_tolerance_test.go
@@ -27,10 +27,10 @@ func TestInstallToleratesRemoveStepFailure(t *testing.T) {
 		t.Fatalf("Install returned error on tolerated remove failure: %v\nout=%q", err, out)
 	}
 	for _, want := range []string{
-		"stub:plugin marketplace remove spacedock:exit=1",
+		"stub:plugin marketplace remove spacedock-edge:exit=1",
 		"stub:plugin marketplace add spacedock-dev/marketplace:exit=0",
-		"stub:plugin uninstall spacedock-edge@spacedock:exit=0",
-		"stub:plugin install spacedock-edge@spacedock:exit=0",
+		"stub:plugin uninstall spacedock@spacedock-edge:exit=0",
+		"stub:plugin install spacedock@spacedock-edge:exit=0",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("combined output missing %q\nout=%q", want, out)
@@ -39,12 +39,12 @@ func TestInstallToleratesRemoveStepFailure(t *testing.T) {
 }
 
 // TestInstallToleratesUninstallStepFailure locks the fresh-box uninstall
-// tolerance half of AC-2: when `claude plugin uninstall spacedock@spacedock`
-// exits 1 (the empirically observed "Plugin not found in installed plugins"
-// shape against claude 2.1.160 on a box where the plugin is not installed) and
-// every other subcommand exits 0, execHost.Install MUST return a nil error and
-// the combined output MUST contain all four steps' stub markers. Without the
-// per-step tolerance flag on the uninstall step this test would fail at step 0.
+// tolerance half of AC-2: when `claude plugin uninstall <channel-id>` exits 1
+// (the empirically observed "Plugin not found in installed plugins" shape against
+// claude 2.1.160 on a box where the plugin is not installed) and every other
+// subcommand exits 0, execHost.Install MUST return a nil error and the combined
+// output MUST contain all four steps' stub markers. Without the per-step tolerance
+// flag on the uninstall step this test would fail at step 0.
 func TestInstallToleratesUninstallStepFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("stub script uses /bin/sh; not portable to Windows")
@@ -57,10 +57,10 @@ func TestInstallToleratesUninstallStepFailure(t *testing.T) {
 		t.Fatalf("Install returned error on tolerated uninstall failure: %v\nout=%q", err, out)
 	}
 	for _, want := range []string{
-		"stub:plugin uninstall spacedock-edge@spacedock:exit=1",
-		"stub:plugin marketplace remove spacedock:exit=0",
+		"stub:plugin uninstall spacedock@spacedock-edge:exit=1",
+		"stub:plugin marketplace remove spacedock-edge:exit=0",
 		"stub:plugin marketplace add spacedock-dev/marketplace:exit=0",
-		"stub:plugin install spacedock-edge@spacedock:exit=0",
+		"stub:plugin install spacedock@spacedock-edge:exit=0",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("combined output missing %q\nout=%q", want, out)

--- a/internal/cli/marketplace_source_override_test.go
+++ b/internal/cli/marketplace_source_override_test.go
@@ -1,0 +1,94 @@
+// ABOUTME: AC-5 SPACEDOCK_MARKETPLACE_SOURCE override — the env var repoints the
+// ABOUTME: install source on both hosts' install paths; unset keeps the default.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// TestMarketplaceSourceOverrideDefault locks the unset case: with no
+// SPACEDOCK_MARKETPLACE_SOURCE in the env, applyMarketplaceSourceOverride leaves the
+// default `spacedock-dev/marketplace` in place — the released binary keeps its
+// production source.
+func TestMarketplaceSourceOverrideDefault(t *testing.T) {
+	saved := marketplaceSource
+	defer func() { marketplaceSource = saved }()
+
+	applyMarketplaceSourceOverride([]string{"PATH=/usr/bin", "HOME=/home/x"})
+	if marketplaceSource != "spacedock-dev/marketplace" {
+		t.Fatalf("marketplaceSource = %q, want default spacedock-dev/marketplace when env unset", marketplaceSource)
+	}
+}
+
+// TestMarketplaceSourceOverrideApplied locks the override case: an explicit
+// SPACEDOCK_MARKETPLACE_SOURCE wins, repointing the source (e.g. at a local
+// marketplace checkout for dogfooding).
+func TestMarketplaceSourceOverrideApplied(t *testing.T) {
+	saved := marketplaceSource
+	defer func() { marketplaceSource = saved }()
+
+	applyMarketplaceSourceOverride([]string{"SPACEDOCK_MARKETPLACE_SOURCE=/tmp/local-marketplace"})
+	if marketplaceSource != "/tmp/local-marketplace" {
+		t.Fatalf("marketplaceSource = %q, want /tmp/local-marketplace (override must win)", marketplaceSource)
+	}
+}
+
+// TestInstallHonorsMarketplaceSourceOverride is the install-seam half of AC-5:
+// after the override is applied, `spacedock install --host codex` passes the
+// overridden source to the install seam — observed at fake.installCmds[1], the
+// actual source the production install would `marketplace add`.
+func TestInstallHonorsMarketplaceSourceOverride(t *testing.T) {
+	savedSource := marketplaceSource
+	savedBranch := devBranch
+	devBranch = "main"
+	defer func() {
+		marketplaceSource = savedSource
+		devBranch = savedBranch
+	}()
+
+	applyMarketplaceSourceOverride([]string{"SPACEDOCK_MARKETPLACE_SOURCE=/tmp/local-marketplace"})
+
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+	code := runInit(context.Background(), []string{"--host", "codex"}, fake, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if len(fake.installCmds) < 2 {
+		t.Fatalf("install seam recorded %v, want at least {host, source}", fake.installCmds)
+	}
+	if got := fake.installCmds[1]; got != "/tmp/local-marketplace" {
+		t.Fatalf("install source = %q, want the overridden /tmp/local-marketplace", got)
+	}
+}
+
+// TestFrontDoorAutoInstallHonorsMarketplaceSourceOverride is the front-door half of
+// AC-5: the codex no-plugin auto-install passes the overridden source to the
+// install seam, so dogfooding a local marketplace works through the single-command
+// front door, not only `install`.
+func TestFrontDoorAutoInstallHonorsMarketplaceSourceOverride(t *testing.T) {
+	savedSource := marketplaceSource
+	savedBranch := devBranch
+	devBranch = "main"
+	defer func() {
+		marketplaceSource = savedSource
+		devBranch = savedBranch
+	}()
+
+	applyMarketplaceSourceOverride([]string{"SPACEDOCK_MARKETPLACE_SOURCE=/tmp/local-marketplace"})
+
+	fake := &fakeHost{manifest: ""} // fresh HOME: no codex plugin installed
+	var stdout, stderr bytes.Buffer
+	code := runCodex(context.Background(), nil, t.TempDir(), fake, lookFound, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if len(fake.installCmds) < 2 {
+		t.Fatalf("install seam recorded %v, want at least {host, source}", fake.installCmds)
+	}
+	if got := fake.installCmds[1]; got != "/tmp/local-marketplace" {
+		t.Fatalf("front-door auto-install source = %q, want the overridden /tmp/local-marketplace", got)
+	}
+}


### PR DESCRIPTION
Codex edge-channel installs now work: edge installs as `spacedock@spacedock-edge` so Codex's plugin-name match passes.

## What changed
- Encode the channel in the marketplace name (`spacedock-edge`), keeping the entry `spacedock`.
- Make both Claude and Codex manifest resolvers channel-aware.
- Make the Codex fresh-install path programmatic, dropping the prose-only install.
- Add the `SPACEDOCK_MARKETPLACE_SOURCE` override.

## Evidence
- Live codex 0.141.0: old `spacedock-edge@spacedock` fails, new `spacedock@spacedock-edge` installs — flip reproduced by hand.
- `go test ./...` green.

---
[z2t](/spacedock-dev/spacedock/blob/012aee734f66ef72268088876ca7852d7b14d6ef/spacedock-marketplace-source-env/index.md)
