### PR TITLE
Fix codex rejection-flow #141 false-positive — structural absent-detector

### DIFF
--- a/internal/ensigncycle/shared_reviewer_reuse_table_test.go
+++ b/internal/ensigncycle/shared_reviewer_reuse_table_test.go
@@ -211,6 +211,32 @@ func TestAssertCodexReviewerReuse(t *testing.T) {
 	absentOnlyOneValidation := noAddressableSurface + "\n" + spawnValidation + "\n" + spawnImpl
 	absentButReuseTool := noAddressableSurface + "\n" + realReuseV2
 
+	// The absence declarations a live Codex FO actually emitted when the host
+	// surface exposed only spawn_agent/wait_agent and it contract-correctly
+	// fresh-dispatched the cycle-2 reviewer. These are verbatim from the six
+	// identical failing rejection-flow transcripts the #141 keepalive lane
+	// produced. The brittle fixed-phrase absent detector matched NONE of them, so
+	// the assertion took its PRESENT branch and RED-flagged a contract-correct
+	// fresh-dispatch (the M7-shape false-positive). The detector must recognize a
+	// genuine reuse-route-absent declaration however the FO words it.
+	liveAbsentWordings := []string{
+		"The available multi-agent surface exposes spawn_agent and wait_agent, but no follow-up/send-message binding.",
+		"This host has no follow-up/send binding for worker reuse.",
+		"Since the cycle-1 reviewer is not addressable on this host, I'm dispatching a fresh validation reviewer for cycle 2.",
+		"This surface has spawn_agent and wait_agent, but no followup_task or equivalent turn-starting reuse route.",
+		"Reviewer reuse is not supported by this tool surface.",
+		"This host cannot address the kept-alive reviewer for follow-up.",
+		"This host exposes the older multi-agent surface: I can spawn and wait for workers, but I do not have a followup_task/live reuse call.",
+		"This Codex surface exposes spawn/wait but no addressable follow-up tool.",
+		"Since this host does not expose a turn-starting addressable-worker binding, I'm fresh-dispatching validation instead of reusing the cycle-1 reviewer.",
+		"This Codex host did not expose an addressable reviewer reuse/follow-up tool.",
+	}
+	liveAbsentTwoFresh := make([]string, len(liveAbsentWordings))
+	for i, w := range liveAbsentWordings {
+		decl := `{"type":"item.completed","item":{"type":"agent_message","text":` + mustJSONString(w) + `}}`
+		liveAbsentTwoFresh[i] = decl + "\n" + spawnValidation + "\n" + spawnImpl + "\n" + freshCycle2Spawn
+	}
+
 	cases := []struct {
 		name    string
 		jsonl   string
@@ -223,6 +249,16 @@ func TestAssertCodexReviewerReuse(t *testing.T) {
 		{"addressable-worker absent: current live wording plus two fresh validation spawns", currentAbsentTwoFresh, false},
 		{"addressable-worker absent: missing second fresh validation spawn must RED", absentOnlyOneValidation, true},
 		{"addressable-worker absent: reuse tool contradicts absent classification", absentButReuseTool, true},
+		{"live FO absence wording 0 + two fresh validation spawns", liveAbsentTwoFresh[0], false},
+		{"live FO absence wording 1 + two fresh validation spawns", liveAbsentTwoFresh[1], false},
+		{"live FO absence wording 2 + two fresh validation spawns", liveAbsentTwoFresh[2], false},
+		{"live FO absence wording 3 + two fresh validation spawns", liveAbsentTwoFresh[3], false},
+		{"live FO absence wording 4 + two fresh validation spawns", liveAbsentTwoFresh[4], false},
+		{"live FO absence wording 5 + two fresh validation spawns", liveAbsentTwoFresh[5], false},
+		{"live FO absence wording 6 + two fresh validation spawns", liveAbsentTwoFresh[6], false},
+		{"live FO absence wording 7 + two fresh validation spawns", liveAbsentTwoFresh[7], false},
+		{"live FO absence wording 8 + two fresh validation spawns", liveAbsentTwoFresh[8], false},
+		{"live FO absence wording 9 + two fresh validation spawns", liveAbsentTwoFresh[9], false},
 		{
 			"loose narration only",
 			`{"type":"item.completed","item":{"type":"agent_message","text":"I will send_input to the validation worker."}}`,

--- a/internal/ensigncycle/shared_reviewer_reuse_test.go
+++ b/internal/ensigncycle/shared_reviewer_reuse_test.go
@@ -348,13 +348,65 @@ func codexReviewerReuseTool(tool string) bool {
 	return tool == "followup_task" || tool == "send_input"
 }
 
+// codexAddressableWorkerAbsent reports whether the FO observed that the live
+// Codex surface exposes no turn-starting reuse route for a completed worker, so a
+// fresh cycle-2 reviewer is the contract-correct choice. The live FO words this
+// observation freely ("no follow-up/send binding for worker reuse", "the cycle-1
+// reviewer is not addressable on this host", "no followup_task or equivalent
+// turn-starting reuse route"), so a fixed phrase list false-RED-flags a
+// contract-correct fresh-dispatch. The detector instead reads the FO's narration
+// (agent_message text only — never command output, which can echo the runtime
+// doc) and treats a message that negates a reuse-route concept as the absence
+// observation. A reuse tool actually appearing in the transcript still overrides
+// this via assertCodexFreshValidationWhenAddressableAbsent.
 func codexAddressableWorkerAbsent(jsonl string) bool {
-	lower := strings.ToLower(jsonl)
-	return strings.Contains(lower, "no followup_task/send_message reuse route exposed") ||
-		strings.Contains(lower, "followup_task/message reuse is unavailable") ||
-		strings.Contains(lower, "no turn-starting follow-up route for a completed worker") ||
-		strings.Contains(lower, "no completed-worker follow-up route") ||
-		strings.Contains(lower, "reviewer reuse is not available in this host")
+	for _, line := range strings.Split(jsonl, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var ev struct {
+			Item struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"item"`
+		}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil || ev.Item.Type != "agent_message" {
+			continue
+		}
+		if codexNarrationNegatesReuseRoute(ev.Item.Text) {
+			return true
+		}
+	}
+	return false
+}
+
+// codexNarrationNegatesReuseRoute reports whether a single FO narration message
+// states that the reuse/follow-up route is absent — a reuse-route concept
+// ("follow-up", "followup_task", "addressable", "reuse") negated within the same
+// message ("no", "not", "cannot", "n't", "without"). Scoping the negation and the
+// concept to one message keeps an affirmative reuse message ("the reviewer can be
+// kept addressable and reused") from matching on an unrelated negation elsewhere.
+func codexNarrationNegatesReuseRoute(text string) bool {
+	lower := strings.ToLower(text)
+	concepts := []string{"follow-up", "follow up", "followup", "addressable", "reuse", "reusable"}
+	hasConcept := false
+	for _, c := range concepts {
+		if strings.Contains(lower, c) {
+			hasConcept = true
+			break
+		}
+	}
+	if !hasConcept {
+		return false
+	}
+	negations := []string{"no ", "not ", "cannot", "n't", "without ", "never "}
+	for _, n := range negations {
+		if strings.Contains(lower, n) {
+			return true
+		}
+	}
+	return false
 }
 
 func assertCodexFreshValidationWhenAddressableAbsent(jsonl string) error {


### PR DESCRIPTION
Fix the codex rejection-flow #141 false-positive: the keepalive assertion miscounted a contract-correct fresh-dispatch as a reviewer-reuse violation (6/15 deterministic).

## What changed
- Replace the brittle 5-canned-phrase absent-detector with a structural one that reads the FO's `agent_message` narration (negation + reuse-route concept), never command output.
- Add 10 verbatim live-FO absence wordings as positive cases; keep every non-tautology guard (genuine missed-reuse, reuse-tool override, ≥2-spawn).

## Evidence
- Diagnosis is candidate-2: on codex 0.141.0 the reuse route is absent, so the FO correctly declares `«addressable-worker»` absent and fresh-dispatches a separate cycle-2 reviewer — not a #141 violation.
- Old detector matched 0/10 live wordings, new matches 10/10; live codex N=4 (absent/fresh branch) all pass; `go test ./internal/ensigncycle ./internal/contractlint` + `go build ./...` green. Codex-FO prose untouched (5991 B).

## Review guidance
Test-only (2 files). Two non-blocking follow-ups filed: live PRESENT/reuse-branch coverage (not exposed on codex 0.141.0) and tightening the negation heuristic against a future route-present masking case.

---
[25](/spacedock-dev/spacedock/blob/92a759f0c3178e5e2b9255c38cb447bdd48fcb37/codex-rejection-flow-keepalive-diagnosis.md)
