### PR TITLE
Codex edge install — per-channel marketplace source (edge branch + channel-specific binary source)

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -17,10 +17,14 @@ marketplace source.
 - stamps the plugin manifests' `version` on `main`.
 
 The marketplace manifest no longer lives in the plugin branch. It is the
-standalone `spacedock-dev/marketplace` repo, whose entries pin each channel by
-ref — `spacedock` (stable, repointed to the released tag) and `spacedock-edge`
-(edge, tracking `next`). Repointing the stable entry is a commit in that repo,
-not a manifest stamp on `main`.
+standalone `spacedock-dev/marketplace` repo, where each channel is a branch with
+its own root `marketplace.json`: the repo root (a marketplace named `spacedock`,
+stable entry repointed to the released tag) and the `edge` branch (a marketplace
+named `spacedock-edge`, entry tracking `next`). The channel lives in the
+marketplace NAME, so a binary adds the channel's branch source —
+`spacedock-dev/marketplace` for stable, `spacedock-dev/marketplace@edge` for edge —
+and the marketplace it registers carries the matching name. Repointing the stable
+entry is a commit on the repo root, not a manifest stamp on `main`.
 
 The tag triggers the release, but goreleaser publishes only after the `e2e-gate`
 job confirms the tagged commit has a green Runtime Live E2E run (or a recorded

--- a/docs/site/get-started/install.md
+++ b/docs/site/get-started/install.md
@@ -48,12 +48,17 @@ claude plugin marketplace add spacedock-dev/marketplace
 claude plugin install spacedock@spacedock
 
 # Edge (tracks next) — marketplace named `spacedock-edge`, entry still `spacedock`
+claude plugin marketplace add spacedock-dev/marketplace@edge
 claude plugin install spacedock@spacedock-edge
 ```
 
 The channel is the marketplace name; the entry name stays `spacedock` on both
 channels (it equals the plugin's own `name`, so the host's entry-name vs
-plugin-name check passes). Codex installs the same way with `codex plugin add`.
+plugin-name check passes). Each channel adds its own marketplace source — the
+stable marketplace lives at the repo root (named `spacedock`), the edge one on
+the `@edge` branch (named `spacedock-edge`) — so the `@edge` ref is what registers
+the `spacedock-edge` marketplace the edge entry resolves from. Codex installs the
+same way with `codex plugin add`.
 
 Set `SPACEDOCK_MARKETPLACE_SOURCE` to install from a local or alternate
 marketplace instead of the default `spacedock-dev/marketplace` — useful for

--- a/internal/cli/channel_marketplace_source_test.go
+++ b/internal/cli/channel_marketplace_source_test.go
@@ -1,0 +1,87 @@
+// ABOUTME: AC-2 channel-specific marketplace source — edge resolves the source
+// ABOUTME: spacedock-dev/marketplace@edge, stable the bare repo; override wins verbatim.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// TestChannelMarketplaceSourceFromDevBranch locks the source-resolution rule the
+// marketplace add carries: a stable binary (devBranch=main) installs from the bare
+// marketplace repo `spacedock-dev/marketplace` (whose root marketplace.json is named
+// `spacedock`), while an edge binary (any other devBranch, e.g. next) installs from
+// `spacedock-dev/marketplace@edge` — the `edge` branch whose root marketplace.json is
+// named `spacedock-edge`. The @edge ref is what makes codex register a marketplace
+// NAMED `spacedock-edge`, so the channel id `spacedock@spacedock-edge` then resolves.
+func TestChannelMarketplaceSourceFromDevBranch(t *testing.T) {
+	saved := marketplaceSource
+	defer func() { marketplaceSource = saved }()
+	marketplaceSource = "spacedock-dev/marketplace"
+
+	cases := []struct {
+		channel    string
+		devBranch  string
+		wantSource string
+	}{
+		{channel: "stable", devBranch: "main", wantSource: "spacedock-dev/marketplace"},
+		{channel: "edge", devBranch: "next", wantSource: "spacedock-dev/marketplace@edge"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.channel, func(t *testing.T) {
+			if got := channelMarketplaceSource(tc.devBranch); got != tc.wantSource {
+				t.Errorf("channelMarketplaceSource(%q) = %q, want %q (the %s channel source)", tc.devBranch, got, tc.wantSource, tc.channel)
+			}
+		})
+	}
+}
+
+// TestChannelMarketplaceSourceOverrideWinsVerbatim locks AC-2's override half: an
+// explicit SPACEDOCK_MARKETPLACE_SOURCE (dogfooding a local/alternate marketplace)
+// replaces the resolved source verbatim on BOTH channels — no `@edge` ref is appended
+// to the operator's chosen source, because that source is already the complete
+// marketplace they want (appending @edge to a local checkout path is meaningless).
+func TestChannelMarketplaceSourceOverrideWinsVerbatim(t *testing.T) {
+	saved := marketplaceSource
+	defer func() { marketplaceSource = saved }()
+	marketplaceSource = "/tmp/local-marketplace"
+
+	for _, devBranch := range []string{"main", "next"} {
+		t.Run(devBranch, func(t *testing.T) {
+			if got := channelMarketplaceSource(devBranch); got != "/tmp/local-marketplace" {
+				t.Errorf("channelMarketplaceSource(%q) = %q, want the overridden /tmp/local-marketplace verbatim on every channel", devBranch, got)
+			}
+		})
+	}
+}
+
+// TestEdgeInstallSeamCarriesEdgeSource is AC-2's install-seam half: `spacedock
+// install --host codex` on an edge binary passes `spacedock-dev/marketplace@edge` to
+// the install seam (observed at installCmds[1]), so the production `marketplace add`
+// targets the edge branch — the fix for the masked bug where the bare source
+// registered a marketplace named `spacedock` and `plugin add spacedock@spacedock-edge`
+// then failed.
+func TestEdgeInstallSeamCarriesEdgeSource(t *testing.T) {
+	savedSource := marketplaceSource
+	savedBranch := devBranch
+	marketplaceSource = "spacedock-dev/marketplace"
+	devBranch = "next"
+	defer func() {
+		marketplaceSource = savedSource
+		devBranch = savedBranch
+	}()
+
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+	code := runInit(context.Background(), []string{"--host", "codex"}, fake, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if len(fake.installCmds) < 2 {
+		t.Fatalf("install seam recorded %v, want at least {host, source}", fake.installCmds)
+	}
+	if got := fake.installCmds[1]; got != "spacedock-dev/marketplace@edge" {
+		t.Fatalf("edge install source = %q, want spacedock-dev/marketplace@edge", got)
+	}
+}

--- a/internal/cli/channel_selection_test.go
+++ b/internal/cli/channel_selection_test.go
@@ -152,8 +152,9 @@ func TestClaudeNoPluginAutoInstallSelectsChannelEntry(t *testing.T) {
 			if got := fake.installCmds[0]; got != "claude" {
 				t.Fatalf("install host = %q, want claude", got)
 			}
-			if got := fake.installCmds[1]; got != marketplaceSource {
-				t.Fatalf("install source = %q, want %q (the marketplace repo)", got, marketplaceSource)
+			wantSource := channelMarketplaceSource(tc.devBranch)
+			if got := fake.installCmds[1]; got != wantSource {
+				t.Fatalf("install source = %q, want %q (the channel-resolved marketplace repo)", got, wantSource)
 			}
 			if got := fake.installCmds[2]; got != tc.devBranch {
 				t.Fatalf("%s channel install devBranch = %q, want %q", tc.channel, got, tc.devBranch)
@@ -217,8 +218,9 @@ func TestCodexNoPluginAutoInstallSelectsChannelEntry(t *testing.T) {
 			if got := fake.installCmds[0]; got != "codex" {
 				t.Fatalf("install host = %q, want codex", got)
 			}
-			if got := fake.installCmds[1]; got != marketplaceSource {
-				t.Fatalf("install source = %q, want %q (the marketplace repo)", got, marketplaceSource)
+			wantSource := channelMarketplaceSource(tc.devBranch)
+			if got := fake.installCmds[1]; got != wantSource {
+				t.Fatalf("install source = %q, want %q (the channel-resolved marketplace repo)", got, wantSource)
 			}
 			if got := fake.installCmds[2]; got != tc.devBranch {
 				t.Fatalf("%s channel install devBranch = %q, want %q (devBranch is the sole codex channel knob)", tc.channel, got, tc.devBranch)

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -323,7 +323,7 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 				return 1
 			}
 			fmt.Fprintf(stderr, "Installing the %s plugin…\n", "claude")
-			if _, err := ops.Install("claude", marketplaceSource, devBranch); err != nil {
+			if _, err := ops.Install("claude", channelMarketplaceSource(devBranch), devBranch); err != nil {
 				fmt.Fprintf(stderr, "spacedock claude: auto-install failed: %v\n", err)
 				return 1
 			}
@@ -506,7 +506,7 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 				return 1
 			}
 			fmt.Fprintf(stderr, "Installing the %s plugin…\n", "codex")
-			if _, err := ops.Install("codex", marketplaceSource, devBranch); err != nil {
+			if _, err := ops.Install("codex", channelMarketplaceSource(devBranch), devBranch); err != nil {
 				fmt.Fprintf(stderr, "spacedock codex: auto-install failed: %v\n", err)
 				return 1
 			}

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -718,7 +718,7 @@ func TestCodexFrontDoorNoPluginAutoInstalls(t *testing.T) {
 			if code != 0 {
 				t.Fatalf("exit = %d, want 0 when codex has no plugin → auto-install + launch (stderr=%q)", code, stderr.String())
 			}
-			wantInstall := []string{"codex", marketplaceSource, devBranch}
+			wantInstall := []string{"codex", channelMarketplaceSource(devBranch), devBranch}
 			if !equalArgv(fake.installCmds, wantInstall) {
 				t.Fatalf("install seam = %v, want %v (the {host, source, branch} seam)", fake.installCmds, wantInstall)
 			}

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -248,6 +248,27 @@ func channelPluginID(devBranch string) string {
 	return channelEntry(devBranch) + "@" + channelMarketplace(devBranch)
 }
 
+// channelMarketplaceSource is the marketplace add source the channel installs from:
+// a stable binary (devBranch=main) installs from the bare repo `spacedock-dev/marketplace`,
+// whose root marketplace.json is named `spacedock`; an edge binary (any other devBranch)
+// installs from `spacedock-dev/marketplace@edge`, the `edge` branch whose root
+// marketplace.json is named `spacedock-edge`. The `@edge` ref is what makes the host
+// register a marketplace NAMED `spacedock-edge`, so the channel id `spacedock@spacedock-edge`
+// then resolves — a bare-source add registers `spacedock` and the edge id lookup fails.
+// An explicit SPACEDOCK_MARKETPLACE_SOURCE override (marketplaceSource != the production
+// default) replaces the source verbatim on every channel: the operator's chosen
+// local/alternate marketplace is already the complete marketplace they want, so no
+// channel ref is appended.
+func channelMarketplaceSource(devBranch string) string {
+	if marketplaceSource != defaultMarketplaceSource {
+		return marketplaceSource
+	}
+	if devBranch == "main" {
+		return marketplaceSource
+	}
+	return marketplaceSource + "@edge"
+}
+
 // Launch replaces the current process with argv via execve, so the host CLI
 // owns the terminal (interactive `claude --agent …`). It returns only when exec
 // itself fails.
@@ -275,12 +296,15 @@ type installStep struct {
 // tracks an installed plugin via its marketplace record, so the marketplace
 // remove later would orphan a live uninstall), drop the existing marketplace
 // declaration for the channel marketplace name (so the next add re-pins the
-// source instead of no-op'ing on "already on disk"), add the marketplace-repo
-// source, then install the channel id the devBranch selects (`spacedock@spacedock`
-// stable / `spacedock@spacedock-edge` edge — the entry is always `spacedock`, the
-// channel is the marketplace name). The marketplace add carries the BARE
-// marketplace-repo source — the channel and version pin live in the marketplace
-// manifest, not an @ref shorthand. The tolerance asymmetry: BOTH cleanup steps
+// source instead of no-op'ing on "already on disk"), add the channel-resolved
+// marketplace source, then install the channel id the devBranch selects
+// (`spacedock@spacedock` stable / `spacedock@spacedock-edge` edge — the entry is
+// always `spacedock`, the channel is the marketplace name). The marketplace add
+// carries the source channelMarketplaceSource resolved: the bare repo for stable
+// (root marketplace.json named `spacedock`), `<repo>@edge` for edge (the `edge`
+// branch whose root marketplace.json is named `spacedock-edge`, so the add
+// registers `spacedock-edge` and the edge id resolves). The version pin lives in
+// the marketplace manifest. The tolerance asymmetry: BOTH cleanup steps
 // (plugin uninstall + marketplace remove) are tolerated as best-effort, because
 // claude exits 1 on the fresh-box cases ("Plugin not found in installed plugins"
 // for uninstall, "Marketplace not found" for remove) with no way to distinguish
@@ -301,10 +325,13 @@ func installArgvSequence(source, devBranch string) []installStep {
 // codexInstallArgvSequence is the codex analog of installArgvSequence: the same
 // 4-command cleanup-then-pin shape, but in codex's verb vocabulary (`plugin
 // remove` / `plugin add`, not claude's `uninstall` / `install`). The marketplace
-// add carries the BARE marketplace-repo source with NO `--ref` — the channel is
-// the marketplace name (`spacedock` stable / `spacedock-edge` edge) the devBranch
-// selects, the entry is always `spacedock`, and the version pin lives in the
-// marketplace manifest, not a branch ref. The tolerance asymmetry matches claude:
+// add carries the source channelMarketplaceSource resolved (no `--ref` flag — any
+// channel ref is part of the source string): the bare repo for stable (root
+// marketplace.json named `spacedock`), `<repo>@edge` for edge (the `edge` branch
+// whose root marketplace.json is named `spacedock-edge`, so the add registers
+// `spacedock-edge` and the channel id `spacedock@spacedock-edge` resolves). The
+// entry is always `spacedock`, and the version pin lives in the marketplace
+// manifest. The tolerance asymmetry matches claude:
 // BOTH cleanup steps (plugin remove + marketplace remove) are tolerated — on a
 // fresh box `plugin remove` exits 0 (idempotent) but `marketplace remove` exits 1
 // ("marketplace is not configured or installed"), and neither is a real failure.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -10,16 +10,21 @@ import (
 	"github.com/spacedock-dev/spacedock/internal/contract"
 )
 
-// marketplaceSource is the marketplace add source: the standalone marketplace
-// repo (NOT the plugin repo). It exposes the channel marketplaces — `spacedock`
-// (stable, pinned to a release tag) and `spacedock-edge` (edge, tracking next
-// HEAD) — each a marketplace.json with the single `spacedock` entry. The binary's
-// devBranch stamp selects which marketplace installs (see channelMarketplace); the
-// version pin lives in the manifest, not an @ref on the install command. It is a
-// var (not a const) so `SPACEDOCK_MARKETPLACE_SOURCE` can override it — pointing
-// the install at a local/alternate marketplace to dogfood a channel fix before it
-// reaches the production marketplace; tests save/restore it.
-var marketplaceSource = "spacedock-dev/marketplace"
+// defaultMarketplaceSource is the production marketplace add source: the standalone
+// marketplace repo (NOT the plugin repo). The channel selects a branch of it via
+// channelMarketplaceSource — stable installs from the bare repo (root marketplace.json
+// named `spacedock`), edge from `@edge` (root marketplace.json named `spacedock-edge`)
+// — each a marketplace.json with the single `spacedock` entry. The version pin lives in
+// the manifest, not an @ref on the install command.
+const defaultMarketplaceSource = "spacedock-dev/marketplace"
+
+// marketplaceSource is the marketplace add source. It is a var (not a const) so
+// `SPACEDOCK_MARKETPLACE_SOURCE` can override it — pointing the install at a
+// local/alternate marketplace to dogfood a channel fix before it reaches the
+// production marketplace; tests save/restore it. When overridden it replaces the
+// resolved source verbatim (channelMarketplaceSource appends no channel ref to an
+// operator's chosen source); unset, it is the production default the channel branches.
+var marketplaceSource = defaultMarketplaceSource
 
 // runInit installs/updates the per-host plugin (claude or codex) then runs doctor.
 // `--check` runs the report without installing. Both hosts install programmatically
@@ -34,7 +39,7 @@ func runInit(ctx context.Context, args []string, ops hostOps, stdout, stderr io.
 	switch host {
 	case "claude":
 		if !check {
-			out, err := ops.Install(host, marketplaceSource, devBranch)
+			out, err := ops.Install(host, channelMarketplaceSource(devBranch), devBranch)
 			if err != nil {
 				fmt.Fprintf(stderr, "spacedock install: host install failed: %v\n", err)
 				return 1
@@ -59,7 +64,7 @@ func runInit(ctx context.Context, args []string, ops hostOps, stdout, stderr io.
 		// installs; a present plugin is refreshed. The install verb is codex's `add`
 		// (supplied by codexInstallArgvSequence), and the channel marketplace the
 		// binary's devBranch selects is the install target.
-		out, err := ops.Install("codex", marketplaceSource, devBranch)
+		out, err := ops.Install("codex", channelMarketplaceSource(devBranch), devBranch)
 		if err != nil {
 			fmt.Fprintf(stderr, "spacedock install: host install failed: %v\n", err)
 			return 1

--- a/internal/cli/init_devbranch_test.go
+++ b/internal/cli/init_devbranch_test.go
@@ -42,12 +42,13 @@ func TestInitTargetsNextWhenDevBranchPinned(t *testing.T) {
 // marketplace remove later would orphan a live uninstall; tolerated, fresh-box
 // exit 1 with "Plugin not found in installed plugins"), then `plugin marketplace
 // remove <marketplace>` (tolerated, fresh-box exit 1 with "not found"), then
-// `plugin marketplace add` with the BARE marketplace-repo source (no @ref — the
-// channel is the marketplace name and the version pin lives in the manifest), then
-// `plugin install <id>`. The id is the channel the devBranch selects, with the
-// channel in the marketplace name: `spacedock@spacedock-edge` for the edge binary
-// (marketplace remove targets `spacedock-edge`), `spacedock@spacedock` for stable.
-// The marketplace-remove step is what defeats the "already on disk" no-op in
+// `plugin marketplace add <source>` with whatever source it is handed (the builder
+// is source-agnostic — channelMarketplaceSource upstream resolves the channel
+// source: bare repo for stable, `<repo>@edge` for edge), then `plugin install
+// <id>`. The id is the channel the devBranch selects, with the channel in the
+// marketplace name: `spacedock@spacedock-edge` for the edge binary (marketplace
+// remove targets `spacedock-edge`), `spacedock@spacedock` for stable. The
+// marketplace-remove step is what defeats the "already on disk" no-op in
 // marketplace add when a stale source is declared. The asymmetry: BOTH cleanup
 // steps (uninstall + remove) are tolerated; BOTH pinning steps (add + install) are
 // fail-fast.

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -39,12 +39,14 @@ func TestInitClaudeIssuesHostPluginCommands(t *testing.T) {
 
 // TestInitMarketplaceSourceIsMarketplaceRepo guards the Model B decouple: the
 // marketplace-add target is the standalone marketplace repo
-// `spacedock-dev/marketplace`, NOT the plugin repo `spacedock-dev/spacedock` (the
-// manifest moved out of the plugin branch). Without this, a silent revert of the
-// marketplaceSource back to the plugin repo would not fail `go test` — both hosts'
-// install seams carry the source, so both paths are asserted.
+// `spacedock-dev/marketplace` (channel-resolved by channelMarketplaceSource — the
+// edge binary adds the `@edge` branch ref), NOT the plugin repo
+// `spacedock-dev/spacedock` (the manifest moved out of the plugin branch). Without
+// this, a silent revert of the marketplaceSource back to the plugin repo would not
+// fail `go test` — both hosts' install seams carry the source, so both paths are
+// asserted.
 func TestInitMarketplaceSourceIsMarketplaceRepo(t *testing.T) {
-	const wantSource = "spacedock-dev/marketplace"
+	wantSource := channelMarketplaceSource(devBranch)
 
 	t.Run("claude-install-seam", func(t *testing.T) {
 		fake := &fakeHost{manifest: compatibleManifest(t)}
@@ -117,7 +119,7 @@ func TestInitCodexInstallReadiness(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
-		wantInstall := []string{"codex", marketplaceSource, devBranch}
+		wantInstall := []string{"codex", channelMarketplaceSource(devBranch), devBranch}
 		if !equalArgv(fake.installCmds, wantInstall) {
 			t.Fatalf("install seam = %v, want %v — codex init on a present plugin must refresh, not no-op", fake.installCmds, wantInstall)
 		}
@@ -189,7 +191,7 @@ func TestInitCodexInstallReadiness(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
-		wantInstall := []string{"codex", marketplaceSource, "next"}
+		wantInstall := []string{"codex", channelMarketplaceSource("next"), "next"}
 		if !equalArgv(fake.installCmds, wantInstall) {
 			t.Fatalf("edge codex install seam = %v, want %v", fake.installCmds, wantInstall)
 		}


### PR DESCRIPTION
The codex and claude edge channels couldn't install; this makes `spacedock install` on the edge channel work end-to-end.

## What changed
- Add `channelMarketplaceSource`: edge installs from `…/marketplace@edge`, stable from the bare repo.
- Create the permanent `edge` branch (root manifest named `spacedock-edge` → `next`).
- Wire the channel-resolved source into `runInit` and front-door auto-install (both hosts).
- Preserve the `SPACEDOCK_MARKETPLACE_SOURCE` override verbatim on every channel.
- Correct `install.md`/`releasing.md` to the branch-per-channel model.

## Evidence
- Channel-source Go tests 3/3; `go test ./...` green.
- Real edge install verified against the published `@edge` marketplace (codex + claude); broken baseline reproduced; adversarial audit clean (4/4 claim-breaking edits go red).

## Review guidance
`channelMarketplaceSource` (host_exec.go): the env-override path must NOT append `@edge` — audit-verified.

---
[fe](/spacedock-dev/spacedock/blob/a0f0846a16212a5b77d40381a1d7381d3baaaa8b/codex-edge-channel-marketplace-source.md)
