### PR TITLE
Reconcile docs/releasing.md to the live release machinery (one consolidated pass)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,19 @@ jobs:
           echo "release commit for $GITHUB_REF_NAME: $RELEASE_COMMIT"
           go run ./cmd/spacedock-release e2e-gate "$RELEASE_COMMIT"
 
+      # Assert the tagged commit's plugin manifests already carry the tag's semver
+      # — the stamp-then-tag ordering docs/releasing.md documents. The checkout
+      # above is at the tagged commit, so these are the tagged commit's manifests.
+      # A mismatch (the v0.20.0 pre-stamp inversion: tag 0.20.0, manifest 0.19.9)
+      # exits non-zero and blocks the cut, since goreleaser needs: this job. The
+      # `if` skips pre-releases (a vX.Y.Z-pre.N tag legitimately differs from its
+      # X.Y.Z manifest), matching the stamp step's pre-release carve-out below.
+      - name: Gate the cut on the tagged manifest matching the tag semver
+        if: "!contains(github.ref, '-')"
+        run: |
+          set -euo pipefail
+          go run ./cmd/spacedock-release manifest-tag-gate "$GITHUB_REF_NAME" .claude-plugin/plugin.json .codex-plugin/plugin.json
+
   goreleaser:
     needs: e2e-gate
     runs-on: macos-latest
@@ -205,6 +218,11 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_VERSION="${GITHUB_REF_NAME#v}"
+          # The tagged commit is the SHA the e2e-gate greened and the manifest-tag
+          # gate matched. Resolve it BEFORE switching to main, so the stable ref
+          # below advances to exactly THIS commit, not whatever main HEAD happens to
+          # be at push time.
+          RELEASE_COMMIT="$(git rev-list -1 "$GITHUB_REF_NAME")"
           git fetch origin main
           git switch main
           go run ./cmd/spacedock-release stamp-version "$RELEASE_VERSION" \
@@ -218,12 +236,14 @@ jobs:
               -- .claude-plugin/plugin.json .codex-plugin/plugin.json
             git push origin main
           fi
-          # Advance the stable channel ref to the stamped release commit. The
+          # Advance the stable channel ref to the TAGGED commit. The
           # spacedock-dev/marketplace stable entry pins source.ref=stable (a moving
           # branch, not a per-release tag), so a fresh `spacedock@spacedock` install
           # resolves whatever this branch points at — this push is what publishes the
           # release to the stable channel, replacing a hand-edit of the marketplace
-          # repo. main HEAD is the stamped release commit and stable is a prior
-          # release commit, so this fast-forwards. Same-repo push, so the default
-          # GITHUB_TOKEN suffices (no cross-repo PAT, unlike the homebrew-tap push).
-          git push origin main:refs/heads/stable
+          # repo. Pushing $RELEASE_COMMIT (the tagged SHA), not `main`, keeps stable
+          # and the tag the SAME commit even if main advanced after the tag fired.
+          # The tagged commit is on main's history, so this fast-forwards. Same-repo
+          # push, so the default GITHUB_TOKEN suffices (no cross-repo PAT, unlike the
+          # homebrew-tap push).
+          git push origin "$RELEASE_COMMIT:refs/heads/stable"

--- a/cmd/spacedock-release/main.go
+++ b/cmd/spacedock-release/main.go
@@ -28,7 +28,9 @@ import (
 // key to today's `0.0.YYYYMMDDNN` (AC-2d). Both rewrite in place. e2e-gate is the
 // release-time precondition: it passes (exit 0) only when a conclusion:success
 // Runtime Live E2E run exists for the commit, or when SPACEDOCK_E2E_GATE_WAIVER
-// is set, and blocks the cut (exit 1) otherwise. notes summarizes the commit log
+// is set, and blocks the cut (exit 1) otherwise. manifest-tag-gate blocks the cut
+// unless every tagged plugin.json's version equals the tag semver (the stamp-then-tag
+// ordering). notes summarizes the commit log
 // since the last tag into clean release notes and, on confirmation, cuts the
 // annotated tag whose body carries them (CI extracts that body and feeds
 // goreleaser via --release-notes).
@@ -46,6 +48,8 @@ func main() {
 		os.Exit(journeyCosts(os.Args[2:]))
 	case "e2e-gate":
 		os.Exit(runE2EGate(os.Args[2:], ghRunListForCommit))
+	case "manifest-tag-gate":
+		os.Exit(runManifestTagGate(os.Args[2:]))
 	case "notes":
 		os.Exit(notes(os.Args[2:]))
 	default:
@@ -321,6 +325,7 @@ Usage:
   spacedock-release bump-calendar <marketplace.json>
   spacedock-release journey-costs <release-version> --metrics-dir <dir> --out <path>
   spacedock-release e2e-gate <release-commit-sha>
+  spacedock-release manifest-tag-gate <tag> <plugin.json> [<plugin.json> ...]
   spacedock-release notes <release-version>
 `)
 }

--- a/cmd/spacedock-release/manifest_tag_gate.go
+++ b/cmd/spacedock-release/manifest_tag_gate.go
@@ -1,0 +1,68 @@
+// ABOUTME: `spacedock-release manifest-tag-gate <tag> <plugin.json>...` — blocks
+// ABOUTME: the cut unless every tagged manifest's version equals the tag semver.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spacedock-dev/spacedock/internal/release"
+)
+
+// runManifestTagGate asserts the tag semver equals the version stamped into each
+// plugin manifest the cutter is about to tag. It reads the manifest version from
+// each file (an independent value from the tag), runs the pure decision predicate,
+// records the outcome to $GITHUB_STEP_SUMMARY, and returns the process exit code:
+// 0 when every manifest matches the tag, 1 when any diverges or cannot be read, 2
+// on a usage error. This is the divergeable guard behind the reconciled
+// releasing.md's stamp-then-tag ordering: a tag-vs-manifest mismatch (the pre-stamp
+// inversion) is caught before goreleaser fires.
+func runManifestTagGate(args []string) int {
+	if len(args) < 2 {
+		fmt.Fprintln(os.Stderr, "spacedock-release manifest-tag-gate: need <tag> <plugin.json> [<plugin.json> ...]")
+		return 2
+	}
+	tag, manifests := args[0], args[1:]
+	for _, path := range manifests {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			reason := fmt.Sprintf("manifest-tag gate BLOCKED for %s: cannot read %s (%v)", tag, path, err)
+			fmt.Fprintln(os.Stderr, reason)
+			recordManifestTagSummary(reason)
+			return 1
+		}
+		version, err := release.ManifestVersion(data)
+		if err != nil {
+			reason := fmt.Sprintf("manifest-tag gate BLOCKED for %s: cannot parse %s (%v)", tag, path, err)
+			fmt.Fprintln(os.Stderr, reason)
+			recordManifestTagSummary(reason)
+			return 1
+		}
+		dec := release.EvaluateManifestTagGate(tag, version)
+		if !dec.Pass {
+			reason := fmt.Sprintf("%s (%s)", dec.Reason, path)
+			fmt.Fprintf(os.Stderr, "spacedock-release manifest-tag-gate: %s\n", reason)
+			recordManifestTagSummary("manifest-tag gate BLOCKED: " + reason)
+			return 1
+		}
+		fmt.Printf("%s (%s)\n", dec.Reason, path)
+	}
+	recordManifestTagSummary(fmt.Sprintf("manifest-tag gate PASSED for %s: all %d manifest(s) match the tag semver", tag, len(manifests)))
+	return 0
+}
+
+// recordManifestTagSummary appends the gate decision to $GITHUB_STEP_SUMMARY when
+// set, so every cut leaves an auditable record. Outside CI the env var is unset
+// and this is a no-op.
+func recordManifestTagSummary(reason string) {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "### Release manifest-tag gate\n\n%s\n", reason)
+}

--- a/cmd/spacedock-release/manifest_tag_gate_test.go
+++ b/cmd/spacedock-release/manifest_tag_gate_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeManifest writes a minimal plugin.json carrying the given version to a temp
+// file and returns its path, so the manifest-tag-gate subcommand is exercised
+// against a real file read rather than a stubbed version string.
+func writeManifest(t *testing.T, version string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "plugin.json")
+	body := `{"name": "spacedock", "version": "` + version + `"}`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestManifestTagGateCommandPassesOnMatch — the subcommand exits 0 when the tag
+// semver equals the manifest version (the stamp-then-tag ordering).
+func TestManifestTagGateCommandPassesOnMatch(t *testing.T) {
+	manifest := writeManifest(t, "0.22.0")
+	if code := runManifestTagGate([]string{"v0.22.0", manifest}); code != 0 {
+		t.Fatalf("manifest-tag-gate exit = %d, want 0 on a matching tag/manifest", code)
+	}
+}
+
+// TestManifestTagGateCommandBlocksOnMismatch — the subcommand exits non-zero when
+// the tagged commit's manifest still reads a prior release (the v0.20.0 inversion).
+func TestManifestTagGateCommandBlocksOnMismatch(t *testing.T) {
+	manifest := writeManifest(t, "0.19.9")
+	if code := runManifestTagGate([]string{"v0.20.0", manifest}); code == 0 {
+		t.Fatalf("manifest-tag-gate exit = 0 on a tag/manifest mismatch; want non-zero (cut blocked)")
+	}
+}
+
+// TestManifestTagGateCommandChecksEveryManifest — both plugin manifests are
+// checked, so a mismatch in either (e.g. the codex manifest lagging) blocks.
+func TestManifestTagGateCommandChecksEveryManifest(t *testing.T) {
+	good := writeManifest(t, "0.22.0")
+	lagging := writeManifest(t, "0.21.0")
+	if code := runManifestTagGate([]string{"v0.22.0", good, lagging}); code == 0 {
+		t.Fatalf("manifest-tag-gate exit = 0 with a lagging second manifest; want non-zero")
+	}
+}
+
+// TestManifestTagGateCommandRejectsMissingArgs — with no manifest argument the
+// subcommand exits with a usage error and does not pass.
+func TestManifestTagGateCommandRejectsMissingArgs(t *testing.T) {
+	if code := runManifestTagGate([]string{"v0.22.0"}); code == 0 {
+		t.Fatalf("manifest-tag-gate exit = 0 with no manifest argument; want non-zero")
+	}
+}
+
+// TestManifestTagGateCommandBlocksUnreadableManifest — a manifest path that does
+// not exist blocks the cut rather than silently passing.
+func TestManifestTagGateCommandBlocksUnreadableManifest(t *testing.T) {
+	if code := runManifestTagGate([]string{"v0.22.0", "/no/such/plugin.json"}); code == 0 {
+		t.Fatalf("manifest-tag-gate exit = 0 on an unreadable manifest; want non-zero")
+	}
+}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -87,18 +87,20 @@ green Runtime Live E2E run for its exact SHA. Stamp and push the release commit 
    the moving `stable` ref to this commit after the tag fires (see "What the Tag
    Push Does").
 
-4. Green that exact commit. Dispatch Runtime Live E2E on the pushed `main` HEAD and
-   wait for a `conclusion: success` run — the `e2e-gate` matches a green run to the
-   tagged SHA, and the workflow is `workflow_dispatch`-only, so nothing greens the
-   commit unless you dispatch it:
+4. Green that exact commit. Capture the release SHA, then dispatch Runtime Live
+   E2E on it and wait for a `conclusion: success` run — the `e2e-gate` matches a
+   green run to the tagged SHA, and the workflow is `workflow_dispatch`-only, so
+   nothing greens the commit unless you dispatch it:
 
    ```bash
+   REL_SHA=$(git rev-parse HEAD)
    gh workflow run "Runtime Live E2E" --ref main
    gh run watch "$(gh run list --workflow 'Runtime Live E2E' --branch main --limit 1 --json databaseId --jq '.[0].databaseId')"
    ```
 
-   The tagged commit must be the SHA this run goes green on. (For an emergency cut
-   when the live matrix is unavailable, the gate accepts the auditable
+   `REL_SHA` is the stamped commit from step 3 (the worktree HEAD you just pushed);
+   it is the SHA this run must go green on, and the SHA you tag in step 6. (For an
+   emergency cut when the live matrix is unavailable, the gate accepts the auditable
    `SPACEDOCK_E2E_GATE_WAIVER` repo variable instead.)
 
 5. Write a changelog. Summarize the commits since the last tag into plain text:
@@ -114,11 +116,13 @@ green Runtime Live E2E run for its exact SHA. Stamp and push the release commit 
 6. Create the annotated tag on the greened commit:
 
    ```bash
-   git tag -a vX.Y.Z -F <changelog-file> $(git rev-parse origin/main)
+   git tag -a vX.Y.Z -F <changelog-file> "$REL_SHA"
    ```
 
-   `$(git rev-parse origin/main)` is the stamped, greened commit from steps 3–4;
-   tag THAT SHA so the `e2e-gate` finds its matching green run.
+   `$REL_SHA` is the stamped, greened commit captured in step 4; tag THAT SHA so
+   the `e2e-gate` finds its matching green run. (Tagging the captured SHA, not
+   `git rev-parse origin/main`, keeps the target stable even if a stray `git fetch`
+   moves `origin/main` between steps.)
 
 7. Review:
 
@@ -167,4 +171,3 @@ a dev-only path.
   marketplace-repo task and is NOT part of this flow.
 - This flow is the v1 adaptation of the original `scripts/release.sh` from the
   upstream spacedock plugin repo.
-```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -14,25 +14,46 @@ marketplace source.
 - publishes the GitHub Release with those assets;
 - bumps BOTH `spacedock-dev/homebrew-tap` casks (`spacedock` stable +
   `spacedock@next` edge) via `HOMEBREW_TAP_TOKEN`;
-- stamps the plugin manifests' `version` on `main`.
+- stamps the plugin manifests' `version` on `main`, then advances the stable
+  channel ref (see below).
 
 The marketplace manifest no longer lives in the plugin branch. It is the
 standalone `spacedock-dev/marketplace` repo, where each channel is a branch with
 its own root `marketplace.json`: the repo root (a marketplace named `spacedock`,
-stable entry repointed to the released tag) and the `edge` branch (a marketplace
-named `spacedock-edge`, entry tracking `next`). The channel lives in the
-marketplace NAME, so a binary adds the channel's branch source —
+the stable entry pinned to `source.ref=stable`) and the `edge` branch (a
+marketplace named `spacedock-edge`, entry tracking `next`). The channel lives in
+the marketplace NAME, so a binary adds the channel's branch source —
 `spacedock-dev/marketplace` for stable, `spacedock-dev/marketplace@edge` for edge —
-and the marketplace it registers carries the matching name. Repointing the stable
-entry is a commit on the repo root, not a manifest stamp on `main`.
+and the marketplace it registers carries the matching name.
+
+The stable entry is NOT repointed per release by a hand-edit in the marketplace
+repo. `stable` is a MOVING BRANCH in THIS repo: after the manifest stamp,
+release.yml resolves the tagged commit as `RELEASE_COMMIT` and runs
+`git push origin "$RELEASE_COMMIT:refs/heads/stable"` (release.yml's "Stamp plugin
+manifests" step), advancing `stable` to that exact tagged commit. A fresh
+`spacedock@spacedock` install resolves whatever `stable` points at, so that push
+is what publishes the release to the stable channel — no marketplace-repo commit.
+
+The post-tag manifest stamp is idempotent: when the tagged commit ALREADY carries
+the release version in `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`
+(it does, under the stamp-then-tag ordering below), the stamp step finds no diff
+and commits nothing; it still advances `stable` to that commit.
 
 The tag triggers the release, but goreleaser publishes only after the `e2e-gate`
 job confirms the tagged commit has a green Runtime Live E2E run (or a recorded
 `SPACEDOCK_E2E_GATE_WAIVER`) — so the commit you tag must be one that has been
-exercised green. A manual release-prep commit is still useful because it produces
-a reviewable annotated-tag changelog and manifest diff before the tag is pushed.
+exercised green. The gate binds the green run to the EXACT tagged commit SHA
+(`run.HeadSha == tagged-commit`, `internal/release/e2egate.go`), and Runtime Live
+E2E is `workflow_dispatch`-only, so it never runs automatically on a fresh commit.
+This is why the cut below stamps and pushes the release commit to `main` FIRST,
+greens THAT commit, and only then tags it — a tag on any commit that has no green
+run for its own SHA is blocked by the gate.
 
 ## Cutting a Stable Release
+
+The cutter tags a commit that ALREADY has both a matching manifest stamp and a
+green Runtime Live E2E run for its exact SHA. Stamp and push the release commit to
+`main`, green that commit, then tag it.
 
 1. Ensure all release content is merged to `main`. Choose the version `X.Y.Z`.
 
@@ -42,18 +63,45 @@ a reviewable annotated-tag changelog and manifest diff before the tag is pushed.
    git worktree add .worktrees/release-X.Y.Z -b release/X.Y.Z origin/main
    ```
 
-3. Bump the version stamps with the release tool, then commit. `stamp-version`
-   writes the release `X.Y.Z` into the plugin manifests:
+3. Stamp the plugin manifests to `X.Y.Z`, commit, and push to `main`. This is the
+   commit the tag will name, so it must land on `main` and be greened BEFORE the
+   tag — a fresh post-tag commit would have no green Runtime Live E2E run for its
+   SHA and the `e2e-gate` would block the cut.
 
    ```bash
    go run ./cmd/spacedock-release stamp-version X.Y.Z .claude-plugin/plugin.json .codex-plugin/plugin.json
    git commit -m "release: bump version to spacedock@X.Y.Z" -- .claude-plugin/plugin.json .codex-plugin/plugin.json
+   git push origin release/X.Y.Z:main
    ```
 
-   The marketplace entry is no longer stamped here — repoint the `spacedock`
-   stable entry's ref in the standalone `spacedock-dev/marketplace` repo.
+   The stamped commit's manifest version now equals `X.Y.Z`. Guard that before
+   tagging — a tag whose semver disagrees with the tagged commit's manifest is the
+   pre-stamp inversion the gate has historically caught (v0.20.0 tagged a commit
+   whose `plugin.json` still read 0.19.9):
 
-4. Write a changelog. Summarize the commits since the last tag into plain text:
+   ```bash
+   go run ./cmd/spacedock-release manifest-tag-gate vX.Y.Z .claude-plugin/plugin.json .codex-plugin/plugin.json
+   ```
+
+   The marketplace entry is not stamped or repointed here: release.yml advances
+   the moving `stable` ref to this commit after the tag fires (see "What the Tag
+   Push Does").
+
+4. Green that exact commit. Dispatch Runtime Live E2E on the pushed `main` HEAD and
+   wait for a `conclusion: success` run — the `e2e-gate` matches a green run to the
+   tagged SHA, and the workflow is `workflow_dispatch`-only, so nothing greens the
+   commit unless you dispatch it:
+
+   ```bash
+   gh workflow run "Runtime Live E2E" --ref main
+   gh run watch "$(gh run list --workflow 'Runtime Live E2E' --branch main --limit 1 --json databaseId --jq '.[0].databaseId')"
+   ```
+
+   The tagged commit must be the SHA this run goes green on. (For an emergency cut
+   when the live matrix is unavailable, the gate accepts the auditable
+   `SPACEDOCK_E2E_GATE_WAIVER` repo variable instead.)
+
+5. Write a changelog. Summarize the commits since the last tag into plain text:
 
    ```bash
    git log $(git describe --tags --abbrev=0 origin/main)..HEAD --oneline
@@ -63,29 +111,33 @@ a reviewable annotated-tag changelog and manifest diff before the tag is pushed.
    what upgrading gives users. Ignore workflow-state churn
    (dispatch/advance/archive/mod-block/pr/report commits).
 
-5. Create the annotated tag locally:
+6. Create the annotated tag on the greened commit:
 
    ```bash
-   git tag -a vX.Y.Z -F <changelog-file>
+   git tag -a vX.Y.Z -F <changelog-file> $(git rev-parse origin/main)
    ```
 
-6. Review:
+   `$(git rev-parse origin/main)` is the stamped, greened commit from steps 3–4;
+   tag THAT SHA so the `e2e-gate` finds its matching green run.
+
+7. Review:
 
    ```bash
    git show vX.Y.Z
-   git diff origin/main..release/X.Y.Z
    ```
 
-   To amend the changelog: `git tag -d vX.Y.Z` then re-tag.
+   To amend the changelog: `git tag -d vX.Y.Z` then re-tag the same commit.
 
-7. Publish after confirmation:
+8. Publish after confirmation:
 
    ```bash
-   git push origin release/X.Y.Z:main
    git push origin vX.Y.Z
    ```
 
-8. Clean up:
+   The release commit is already on `main` from step 3; pushing the tag fires
+   `release.yml`, which gates on the green run for this commit and then publishes.
+
+9. Clean up:
 
    ```bash
    git worktree remove .worktrees/release-X.Y.Z
@@ -109,5 +161,10 @@ a dev-only path.
 - macOS binaries are adhoc-signed, not yet notarized; the Homebrew cask's
   postflight strips the `com.apple.quarantine` xattr as the interim Gatekeeper
   fix until Developer-ID notarization lands.
+- The `spacedock-dev/marketplace` repo's `next` entry carries a dead `version`
+  field and a tag-vs-branch channel structure that want cleanup. That repo is
+  standalone and unreachable from here, so the cleanup is deferred to a
+  marketplace-repo task and is NOT part of this flow.
 - This flow is the v1 adaptation of the original `scripts/release.sh` from the
   upstream spacedock plugin repo.
+```

--- a/internal/release/channel_agreement_guard_test.go
+++ b/internal/release/channel_agreement_guard_test.go
@@ -154,34 +154,64 @@ func TestStableChannelBinaryPairAgreesOnMain(t *testing.T) {
 	}
 }
 
-// stampStepAdvancesStableRef reports whether the "Stamp plugin manifests" step
-// pushes the stamped commit to the stable channel ref. It looks for a
-// `git push origin <src>:refs/heads/stable` command in the step's run block.
-func stampStepAdvancesStableRef(workflow string) bool {
+// stableRefPushSource returns the push source (the part before `:refs/heads/stable`)
+// the "Stamp plugin manifests" step advances the stable channel ref to, with any
+// surrounding shell quotes stripped, or "" when the step has no such push. It looks
+// for a `git push origin <src>:refs/heads/stable` command in the step's run block.
+func stableRefPushSource(workflow string) string {
 	for _, step := range parseWorkflowSteps(workflow) {
 		if step.name != "Stamp plugin manifests to the release version" {
 			continue
 		}
 		for _, command := range executableShellCommands(step.run) {
 			fields := strings.Fields(command)
-			if len(fields) == 4 && fields[0] == "git" && fields[1] == "push" && fields[2] == "origin" && strings.HasSuffix(fields[3], ":refs/heads/stable") {
-				return true
+			if len(fields) != 4 || fields[0] != "git" || fields[1] != "push" || fields[2] != "origin" {
+				continue
+			}
+			refspec := strings.Trim(fields[3], `"'`)
+			if src, ok := strings.CutSuffix(refspec, ":refs/heads/stable"); ok {
+				return src
 			}
 		}
 	}
-	return false
+	return ""
 }
 
-// TestStampStepAdvancesStableRef locks the stable-channel publish mechanism: the
-// release stamp step MUST push the release commit to the `stable` ref, because the
-// spacedock-dev/marketplace stable entry pins source.ref=stable. Without this push
-// the stable channel would freeze at the prior release forever (a fresh
-// `spacedock@spacedock` install would resolve the old commit), since the marketplace
-// manifest is intentionally static and no longer hand-edited per release. The
-// command is parsed out of the real release.yml, so dropping the push reds this.
-func TestStampStepAdvancesStableRef(t *testing.T) {
-	if !stampStepAdvancesStableRef(readReleaseWorkflow(t)) {
-		t.Error("release.yml stamp step does not push to refs/heads/stable; the stable marketplace channel (source.ref=stable) would never advance past the prior release")
+// TestStampStepAdvancesStableRefToTaggedCommit locks the stable-channel publish
+// mechanism AND the tag-binding: the release stamp step MUST push the TAGGED commit
+// ($RELEASE_COMMIT) to the `stable` ref, because the spacedock-dev/marketplace
+// stable entry pins source.ref=stable. Without this push the stable channel would
+// freeze at the prior release forever (a fresh `spacedock@spacedock` install would
+// resolve the old commit). Pushing the tagged SHA rather than `main` keeps stable
+// and the tag the SAME commit even if main advanced after the tag fired — the
+// former `main:refs/heads/stable` form could point stable at a different commit
+// than the tag. The command is parsed out of the real release.yml, so dropping the
+// push, or regressing to a `main` source, reds this.
+func TestStampStepAdvancesStableRefToTaggedCommit(t *testing.T) {
+	src := stableRefPushSource(readReleaseWorkflow(t))
+	if src == "" {
+		t.Fatal("release.yml stamp step does not push to refs/heads/stable; the stable marketplace channel (source.ref=stable) would never advance past the prior release")
+	}
+	if src != "$RELEASE_COMMIT" {
+		t.Errorf("stable ref is advanced to %q, not the tagged commit $RELEASE_COMMIT; stable and the tag could diverge if main advances after the tag fires", src)
+	}
+}
+
+// TestStableRefGuardRejectsMainSource is the adversarial twin: regress the stable
+// push back to the divergeable `main:refs/heads/stable` form and the guard must
+// RED, because that source resolves to whatever main HEAD is at push time rather
+// than the tagged commit.
+func TestStableRefGuardRejectsMainSource(t *testing.T) {
+	workflow := readReleaseWorkflow(t)
+	adversarial := strings.Replace(workflow,
+		`git push origin "$RELEASE_COMMIT:refs/heads/stable"`,
+		`git push origin main:refs/heads/stable`,
+		1)
+	if adversarial == workflow {
+		t.Fatal("fixture release.yml missing the `$RELEASE_COMMIT:refs/heads/stable` push to regress")
+	}
+	if src := stableRefPushSource(adversarial); src == "$RELEASE_COMMIT" {
+		t.Fatal("guard still saw the tagged-commit source after regressing to a main source")
 	}
 }
 

--- a/internal/release/manifest_tag_gate.go
+++ b/internal/release/manifest_tag_gate.go
@@ -1,0 +1,45 @@
+// ABOUTME: Release-time guard predicate — the tagged commit's plugin.json version
+// ABOUTME: must equal the tag's semver, so a tag/manifest mismatch blocks the cut.
+package release
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ManifestTagDecision is the outcome of comparing a release tag's semver against
+// the version stamped into the tagged commit's plugin manifest. Pass gates whether
+// the cut may proceed; Reason explains the match or the mismatch for the step log.
+type ManifestTagDecision struct {
+	Pass   bool
+	Reason string
+}
+
+// EvaluateManifestTagGate decides whether a release may be cut by comparing two
+// INDEPENDENT values: the git tag's semver (tagVersion, with or without a leading
+// `v`) and the version field read from the tagged commit's plugin.json
+// (manifestVersion). They originate from different artifacts — the annotated tag
+// and the manifest blob — and the real release history proves they can diverge
+// (the v0.20.0 cut tagged a commit whose manifest still read 0.19.9). The gate
+// passes only when the normalized tag semver equals the manifest version, so a
+// pre-stamp/post-stamp inversion that leaves the manifest at the prior release is
+// caught before goreleaser fires. An empty manifest version (a stamp that never
+// ran) never passes.
+func EvaluateManifestTagGate(tagVersion, manifestVersion string) ManifestTagDecision {
+	tag := strings.TrimPrefix(strings.TrimSpace(tagVersion), "v")
+	manifest := strings.TrimSpace(manifestVersion)
+	if manifest == "" {
+		return ManifestTagDecision{
+			Reason: fmt.Sprintf("tagged commit's plugin.json has no version; tag %s expects %s", tagVersion, tag),
+		}
+	}
+	if tag != manifest {
+		return ManifestTagDecision{
+			Reason: fmt.Sprintf("tag %s does not match tagged commit's plugin.json version %s; stamp the manifest to %s and tag THAT commit", tagVersion, manifest, tag),
+		}
+	}
+	return ManifestTagDecision{
+		Pass:   true,
+		Reason: fmt.Sprintf("tag %s matches tagged commit's plugin.json version %s", tagVersion, manifest),
+	}
+}

--- a/internal/release/manifest_tag_gate_test.go
+++ b/internal/release/manifest_tag_gate_test.go
@@ -1,0 +1,76 @@
+package release
+
+import (
+	"strings"
+	"testing"
+)
+
+// The manifest/tag agreement guard compares two INDEPENDENT values: the git tag
+// semver and the version stamped into the tagged commit's plugin.json. They come
+// from different sources (the annotated tag vs the manifest blob) and the real
+// release history proves they can disagree — so this is a divergeable check, not
+// a tautology. The fixtures below encode that history: the v0.20.0 cut tagged a
+// commit whose plugin.json still read 0.19.9 (the pre-stamp/post-stamp inversion
+// the reconciled releasing.md removes), whereas the v0.22.0 cut tagged a commit
+// whose plugin.json already read 0.22.0.
+const (
+	divergedTag      = "v0.20.0"
+	divergedManifest = "0.19.9"
+	agreedTag        = "v0.22.0"
+	agreedManifest   = "0.22.0"
+)
+
+// TestManifestTagGateBlocksDivergedHistory locks the block case against the real
+// v0.20.0 history: a tag whose semver does not equal the tagged commit's manifest
+// version must NOT pass — that is exactly the ungated pre-stamp inversion the
+// reconciled procedure forbids. The two values are independent (tag object vs
+// manifest blob), so a manifest left at the prior release reds the gate.
+func TestManifestTagGateBlocksDivergedHistory(t *testing.T) {
+	dec := EvaluateManifestTagGate(divergedTag, divergedManifest)
+	if dec.Pass {
+		t.Fatalf("gate passed a tag/manifest mismatch (%s vs %s); the v0.20.0 inversion must block", divergedTag, divergedManifest)
+	}
+	if !strings.Contains(dec.Reason, divergedTag) || !strings.Contains(dec.Reason, divergedManifest) {
+		t.Errorf("block reason does not cite both diverging values; got: %s", dec.Reason)
+	}
+}
+
+// TestManifestTagGatePassesWhenStamped locks the pass case against the real
+// v0.22.0 history: when the tagged commit's manifest already carries the tag's
+// semver (the stamp-then-tag ordering the reconciled procedure documents), the
+// gate passes.
+func TestManifestTagGatePassesWhenStamped(t *testing.T) {
+	dec := EvaluateManifestTagGate(agreedTag, agreedManifest)
+	if !dec.Pass {
+		t.Fatalf("gate blocked a matching tag/manifest pair (%s vs %s): %s", agreedTag, agreedManifest, dec.Reason)
+	}
+}
+
+// TestManifestTagGateNormalizesTagPrefix proves the comparison is on semver, not
+// raw strings: the `v` prefix on the git tag is stripped before the compare, so a
+// `vX.Y.Z` tag matches an `X.Y.Z` manifest. Without normalization every release
+// would falsely diverge.
+func TestManifestTagGateNormalizesTagPrefix(t *testing.T) {
+	if dec := EvaluateManifestTagGate("v1.2.3", "1.2.3"); !dec.Pass {
+		t.Fatalf("gate treated the tag `v` prefix as a mismatch: %s", dec.Reason)
+	}
+	if dec := EvaluateManifestTagGate("1.2.3", "1.2.3"); !dec.Pass {
+		t.Fatalf("gate blocked a bare (already-normalized) tag/manifest match: %s", dec.Reason)
+	}
+}
+
+// TestManifestTagGateBlocksOffByOne proves the off-by-one inversion (tag one ahead
+// of the manifest, the exact shape of the v0.20.1..v0.20.3 post-stamp lag) blocks.
+func TestManifestTagGateBlocksOffByOne(t *testing.T) {
+	if dec := EvaluateManifestTagGate("v0.20.1", "0.20.0"); dec.Pass {
+		t.Fatalf("gate passed a tag one minor-patch ahead of the manifest (the post-stamp lag inversion)")
+	}
+}
+
+// TestManifestTagGateBlocksEmptyManifest proves a manifest with no resolvable
+// version (a stamp that never ran) blocks rather than silently passing.
+func TestManifestTagGateBlocksEmptyManifest(t *testing.T) {
+	if dec := EvaluateManifestTagGate("v0.22.0", ""); dec.Pass {
+		t.Fatalf("gate passed an empty manifest version")
+	}
+}

--- a/internal/release/manifest_tag_gate_workflow_test.go
+++ b/internal/release/manifest_tag_gate_workflow_test.go
@@ -1,0 +1,163 @@
+package release
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestReleaseWorkflowGatesGoreleaserOnManifestTag locks the wiring half of AC-2:
+// the real release.yml must run `spacedock-release manifest-tag-gate` over the
+// tagged manifests in a job the goreleaser carrier `needs:`, so a tag whose semver
+// disagrees with the tagged commit's plugin.json is BLOCKED before goreleaser
+// fires — not left to an advisory manual step. Both halves are parsed from the
+// workflow YAML (not from instruction prose):
+//   - some job runs the SHA-free manifest-tag-gate step over both plugin manifests
+//     with the tag ($GITHUB_REF_NAME), AND
+//   - the goreleaser-carrying job `needs:` that gate job.
+func TestReleaseWorkflowGatesGoreleaserOnManifestTag(t *testing.T) {
+	release := readWorkflow(t, "release.yml")
+	if err := assertReleaseWorkflowGatesGoreleaserOnManifestTag(release); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReleaseWorkflowManifestTagGuardRejectsDroppedStep is the adversarial twin
+// for the gate-step half: remove the manifest-tag-gate invocation and the guard
+// must RED, because goreleaser would then cut without the manifest/tag check ever
+// running (the cycle-1 advisory-only hole). A guard that stays green here is a hole.
+func TestReleaseWorkflowManifestTagGuardRejectsDroppedStep(t *testing.T) {
+	release := readWorkflow(t, "release.yml")
+	if err := assertReleaseWorkflowGatesGoreleaserOnManifestTag(release); err != nil {
+		t.Fatalf("real release.yml unexpectedly fails the manifest-tag-gate guard before mutation: %v", err)
+	}
+
+	adversarial := strings.Replace(release,
+		`go run ./cmd/spacedock-release manifest-tag-gate "$GITHUB_REF_NAME" .claude-plugin/plugin.json .codex-plugin/plugin.json`,
+		`echo "skipping manifest-tag gate"`,
+		1)
+	if adversarial == release {
+		t.Fatal("fixture workflow missing the manifest-tag-gate invocation to drop")
+	}
+	if err := assertReleaseWorkflowGatesGoreleaserOnManifestTag(adversarial); err == nil {
+		t.Fatal("manifest-tag-gate guard accepted a workflow with the gate step dropped")
+	}
+}
+
+// TestReleaseWorkflowManifestTagGuardRejectsDroppedNeedsEdge is the adversarial
+// twin for the needs-edge half: drop the goreleaser job's `needs:` on the gate job
+// and the guard must RED, because goreleaser would run in parallel with (or before)
+// the gate rather than waiting on it.
+func TestReleaseWorkflowManifestTagGuardRejectsDroppedNeedsEdge(t *testing.T) {
+	release := readWorkflow(t, "release.yml")
+	adversarial := strings.Replace(release,
+		"  goreleaser:\n    needs: e2e-gate\n",
+		"  goreleaser:\n",
+		1)
+	if adversarial == release {
+		t.Fatal("fixture workflow missing the goreleaser `needs: e2e-gate` edge to drop")
+	}
+	if err := assertReleaseWorkflowGatesGoreleaserOnManifestTag(adversarial); err == nil {
+		t.Fatal("manifest-tag-gate guard accepted a goreleaser job with the needs edge to the gate job dropped")
+	}
+}
+
+// TestReleaseWorkflowManifestTagGateSkipsPreReleases locks the pre-release carve-
+// out: the gate step must carry `if: !contains(github.ref, '-')`, matching the
+// stamp step, so a `vX.Y.Z-pre.N` tag (whose manifest legitimately differs from
+// the hyphenated tag semver) does NOT self-block. Without the skip every pre-release
+// reds the gate (the audit confirmed `0.23.0-pre.1` vs manifest `0.23.0` exits 1).
+func TestReleaseWorkflowManifestTagGateSkipsPreReleases(t *testing.T) {
+	release := readWorkflow(t, "release.yml")
+	step := manifestTagGateStep(release)
+	if step == nil {
+		t.Fatal("release.yml has no manifest-tag-gate step")
+	}
+	if !ifSkipsPreRelease(step.ifCond) {
+		t.Fatalf("manifest-tag-gate step does not skip pre-releases; if = %q, want a `!contains(github.ref, '-')` guard", step.ifCond)
+	}
+}
+
+// ifSkipsPreRelease reports whether a step `if:` expression carries the
+// `!contains(github.ref, '-')` pre-release skip (whitespace-insensitive).
+func ifSkipsPreRelease(ifCond string) bool {
+	normalized := strings.ReplaceAll(ifCond, " ", "")
+	return strings.Contains(normalized, "!contains(github.ref,'-')")
+}
+
+// manifestTagGateStep returns the workflow step that invokes the manifest-tag-gate
+// subcommand, or nil when none does.
+func manifestTagGateStep(workflow string) *workflowStep {
+	for _, job := range parseWorkflowJobs(workflow) {
+		for i := range job.steps {
+			for _, command := range executableShellCommands(job.steps[i].run) {
+				if isManifestTagGateInvocation(command) {
+					return &job.steps[i]
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// isManifestTagGateInvocation reports whether command runs the manifest-tag-gate
+// subcommand over the tag ($GITHUB_REF_NAME) and both plugin manifests, so a step
+// that drops the tag binding or a manifest is not recognized.
+func isManifestTagGateInvocation(command string) bool {
+	return strings.Contains(command, `go run ./cmd/spacedock-release manifest-tag-gate `) &&
+		strings.Contains(command, `"$GITHUB_REF_NAME"`) &&
+		strings.Contains(command, `.claude-plugin/plugin.json`) &&
+		strings.Contains(command, `.codex-plugin/plugin.json`)
+}
+
+// assertReleaseWorkflowGatesGoreleaserOnManifestTag binds the AC-2 wiring to the
+// parsed job graph: some job runs the manifest-tag-gate step over the tagged
+// manifests, and the goreleaser carrier `needs:` that job. The predicate's own
+// tag-vs-manifest comparison is unit-tested separately; this guard proves the
+// WIRING gates the cut on it.
+func assertReleaseWorkflowGatesGoreleaserOnManifestTag(workflow string) error {
+	jobs := parseWorkflowJobs(workflow)
+
+	var goreleaserCarriers []workflowJob
+	gateJobNames := map[string]bool{}
+	for _, job := range jobs {
+		carriesGoreleaser := false
+		invokesGate := false
+		for _, step := range job.steps {
+			if strings.HasPrefix(step.uses, "goreleaser/goreleaser-action@") {
+				carriesGoreleaser = true
+			}
+			for _, command := range executableShellCommands(step.run) {
+				if isManifestTagGateInvocation(command) {
+					invokesGate = true
+				}
+			}
+		}
+		if carriesGoreleaser {
+			goreleaserCarriers = append(goreleaserCarriers, job)
+		}
+		if invokesGate {
+			gateJobNames[job.name] = true
+		}
+	}
+
+	if len(goreleaserCarriers) == 0 {
+		return fmt.Errorf("release.yml has no job carrying the goreleaser action")
+	}
+	if len(gateJobNames) == 0 {
+		return fmt.Errorf("release.yml has no job that runs `spacedock-release manifest-tag-gate \"$GITHUB_REF_NAME\"` over both plugin manifests")
+	}
+
+	for _, carrier := range goreleaserCarriers {
+		needsAGate := false
+		for _, need := range carrier.needs {
+			if gateJobNames[need] {
+				needsAGate = true
+			}
+		}
+		if !needsAGate {
+			return fmt.Errorf("release.yml goreleaser job %q does not declare needs: on the manifest-tag-gate job — a tag/manifest mismatch could reach goreleaser unchecked", carrier.name)
+		}
+	}
+	return nil
+}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -33,6 +33,21 @@ func replaceFirstVersion(blob []byte, value string) []byte {
 	return out
 }
 
+// ManifestVersion reads the top-level `version` field of a plugin manifest
+// (plugin.json / .codex-plugin/plugin.json). It returns an empty string with no
+// error when the manifest parses but carries no top-level `version` (a stamp that
+// never ran), so the manifest/tag gate can block on a missing version rather than
+// erroring. A manifest that does not parse is an error.
+func ManifestVersion(manifest []byte) (string, error) {
+	var top struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(manifest, &top); err != nil {
+		return "", fmt.Errorf("parse manifest: %w", err)
+	}
+	return top.Version, nil
+}
+
 // StampVersion rewrites the top-level `version` field of a plugin manifest
 // (plugin.json / .codex-plugin/plugin.json) to version, preserving the rest of
 // the file's formatting. When the manifest has no top-level `version` key (e.g.


### PR DESCRIPTION
Reconcile docs/releasing.md to the live release machinery and CI-enforce the tag/manifest match, so a cutter tags only an e2e-green, correctly-stamped commit.

## What changed

- Rewrite "Cutting a Stable Release" to tag the e2e-green commit, not a fresh pre-stamp SHA
- Add a CI-enforced `manifest-tag-gate` (goreleaser `needs:` it) blocking a tag/manifest version mismatch
- Advance the moving `stable` branch to the tagged commit SHA, not main HEAD
- Describe the moving-`stable` auto-advance and idempotent post-tag stamp; drop the false manual-repoint prose
- Integrate the per-channel (edge) marketplace model so the cut and channel docs read as one

## Evidence

- `go test ./...` 16/16 packages passed; `manifest-tag-gate` exercised against real v0.20.0 (BLOCK) / v0.22.0 (PASS) history
- Detached adversarial audit on a throwaway clone: the `main:`-push and dropped-gate regressions RED, restore green

## Review guidance

High-stakes release machinery — the load-bearing change is the `manifest-tag-gate` CI wiring (release.yml e2e-gate step + goreleaser `needs:`).

---
[7y](/spacedock-dev/spacedock/blob/198646cabc0302f77a5c21d11294e124d9b6f8b8/releasing-doc-pre-stamp-drift.md)
