### PR TITLE
Keep the spacedock launcher resident — spawn the host instead of exec'ing away

### DIFF
--- a/docs/runtime-support.md
+++ b/docs/runtime-support.md
@@ -82,7 +82,9 @@ Add support in small layers. Each layer should have its own proof.
 
 ## Launcher binary propagation through wrappers
 
-`spacedock claude` and `spacedock codex` attach `SPACEDOCK_BIN` to the process they exec, including the outer `safehouse -- ...` process when safehouse wrapping is active. Spacedock does not modify safehouse internals or assume a private passthrough mechanism; if a wrapper or runtime strips `SPACEDOCK_BIN` before the agent session observes it, the skill contract's `${SPACEDOCK_BIN:-spacedock}` convention degrades to the existing `$PATH` lookup.
+`spacedock claude` and `spacedock codex` attach `SPACEDOCK_BIN` to the host process they spawn, including the outer `safehouse -- ...` process when safehouse wrapping is active. Spacedock does not modify safehouse internals or assume a private passthrough mechanism; if a wrapper or runtime strips `SPACEDOCK_BIN` before the agent session observes it, the skill contract's `${SPACEDOCK_BIN:-spacedock}` convention degrades to the existing `$PATH` lookup.
+
+The launcher stays resident as the host's parent: it spawns the host as a child, inherits the terminal, forwards externally-targeted signals (`SIGTERM`/`SIGHUP`) while letting terminal signals (Ctrl-C, resize) reach the host through the shared foreground process group, and exits with the host's exit code — rather than replacing itself with the host. This keeps the `spacedock <host> …` command legible in process listings and session managers (for example zellij's restart view) and lets the launcher supervise companion processes alongside the session in future. (Unix launch lane; `spacedock <host>` is not a supported launch path on Windows.)
 
 ## Acceptance checklist
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/spacedock-dev/spacedock
 go 1.22
 
 require (
+	github.com/creack/pty v1.1.24
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.9
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -33,9 +33,11 @@ type hostOps interface {
 	// when no plugin is installed (a distinct, non-error state). A non-nil error
 	// means the host CLI itself failed.
 	ResolveManifest(host string) (string, error)
-	// Launch execs argv with env, replacing the current process on success
-	// (production) or recording it (test). It returns only on failure to launch.
-	Launch(argv []string, env []string) error
+	// Launch spawns argv with env as a resident child and waits (production) or
+	// records it (test), returning the host's propagated exit code. The error is
+	// reserved for a launch failure (host binary not found, fork failure), not a
+	// non-zero host exit.
+	Launch(argv []string, env []string) (int, error)
 	// Install issues the host plugin commands to install/update the plugin from
 	// source, returning combined output. devBranch selects the marketplace channel
 	// entry the install targets (see channelEntry).
@@ -374,11 +376,12 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 		argv = safehouse.Wrap(inner, append(launcherBinEnvPassFlags(), extra...))
 	}
 
-	if err := ops.Launch(argv, withAgentTeams(launchEnv(os.Environ()))); err != nil {
+	code, err := ops.Launch(argv, withAgentTeams(launchEnv(os.Environ())))
+	if err != nil {
 		fmt.Fprintf(stderr, "spacedock claude: launch failed: %v\n", err)
 		return 1
 	}
-	return 0
+	return code
 }
 
 // warnStrayPromptAfterDash emits an advisory stderr warning when a bare positional
@@ -556,11 +559,12 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 		argv = safehouse.Wrap(inner, append(launcherBinEnvPassFlags(), extra...))
 	}
 
-	if err := ops.Launch(argv, launchEnv(os.Environ())); err != nil {
+	code, err := ops.Launch(argv, launchEnv(os.Environ()))
+	if err != nil {
 		fmt.Fprintf(stderr, "spacedock codex: launch failed: %v\n", err)
 		return 1
 	}
-	return 0
+	return code
 }
 
 // codexResume reports whether the codex passthrough begins with the `resume`

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -23,6 +23,7 @@ type fakeHost struct {
 	resolveErr  error
 	launchedArg []string // argv captured by Launch
 	launchedEnv []string // env captured by Launch
+	launchCode  int      // host exit code Launch returns (default 0)
 	launchErr   error
 	installCmds []string // host commands captured by Install
 	installOut  string
@@ -32,10 +33,10 @@ func (f *fakeHost) ResolveManifest(host string) (string, error) {
 	return f.manifest, f.resolveErr
 }
 
-func (f *fakeHost) Launch(argv []string, env []string) error {
+func (f *fakeHost) Launch(argv []string, env []string) (int, error) {
 	f.launchedArg = argv
 	f.launchedEnv = env
-	return f.launchErr
+	return f.launchCode, f.launchErr
 }
 
 func (f *fakeHost) Install(host, source, branch string) (string, error) {

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -1,5 +1,5 @@
 // ABOUTME: Production hostOps — resolves the installed plugin manifest via
-// ABOUTME: `claude/codex plugin list --json`, execs the host, and shells installs.
+// ABOUTME: `claude/codex plugin list --json`, spawns the host, and shells installs.
 package cli
 
 import (
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 // execHost backs hostOps with the real host CLIs and process exec.
@@ -269,15 +268,36 @@ func channelMarketplaceSource(devBranch string) string {
 	return marketplaceSource + "@edge"
 }
 
-// Launch replaces the current process with argv via execve, so the host CLI
-// owns the terminal (interactive `claude --agent …`). It returns only when exec
-// itself fails.
-func (execHost) Launch(argv []string, env []string) error {
+// Launch spawns argv as a child and stays resident as its parent: the launcher
+// inherits the real terminal (interactive `claude --agent …`), forwards
+// externally-targeted signals while letting terminal signals reach the host
+// through the shared foreground process group, waits, and returns the host's
+// propagated exit code. The host is NOT placed in its own process group (no
+// Setpgid), so it owns the controlling TTY and the kernel delivers
+// terminal-generated signals to it directly. The returned int is the host's exit
+// code (signal-death rendered as 128+signum on unix); a non-nil error is a
+// *launch* failure (host binary not found, fork failure), never a non-zero host
+// exit.
+func (execHost) Launch(argv []string, env []string) (int, error) {
 	bin, err := exec.LookPath(argv[0])
 	if err != nil {
-		return err
+		return 1, err
 	}
-	return syscall.Exec(bin, argv, env)
+	cmd := exec.Command(bin, argv[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = env
+	// Install signal handling BEFORE Start so no terminal signal races the
+	// launcher's default disposition (a default SIGINT would kill the launcher
+	// before the host is even up). Unix-only; a no-op on other platforms.
+	stop := forwardHostSignals(cmd)
+	defer stop()
+	if err := cmd.Start(); err != nil {
+		return 1, err
+	}
+	waitErr := cmd.Wait()
+	return hostExitCode(cmd.ProcessState, waitErr), nil
 }
 
 // installStep is one entry in the install upgrade sequence: an argv to pass to

--- a/internal/cli/host_launch_other.go
+++ b/internal/cli/host_launch_other.go
@@ -1,0 +1,32 @@
+// ABOUTME: Non-unix compile shim for the resident launcher — the portable
+// ABOUTME: spawn-wait core builds, with no signal model and a plain exit code.
+//go:build !unix
+
+package cli
+
+import (
+	"os"
+	"os/exec"
+)
+
+// forwardHostSignals is a no-op off unix: the resident-launcher signal model
+// (terminal-generated delivery through a shared foreground process group) is a
+// unix contract. `spacedock <host>` is not a supported launch path on Windows
+// (syscall.Exec returned EWINDOWS even before this change); only compile-safety
+// is in scope.
+func forwardHostSignals(cmd *exec.Cmd) func() {
+	return func() {}
+}
+
+// hostExitCode returns the portable exit code for a finished host process. A nil
+// waitErr is a clean exit 0; otherwise ProcessState.ExitCode() carries the host's
+// status (-1 when unavailable), with no unix signal-death refinement.
+func hostExitCode(ps *os.ProcessState, waitErr error) int {
+	if waitErr == nil {
+		return 0
+	}
+	if ps != nil {
+		return ps.ExitCode()
+	}
+	return 1
+}

--- a/internal/cli/host_launch_pty_test.go
+++ b/internal/cli/host_launch_pty_test.go
@@ -1,0 +1,101 @@
+// ABOUTME: AC-3 resident-launcher PTY test — under a real controlling terminal,
+// ABOUTME: Ctrl-C/resize reach the host while the launcher survives and propagates.
+//go:build unix
+
+package cli
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/creack/pty"
+)
+
+// startLauncherOnPTY starts the launcher role on a fresh controlling terminal
+// sized 24x80 and drains the master so the slave never blocks. The launcher
+// becomes the session leader (pty.Start sets Setsid/Setctty), so its process
+// group is the terminal's foreground group; the stub it spawns (no Setpgid)
+// shares that group. The caller waits on cmd and reads the stub's logfile.
+func startLauncherOnPTY(t *testing.T, log, mode string) (*os.File, *exec.Cmd) {
+	t.Helper()
+	cmd := roleCmd(t, "launcher", log, mode)
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 24, Cols: 80})
+	if err != nil {
+		t.Fatalf("pty.StartWithSize: %v", err)
+	}
+	t.Cleanup(func() { _ = ptmx.Close() })
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	go func() { _, _ = io.Copy(io.Discard, ptmx) }()
+	return ptmx, cmd
+}
+
+// TestLaunchPTYTerminalSignals is AC-3: under a real controlling terminal the
+// host's stdin is a TTY at the real window size, a terminal Ctrl-C reaches the
+// host while the launcher survives to propagate, a resize delivers SIGWINCH, and
+// an external SIGTERM to the launcher pid is forwarded — all observed via the
+// stub's logfile + the launcher's exit code.
+func TestLaunchPTYTerminalSignals(t *testing.T) {
+	t.Run("host stdin is a real TTY at the real window size, and Ctrl-C reaches it", func(t *testing.T) {
+		log := newStubLog(t)
+		ptmx, cmd := startLauncherOnPTY(t, log, "wait")
+		if !waitForLog(t, log, "STARTED") {
+			t.Fatalf("stub never started; log=%q", readLog(t, log))
+		}
+		rec := readStubRecord(t, log)
+		if !rec.isatty {
+			t.Fatalf("host stdin is not a TTY (isatty=false); STARTED=%q", readLog(t, log))
+		}
+		if rec.rows != 24 || rec.cols != 80 {
+			t.Fatalf("host winsize=%dx%d, want 24x80 (host must see the real terminal size)", rec.rows, rec.cols)
+		}
+		// Ctrl-C through the line discipline → SIGINT to the foreground group.
+		if _, err := ptmx.Write([]byte{0x03}); err != nil {
+			t.Fatalf("write Ctrl-C: %v", err)
+		}
+		if !waitForLog(t, log, "SIGNAL interrupt") {
+			t.Fatalf("host never saw SIGINT after Ctrl-C; log=%q", readLog(t, log))
+		}
+		_ = cmd.Wait()
+		if c := exitCodeOf(cmd); c != 130 {
+			t.Fatalf("launcher exit=%d, want 130 (it must survive Ctrl-C and propagate the host's exit)", c)
+		}
+	})
+
+	t.Run("terminal resize delivers SIGWINCH to the host", func(t *testing.T) {
+		log := newStubLog(t)
+		ptmx, cmd := startLauncherOnPTY(t, log, "wait")
+		if !waitForLog(t, log, "STARTED") {
+			t.Fatalf("stub never started; log=%q", readLog(t, log))
+		}
+		if err := pty.Setsize(ptmx, &pty.Winsize{Rows: 40, Cols: 120}); err != nil {
+			t.Fatalf("pty.Setsize: %v", err)
+		}
+		if !waitForLog(t, log, "SIGNAL window size changes") {
+			t.Fatalf("host never saw SIGWINCH after resize; log=%q", readLog(t, log))
+		}
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		_ = cmd.Wait()
+	})
+
+	t.Run("external SIGTERM to the launcher pid is forwarded to the host", func(t *testing.T) {
+		log := newStubLog(t)
+		_, cmd := startLauncherOnPTY(t, log, "wait")
+		if !waitForLog(t, log, "STARTED") {
+			t.Fatalf("stub never started; log=%q", readLog(t, log))
+		}
+		// Pid-targeted: only the launcher receives it; it must forward to the host.
+		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+			t.Fatalf("signal launcher: %v", err)
+		}
+		if !waitForLog(t, log, "SIGNAL terminated") {
+			t.Fatalf("host never saw the forwarded SIGTERM; log=%q", readLog(t, log))
+		}
+		_ = cmd.Wait()
+		if c := exitCodeOf(cmd); c != 143 {
+			t.Fatalf("launcher exit=%d, want 143 (forwarded SIGTERM tears the pair down)", c)
+		}
+	})
+}

--- a/internal/cli/host_launch_pty_test.go
+++ b/internal/cli/host_launch_pty_test.go
@@ -55,7 +55,7 @@ func TestLaunchPTYTerminalSignals(t *testing.T) {
 		if _, err := ptmx.Write([]byte{0x03}); err != nil {
 			t.Fatalf("write Ctrl-C: %v", err)
 		}
-		if !waitForLog(t, log, "SIGNAL interrupt") {
+		if !waitForLog(t, log, "SIGNAL SIGINT") {
 			t.Fatalf("host never saw SIGINT after Ctrl-C; log=%q", readLog(t, log))
 		}
 		_ = cmd.Wait()
@@ -73,8 +73,11 @@ func TestLaunchPTYTerminalSignals(t *testing.T) {
 		if err := pty.Setsize(ptmx, &pty.Winsize{Rows: 40, Cols: 120}); err != nil {
 			t.Fatalf("pty.Setsize: %v", err)
 		}
-		if !waitForLog(t, log, "SIGNAL window size changes") {
-			t.Fatalf("host never saw SIGWINCH after resize; log=%q", readLog(t, log))
+		// Match the resize-triggered SIGWINCH specifically (its new dimensions),
+		// via a platform-stable marker — syscall.Signal.String() renders SIGWINCH
+		// differently on Linux ("window changed") vs darwin ("window size changes").
+		if !waitForLog(t, log, "SIGNAL SIGWINCH winsize=40x120") {
+			t.Fatalf("host never saw the resize SIGWINCH (40x120); log=%q", readLog(t, log))
 		}
 		_ = cmd.Process.Signal(syscall.SIGTERM)
 		_ = cmd.Wait()
@@ -90,7 +93,7 @@ func TestLaunchPTYTerminalSignals(t *testing.T) {
 		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 			t.Fatalf("signal launcher: %v", err)
 		}
-		if !waitForLog(t, log, "SIGNAL terminated") {
+		if !waitForLog(t, log, "SIGNAL SIGTERM") {
 			t.Fatalf("host never saw the forwarded SIGTERM; log=%q", readLog(t, log))
 		}
 		_ = cmd.Wait()

--- a/internal/cli/host_launch_test.go
+++ b/internal/cli/host_launch_test.go
@@ -1,0 +1,357 @@
+// ABOUTME: AC-1/AC-2 resident-launcher behavior tests — a re-exec helper-process
+// ABOUTME: harness proves host PPID parentage, the exec baseline, and exit codes.
+//go:build unix
+
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+// launchTestRoleEnv selects which helper-process role the re-exec'd test binary
+// plays. The default (unset) runs the normal test suite; the launcher/execlauncher
+// roles spawn the stub through the real launch path / the exec baseline, and the
+// stub role reports its process identity + TTY state to a logfile.
+const launchTestRoleEnv = "SPACEDOCK_LAUNCH_TEST_ROLE"
+
+// TestMain dispatches the helper-process roles before the test suite runs. Each
+// role reads its logfile path and mode from os.Args[1]/os.Args[2] and os.Exits;
+// only the default arm runs the tests. This is the os/exec helper-process pattern
+// — the test binary re-execs itself instead of compiling separate fixtures, so
+// execHost.Launch runs in a genuine child process under the test's control.
+func TestMain(m *testing.M) {
+	switch os.Getenv(launchTestRoleEnv) {
+	case "stub":
+		stubHostRole()
+	case "launcher":
+		launcherRole()
+	case "execlauncher":
+		execLauncherRole()
+	default:
+		os.Exit(m.Run())
+	}
+}
+
+// launcherRole spawns the stub through the production resident-parent path
+// (execHost.Launch) and propagates its exit code — the SUT under AC-1/AC-2.
+func launcherRole() {
+	self, err := os.Executable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "launcher role: executable:", err)
+		os.Exit(1)
+	}
+	argv := []string{self, os.Args[1], os.Args[2]}
+	env := append(withoutEnv(os.Environ(), launchTestRoleEnv), launchTestRoleEnv+"=stub")
+	code, err := execHost{}.Launch(argv, env)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "launcher role: launch:", err)
+		os.Exit(1)
+	}
+	os.Exit(code)
+}
+
+// execLauncherRole is the syscall.Exec baseline (today's pre-change model): it
+// replaces its own image with the stub, so no resident parent remains. AC-1 reads
+// the contrast — under exec the stub's pid IS the launcher's pid.
+func execLauncherRole() {
+	self, err := os.Executable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "execlauncher role: executable:", err)
+		os.Exit(1)
+	}
+	argv := []string{self, os.Args[1], os.Args[2]}
+	env := append(withoutEnv(os.Environ(), launchTestRoleEnv), launchTestRoleEnv+"=stub")
+	if err := syscall.Exec(self, argv, env); err != nil {
+		fmt.Fprintln(os.Stderr, "execlauncher role: exec:", err)
+		os.Exit(1)
+	}
+}
+
+// winsize mirrors struct winsize (TIOCGWINSZ): rows, cols, xpix, ypix.
+type winsize struct{ Row, Col, Xpix, Ypix uint16 }
+
+// stubIsattyAndSize runs TIOCGWINSZ on fd. Success is a genuine isatty test (a
+// pipe/file errors out); the size proves SIGWINCH-relevant terminal state is
+// visible to the child.
+func stubIsattyAndSize(fd uintptr) (bool, winsize) {
+	var ws winsize
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&ws)))
+	return errno == 0, ws
+}
+
+// stubHostRole is the stub "host": it logs its process identity + TTY state, then
+// either exits immediately with a chosen code, dies by a named signal, or waits
+// in a signal loop (recording every signal it receives). Args: <logPath> <mode>.
+func stubHostRole() {
+	logPath := os.Args[1]
+	mode := os.Args[2]
+	lf, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "stub role: open log:", err)
+		os.Exit(99)
+	}
+	defer lf.Close()
+	logf := func(format string, a ...any) {
+		fmt.Fprintf(lf, "stub "+format+"\n", a...)
+		lf.Sync()
+	}
+
+	atty, ws := stubIsattyAndSize(os.Stdin.Fd())
+	started := fmt.Sprintf("STARTED pid=%d ppid=%d pgid=%d isatty=%v winsize=%dx%d",
+		os.Getpid(), os.Getppid(), syscall.Getpgrp(), atty, ws.Row, ws.Col)
+
+	if sigName, ok := strings.CutPrefix(mode, "killself:"); ok {
+		// Genuine signal death (no handler installed): the launcher's Wait sees
+		// WIFSIGNALED and must render 128+signum. Stronger than an explicit
+		// os.Exit(128+n) — it exercises the launcher's signal-status branch.
+		logf("%s", started)
+		sig := signalByName(sigName)
+		logf("KILLSELF %v", sig)
+		_ = syscall.Kill(os.Getpid(), sig)
+		time.Sleep(2 * time.Second)
+		logf("EXIT 125 (signal did not land)")
+		os.Exit(125)
+	}
+
+	if mode != "wait" {
+		logf("%s", started)
+		code, _ := strconv.Atoi(mode)
+		logf("EXIT %d (immediate)", code)
+		os.Exit(code)
+	}
+
+	// Register the signal handlers BEFORE announcing STARTED, so a terminal signal
+	// the test injects the instant it observes STARTED cannot land before the stub
+	// is listening — which would hit the default disposition (SIGINT killing the
+	// stub pre-log, SIGWINCH silently ignored) and lose the evidence.
+	ch := make(chan os.Signal, 8)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGWINCH, syscall.SIGHUP)
+	logf("%s", started)
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case sig := <-ch:
+			logf("SIGNAL %v", sig)
+			switch sig {
+			case syscall.SIGINT:
+				logf("EXIT 130 (saw SIGINT)")
+				os.Exit(130)
+			case syscall.SIGTERM:
+				logf("EXIT 143 (saw SIGTERM)")
+				os.Exit(143)
+			case syscall.SIGHUP:
+				logf("EXIT 129 (saw SIGHUP)")
+				os.Exit(129)
+				// SIGWINCH: keep running, just record it.
+			}
+		case <-deadline:
+			logf("EXIT 124 (timeout, no signal)")
+			os.Exit(124)
+		}
+	}
+}
+
+func signalByName(name string) syscall.Signal {
+	switch name {
+	case "SIGINT":
+		return syscall.SIGINT
+	case "SIGTERM":
+		return syscall.SIGTERM
+	case "SIGHUP":
+		return syscall.SIGHUP
+	case "SIGQUIT":
+		return syscall.SIGQUIT
+	case "SIGKILL":
+		return syscall.SIGKILL
+	default:
+		return syscall.SIGTERM
+	}
+}
+
+// stubRecord is the parsed STARTED line the stub writes to its logfile.
+type stubRecord struct {
+	pid, ppid  int
+	isatty     bool
+	rows, cols int
+}
+
+// newStubLog returns a fresh temp logfile path the stub appends to.
+func newStubLog(t *testing.T) string {
+	t.Helper()
+	return t.TempDir() + "/stub.log"
+}
+
+// roleCmd builds (but does not start) an *exec.Cmd that re-execs the test binary
+// in the given helper role with the stub's log path + mode as its args.
+func roleCmd(t *testing.T, role, logPath, mode string) *exec.Cmd {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	cmd := exec.Command(self, logPath, mode)
+	cmd.Env = append(withoutEnv(os.Environ(), launchTestRoleEnv), launchTestRoleEnv+"="+role)
+	return cmd
+}
+
+// readLog returns the current logfile contents (empty if absent).
+func readLog(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// waitForLog polls the logfile until needle appears or the timeout elapses.
+func waitForLog(t *testing.T, path, needle string) bool {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(readLog(t, path), needle) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// readStubRecord parses the stub's STARTED line into a stubRecord.
+func readStubRecord(t *testing.T, path string) stubRecord {
+	t.Helper()
+	var rec stubRecord
+	body := readLog(t, path)
+	sc := bufio.NewScanner(strings.NewReader(body))
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.Contains(line, "STARTED") {
+			continue
+		}
+		for _, tok := range strings.Fields(line) {
+			k, v, ok := strings.Cut(tok, "=")
+			if !ok {
+				continue
+			}
+			switch k {
+			case "pid":
+				rec.pid, _ = strconv.Atoi(v)
+			case "ppid":
+				rec.ppid, _ = strconv.Atoi(v)
+			case "isatty":
+				rec.isatty = v == "true"
+			case "winsize":
+				if r, c, ok := strings.Cut(v, "x"); ok {
+					rec.rows, _ = strconv.Atoi(r)
+					rec.cols, _ = strconv.Atoi(c)
+				}
+			}
+		}
+		return rec
+	}
+	t.Fatalf("no STARTED line in stub log: %q", body)
+	return rec
+}
+
+// exitCodeOf returns the finished command's exit code. The launcher always exits
+// normally (it converts the host's status itself), so ProcessState.ExitCode()
+// carries the propagated code.
+func exitCodeOf(cmd *exec.Cmd) int {
+	if cmd.ProcessState == nil {
+		return -1
+	}
+	return cmd.ProcessState.ExitCode()
+}
+
+// TestLaunchResidentParent is AC-1: while the host runs, the launcher stays
+// resident as the host's parent (host.ppid == launcher.pid, host.pid !=
+// launcher.pid), where the syscall.Exec baseline has no resident parent at all
+// (host.pid == launcher.pid). Both observed from the stub's reported identity.
+func TestLaunchResidentParent(t *testing.T) {
+	t.Run("resident-parent model: host is a child of the live launcher", func(t *testing.T) {
+		log := newStubLog(t)
+		cmd := roleCmd(t, "launcher", log, "wait")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start launcher: %v", err)
+		}
+		t.Cleanup(func() { _ = cmd.Process.Kill() })
+		if !waitForLog(t, log, "STARTED") {
+			t.Fatalf("stub never started; log=%q", readLog(t, log))
+		}
+		rec := readStubRecord(t, log)
+		launcherPid := cmd.Process.Pid
+		if rec.ppid != launcherPid {
+			t.Fatalf("host.ppid=%d, want launcher.pid=%d (host must be a child of the resident launcher)", rec.ppid, launcherPid)
+		}
+		if rec.pid == launcherPid {
+			t.Fatalf("host.pid=%d == launcher.pid — host must be a distinct child, not the launcher's image", rec.pid)
+		}
+		// Tear down: SIGTERM the launcher, which forwards to the host.
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		_ = cmd.Wait()
+	})
+
+	t.Run("exec baseline: no resident parent — host IS the launcher image", func(t *testing.T) {
+		log := newStubLog(t)
+		cmd := roleCmd(t, "execlauncher", log, "wait")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start execlauncher: %v", err)
+		}
+		t.Cleanup(func() { _ = cmd.Process.Kill() })
+		if !waitForLog(t, log, "STARTED") {
+			t.Fatalf("stub never started; log=%q", readLog(t, log))
+		}
+		rec := readStubRecord(t, log)
+		launcherPid := cmd.Process.Pid
+		if rec.pid != launcherPid {
+			t.Fatalf("baseline host.pid=%d, want == launcher.pid=%d (exec replaces the image)", rec.pid, launcherPid)
+		}
+		if rec.ppid == launcherPid {
+			t.Fatalf("baseline host.ppid=%d == launcher.pid — exec must leave NO resident parent (the metric moves the wrong way)", rec.ppid)
+		}
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		_ = cmd.Wait()
+	})
+}
+
+// TestLaunchExitCodePropagation is AC-2: the launcher exits with the host's exit
+// code — clean 0, a nonzero N, and a genuine signal death rendered 128+signum.
+// The signal-death cases kill the host with no handler (true WIFSIGNALED), so the
+// launcher's signal-status branch is exercised, not an explicit host os.Exit.
+func TestLaunchExitCodePropagation(t *testing.T) {
+	cases := []struct {
+		name string
+		mode string
+		want int
+	}{
+		{"clean exit 0", "0", 0},
+		{"nonzero exit 7", "7", 7},
+		{"nonzero exit 42", "42", 42},
+		{"SIGTERM death renders 143", "killself:SIGTERM", 143},
+		{"SIGINT death renders 130", "killself:SIGINT", 130},
+		{"SIGKILL death renders 137", "killself:SIGKILL", 137},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			log := newStubLog(t)
+			cmd := roleCmd(t, "launcher", log, tc.mode)
+			if err := cmd.Start(); err != nil {
+				t.Fatalf("start launcher: %v", err)
+			}
+			_ = cmd.Wait()
+			if got := exitCodeOf(cmd); got != tc.want {
+				t.Fatalf("launcher exit=%d, want %d (stub log=%q)", got, tc.want, readLog(t, log))
+			}
+		})
+	}
+}

--- a/internal/cli/host_launch_test.go
+++ b/internal/cli/host_launch_test.go
@@ -137,22 +137,33 @@ func stubHostRole() {
 	ch := make(chan os.Signal, 8)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGWINCH, syscall.SIGHUP)
 	logf("%s", started)
-	deadline := time.After(10 * time.Second)
+	deadline := time.After(30 * time.Second)
 	for {
 		select {
 		case sig := <-ch:
-			logf("SIGNAL %v", sig)
+			// Log a STABLE, platform-independent marker per signal — NOT
+			// syscall.Signal.String(), whose rendering diverges across OSes
+			// (SIGWINCH is "window size changes" on darwin/BSD but "window
+			// changed" on Linux, which silently broke the cross-platform match).
 			switch sig {
 			case syscall.SIGINT:
+				logf("SIGNAL SIGINT")
 				logf("EXIT 130 (saw SIGINT)")
 				os.Exit(130)
 			case syscall.SIGTERM:
+				logf("SIGNAL SIGTERM")
 				logf("EXIT 143 (saw SIGTERM)")
 				os.Exit(143)
 			case syscall.SIGHUP:
+				logf("SIGNAL SIGHUP")
 				logf("EXIT 129 (saw SIGHUP)")
 				os.Exit(129)
-				// SIGWINCH: keep running, just record it.
+			case syscall.SIGWINCH:
+				// Re-read the size so the marker proves the RESIZE reached the
+				// host (its new dimensions), not an incidental startup SIGWINCH.
+				// Keep running.
+				_, ws := stubIsattyAndSize(os.Stdin.Fd())
+				logf("SIGNAL SIGWINCH winsize=%dx%d", ws.Row, ws.Col)
 			}
 		case <-deadline:
 			logf("EXIT 124 (timeout, no signal)")
@@ -214,10 +225,12 @@ func readLog(t *testing.T, path string) string {
 	return string(b)
 }
 
-// waitForLog polls the logfile until needle appears or the timeout elapses.
+// waitForLog polls the logfile until needle appears or the timeout elapses. The
+// budget is generous (well under the stub's own 30s self-exit) so a loaded CI
+// runner has headroom; the happy path returns as soon as the marker appears.
 func waitForLog(t *testing.T, path, needle string) bool {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		if strings.Contains(readLog(t, path), needle) {
 			return true

--- a/internal/cli/host_launch_unix.go
+++ b/internal/cli/host_launch_unix.go
@@ -1,0 +1,79 @@
+// ABOUTME: Unix resident-launcher signal model + exit-code mapping — absorb the
+// ABOUTME: terminal signals, forward the externally-targeted ones, 128+signum.
+//go:build unix
+
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+// forwardHostSignals wires the launcher's signal disposition for the
+// shared-foreground-group model and returns a stop function the caller defers.
+// The host shares the launcher's process group (no Setpgid), which the shell
+// already made the terminal's foreground group, so the kernel delivers
+// terminal-generated signals to the host directly. The launcher therefore:
+//   - ABSORBS SIGINT/SIGQUIT (via a Go handler, not SIG_IGN — SIG_IGN is
+//     inherited across exec and would silently un-interruptible a default-
+//     disposition host). The host already got its own copy from the foreground
+//     group, so re-forwarding would double-deliver; the launcher just stays
+//     resident. (SIGINT-absorb is spike-validated; SIGQUIT-absorb is by analogy
+//     — same terminal-generated, shared-group reasoning.)
+//   - FORWARDS SIGTERM/SIGHUP, which reach only the launcher when sent to its
+//     pid (a `kill` or a zellij pane close), so relaying them tears the pair
+//     down together. (SIGTERM-forward is spike-validated; SIGHUP-forward is by
+//     analogy — same pid-targeted reasoning. A controlling-terminal hangup that
+//     hits the whole foreground group makes the host receive SIGHUP twice, which
+//     is a harmless idempotent teardown.)
+//
+// SIGTSTP/SIGCONT/SIGWINCH are left at their default disposition: Ctrl-Z then
+// suspends the whole foreground group and the shell's fg/bg resumes it (correct
+// shared-group job control), and SIGWINCH's default is ignore so the launcher
+// survives while the host gets its own copy from the foreground group.
+func forwardHostSignals(cmd *exec.Cmd) func() {
+	ch := make(chan os.Signal, 16)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGHUP)
+	go func() {
+		for sig := range ch {
+			switch sig {
+			case syscall.SIGTERM, syscall.SIGHUP:
+				if cmd.Process != nil {
+					_ = cmd.Process.Signal(sig)
+				}
+			default:
+				// SIGINT/SIGQUIT: the kernel already delivered this to the host
+				// via the shared foreground group. Absorb it here so the launcher
+				// stays resident; do NOT re-forward.
+			}
+		}
+	}()
+	return func() {
+		signal.Stop(ch)
+		close(ch)
+	}
+}
+
+// hostExitCode maps a finished host process to the exit code the launcher
+// propagates. A nil waitErr is a clean exit 0. A non-zero exit yields the host's
+// status; a signal death refines to the shell's 128+signum convention via the
+// WaitStatus. Any other Wait anomaly collapses to 1.
+func hostExitCode(ps *os.ProcessState, waitErr error) int {
+	if waitErr == nil {
+		return 0
+	}
+	if ee, ok := waitErr.(*exec.ExitError); ok {
+		if ws, ok := ee.Sys().(syscall.WaitStatus); ok {
+			if ws.Signaled() {
+				return 128 + int(ws.Signal())
+			}
+			return ws.ExitStatus()
+		}
+		if ps != nil {
+			return ps.ExitCode()
+		}
+	}
+	return 1
+}

--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -29,7 +29,7 @@ const piSpacedockPackageSource = "git:github.com/spacedock-dev/spacedock"
 type piRuntimeOps interface {
 	LookPath(name string) (string, error)
 	Stat(path string) error
-	Launch(argv []string, env []string) error
+	Launch(argv []string, env []string) (int, error)
 	// PiInstall runs `pi install <source>` and returns its combined output. The
 	// real implementation execs `pi`; tests record the source and return canned
 	// output. This is the install seam that retires Pi's check-only status.
@@ -57,7 +57,7 @@ type execPiRuntimeOps struct{}
 
 func (execPiRuntimeOps) LookPath(name string) (string, error) { return exec.LookPath(name) }
 func (execPiRuntimeOps) Stat(path string) error               { _, err := os.Stat(path); return err }
-func (execPiRuntimeOps) Launch(argv []string, env []string) error {
+func (execPiRuntimeOps) Launch(argv []string, env []string) (int, error) {
 	return execHost{}.Launch(argv, env)
 }
 
@@ -317,11 +317,12 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 		}
 		argv = safehouse.Wrap(argv, piExtra)
 	}
-	if err := ops.Launch(argv, launchEnv(os.Environ())); err != nil {
+	code, err := ops.Launch(argv, launchEnv(os.Environ()))
+	if err != nil {
 		fmt.Fprintf(stderr, "spacedock pi: launch failed: %v\n", err)
 		return 1
 	}
-	return 0
+	return code
 }
 
 func runInitWithPi(ctx context.Context, args []string, hostOps hostOps, piOps piRuntimeOps, env []string, stdout, stderr io.Writer) int {

--- a/internal/cli/pi_frontdoor_test.go
+++ b/internal/cli/pi_frontdoor_test.go
@@ -18,6 +18,7 @@ type fakePiRuntimeOps struct {
 	statOK        map[string]bool
 	launched      []string
 	launchedEnv   []string
+	launchCode    int // host exit code Launch returns (default 0)
 	piInstalls    []string // sources captured by PiInstall
 	piInstallOut  string
 	piInstallErr  error
@@ -38,10 +39,10 @@ func (f *fakePiRuntimeOps) Stat(path string) error {
 	return errors.New("missing")
 }
 
-func (f *fakePiRuntimeOps) Launch(argv []string, env []string) error {
+func (f *fakePiRuntimeOps) Launch(argv []string, env []string) (int, error) {
 	f.launched = append([]string(nil), argv...)
 	f.launchedEnv = append([]string(nil), env...)
-	return nil
+	return f.launchCode, nil
 }
 
 func (f *fakePiRuntimeOps) PiInstall(source string) (string, error) {
@@ -698,7 +699,7 @@ func TestPiRuntimeDevOverrideSatisfiesPackageGate(t *testing.T) {
 		home := t.TempDir()
 		var stdout, stderr bytes.Buffer
 		code := runPi(context.Background(), []string{"do work", "--plugin-dir", repo, "--", "--print"}, "/non-repo-cwd",
-			append(piTestEnv(pkg, home)), &fakePiRuntimeOps{
+			piTestEnv(pkg, home), &fakePiRuntimeOps{
 				lookPath:      piHealthyPathFixtures(),
 				statOK:        statOKForPiResources(repo, pkg),
 				packageStatus: piPackageStatus{}, // not installed

--- a/internal/ensigncycle/streamwatch_test.go
+++ b/internal/ensigncycle/streamwatch_test.go
@@ -562,7 +562,7 @@ func parseInboxDoneSender(text string) string {
 
 // streamEntry is the parsed shape of one stream-json JSONL line — only the
 // fields the watcher reads. claude's stream-json is standard Claude Code output
-// (spacedock claude syscall.Exec-forwards --output-format stream-json verbatim),
+// (spacedock claude forwards --output-format stream-json to the host verbatim),
 // so these shapes match what the upstream Python watcher parses.
 type streamEntry struct {
 	Type      string         `json:"type"`

--- a/internal/ensigncycle/streamwatch_unit_test.go
+++ b/internal/ensigncycle/streamwatch_unit_test.go
@@ -640,7 +640,7 @@ func TestExpectConditionFinalDrainCheckWinsOverExit(t *testing.T) {
 // --- synthetic stream-json line builders ---------------------------------
 //
 // These emit the standard Claude Code stream-json shapes the watcher parses.
-// `spacedock claude` syscall.Exec-replaces itself with `claude`, forwarding
+// `spacedock claude` spawns `claude` as a resident child, forwarding
 // --output-format stream-json verbatim, so the live pipe carries exactly these
 // shapes (Spike in the entity body). Each builder returns one JSONL line.
 


### PR DESCRIPTION
The launcher now stays resident as the host's parent instead of exec'ing away — keeping `spacedock <host>` legible in process listings and enabling future sidecars.

## What changed
- Replace `syscall.Exec` with a resident-parent spawn-wait sharing the terminal's foreground process group.
- Forward externally-targeted signals (SIGTERM/SIGHUP); let terminal signals (Ctrl-C, resize) reach the host directly.
- Return the host's exit code via a `(int, error)` `Launch` signature, threaded through all three hosts.
- Scope the signal model to unix; keep Windows compiling (no behavior claim).

## Evidence
- AC suite green: resident-parent 2/2, exit-code propagation 6/6 (incl. signal-death), PTY terminal-signals 3/3; GOOS=windows build+vet pass.
- Detached adversarial signal-matrix audit: 3 mutation-confirmed probes, no code defect.

---
[vv](/spacedock-dev/spacedock/blob/f41b7b578acf27712c83d4ba9cf07e2121304db5/launcher-resident-process/index.md)