### PR TITLE
Fix the #442 launcher signal-forwarding data race — start forwardHostSignals after cmd.Start()

### DIFF
--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -288,14 +288,19 @@ func (execHost) Launch(argv []string, env []string) (int, error) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = env
-	// Install signal handling BEFORE Start so no terminal signal races the
-	// launcher's default disposition (a default SIGINT would kill the launcher
-	// before the host is even up). Unix-only; a no-op on other platforms.
-	stop := forwardHostSignals(cmd)
+	// Arm signal handling BEFORE Start so no terminal signal races the launcher's
+	// default disposition (a default SIGINT would kill the launcher before the
+	// host is even up); a signal arriving during fork/exec queues on the buffered
+	// channel. Begin forwarding only AFTER Start returns, so the go-statement that
+	// spawns the pump carries a happens-before edge from Start's write of
+	// cmd.Process to the goroutine's read of it (forwarding before that edge would
+	// race Start's write). Unix-only; both are no-ops on other platforms.
+	forward, stop := forwardHostSignals(cmd)
 	defer stop()
 	if err := cmd.Start(); err != nil {
 		return 1, err
 	}
+	forward()
 	waitErr := cmd.Wait()
 	return hostExitCode(cmd.ProcessState, waitErr), nil
 }

--- a/internal/cli/host_launch_other.go
+++ b/internal/cli/host_launch_other.go
@@ -13,9 +13,9 @@ import (
 // (terminal-generated delivery through a shared foreground process group) is a
 // unix contract. `spacedock <host>` is not a supported launch path on Windows
 // (syscall.Exec returned EWINDOWS even before this change); only compile-safety
-// is in scope.
-func forwardHostSignals(cmd *exec.Cmd) func() {
-	return func() {}
+// is in scope. Both returned functions are no-ops.
+func forwardHostSignals(cmd *exec.Cmd) (forward func(), stop func()) {
+	return func() {}, func() {}
 }
 
 // hostExitCode returns the portable exit code for a finished host process. A nil

--- a/internal/cli/host_launch_test.go
+++ b/internal/cli/host_launch_test.go
@@ -337,6 +337,45 @@ func TestLaunchResidentParent(t *testing.T) {
 	})
 }
 
+// TestLaunchSignalForwardNoDataRace drives the real execHost.Launch in-process so
+// the forwarding goroutine runs under the testing harness' race detector. A
+// STARTED-gated self-SIGTERM forces that goroutine to read cmd.Process: when the
+// goroutine is spawned BEFORE cmd.Start() writes cmd.Process (no happens-before
+// edge) the read races the write and -race fails the test; spawning it AFTER Start
+// makes the go-statement edge order write → read, so the read is race-free. The
+// forwarded SIGTERM also tears the stub down (exit 143), confirming the forward
+// still works (AC-2). The self-signal is gated on STARTED so the launcher's
+// handler is provably armed and catches it — never the test's default SIGTERM
+// disposition.
+func TestLaunchSignalForwardNoDataRace(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	log := newStubLog(t)
+	argv := []string{self, log, "wait"}
+	env := append(withoutEnv(os.Environ(), launchTestRoleEnv), launchTestRoleEnv+"=stub")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if !waitForLog(t, log, "STARTED") {
+			t.Errorf("stub never started; log=%q", readLog(t, log))
+			return
+		}
+		_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
+	}()
+
+	code, err := execHost{}.Launch(argv, env)
+	<-done
+	if err != nil {
+		t.Fatalf("Launch returned error: %v (stub log=%q)", err, readLog(t, log))
+	}
+	if code != 143 {
+		t.Fatalf("launcher exit=%d, want 143 (forwarded SIGTERM must tear the stub down; stub log=%q)", code, readLog(t, log))
+	}
+}
+
 // TestLaunchExitCodePropagation is AC-2: the launcher exits with the host's exit
 // code — clean 0, a nonzero N, and a genuine signal death rendered 128+signum.
 // The signal-death cases kill the host with no handler (true WIFSIGNALED), so the

--- a/internal/cli/host_launch_unix.go
+++ b/internal/cli/host_launch_unix.go
@@ -11,8 +11,16 @@ import (
 	"syscall"
 )
 
-// forwardHostSignals wires the launcher's signal disposition for the
-// shared-foreground-group model and returns a stop function the caller defers.
+// forwardHostSignals arms the launcher's signal disposition for the
+// shared-foreground-group model and returns a forward function and a stop
+// function the caller defers. Arming (signal.Notify) runs here, before the
+// caller's cmd.Start(), so a signal delivered during the fork/exec window queues
+// on the buffered channel rather than hitting the launcher's default disposition.
+// The caller invokes forward AFTER cmd.Start() returns: the go-statement that
+// spawns the pump then carries a happens-before edge from Start's write of
+// cmd.Process to the goroutine's read of it, so the read is synchronized (and any
+// queued early signal drains from the buffered channel once the pump runs).
+//
 // The host shares the launcher's process group (no Setpgid), which the shell
 // already made the terminal's foreground group, so the kernel delivers
 // terminal-generated signals to the host directly. The launcher therefore:
@@ -33,27 +41,30 @@ import (
 // suspends the whole foreground group and the shell's fg/bg resumes it (correct
 // shared-group job control), and SIGWINCH's default is ignore so the launcher
 // survives while the host gets its own copy from the foreground group.
-func forwardHostSignals(cmd *exec.Cmd) func() {
+func forwardHostSignals(cmd *exec.Cmd) (forward func(), stop func()) {
 	ch := make(chan os.Signal, 16)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGHUP)
-	go func() {
-		for sig := range ch {
-			switch sig {
-			case syscall.SIGTERM, syscall.SIGHUP:
-				if cmd.Process != nil {
-					_ = cmd.Process.Signal(sig)
+	forward = func() {
+		go func() {
+			for sig := range ch {
+				switch sig {
+				case syscall.SIGTERM, syscall.SIGHUP:
+					if cmd.Process != nil {
+						_ = cmd.Process.Signal(sig)
+					}
+				default:
+					// SIGINT/SIGQUIT: the kernel already delivered this to the host
+					// via the shared foreground group. Absorb it here so the launcher
+					// stays resident; do NOT re-forward.
 				}
-			default:
-				// SIGINT/SIGQUIT: the kernel already delivered this to the host
-				// via the shared foreground group. Absorb it here so the launcher
-				// stays resident; do NOT re-forward.
 			}
-		}
-	}()
-	return func() {
+		}()
+	}
+	stop = func() {
 		signal.Stop(ch)
 		close(ch)
 	}
+	return forward, stop
 }
 
 // hostExitCode maps a finished host process to the exit code the launcher


### PR DESCRIPTION
Closes a data race on the launcher's terminal-signal forwarding path so no SIGTERM/SIGHUP is dropped while the host process starts.

## What changed
- Start the signal-forwarding goroutine after `cmd.Start()`, establishing a happens-before edge to its `cmd.Process` read.
- Keep `signal.Notify` before `Start` so a signal during fork/exec queues on the buffered channel and drains.
- Add an in-process `-race` regression test that fails on the pre-fix ordering.

## Evidence
- `go test ./... -race`: all packages pass; new `TestLaunchSignalForwardNoDataRace` deterministic (20/20 fixed-GREEN, 10/10 reverted-RED).
- Detached adversarial audit (throwaway checkout): no hole — both test legs catch claim-breaking edits.

## Review guidance
- Front-door launcher teardown; the fix is the goroutine-creation ordering in `host_exec.go` / `host_launch_unix.go`.

---
[3p](/spacedock-dev/spacedock/blob/5041b73be83f664b450250251a6872306c72dcd3/launcher-signal-forward-race-fix.md)
