### PR TITLE
dispatch build — warn + document --team-name on claude (auto-team is default; legacy shape is silent)

### DIFF
--- a/internal/claudeteam/claudeteam.go
+++ b/internal/claudeteam/claudeteam.go
@@ -77,3 +77,20 @@ func BareModeAdvisory(w io.Writer) {
 			"If you intend teams mode, run ToolSearch select:TeamCreate and TeamCreate first. "+
 			"If bare is intentional, this warning can be ignored.")
 }
+
+// LegacyTeamNameAdvisory writes the --team-name-on-claude warning to w. It names
+// Claude-only concepts (the auto-team default, the legacy TeamCreate registry), so
+// the text lives in the Claude seam beside BareModeAdvisory. The generic build path
+// calls it when a non-bare claude dispatch passes a team_name — the teamName != ""
+// complement of merged mode — where auto-team is the default and the explicit
+// --team-name selects the sunsetting legacy shape. Unlike BareModeAdvisory it needs
+// no probe: the trigger is wholly in the CLI args. Stderr-only; the dispatch
+// envelope is untouched.
+func LegacyTeamNameAdvisory(w io.Writer) {
+	fmt.Fprintln(w,
+		"WARN: --team-name selects the legacy TeamCreate-registry dispatch shape "+
+			"(team_name present, run_in_background absent). On host=claude, auto-team "+
+			"is the default — omit --team-name to emit the auto-team shape (name + "+
+			"run_in_background, no team_name). If you mean the legacy team-registry "+
+			"path, this warning can be ignored.")
+}

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -690,6 +690,18 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 		out.RunInBackground = &runInBackground
 	}
 
+	// Foot-gun guard: a non-bare claude dispatch that passes team_name selects the
+	// legacy TeamCreate-registry envelope just assembled above (team_name present,
+	// run_in_background absent) rather than the auto-team default — the teamName != ""
+	// complement of mergedMode, the same three signals, no new detection and no
+	// probe. The advisory fires here, after every error guard, so it warns only when
+	// the legacy envelope is actually being emitted; a build that errors out (no
+	// envelope) stays advisory-free. Stderr-only: the envelope above is untouched.
+	// The text lives in the Claude seam beside BareModeAdvisory.
+	if !bareMode && host == "claude" && teamName != "" {
+		claudeteam.LegacyTeamNameAdvisory(stderr)
+	}
+
 	return emitBuildJSON(stdout, out)
 }
 

--- a/internal/dispatch/build_team_name_advisory_test.go
+++ b/internal/dispatch/build_team_name_advisory_test.go
@@ -1,0 +1,116 @@
+// ABOUTME: AC-1/AC-2/AC-3 — the --team-name-on-claude stderr advisory fires on the
+// ABOUTME: legacy arm, is silent on the merged arm, and the --help docs the shape flags.
+package dispatch
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// teamNameAdvisoryMarker is a stable fragment of the legacy --team-name advisory.
+// The gate keys on its presence/absence rather than the full sentence so a future
+// wording tweak in claudeteam.LegacyTeamNameAdvisory does not break the test
+// (matches the advisoryMarker convention in build_advisory_probe_test.go).
+const teamNameAdvisoryMarker = "legacy TeamCreate-registry dispatch shape"
+
+// TestBuildLegacyTeamNameAdvisory is AC-1's behavioral gate: on host=claude, a
+// build that passes team_name emits exactly the legacy advisory on stderr while
+// the same inputs WITHOUT team_name (the merged shape) emit none. The legacy arm
+// also re-asserts the legacy envelope shape on stdout (team_name present,
+// run_in_background absent) — AC-3 in the same arm: the advisory is stderr-only
+// and does not flip the emitted dispatch envelope.
+func TestBuildLegacyTeamNameAdvisory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := t.TempDir()
+	wd := writeGood(t, root)
+	ep := writeFlatEntity(t, wd, "backlog", "")
+
+	legacyStdin := mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    ep,
+		"workflow_dir":   wd,
+		"stage":          "backlog",
+		"checklist":      []string{"- a"},
+		"host":           "claude",
+		"team_name":      "fixture-team",
+		"bare_mode":      false,
+	}, nil)
+	mergedStdin := mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    ep,
+		"workflow_dir":   wd,
+		"stage":          "backlog",
+		"checklist":      []string{"- a"},
+		"host":           "claude",
+		"bare_mode":      false,
+		// team_name intentionally absent: the merged .178+ shape.
+	}, nil)
+
+	legacy := runNative(legacyStdin, "build", "--workflow-dir", wd)
+	if legacy.exit != 0 {
+		t.Fatalf("legacy --team-name build exit=%d, want 0\nstderr:\n%s", legacy.exit, legacy.stderr)
+	}
+	merged := runNative(mergedStdin, "build", "--workflow-dir", wd)
+	if merged.exit != 0 {
+		t.Fatalf("merged build exit=%d, want 0\nstderr:\n%s", merged.exit, merged.stderr)
+	}
+
+	// AC-1: advisory PRESENT on the --team-name arm, ABSENT on the merged arm.
+	if !strings.Contains(legacy.stderr, teamNameAdvisoryMarker) {
+		t.Errorf("host=claude --team-name build must emit the legacy advisory; stderr=%q", legacy.stderr)
+	}
+	if strings.Contains(merged.stderr, teamNameAdvisoryMarker) {
+		t.Errorf("merged build (no --team-name) must emit NO legacy advisory; stderr=%q", merged.stderr)
+	}
+	// Exactly one advisory line on the legacy arm (not one per nothing).
+	if got := strings.Count(legacy.stderr, teamNameAdvisoryMarker); got != 1 {
+		t.Errorf("legacy advisory must appear exactly once; got %d:\n%s", got, legacy.stderr)
+	}
+
+	// AC-3 (same arm): the legacy envelope shape is unchanged by the advisory —
+	// team_name present, run_in_background absent on the --team-name arm; and the
+	// merged arm keeps run_in_background present, team_name absent.
+	var legacyOut mergedBuildOutput
+	if err := json.Unmarshal([]byte(legacy.stdout), &legacyOut); err != nil {
+		t.Fatalf("legacy stdout is not build JSON: %v\n%s", err, legacy.stdout)
+	}
+	if legacyOut.TeamName == nil || *legacyOut.TeamName != "fixture-team" {
+		t.Errorf("legacy --team-name envelope must keep team_name=%q; got %v", "fixture-team", legacyOut.TeamName)
+	}
+	if legacyOut.RunInBackground != nil {
+		t.Errorf("legacy --team-name envelope must NOT gain run_in_background; got %v", *legacyOut.RunInBackground)
+	}
+	var mergedOut mergedBuildOutput
+	if err := json.Unmarshal([]byte(merged.stdout), &mergedOut); err != nil {
+		t.Fatalf("merged stdout is not build JSON: %v\n%s", err, merged.stdout)
+	}
+	if mergedOut.TeamName != nil {
+		t.Errorf("merged envelope must omit team_name; got %q", *mergedOut.TeamName)
+	}
+	if mergedOut.RunInBackground == nil || !*mergedOut.RunInBackground {
+		t.Errorf("merged envelope must keep run_in_background=true; got %v", mergedOut.RunInBackground)
+	}
+}
+
+// TestBuildHelpDocumentsShapeFlags is AC-2's golden: dispatch build --help stdout
+// documents the shape-selecting flags (--host, --team-name, --bare-mode), with the
+// --team-name line naming the legacy shape and the auto-team default. Behavioral:
+// it runs the command and reads stdout, not a source grep.
+func TestBuildHelpDocumentsShapeFlags(t *testing.T) {
+	res := runNative("", "build", "--help")
+	if res.exit != 0 {
+		t.Fatalf("dispatch build --help exit=%d, want 0\nstderr=%q", res.exit, res.stderr)
+	}
+	if res.stderr != "" {
+		t.Fatalf("dispatch build --help stderr=%q, want empty", res.stderr)
+	}
+	assertContainsAll(t, res.stdout,
+		"--host",
+		"--team-name",
+		"--bare-mode",
+		"legacy TeamCreate-registry dispatch shape",
+		"auto-team is the default",
+	)
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -287,6 +287,9 @@ Build an ensign dispatch artifact from stdin JSON and write the JSON envelope to
 
 Flags:
   --workflow-dir DIR   Workflow definition directory containing README.md.
+  --host HOST          Override the runtime host (claude|codex|pi). Defaults to the detected runtime.
+  --team-name NAME     Select the legacy TeamCreate-registry dispatch shape. On host=claude, auto-team is the default — omit this unless you mean legacy team mode.
+  --bare-mode          Emit the bare sequential shape (no name, no team_name, no run_in_background).
 
 Stdin JSON fields:
   schema_version  Dispatch schema version. The current supported value is 2.

--- a/internal/dispatch/testdata/golden/build-abs-worktree.txt
+++ b/internal/dispatch/testdata/golden/build-abs-worktree.txt
@@ -16,6 +16,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action

--- a/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-feedback+scope+reflow.txt
@@ -16,6 +16,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+nonworktree+team.txt
@@ -16,6 +16,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+flat+worktree+team.txt
@@ -16,6 +16,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action

--- a/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-single+folder+worktree+team.txt
@@ -16,6 +16,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+flat+worktree+team.txt
@@ -16,6 +16,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+nonworktree+team.txt
@@ -16,6 +16,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action

--- a/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
+++ b/internal/dispatch/testdata/golden/build-crossproduct-split+folder+worktree+team.txt
@@ -16,6 +16,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action

--- a/internal/dispatch/testdata/golden/build-html-escape.txt
+++ b/internal/dispatch/testdata/golden/build-html-escape.txt
@@ -16,6 +16,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action

--- a/internal/dispatch/testdata/golden/build-model-defaults-haiku.txt
+++ b/internal/dispatch/testdata/golden/build-model-defaults-haiku.txt
@@ -17,3 +17,4 @@
 
 ===== stderr =====
 [build] effective_model=haiku (from defaults) → Agent model=haiku
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.

--- a/internal/dispatch/testdata/golden/build-model-null.txt
+++ b/internal/dispatch/testdata/golden/build-model-null.txt
@@ -16,3 +16,4 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.

--- a/internal/dispatch/testdata/golden/build-model-stage-wins-opus.txt
+++ b/internal/dispatch/testdata/golden/build-model-stage-wins-opus.txt
@@ -17,3 +17,4 @@
 
 ===== stderr =====
 [build] effective_model=opus (from stage) → Agent model=opus
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.

--- a/internal/dispatch/testdata/golden/build-mods.txt
+++ b/internal/dispatch/testdata/golden/build-mods.txt
@@ -17,6 +17,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action

--- a/internal/dispatch/testdata/golden/build-nonascii-title.txt
+++ b/internal/dispatch/testdata/golden/build-nonascii-title.txt
@@ -16,6 +16,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action

--- a/internal/dispatch/testdata/golden/build-schemaversion-float-2.0.txt
+++ b/internal/dispatch/testdata/golden/build-schemaversion-float-2.0.txt
@@ -16,3 +16,4 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.

--- a/internal/dispatch/testdata/golden/build-schemaversion-int-2.txt
+++ b/internal/dispatch/testdata/golden/build-schemaversion-int-2.txt
@@ -16,3 +16,4 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.

--- a/internal/dispatch/testdata/golden/build-space-path.txt
+++ b/internal/dispatch/testdata/golden/build-space-path.txt
@@ -16,6 +16,7 @@
 }
 
 ===== stderr =====
+WARN: --team-name selects the legacy TeamCreate-registry dispatch shape (team_name present, run_in_background absent). On host=claude, auto-team is the default — omit --team-name to emit the auto-team shape (name + run_in_background, no team_name). If you mean the legacy team-registry path, this warning can be ignored.
 
 ===== body =====
 ## First action


### PR DESCRIPTION
Warn when `--team-name` silently selects the legacy dispatch shape on host=claude, and surface the shape-selecting flags in dispatch build --help.

## What changed
- Emit a stderr advisory when `--team-name` is passed on host=claude (success path; the dispatch envelope is untouched).
- Document `--host`, `--team-name`, and `--bare-mode` in `dispatch build --help`.
- Add a two-arm advisory test and a `--help` golden; the legacy-envelope shape stays frozen.

## Evidence
- All 3 ACs live-verified against a binary built from this branch (advisory present/absent two-arm, `--help` lists the flags, envelope byte-unchanged); no existing assertion weakened.
- `go test ./internal/dispatch/ ./internal/claudeteam/` — all passed.

---
[0qt](/spacedock-dev/spacedock/blob/spacedock-state/dev/dispatch-build-team-name-advisory.md)
