### PR TITLE
status --ac-scan: enumerate ACs annotated inside the bold (e.g. AC-1 (VALUE))

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -128,7 +128,7 @@ A task moves to validation after implementation is complete. The work here is to
 - **Outputs:**
   - Run applicable tests from the Testing Resources section and report results.
   - Verify each acceptance criterion with evidence.
-  - Pull every `**AC-N**` item from the entity body's `## Acceptance criteria` section; reproduce the evidence cited in each "Verified by" clause; flag any AC without evidence.
+  - Pull every `**AC-N**` item (including a value annotation inside the bold, e.g. `**AC-1 (VALUE)**`) from the entity body's `## Acceptance criteria` section; reproduce the evidence cited in each "Verified by" clause; flag any AC without evidence.
   - Reproduce each AC's cited evidence; reject any AC whose evidence is self-referential, or whose only deliverable is a decision with nothing shipped (that belongs in the roadmap, not a terminal dev task). Dev-workflow policy: an AC's proof is code, command, or state. A non-development workflow's AC proof may legitimately be a published artifact, a metric, or a human review.
   - Check that the task body, acceptance criteria, implementation, and tests reflect the latest captain feedback.
   - Reject when tests pass but prove an obsolete, over-specified, or wrong target behavior.

--- a/internal/status/cycle3_extract_test.go
+++ b/internal/status/cycle3_extract_test.go
@@ -557,6 +557,69 @@ func TestACScanScopeIsLoadBearing(t *testing.T) {
 	}
 }
 
+// annotatedACFixturePath returns the committed fixture whose ## Acceptance
+// criteria section annotates the value AC inside the bold (**AC-1 (VALUE)**),
+// alongside a bare **AC-2** and a prose-only "see AC-3 above" mention — the
+// over-match discriminator for the broadened heading matcher.
+func annotatedACFixturePath(t *testing.T) string {
+	t.Helper()
+	p, err := filepath.Abs(filepath.Join("testdata", "section-reader", "annotated-ac-fixture.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestACScanEnumeratesAnnotatedAC (AC-1 + AC-2) asserts --ac-scan enumerates an
+// AC whose bold span carries an annotation: **AC-1 (VALUE)** lists with id AC-1,
+// exactly as the bare **AC-2** does, so the value AC the README ideation policy
+// recommends is no longer silently dropped from the gate cross-check. The
+// enumerated id set is EXACTLY {AC-1, AC-2}: AC-1 once, AC-2 once (no
+// over-match), AC-3 absent (the prose "see AC-3 above" is not a heading, proving
+// the **…** delimiter requirement survived the broadening). RED on the bare
+// matcher (AC-1 absent), GREEN after acHeadingRe gains the trailing-label form.
+func TestACScanEnumeratesAnnotatedAC(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("testdata", "seq-workflow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := pinnedEnv(t)
+	fixture := annotatedACFixturePath(t)
+
+	out, stderr, code := runNative(t, root, env, "--workflow-dir", root, "--read", fixture, "--stage", "ideation", "--ac-scan", "--json")
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	var doc acScanEnvelope
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, out)
+	}
+	// Count each enumerated id's occurrences: the set must be exactly {AC-1, AC-2}.
+	counts := map[string]int{}
+	for _, ac := range doc.ACs {
+		counts[ac.ID]++
+	}
+	if counts["AC-1"] != 1 {
+		t.Errorf("AC-1 enumerated %d time(s), want exactly 1 (the annotated value AC must list as AC-1)", counts["AC-1"])
+	}
+	if counts["AC-2"] != 1 {
+		t.Errorf("AC-2 enumerated %d time(s), want exactly 1 (bare AC, no over-match)", counts["AC-2"])
+	}
+	if counts["AC-3"] != 0 {
+		t.Errorf("AC-3 enumerated %d time(s), want 0 (the prose 'see AC-3 above' is not a heading)", counts["AC-3"])
+	}
+	if len(doc.ACs) != 2 {
+		t.Fatalf("enumerated %d ACs, want exactly 2 ({AC-1, AC-2}): %v\n%s", len(doc.ACs), counts, out)
+	}
+	// AC-1's evidence flag is exercised: its DONE evidence line cites AC-1, so a
+	// correctly-enumerated AC-1 reports unevidenced=false (not merely "present").
+	for _, ac := range doc.ACs {
+		if ac.ID == "AC-1" && ac.Unevidenced != "false" {
+			t.Errorf("AC-1 unevidenced = %q, want \"false\" (cited in the ideation DONE evidence)", ac.Unevidenced)
+		}
+	}
+}
+
 // TestGateModeLoudFailures (AC-5) asserts the gate modes fail loudly with a
 // non-zero exit and a named diagnostic, never a partial/silent emit: missing
 // --stage, a --stage matching no report (no silent positional-last fallback),

--- a/internal/status/gate_extract.go
+++ b/internal/status/gate_extract.go
@@ -48,8 +48,13 @@ var checklistBulletRe = regexp.MustCompile(`^-\s+(DONE|SKIPPED|FAILED):\s*(.*)$`
 
 // acHeadingRe matches an `**AC-N**` acceptance-criteria heading and captures the
 // AC id. The id is tokenized on the heading boundary (AC- followed by an
-// alphanumeric run), never split on `-` (the spike's AC-id boundary finding).
-var acHeadingRe = regexp.MustCompile(`\*\*(AC-[0-9A-Za-z]+)\*\*`)
+// alphanumeric run), never split on `-` (the spike's AC-id boundary finding). An
+// asterisk-free trailing label inside the bold span is allowed and discarded, so
+// `**AC-1 (VALUE)**` enumerates as `AC-1` exactly as bare `**AC-1**` — the value
+// AC the README ideation policy recommends is no longer dropped. The `[^*]*`
+// label excludes `*`, so it cannot span a `**` boundary: two headings on one line
+// (`**AC-1** … **AC-2**`) still enumerate separately and never merge.
+var acHeadingRe = regexp.MustCompile(`\*\*(AC-[0-9A-Za-z]+)[^*]*\*\*`)
 
 // acTokenRe matches an AC-N token anywhere in a line, for citation scanning.
 var acTokenRe = regexp.MustCompile(`\bAC-[0-9A-Za-z]+\b`)

--- a/internal/status/testdata/section-reader/annotated-ac-fixture.md
+++ b/internal/status/testdata/section-reader/annotated-ac-fixture.md
@@ -1,0 +1,26 @@
+---
+id: annotated-ac-fixture-id
+title: annotated acceptance-criteria fixture
+status: ideation
+---
+
+Intro prose owned by no section.
+
+## Acceptance criteria
+
+- **AC-1 (VALUE)** the value criterion, with its annotation INSIDE the bold span.
+
+(see AC-3 above for the prose-only control — a bare mention, never a heading.)
+
+- **AC-2** the bare second criterion, no annotation.
+
+## Stage Report: ideation
+
+- DONE: prove the value criterion
+  AC-1 evidenced here in the ideation DONE line
+- SKIPPED: the live drive
+  deferred to a later member
+
+### Summary
+
+Ideation summary prose; AC-3 is named only in passing, never as a heading.


### PR DESCRIPTION
Make the deterministic gate AC cross-check see value-annotated acceptance criteria, so the value AC can no longer hide from `status --ac-scan`.

## What changed
- Broaden the `--ac-scan` heading matcher so a label inside the bold (`**AC-1 (VALUE)**`) enumerates as its bare id.
- Use `[^*]*` so a match can never span a `**` boundary — no over-match.
- Add `TestACScanEnumeratesAnnotatedAC` + `annotated-ac-fixture.md` (RED on the bare matcher, GREEN after).
- Sync the dev README validation cross-check prose at `:131`.

## Evidence
- `go test ./internal/status/...` — all passed; `TestACScanEnumeratesAnnotatedAC` PASS.
- Measured on rebuilt baseline+fixed binaries: real `fn-binding-refinements.md` 7→8 ACs (`**AC-4 (value guardrail)**` surfaces); fixture id set exactly {AC-1, AC-2}.

---
[48g](/spacedock-dev/spacedock/blob/spacedock-state/dev/ac-scan-value-annotation-skip.md)
