### PR TITLE
contract: name grep the primary section-locator for plain entity-body reads

### DIFF
--- a/skills/ensign/references/ensign-shared-core.md
+++ b/skills/ensign/references/ensign-shared-core.md
@@ -89,7 +89,7 @@ Rules:
 - Every checklist item must appear.
 - Use the checklist item text verbatim for `{item text}` when possible (copy/paste).
 - Do not use markdown checkbox markers.
-- Append the report at the end of the entity file — get the append point from `wc -l <entity-path>` and append after the last line; do not read the entire entity body to find an insertion point.
+- Append the report at the end of the entity file — get the file's `total_lines` from `status --read <entity-path> --json` and append after it; do not read the entire entity body to find an insertion point.
 - If redoing a stage after rejection, append a new `## Stage Report: {stage_name} (cycle N)` section at the end rather than locating and overwriting the prior report.
 
 ## Completion

--- a/skills/ensign/references/ensign-shared-core.md
+++ b/skills/ensign/references/ensign-shared-core.md
@@ -15,7 +15,7 @@ Read the assignment context provided by the first officer. It defines:
 
 ## Working
 
-1. Read the entity file before making changes — when you need only specific sections (the relevant stage-def section, your prior report), `status --read <entity-path> --json` returns each section's `offset`/`lines` for a scoped `Read`, rather than the whole body.
+1. Read the entity file before making changes — for a specific section (the relevant stage-def section, your prior report), locate its heading with `grep -nE '^#{1,4} '` and scoped-`Read(offset, limit)` the span to the next heading. `status --read <entity-path> --json` is the fence-safe fallback when the body carries fenced markdown-like content that bare grep over-counts.
 2. If you were given a worktree path, keep all reads, writes, and commits under that worktree.
 3. Perform the work described in the stage definition.
 4. Update the entity file body, not the frontmatter.
@@ -89,7 +89,7 @@ Rules:
 - Every checklist item must appear.
 - Use the checklist item text verbatim for `{item text}` when possible (copy/paste).
 - Do not use markdown checkbox markers.
-- Append the report at the end of the entity file — get the file's `total_lines` from `status --read <entity-path> --json` and append after it; do not read the entire entity body to find an insertion point.
+- Append the report at the end of the entity file — get the append point from `wc -l <entity-path>` and append after the last line; do not read the entire entity body to find an insertion point.
 - If redoing a stage after rejection, append a new `## Stage Report: {stage_name} (cycle N)` section at the end rather than locating and overwriting the prior report.
 
 ## Completion

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -97,7 +97,7 @@ Stay at the project root. Do not `cd` into worktrees. Use `git -C {path}` for op
 
 When a worker completes:
 
-1. Read the entity file's last `## Stage Report` section — `status --read <ref> --json`, take the last `## Stage Report` heading's `offset`/`lines`, then `Read(offset, limit)` that range, instead of loading the whole body.
+1. Read the entity file's last `## Stage Report` section — `grep -n '## Stage Report' <ref>` gives every heading line; scoped-`Read(offset, limit)` from the last one to EOF, instead of loading the whole body.
 2. Review it against the checklist — every dispatched item must appear as DONE, SKIPPED, or FAILED — and produce the explicit count summary `{N} done, {N} skipped, {N} failed`.
 3. If items are missing, send the worker back once to repair the report.
 4. Check whether the completed stage is gated.
@@ -226,7 +226,7 @@ Don't ask permission for a step the contract already allows (the reversible-work
 
 - When a dispatched-ideation design rests on an unverified mechanism (format round-trip, runtime handoff, a tool actually supporting a flag), exercise the riskiest path end-to-end first — the smallest run that would invalidate the work if it broke. Evidence goes in the entity body; "no spike needed" is recorded with proven mechanisms. The integration-level analog of the AC rule: arrive at the gate with the riskiest claim demonstrated, not asserted.
 - When checking whether tool X supports Y, read X's schema via ToolSearch before grepping for callers — usage presence is not existence evidence.
-- Prefer Grep over Read for targeted entity-body inspection. Anchor on heading or field name (`## Stage Report`, `### Feedback Cycles`, a specific frontmatter field). Read only when you need the full text. To pull a whole named section, `status --read <ref> --json` returns its `offset`/`lines` so the follow-up `Read(offset, limit)` is section-scoped, not whole-file.
+- Prefer Grep over Read for targeted entity-body inspection; Read whole only when you need the full text. Anchor on a heading or field name (`## Stage Report`, `### Feedback Cycles`, a frontmatter field): `grep -n` gives the heading line (the section offset) and the next heading bounds its span, so the follow-up `Read(offset, limit)` is section-scoped. `status --read <ref> --json` is the fence-safe fallback when markdown-like fenced content makes grep over-count headings.
 - On Claude Code, a `Read` followed by a Bash mutation of the same file (including `status --set`) triggers the file-staleness safety net, echoing the file back as cache-write tokens. Grep does not participate. Trust `status --set` stdout (`field: old -> new`, `field: old -> ` for clear-to-empty, `field:  -> {timestamp}` for bare-timestamp auto-fill) to narrate mutations without re-reading.
 
 ## Issue Filing

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -97,7 +97,7 @@ Stay at the project root. Do not `cd` into worktrees. Use `git -C {path}` for op
 
 When a worker completes:
 
-1. Read the entity file's last `## Stage Report` section — `grep -n '## Stage Report' <ref>` gives every heading line; scoped-`Read(offset, limit)` from the last one to EOF, instead of loading the whole body.
+1. Read the entity file's last `## Stage Report` section — `status --read <ref> --json`, take the last `## Stage Report` heading's `offset`/`lines`, then `Read(offset, limit)` that range, instead of loading the whole body.
 2. Review it against the checklist — every dispatched item must appear as DONE, SKIPPED, or FAILED — and produce the explicit count summary `{N} done, {N} skipped, {N} failed`.
 3. If items are missing, send the worker back once to repair the report.
 4. Check whether the completed stage is gated.


### PR DESCRIPTION
Name `grep` the primary section-locator for plain entity-body inspection in the FO and ensign cores, where it already covers what `status --read` did — trimming redundant guidance, not the tool.

## What changed
- Ensign `## Working` bullet and FO Prefer-Grep bullet: locate a section's heading with `grep` and scoped-`Read` the span; keep `status --read --json` as the explicit fence-safe fallback.
- Scope corrected by a detached adversarial audit: kept `status --read` at the gate-critical last-`## Stage Report` read and the append-point count, where its fence-awareness / newline-robust count is load-bearing (not redundant).

## Evidence
- `go test ./internal/dispatch/ -run TestBuild` — goldens byte-identical (negative control: runtime-loaded skill prose, not dispatch text); `contractlint` + `ensigncycle` — passed.
- Detached adversarial audit: CLEAN after the scope correction (a Site-D regression was found and closed before merge).
- Adoption instrument (f5) verified live and non-vacuous; AC-1 stands as a forward-looking non-regression check per the captain-ratified degradation.

## Review guidance
Net change is exactly two inspection bullets (Sites A & C); the gate/append-critical reads stay on the structured `status --read`.

---
[82k](/spacedock-dev/spacedock/blob/spacedock-state/dev/read-guidance-redundant-with-grep.md)
