### PR TITLE
ensign-core: stage-neutralize the Split-Root State Contract + add a regression guard

### DIFF
--- a/internal/contractlint/ensign_core_stage_absence_test.go
+++ b/internal/contractlint/ensign_core_stage_absence_test.go
@@ -1,0 +1,138 @@
+// ABOUTME: Structural-absence guard keeping concrete workflow stage-name enumerations
+// ABOUTME: out of the universal ensign core, which loads per-dispatch and must stay stage-neutral.
+package contractlint
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// ensignSharedCore is the universal ensign core, loaded on EVERY worker dispatch via
+// the `Skill(skill="spacedock:ensign")` first-action. Because the ensign also runs
+// non-dev workflows (ticket, experiment, survey), the core must name no concrete
+// workflow stage: a stage-name parenthetical here is a per-dispatch stage-neutrality
+// leak. The dev stage discipline rides the dev-shape scaffolding the dev ensign
+// fetches per-dispatch (see internal/dispatch's behavior-loss control), not this core.
+var ensignSharedCore = filepath.Join("ensign", "references", "ensign-shared-core.md")
+
+// stageNameAlt is the dev workflow's concrete stage vocabulary. A parenthetical that
+// comma-enumerates two or more of these names is a stage-neutrality leak.
+const stageNameAlt = `(?:backlog|ideation|implementation|validation|done)`
+
+// stageEnumParenRe matches a parenthetical ENUMERATING workflow stage names — an open
+// paren wrapping a comma-separated list of two or more stage-name tokens, e.g.
+// `(implementation, validation)` or `(ideation, backlog)`. The expected value comes
+// from the EXTERNAL rule (the universal core is stage-neutral), not the file's own
+// prose, so a stage-neutral paraphrase carries no match and a re-introduced stage-name
+// parenthetical does — same structural-absence family as
+// TestFOContractCoresHaveNoDeferredTierToken. A bare-word match is deliberately NOT
+// used: it would wrongly flag incidental English like "Signaling done" (core line 51).
+var stageEnumParenRe = regexp.MustCompile(`\(\s*` + stageNameAlt + `\b(?:\s*,\s*` + stageNameAlt + `\b)+\s*\)`)
+
+// lineEnumeratesStageNames reports whether a line carries a workflow-stage-enumeration
+// parenthetical. This is the single scanner the absence check, its discriminator
+// control, and the re-insertion control all drive, so defeating it reds every caller.
+func lineEnumeratesStageNames(line string) bool {
+	return stageEnumParenRe.MatchString(line)
+}
+
+// scanForStageEnumeration returns the 1-based line numbers of content whose text
+// carries a stage-enumeration parenthetical.
+func scanForStageEnumeration(content string) []int {
+	var hits []int
+	for i, line := range strings.Split(content, "\n") {
+		if lineEnumeratesStageNames(line) {
+			hits = append(hits, i+1)
+		}
+	}
+	return hits
+}
+
+// TestEnsignCoreEnumeratesNoStageNames is a structural-ABSENCE check: the universal
+// ensign core may carry no parenthetical enumerating concrete workflow stage names.
+// The leak this guards against was the Split-Root State Contract's worktree-illustration
+// parentheticals (`(implementation, validation)`, `(ideation, backlog)`); the whole
+// file is scanned so a re-introduction at any site fails. Non-vacuity is held by the
+// paired discriminator and re-insertion controls below.
+func TestEnsignCoreEnumeratesNoStageNames(t *testing.T) {
+	path := filepath.Join(skillsRoot(t), ensignSharedCore)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read ensign core %s: %v", path, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	for _, ln := range scanForStageEnumeration(string(data)) {
+		t.Errorf("%s:%d enumerates concrete workflow stage names in a parenthetical — the universal ensign core loads per-dispatch and must stay stage-neutral (dev stage discipline rides the dev-shape scaffolding): %q", path, ln, strings.TrimSpace(lines[ln-1]))
+	}
+}
+
+// TestStageEnumerationScannerDiscriminates is the DISCRIMINATOR control: it proves the
+// scanner flags the genuine pre-strip leak shapes and passes the stage-neutral phrasing
+// the strip produces (plus the incidental "Signaling done") — so
+// TestEnsignCoreEnumeratesNoStageNames can never pass vacuously (e.g. by a typo'd regex
+// that never matches anything).
+func TestStageEnumerationScannerDiscriminates(t *testing.T) {
+	// Genuine pre-strip leak lines — each MUST flag.
+	mustFlag := []string{
+		"With a worktree (implementation, validation), the worktree isolates the deliverable work product only.",
+		"Without one (ideation, backlog), you run from the repo root; entity/report still go to the state checkout.",
+	}
+	for _, line := range mustFlag {
+		if !lineEnumeratesStageNames(line) {
+			t.Errorf("discriminator control: a genuine stage-enumeration leak line was NOT flagged (the scanner would pass vacuously): %q", line)
+		}
+	}
+
+	// Stage-neutral phrasings (and incidental stage words) — each MUST pass.
+	mustPass := []string{
+		"With a worktree, the worktree isolates the deliverable work product only. Without one, you run from the repo root; entity/report still go to the state checkout.",
+		"Signaling done without committing forces the FO to re-dispatch just to get a commit — the most common cause of nudge loops.",
+	}
+	for _, line := range mustPass {
+		if lineEnumeratesStageNames(line) {
+			t.Errorf("discriminator control: a stage-neutral phrasing was wrongly flagged: %q", line)
+		}
+	}
+}
+
+// TestEnsignCoreStageEnumerationGuardRedsOnReinsertion is the RE-INSERTION control: it
+// drives the same scanner over the REAL shipped core after splicing each stage-name
+// parenthetical back into the worktree-isolation sentence, and asserts the absence scan
+// reds. This proves the guard catches a regression in the file itself, not only in
+// hand-written discriminator strings — closing the "the regex never matched the real
+// content anyway" vacuity gap.
+func TestEnsignCoreStageEnumerationGuardRedsOnReinsertion(t *testing.T) {
+	path := filepath.Join(skillsRoot(t), ensignSharedCore)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read ensign core %s: %v", path, err)
+	}
+	original := string(data)
+	if hits := scanForStageEnumeration(original); len(hits) != 0 {
+		t.Fatalf("re-insertion control precondition: shipped core already enumerates stage names at line(s) %v — the absence check should have caught this", hits)
+	}
+
+	reinsertions := []struct {
+		name   string
+		anchor string
+		leak   string
+	}{
+		{"implementation/validation", "With a worktree, the worktree isolates", "With a worktree (implementation, validation), the worktree isolates"},
+		{"ideation/backlog", "Without one, you run from the repo root", "Without one (ideation, backlog), you run from the repo root"},
+	}
+	for _, rc := range reinsertions {
+		if !strings.Contains(original, rc.anchor) {
+			t.Fatalf("re-insertion control %q: anchor not found in the core, cannot mutate: %q", rc.name, rc.anchor)
+		}
+		mutated := strings.Replace(original, rc.anchor, rc.leak, 1)
+		if mutated == original {
+			t.Fatalf("re-insertion control %q: splicing the leak back in was a no-op", rc.name)
+		}
+		if hits := scanForStageEnumeration(mutated); len(hits) == 0 {
+			t.Errorf("re-insertion control %q: the guard did NOT red after re-inserting %q into the core (the absence check is vacuous against this regression)", rc.name, rc.leak)
+		}
+	}
+}

--- a/internal/contractlint/ensign_core_stage_absence_test.go
+++ b/internal/contractlint/ensign_core_stage_absence_test.go
@@ -19,18 +19,30 @@ import (
 var ensignSharedCore = filepath.Join("ensign", "references", "ensign-shared-core.md")
 
 // stageNameAlt is the dev workflow's concrete stage vocabulary. A parenthetical that
-// comma-enumerates two or more of these names is a stage-neutrality leak.
+// enumerates two or more of these names — joined by a comma, slash, semicolon, or
+// whitespace — is a stage-neutrality leak.
 const stageNameAlt = `(?:backlog|ideation|implementation|validation|done)`
 
 // stageEnumParenRe matches a parenthetical ENUMERATING workflow stage names — an open
-// paren wrapping a comma-separated list of two or more stage-name tokens, e.g.
-// `(implementation, validation)` or `(ideation, backlog)`. The expected value comes
-// from the EXTERNAL rule (the universal core is stage-neutral), not the file's own
-// prose, so a stage-neutral paraphrase carries no match and a re-introduced stage-name
+// paren wrapping a list of two or more stage-name tokens joined by any of the common
+// separators `,` `/` `;` or whitespace, e.g. `(implementation, validation)`,
+// `(implementation/validation)`, `(implementation; validation)`, or
+// `(implementation validation)`. The separator class is widened past the comma so the
+// natural shorthands cannot re-leak the vocab unflagged. The expected value comes from
+// the EXTERNAL rule (the universal core is stage-neutral), not the file's own prose, so
+// a stage-neutral paraphrase carries no match and a re-introduced stage-name
 // parenthetical does — same structural-absence family as
-// TestFOContractCoresHaveNoDeferredTierToken. A bare-word match is deliberately NOT
-// used: it would wrongly flag incidental English like "Signaling done" (core line 51).
-var stageEnumParenRe = regexp.MustCompile(`\(\s*` + stageNameAlt + `\b(?:\s*,\s*` + stageNameAlt + `\b)+\s*\)`)
+// TestFOContractCoresHaveNoDeferredTierToken.
+//
+// By-design tradeoffs (kept narrow to avoid over-flagging incidental English):
+//   - A bare word is NOT matched — it would wrongly flag "Signaling done" (core line 51).
+//   - A single-name parenthetical (e.g. `(implementation)` alone) is NOT matched; the
+//     leak shape this guards is a multi-name ENUMERATION, and the `+` requires ≥2 names.
+//   - Non-dev stage vocab (a ticket/experiment/survey workflow's own stage names) is NOT
+//     matched — stageNameAlt lists only the dev stages, the host whose names leaked here.
+//   - The parenthetical must START with a stage name and be a pure stage-name list, so an
+//     incidental "done" buried in English prose inside parens does not engage the scanner.
+var stageEnumParenRe = regexp.MustCompile(`\(\s*` + stageNameAlt + `\b(?:[,/;\s]+` + stageNameAlt + `\b)+\s*\)`)
 
 // lineEnumeratesStageNames reports whether a line carries a workflow-stage-enumeration
 // parenthetical. This is the single scanner the absence check, its discriminator
@@ -75,10 +87,15 @@ func TestEnsignCoreEnumeratesNoStageNames(t *testing.T) {
 // TestEnsignCoreEnumeratesNoStageNames can never pass vacuously (e.g. by a typo'd regex
 // that never matches anything).
 func TestStageEnumerationScannerDiscriminates(t *testing.T) {
-	// Genuine pre-strip leak lines — each MUST flag.
+	// Genuine pre-strip leak lines — each MUST flag. The comma form is the original
+	// leak; the slash, semicolon, and bare-whitespace forms are the natural shorthands
+	// an author would reach for, and the widened separator class must bite on each.
 	mustFlag := []string{
 		"With a worktree (implementation, validation), the worktree isolates the deliverable work product only.",
 		"Without one (ideation, backlog), you run from the repo root; entity/report still go to the state checkout.",
+		"With a worktree (implementation/validation), the worktree isolates the deliverable work product only.",
+		"With a worktree (implementation; validation), the worktree isolates the deliverable work product only.",
+		"With a worktree (implementation validation), the worktree isolates the deliverable work product only.",
 	}
 	for _, line := range mustFlag {
 		if !lineEnumeratesStageNames(line) {

--- a/internal/dispatch/build_stage_discipline_delivery_test.go
+++ b/internal/dispatch/build_stage_discipline_delivery_test.go
@@ -1,0 +1,145 @@
+// ABOUTME: Behavior-loss control — proves dev stage discipline rides the dev-shape
+// ABOUTME: show-stage-def fetch, not the universal ensign core, so neutralizing the core loses none.
+package dispatch
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// devDisciplineSentinel is a freshly-minted token written ONLY into the fixture
+// README's ### ideation / ### implementation subsections. Because the test invents
+// it, it cannot appear in the shipped universal ensign core — so its absence from the
+// dispatch body (which delivers the core by reference, via the Skill first-action)
+// proves the stage prose is not inlined into the assignment, and its presence in
+// show-stage-def output proves the fetch delivers it.
+const devDisciplineSentinel = "DEV-DISCIPLINE-SENTINEL"
+
+// readmeDevDiscipline is a dev-shape workflow README that plants the sentinel in the
+// ideation and implementation stage subsections (and deliberately not in backlog /
+// validation / done), so a stage with the discipline and a stage without it can both
+// be exercised through show-stage-def.
+const readmeDevDiscipline = `---
+entity-type: task
+id-style: slug
+stages:
+  defaults:
+    worktree: false
+    concurrency: 1
+  states:
+    - name: backlog
+      initial: true
+    - name: ideation
+    - name: implementation
+      worktree: true
+    - name: validation
+      worktree: true
+      feedback-to: implementation
+    - name: done
+      terminal: true
+---
+# Dev Discipline Fixture
+
+### backlog
+
+seed.
+
+- **Outputs:** x.
+
+### ideation
+
+Flesh out the approach. ` + devDisciplineSentinel + `
+
+- **Outputs:** the design.
+
+### implementation
+
+Produce the deliverable. ` + devDisciplineSentinel + `
+
+- **Outputs:** the deliverable.
+
+### validation
+
+Independently verify.
+
+- **Outputs:** the verdict.
+
+### done
+
+term.
+`
+
+// TestBuildStageDisciplineRidesFetchNotInlineAssignment is the behavior-loss control
+// for neutralizing the universal ensign core. It proves a dev-workflow ensign still
+// receives dev stage discipline through the dev-shape scaffolding — the README
+// ### {stage} subsection delivered via the assignment's show-stage-def fetch line —
+// and NOT through the universal core. So removing the core's illustrative dev
+// stage-name parentheticals loses no discipline: the core never carried the discipline
+// to begin with; the fetch does.
+func TestBuildStageDisciplineRidesFetchNotInlineAssignment(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "README.md"), readmeDevDiscipline)
+	entityPath := filepath.Join(root, "thing.md")
+	writeFile(t, entityPath, entityFM("Thing", "ideation", ""))
+	gitInit(t, root)
+
+	stdin := mergeStdin(map[string]any{
+		"schema_version": 2,
+		"entity_path":    entityPath,
+		"workflow_dir":   root,
+		"stage":          "ideation",
+		"checklist":      []string{"- a"},
+		"team_name":      "fixture-team",
+		"bare_mode":      false,
+	}, nil)
+
+	native := runNative(stdin, "build", "--workflow-dir", root)
+	if native.exit != 0 {
+		t.Fatalf("build exit %d, stderr:\n%s", native.exit, native.stderr)
+	}
+	body := readDispatchBody(t, dispatchFilePathFromStdout(t, native.stdout))
+
+	// The assignment loads the universal ensign core by REFERENCE (the Skill
+	// first-action directive), not inline.
+	if !strings.Contains(body, `Skill(skill="spacedock:ensign")`) {
+		t.Errorf("dispatch body missing the universal-core load directive (Skill first-action):\n%s", body)
+	}
+
+	// Stage discipline rides the show-stage-def fetch line, fetched on demand.
+	wantFetch := LauncherCommand() + " dispatch show-stage-def --workflow-dir " + shlexQuote(root) + " --stage ideation"
+	if !strings.Contains(body, wantFetch) {
+		t.Errorf("dispatch body missing the show-stage-def fetch line\nwant contains: %s\n---body---\n%s", wantFetch, body)
+	}
+
+	// The stage prose is NOT inlined into the assignment: the sentinel that lives in
+	// the README's ### ideation subsection must not appear in the dispatch body. The
+	// universal ensign core that the Skill directive loads never carries this
+	// test-minted sentinel either — it exists only in the fixture README.
+	if strings.Contains(body, devDisciplineSentinel) {
+		t.Errorf("dispatch body INLINED the stage prose — the %s sentinel leaked into the assignment instead of riding the fetch:\n%s", devDisciplineSentinel, body)
+	}
+
+	// Running the fetch line returns the ### ideation subsection carrying the sentinel:
+	// the dev discipline reaches the ensign through the show-stage-def fetch.
+	fetched := runNative("", "show-stage-def", "--workflow-dir", root, "--stage", "ideation")
+	if fetched.exit != 0 {
+		t.Fatalf("show-stage-def ideation exit %d, stderr:\n%s", fetched.exit, fetched.stderr)
+	}
+	if !strings.Contains(fetched.stdout, devDisciplineSentinel) {
+		t.Errorf("show-stage-def ideation did not return the stage-discipline sentinel:\n%s", fetched.stdout)
+	}
+
+	// Perturbation control: a stage WITHOUT the sentinel (validation) returns no
+	// sentinel — show-stage-def returns ONLY the requested stage's subsection, so a
+	// false green from the sentinel leaking across stages is excluded.
+	plain := runNative("", "show-stage-def", "--workflow-dir", root, "--stage", "validation")
+	if plain.exit != 0 {
+		t.Fatalf("show-stage-def validation exit %d, stderr:\n%s", plain.exit, plain.stderr)
+	}
+	if strings.Contains(plain.stdout, devDisciplineSentinel) {
+		t.Errorf("perturbation control: show-stage-def validation (no sentinel planted) returned the sentinel:\n%s", plain.stdout)
+	}
+}

--- a/skills/ensign/references/ensign-shared-core.md
+++ b/skills/ensign/references/ensign-shared-core.md
@@ -33,7 +33,7 @@ For worktree-backed entities, active stage/status/report/body state belongs in t
 
 ### Split-Root State Contract
 
-When the workflow is split-root (README declares `state:` checkout, e.g. `state: .spacedock-state`), the entity body and your stage report live in the state checkout the dispatch hands you as the entity path, NOT alongside the code. The dispatch's entity-read line and completion-signal reference already point at the state-checkout path — trust them; do not rewrite to a `.worktrees/` copy. With a worktree (implementation, validation), the worktree isolates the deliverable work product only. Without one (ideation, backlog), you run from the repo root; entity/report still go to the state checkout.
+When the workflow is split-root (README declares `state:` checkout, e.g. `state: .spacedock-state`), the entity body and your stage report live in the state checkout the dispatch hands you as the entity path, NOT alongside the code. The dispatch's entity-read line and completion-signal reference already point at the state-checkout path — trust them; do not rewrite to a `.worktrees/` copy. With a worktree, the worktree isolates the deliverable work product only. Without one, you run from the repo root; entity/report still go to the state checkout.
 
 **Concurrency-safe state commits.** The state checkout is one shared, non-branched git index. A bare `git add -A` / `git commit` sweeps up a sibling writer's staged entity. You MUST commit path-scoped: `git -C {state_checkout} add {entity_path} && git -C {state_checkout} commit -m "…" -- {entity_path}`. Retry on `index.lock` contention after ~2s. Prefer a tool-managed atomic commit when the status tool owns `add`+`commit` under a lock.
 


### PR DESCRIPTION
Stage-neutralize the universal ensign core: remove the dev-stage-name illustration that violated stage-neutrality on every worker dispatch, and re-establish a regression guard.

## What changed
- Drop the two dev-stage-name parentheticals from the ensign core's `### Split-Root State Contract` (the worktree-isolation rule is preserved verbatim; they were illustration, and the per-dispatch assignment already signals whether a worktree exists).
- Add a `contractlint` structural-absence guard that flags any parenthetical enumerating ≥2 dev stage names across `,` `/` `;` and whitespace separators, with discriminator + re-insertion controls.
- Add a dispatch delivery test proving dev stage discipline rides the `show-stage-def` fetch, not the universal core.

## Evidence
- `go test ./internal/contractlint/ ./internal/dispatch/` — passed; guard non-vacuity verified against the real core (separator-variant re-insertion reds the absence scan).
- Detached adversarial audit: CLEAN — a slash-separator coverage gap in the guard was found and closed before merge.

## Review guidance
One ensign-core line + two test files; the guard intentionally excludes single-name / non-dev / prose-connective forms (documented in the regex comment).

---
[scr](/spacedock-dev/spacedock/blob/spacedock-state/dev/stage-neutralize-ensign-core.md)
