### PR TITLE
codex --plugin-dir advisory: drop the internal branch name from shipped CLI output

### DIFF
--- a/internal/cli/codex_marketplace.go
+++ b/internal/cli/codex_marketplace.go
@@ -120,8 +120,7 @@ func WriteCodexLocalMarketplace(marketplaceRoot, repoRoot, marketplaceName strin
 // so a throwaway dir removed after install would hard-fail every subsequent codex
 // invocation. It prints the version-masquerade advisory on every call: a
 // `--plugin-dir` install reports the checkout's checked-in .codex-plugin/plugin.json
-// version, not necessarily its current HEAD (the full stamping fix lives in
-// next-post-release-preversion-bump).
+// version, not necessarily its current HEAD (the full stamping fix is deferred).
 func installCodexLocalPluginDir(ops hostOps, checkout string, stderr io.Writer) error {
 	marketplaceRoot := filepath.Join(codexHome(), "spacedock-plugin-dir", channelMarketplace(devBranch))
 	if err := os.MkdirAll(marketplaceRoot, 0o755); err != nil {
@@ -138,8 +137,7 @@ func installCodexLocalPluginDir(ops hostOps, checkout string, stderr io.Writer) 
 	fmt.Fprintf(stderr,
 		"Installed codex plugin from %s.\n"+
 			"version-masquerade advisory: the reported version reflects the checkout's "+
-			"checked-in .codex-plugin/plugin.json, not necessarily its current HEAD — "+
-			"see next-post-release-preversion-bump.\n",
+			"checked-in .codex-plugin/plugin.json, not necessarily its current HEAD.\n",
 		checkout)
 	return nil
 }

--- a/internal/cli/codex_plugin_dir_test.go
+++ b/internal/cli/codex_plugin_dir_test.go
@@ -76,7 +76,9 @@ func TestRunCodexPluginDirInstallsThenLaunchesWithoutTheFlag(t *testing.T) {
 // TestCodexPluginDirAdvisoryPresenceAndAbsence is AC-3: every --plugin-dir codex
 // install prints the version-masquerade advisory; a plain (non---plugin-dir) launch
 // prints none. The pair (not a presence-only check) means the test cannot pass by
-// printing the advisory unconditionally.
+// printing the advisory unconditionally. The present subtest also guards that the
+// advisory carries its meaning-bearing clause (not necessarily its current HEAD) and
+// leaks no internal branch identifier.
 func TestCodexPluginDirAdvisoryPresenceAndAbsence(t *testing.T) {
 	const advisory = "version-masquerade advisory"
 
@@ -91,6 +93,12 @@ func TestCodexPluginDirAdvisoryPresenceAndAbsence(t *testing.T) {
 		}
 		if !strings.Contains(stderr.String(), advisory) {
 			t.Fatalf("stderr missing the version-masquerade advisory: %q", stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "not necessarily its current HEAD") {
+			t.Fatalf("advisory lost its meaning-bearing clause: %q", stderr.String())
+		}
+		if strings.Contains(stderr.String(), "next-post-release-preversion-bump") {
+			t.Fatalf("advisory leaks the internal branch identifier: %q", stderr.String())
 		}
 	})
 


### PR DESCRIPTION
Drop the internal branch name from the codex `--plugin-dir` version-masquerade advisory so shipped CLI output carries no identifier an end user cannot act on.

## What changed
- Reword the advisory in `installCodexLocalPluginDir` to end at "not necessarily its current HEAD" (no `next-post-release-preversion-bump`).
- Clean the companion docstring the same way ("the full stamping fix is deferred").
- Add a test guard asserting the shipped advisory contains no internal branch token, plus a surviving-meaning assertion.

## Evidence
- `internal/cli`: all tests pass; `go build ./...` green.
- AC-1 is baseline-fails-on-main (the token emits today), so the guard can move the wrong way; the presence/absence pair stays green.

---
[ac](/spacedock-dev/spacedock/blob/2b5cc9416662bf25109adc20c80791daa794e92b/codex-plugin-dir-advisory-internal-ref.md)
