### PR TITLE
e2e-gate --status success filter hides re-run-to-green Runtime Live E2E runs from the release gate

### DIFF
--- a/cmd/spacedock-release/e2e_gate.go
+++ b/cmd/spacedock-release/e2e_gate.go
@@ -15,14 +15,19 @@ import (
 // without a live gh.
 type runListFunc func(commit string) ([]byte, error)
 
-// ghRunListForCommit queries the green Runtime Live E2E runs whose head commit is
-// the release commit. `--status success` excludes parked/waiting runs (the spike
-// proved a parked run is never success), and `-c <commit>` binds the query to the
-// exact tagged commit so a green run on some other line cannot satisfy the gate.
+// ghRunListForCommit queries the Runtime Live E2E runs whose head commit is the
+// release commit; `-c <commit>` binds the query to the exact tagged commit so a
+// green run on some other line cannot satisfy the gate. The query deliberately
+// omits `--status success`: gh's `--status` filter can lag a run's `conclusion`
+// right after a re-run flips it to green (observed at the v0.23.0 cut — the
+// filtered query returned `[]` while the same query without `--status` already
+// saw the success), so the pre-filter costs genuine re-run-to-green cuts and
+// buys nothing. Excluding parked/waiting runs is EvaluateE2EGate's job: its
+// predicate requires conclusion == "success", so an empty-conclusion parked run
+// never qualifies regardless of what this query returns.
 func ghRunListForCommit(commit string) ([]byte, error) {
 	cmd := exec.Command("gh", "run", "list",
 		"--workflow", "Runtime Live E2E",
-		"--status", "success",
 		"-c", commit,
 		"--json", "databaseId,headSha,conclusion,status",
 	)

--- a/cmd/spacedock-release/e2e_gate_test.go
+++ b/cmd/spacedock-release/e2e_gate_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -79,6 +80,90 @@ func TestE2EGateCommandRejectsMissingCommit(t *testing.T) {
 	code := runE2EGate(nil, fakeRunLister(greenForCommit))
 	if code == 0 {
 		t.Fatalf("e2e-gate exit = 0 with no release commit argument; want non-zero")
+	}
+}
+
+// writeGhStatusLagShim writes a `gh` shim that reproduces the v0.23.0 gate-time
+// filter-consistency lag: when argv carries a bare `--status` flag it prints
+// `[]` (the observed behavior of `--status success` right after a re-run flips
+// a run to green), and otherwise it prints fixtureJSON (the unfiltered query,
+// which already saw the success). This drives the REAL ghRunListForCommit
+// end-to-end — the fakeRunLister seam above bypasses the args entirely and
+// cannot see the bug.
+func writeGhStatusLagShim(t *testing.T, fixtureJSON string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("gh stub shim is a POSIX shell script")
+	}
+	dir := t.TempDir()
+	// echo, not cat: the stub PATH contains only this shim, so an external `cat`
+	// would itself fail to resolve. echo is a shell builtin.
+	script := `#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "--status" ]; then
+    echo '[]'
+    exit 0
+  fi
+done
+echo '` + fixtureJSON + `'
+`
+	path := filepath.Join(dir, "gh")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// rerunToGreenJSON pins the 2026-06-30 gate-time observation: the only success
+// entry for the release commit is a run that was re-run to green (attempt 2).
+const rerunToGreenJSON = `[
+  {"databaseId": 28429490220, "headSha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "conclusion": "success", "status": "completed", "attempt": 2}
+]`
+
+// parkedOnlyJSON has no success entry at all — only a parked/waiting run.
+const parkedOnlyJSON = `[
+  {"databaseId": 28400000000, "headSha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "conclusion": "", "status": "waiting"}
+]`
+
+// TestE2EGateCommandPassesOnRerunToGreenLiveRun is T1 (AC-1): drives the REAL
+// ghRunListForCommit against the gh shim. RED under today's query shape (argv
+// carries `--status success`, so the shim replays the filter-consistency lag
+// and returns `[]`, blocking a genuinely green cut); GREEN once
+// ghRunListForCommit drops `--status success` (the shim then sees no bare
+// `--status` arg and returns the fixture, so the gate matches the run).
+func TestE2EGateCommandPassesOnRerunToGreenLiveRun(t *testing.T) {
+	stubDir := writeGhStatusLagShim(t, rerunToGreenJSON)
+	t.Setenv("PATH", stubDir)
+
+	summary := newSummaryFile(t)
+	t.Setenv("GITHUB_STEP_SUMMARY", summary)
+	t.Setenv("SPACEDOCK_E2E_GATE_WAIVER", "")
+
+	code := runE2EGate([]string{gateCommit}, ghRunListForCommit)
+	if code != 0 {
+		t.Fatalf("e2e-gate exit = %d, want 0 for a re-run-to-green Runtime Live E2E run (AC-1)", code)
+	}
+	if got := readFile(t, summary); !strings.Contains(got, "28429490220") {
+		t.Errorf("step summary did not cite the matched re-run-to-green run:\n%s", got)
+	}
+}
+
+// TestE2EGateCommandBlocksParkedOnlyRunViaLiveQuery is T2 (AC-2): a
+// parked-only fixture still blocks the cut under the new (unfiltered) query
+// shape. The parked-run defense lives in EvaluateE2EGate's predicate (empty
+// conclusion never matches), not in the dropped `--status` flag, so removing
+// the flag must not regress this.
+func TestE2EGateCommandBlocksParkedOnlyRunViaLiveQuery(t *testing.T) {
+	stubDir := writeGhStatusLagShim(t, parkedOnlyJSON)
+	t.Setenv("PATH", stubDir)
+
+	summary := newSummaryFile(t)
+	t.Setenv("GITHUB_STEP_SUMMARY", summary)
+	t.Setenv("SPACEDOCK_E2E_GATE_WAIVER", "")
+
+	code := runE2EGate([]string{gateCommit}, ghRunListForCommit)
+	if code == 0 {
+		t.Fatalf("e2e-gate exit = 0 on a parked-only run list; want non-zero (cut blocked, AC-2)")
 	}
 }
 

--- a/cmd/spacedock-release/e2e_gate_test.go
+++ b/cmd/spacedock-release/e2e_gate_test.go
@@ -90,6 +90,15 @@ func TestE2EGateCommandRejectsMissingCommit(t *testing.T) {
 // which already saw the success). This drives the REAL ghRunListForCommit
 // end-to-end — the fakeRunLister seam above bypasses the args entirely and
 // cannot see the bug.
+//
+// It also pins the query's ONLY binding to the live matrix: `--workflow
+// "Runtime Live E2E"` is not among the fetched `--json` fields, so nothing else
+// in the predicate distinguishes a Runtime Live E2E run from an unrelated green
+// run on the release commit (e.g. ordinary push CI). The shim prints `[]`
+// unless argv carries that exact `--workflow "Runtime Live E2E"` pair, so
+// dropping the token from ghRunListForCommit fails the gate closed here — a
+// regression that dropped it would otherwise fail OPEN (any green run on the
+// commit would satisfy the gate).
 func writeGhStatusLagShim(t *testing.T, fixtureJSON string) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -99,12 +108,22 @@ func writeGhStatusLagShim(t *testing.T, fixtureJSON string) string {
 	// echo, not cat: the stub PATH contains only this shim, so an external `cat`
 	// would itself fail to resolve. echo is a shell builtin.
 	script := `#!/bin/sh
+have_workflow=0
+prev=""
 for arg in "$@"; do
+  if [ "$prev" = "--workflow" ] && [ "$arg" = "Runtime Live E2E" ]; then
+    have_workflow=1
+  fi
   if [ "$arg" = "--status" ]; then
     echo '[]'
     exit 0
   fi
+  prev="$arg"
 done
+if [ "$have_workflow" != "1" ]; then
+  echo '[]'
+  exit 0
+fi
 echo '` + fixtureJSON + `'
 `
 	path := filepath.Join(dir, "gh")

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -93,7 +93,9 @@ green Runtime Live E2E run for its exact SHA. Stamp and push the release commit 
 4. Green that exact commit. Capture the release SHA, then dispatch Runtime Live
    E2E on it and wait for a `conclusion: success` run — the `e2e-gate` matches a
    green run to the tagged SHA, and the workflow is `workflow_dispatch`-only, so
-   nothing greens the commit unless you dispatch it:
+   nothing greens the commit unless you dispatch it. A lane that flakes can be
+   re-run to green (`gh run rerun <run-id> --failed`); the re-run-to-green run
+   satisfies the gate — no fresh dispatch needed:
 
    ```bash
    REL_SHA=$(git rev-parse HEAD)

--- a/internal/release/e2egate_workflow_test.go
+++ b/internal/release/e2egate_workflow_test.go
@@ -13,7 +13,7 @@ import (
 //   - the goreleaser-carrying job declares `needs:` including `e2e-gate`, and
 //   - the e2e-gate job resolves the tagged commit SHA and runs the
 //     `spacedock-release e2e-gate` step over that SHA (which itself queries
-//     `gh run list --workflow "Runtime Live E2E" --status success -c <sha>`).
+//     `gh run list --workflow "Runtime Live E2E" -c <sha>`).
 func TestReleaseWorkflowGatesGoreleaserOnE2E(t *testing.T) {
 	release := readWorkflow(t, "release.yml")
 	if err := assertReleaseWorkflowGatesGoreleaserOnE2E(release); err != nil {


### PR DESCRIPTION
A Runtime Live E2E run re-run to green was invisible to the release e2e-gate, blocking the v0.23.0 cut on a genuinely green matrix.

## What changed
- Drop `--status success` from the e2e-gate's `gh run list` query
- Add shim-driven tests exercising the real query builder
- Pin `--workflow "Runtime Live E2E"` as the live-matrix binding
- Rewrite the parked-run doc comment; document re-run-to-green in docs/releasing.md

## Evidence
- `go test ./...` 15/15 packages passed; `-race` green on both touched packages
- Detached adversarial audit: all claim-breaking mutants caught; fail-open `--workflow` hole closed in cycle 1

---
[q3](/spacedock-dev/spacedock/blob/8000f6d7656d0210c21cf9a404d626076095cd06/e2e-gate-rerun-status-filter.md)