### PR TITLE
state ready/sweep/commit auto-discover the lone workflow (drop the --workflow-dir requirement)

### DIFF
--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -93,17 +93,7 @@ func parseStateInitArgs(args []string, dir string, stderr io.Writer) (workflowDi
 			return "", 2
 		}
 	}
-	if workflowDir == "" {
-		discovered, ok := status.DiscoverWorkflowDir(dir)
-		if !ok {
-			fmt.Fprintln(stderr, "spacedock state init: no workflow here — pass --workflow-dir or run inside a workflow")
-			return "", 1
-		}
-		workflowDir = discovered
-	} else if !filepath.IsAbs(workflowDir) {
-		workflowDir = filepath.Join(dir, workflowDir)
-	}
-	return workflowDir, 0
+	return resolveWorkflowDir(workflowDir, dir, stderr)
 }
 
 // runStateNew implements `spacedock state new`. It is the BIRTH half of the
@@ -353,17 +343,7 @@ func parseStateNewArgs(args []string, dir string, stderr io.Writer) (workflowDir
 			return "", 2
 		}
 	}
-	if workflowDir == "" {
-		discovered, ok := status.DiscoverWorkflowDir(dir)
-		if !ok {
-			fmt.Fprintln(stderr, "spacedock state new: no workflow here — pass --workflow-dir or run inside a workflow")
-			return "", 1
-		}
-		workflowDir = discovered
-	} else if !filepath.IsAbs(workflowDir) {
-		workflowDir = filepath.Join(dir, workflowDir)
-	}
-	return workflowDir, 0
+	return resolveWorkflowDir(workflowDir, dir, stderr)
 }
 
 // runGit runs a git command in dir, returning success and combined output. On

--- a/internal/cli/state_from_root_test.go
+++ b/internal/cli/state_from_root_test.go
@@ -1,0 +1,193 @@
+// ABOUTME: Real-git e2e — bare `state ready/sweep/commit/init/new` (no --workflow-dir)
+// ABOUTME: auto-discover the lone nested workflow from the repo toplevel (AC-1, AC-2).
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// TestStateReadyFromRootResolves pins AC-1: bare `state ready`, run with the repo
+// toplevel as cwd and no --workflow-dir, resolves the single nested workflow via
+// the downward-scan fallback and performs the same boot-pull integration as the
+// explicit --workflow-dir path.
+func TestStateReadyFromRootResolves(t *testing.T) {
+	_, workflowA, workflowB, _ := twoHostStateWorkflow(t)
+	checkoutB := filepath.Join(workflowB, ".spacedock-state")
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+	hostB := filepath.Dir(filepath.Dir(workflowB))
+
+	writeEntity(t, workflowA, "alpha-task", "---\nstatus: ideation\n---\n# Alpha (A)\n")
+	if code, _, errOut := runStateCommitCmd(t, hostA, workflowA, "alpha-task", "-m", "A: add alpha"); code != 0 {
+		t.Fatalf("A's commit should succeed; exit=%d stderr=%q", code, errOut)
+	}
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "ready"},
+		os.Environ(), hostB, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("bare state ready from root should exit 0; got exit=%d stderr=%q", code, errBuf.String())
+	}
+	if _, err := os.Stat(filepath.Join(checkoutB, "alpha-task.md")); err != nil {
+		t.Fatalf("bare state ready from root should have integrated A's alpha-task: %v", err)
+	}
+}
+
+// TestStateSweepFromRootResolves pins AC-1: bare `state sweep` from the repo
+// toplevel resolves the nested workflow and stays read-only (HEAD unchanged),
+// mirroring TestStateSweepIsReadOnly with no --workflow-dir.
+func TestStateSweepFromRootResolves(t *testing.T) {
+	_, workflowA, _, _ := twoHostStateWorkflow(t)
+	checkoutA := filepath.Join(workflowA, ".spacedock-state")
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+
+	headBefore := strings.TrimSpace(git(t, checkoutA, "rev-parse", "HEAD"))
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "sweep", "--json"},
+		os.Environ(), hostA, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("bare state sweep from root should exit 0; got exit=%d stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), `"command": "state sweep"`) {
+		t.Fatalf("sweep --json should carry the command envelope; json:\n%s", out.String())
+	}
+	headAfter := strings.TrimSpace(git(t, checkoutA, "rev-parse", "HEAD"))
+	if headAfter != headBefore {
+		t.Fatalf("bare state sweep from root must be read-only; HEAD changed %s -> %s", headBefore, headAfter)
+	}
+}
+
+// TestStateCommitFromRootResolves pins AC-1: bare `state commit <slug>` from the
+// repo toplevel resolves the nested workflow and lands the path-scoped commit in
+// the state checkout's git log, same as the explicit --workflow-dir path.
+func TestStateCommitFromRootResolves(t *testing.T) {
+	bare, workflowA, _, stateBranch := twoHostStateWorkflow(t)
+	checkoutA := filepath.Join(workflowA, ".spacedock-state")
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+
+	writeEntity(t, workflowA, "first-task", "---\nstatus: implementation\n---\n# First Task (A)\n")
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "commit", "first-task", "-m", "A: from root"},
+		os.Environ(), hostA, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("bare state commit from root should exit 0; got exit=%d stderr=%q", code, errBuf.String())
+	}
+	names := git(t, checkoutA, "show", "--name-only", "--pretty=format:", "HEAD")
+	if !strings.Contains(names, "first-task.md") {
+		t.Fatalf("bare commit from root should include first-task.md; name-only:\n%s", names)
+	}
+	originFirst := showOriginFile(t, bare, stateBranch, "first-task.md")
+	if !strings.Contains(originFirst, "status: implementation") {
+		t.Fatalf("origin first-task should carry the from-root commit; got:\n%s", originFirst)
+	}
+}
+
+// TestStateInitFromRootResolves pins the AC-1 extension to `state init`: a fresh
+// clone with an absent state checkout resumes it via bare `state init` run from
+// the repo toplevel, no --workflow-dir.
+func TestStateInitFromRootResolves(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+
+	hostClone := filepath.Join(t.TempDir(), "host")
+	git(t, t.TempDir(), "clone", "-q", bare, hostClone)
+	git(t, hostClone, "config", "user.email", "t@t")
+	git(t, hostClone, "config", "user.name", "t")
+	commissionSplitWorkflow(t, hostClone)
+	git(t, hostClone, "push", "-q", "origin", "HEAD")
+
+	fresh := filepath.Join(t.TempDir(), "fresh")
+	git(t, t.TempDir(), "clone", "-q", bare, fresh)
+	git(t, fresh, "config", "user.email", "t@t")
+	git(t, fresh, "config", "user.name", "t")
+	freshState := filepath.Join(fresh, "docs", "dev", ".spacedock-state")
+
+	if _, err := os.Stat(freshState); !os.IsNotExist(err) {
+		t.Fatalf("precondition: fresh clone should NOT have the state path yet (err=%v)", err)
+	}
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "init"},
+		os.Environ(), fresh, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("bare state init from root should exit 0; got exit=%d stderr=%q", code, errBuf.String())
+	}
+	if _, err := os.Stat(freshState); err != nil {
+		t.Fatalf("bare state init from root should have created the state worktree: %v", err)
+	}
+}
+
+// TestStateNewFromRootResolves pins the AC-1 extension to `state new`: an
+// already-present split-root README (not yet birthed) is birthed by bare
+// `state new` run from the repo toplevel, no --workflow-dir.
+func TestStateNewFromRootResolves(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	hostClone, workflowDir := writeSplitReadmeRepo(t)
+	statePath := filepath.Join(workflowDir, ".spacedock-state")
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "new"},
+		os.Environ(), hostClone, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("bare state new from root should exit 0; got exit=%d stdout=%q stderr=%q", code, out.String(), errBuf.String())
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("bare state new from root should have created the state worktree: %v", err)
+	}
+}
+
+// TestStateVerbsFromRootRefuseAmbiguousWorkflows pins AC-2: with two commissioned
+// workflows nested under a plain toplevel, the bare state verbs refuse (non-zero
+// exit) and stderr names both candidate dirs and instructs --workflow-dir — the
+// same refusal spacedock new emits (TestNewFromRootMultiWorkflowRefuses).
+func TestStateVerbsFromRootRefuseAmbiguousWorkflows(t *testing.T) {
+	root := t.TempDir()
+	for _, rel := range []string{"docs/dev", "docs/ops"} {
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(full, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(full, "README.md"), []byte(splitWorkflowReadme), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git(t, root, "init", "-q")
+	git(t, root, "add", "-A")
+	git(t, root, "commit", "-q", "-m", "two commissioned workflows")
+
+	dev := filepath.Join(root, "docs", "dev")
+	ops := filepath.Join(root, "docs", "ops")
+	if real, err := filepath.EvalSymlinks(dev); err == nil {
+		dev = real
+	}
+	if real, err := filepath.EvalSymlinks(ops); err == nil {
+		ops = real
+	}
+
+	for _, args := range [][]string{
+		{"state", "sweep"},
+		{"state", "ready"},
+		{"state", "commit", "any-slug", "-m", "msg"},
+	} {
+		var out, errBuf strings.Builder
+		code := run(context.Background(), args, os.Environ(), root, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+		if code == 0 {
+			t.Fatalf("bare %v with two workflows must refuse (non-zero)", args)
+		}
+		errOut := errBuf.String()
+		if !strings.Contains(errOut, dev) || !strings.Contains(errOut, ops) {
+			t.Fatalf("bare %v ambiguity error must name both candidates, got: %q", args, errOut)
+		}
+		if !strings.Contains(errOut, "--workflow-dir") {
+			t.Fatalf("bare %v ambiguity error must instruct --workflow-dir, got: %q", args, errOut)
+		}
+	}
+}

--- a/internal/cli/state_from_root_test.go
+++ b/internal/cli/state_from_root_test.go
@@ -1,9 +1,11 @@
 // ABOUTME: Real-git e2e — bare `state ready/sweep/commit/init/new` (no --workflow-dir)
-// ABOUTME: auto-discover the lone nested workflow from the repo toplevel (AC-1, AC-2).
+// ABOUTME: auto-discover the lone nested workflow from the repo toplevel (AC-1, AC-2),
+// ABOUTME: and an explicit --workflow-dir always wins over auto-discovery.
 package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,9 +42,12 @@ func TestStateReadyFromRootResolves(t *testing.T) {
 
 // TestStateSweepFromRootResolves pins AC-1: bare `state sweep` from the repo
 // toplevel resolves the nested workflow and stays read-only (HEAD unchanged),
-// mirroring TestStateSweepIsReadOnly with no --workflow-dir.
+// mirroring TestStateSweepIsReadOnly with no --workflow-dir. The state_branch
+// assertion is load-bearing: sweep exits 0 with a valid-looking empty envelope
+// even when resolution lands on the wrong (but existing) directory, so only
+// the presence of the real workflow's branch name proves the right dir resolved.
 func TestStateSweepFromRootResolves(t *testing.T) {
-	_, workflowA, _, _ := twoHostStateWorkflow(t)
+	_, workflowA, _, stateBranch := twoHostStateWorkflow(t)
 	checkoutA := filepath.Join(workflowA, ".spacedock-state")
 	hostA := filepath.Dir(filepath.Dir(workflowA))
 
@@ -56,6 +61,9 @@ func TestStateSweepFromRootResolves(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), `"command": "state sweep"`) {
 		t.Fatalf("sweep --json should carry the command envelope; json:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), fmt.Sprintf(`"state_branch": %q`, stateBranch)) {
+		t.Fatalf("sweep --json should carry the resolved workflow's state_branch %q (proves the nested workflow, not the toplevel, resolved); json:\n%s", stateBranch, out.String())
 	}
 	headAfter := strings.TrimSpace(git(t, checkoutA, "rev-parse", "HEAD"))
 	if headAfter != headBefore {
@@ -189,5 +197,63 @@ func TestStateVerbsFromRootRefuseAmbiguousWorkflows(t *testing.T) {
 		if !strings.Contains(errOut, "--workflow-dir") {
 			t.Fatalf("bare %v ambiguity error must instruct --workflow-dir, got: %q", args, errOut)
 		}
+	}
+}
+
+// setupStandaloneSplitWorkflow creates a minimal split-root workflow at
+// root/relPath: a commissioned README declaring `state: .spacedock-state`, and
+// a standalone git repo (no origin, no linked worktree) at the state checkout
+// seeded with one entity file named slug+".md". This is enough to observe which
+// checkout directory a state-verb mutation lands in, without the orphan-branch
+// machinery TestCommissionOrphanBranchScaffolding etc. already pin elsewhere.
+func setupStandaloneSplitWorkflow(t *testing.T, root, relPath, slug string) (workflowDir string) {
+	t.Helper()
+	workflowDir = filepath.Join(root, relPath)
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "README.md"), []byte(splitWorkflowReadme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	checkout := filepath.Join(workflowDir, ".spacedock-state")
+	if err := os.MkdirAll(checkout, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git(t, checkout, "init", "-q")
+	if err := os.WriteFile(filepath.Join(checkout, slug+".md"),
+		[]byte("---\nstatus: ideation\n---\n# "+slug+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return workflowDir
+}
+
+// TestStateCommitExplicitWorkflowDirOverridesDiscovery pins M1: an explicit
+// --workflow-dir always wins over auto-discovery, even when discovery would
+// otherwise succeed. Workflow A and B are both real, live candidates; the verb
+// runs with cwd inside A (whose walk-up immediately resolves A) but names B via
+// --workflow-dir. A resolver that lets a successful discovery silently override
+// the explicit flag would mutate A instead of B.
+func TestStateCommitExplicitWorkflowDirOverridesDiscovery(t *testing.T) {
+	root := t.TempDir()
+	workflowA := setupStandaloneSplitWorkflow(t, root, "docs/dev", "task-a")
+	workflowB := setupStandaloneSplitWorkflow(t, root, "docs/ops", "task-b")
+	checkoutA := filepath.Join(workflowA, ".spacedock-state")
+	checkoutB := filepath.Join(workflowB, ".spacedock-state")
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "commit", "task-b", "-m", "explicit-B", "--workflow-dir", workflowB},
+		os.Environ(), workflowA, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("state commit with explicit --workflow-dir should exit 0; got exit=%d stderr=%q", code, errBuf.String())
+	}
+
+	namesB := git(t, checkoutB, "log", "--name-only", "--pretty=format:", "-1")
+	if !strings.Contains(namesB, "task-b.md") {
+		t.Fatalf("explicit --workflow-dir=B commit should land in B's checkout; B log:\n%s", namesB)
+	}
+	// A's checkout must have zero commits — an explicit flag naming B must never
+	// let A's cwd-driven discovery redirect the mutation there instead.
+	if _, ok := gitOK(t, checkoutA, "log", "-1"); ok {
+		t.Fatalf("explicit --workflow-dir=B must NOT touch A's checkout, but A has a commit")
 	}
 }

--- a/internal/cli/state_from_root_test.go
+++ b/internal/cli/state_from_root_test.go
@@ -220,6 +220,8 @@ func setupStandaloneSplitWorkflow(t *testing.T, root, relPath, slug string) (wor
 		t.Fatal(err)
 	}
 	git(t, checkout, "init", "-q")
+	git(t, checkout, "config", "user.email", "t@t")
+	git(t, checkout, "config", "user.name", "t")
 	if err := os.WriteFile(filepath.Join(checkout, slug+".md"),
 		[]byte("---\nstatus: ideation\n---\n# "+slug+"\n"), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/cli/state_sync.go
+++ b/internal/cli/state_sync.go
@@ -383,7 +383,7 @@ func parseStateCommitArgs(args []string, dir string, stderr io.Writer) (slug, wo
 		fmt.Fprintln(stderr, "spacedock state commit: missing required <slug> argument")
 		return "", "", "", false, 2
 	}
-	workflowDir, code = resolveWorkflowDir("state commit", workflowDir, dir, stderr)
+	workflowDir, code = resolveWorkflowDir(workflowDir, dir, stderr)
 	return slug, workflowDir, msg, jsonOut, code
 }
 
@@ -407,21 +407,17 @@ func parseWorkflowJSONArgs(command string, args []string, dir string, stderr io.
 			return "", false, 2
 		}
 	}
-	workflowDir, code = resolveWorkflowDir(command, workflowDir, dir, stderr)
+	workflowDir, code = resolveWorkflowDir(workflowDir, dir, stderr)
 	return workflowDir, jsonOut, code
 }
 
 // resolveWorkflowDir resolves the workflow dir: an explicit relative --workflow-dir
-// is joined against dir; an empty one is discovered from dir. Mirrors the
-// init/new arg handling so all four state verbs agree on workflow discovery.
-func resolveWorkflowDir(command, workflowDir, dir string, stderr io.Writer) (string, int) {
+// is joined against dir; an empty one is discovered from dir via the shared
+// walk-up + downward-fallback resolver, the same one status/new/merge guard use —
+// so all five state verbs agree on workflow discovery.
+func resolveWorkflowDir(workflowDir, dir string, stderr io.Writer) (string, int) {
 	if workflowDir == "" {
-		discovered, ok := status.DiscoverWorkflowDir(dir)
-		if !ok {
-			fmt.Fprintf(stderr, "spacedock %s: no workflow here — pass --workflow-dir or run inside a workflow\n", command)
-			return "", 1
-		}
-		return discovered, 0
+		return status.ResolveWorkflowDir(dir, stderr)
 	}
 	if !filepath.IsAbs(workflowDir) {
 		return filepath.Join(dir, workflowDir), 0

--- a/internal/status/discover_walkup.go
+++ b/internal/status/discover_walkup.go
@@ -3,6 +3,7 @@
 package status
 
 import (
+	"io"
 	"path/filepath"
 	"strings"
 )
@@ -32,6 +33,20 @@ func DiscoverWorkflowDir(startDir string) (string, bool) {
 		}
 		d = parent
 	}
+}
+
+// ResolveWorkflowDir resolves the workflow directory when no --workflow-dir (or
+// PIPELINE_DIR/--root) override applies: walk up from dir to the enclosing
+// commissioned workflow via DiscoverWorkflowDir, falling back to a downward scan
+// from the git toplevel when the walk-up misses. Exactly one downward match
+// resolves; zero or multiple matches write a named diagnostic to stderr and
+// return a non-zero code. Shared by status dispatch, merge guard, and the state
+// verbs so every no-flag invocation agrees on discovery.
+func ResolveWorkflowDir(dir string, stderr io.Writer) (string, int) {
+	if discovered, ok := DiscoverWorkflowDir(dir); ok {
+		return discovered, 0
+	}
+	return discoverWorkflowDownward(dir, stderr)
 }
 
 // stateCheckoutParent reports whether pointedDir is the state checkout of an

--- a/internal/status/merge.go
+++ b/internal/status/merge.go
@@ -72,13 +72,11 @@ func MergeGuard(args []string, dir string, stdout, stderr io.Writer) int {
 
 	pipelineDir := workflowDir
 	if pipelineDir == "" {
-		if discovered, ok := DiscoverWorkflowDir(dir); ok {
-			pipelineDir = discovered
-		} else if resolved, rc := discoverWorkflowDownward(dir, stderr); rc != 0 {
+		resolved, rc := ResolveWorkflowDir(dir, stderr)
+		if rc != 0 {
 			return rc
-		} else {
-			pipelineDir = resolved
 		}
+		pipelineDir = resolved
 	}
 
 	roots, err := resolveRoots(pipelineDir, dir)

--- a/internal/status/native_runner.go
+++ b/internal/status/native_runner.go
@@ -73,13 +73,11 @@ func dispatch(probe claudeteam.TeamStateProbe, args []string, dir string, e env,
 		pipelineDir = e.get("PIPELINE_DIR")
 	}
 	if pipelineDir == "" && rootPath == "" {
-		if discovered, ok := DiscoverWorkflowDir(dir); ok {
-			pipelineDir = discovered
-		} else if resolved, rc := discoverWorkflowDownward(dir, stderr); rc != 0 {
+		resolved, rc := ResolveWorkflowDir(dir, stderr)
+		if rc != 0 {
 			return rc
-		} else {
-			pipelineDir = resolved
 		}
+		pipelineDir = resolved
 	}
 
 	setResult, err := parseSetArgs(args)


### PR DESCRIPTION
Bare `spacedock state ready`/`sweep`/`commit` now auto-discover the lone commissioned workflow, ending the fail-then-retry papercut at every FO boot.

## What changed
- Extract the walk-up + downward discovery combo into one exported resolver in internal/status
- Route all five state verbs, status dispatch, and merge guard through it
- Remove the duplicated inline discovery from state init/new
- Add from-root CLI tests, explicit-flag precedence pin, and two-workflow refusal

## Evidence
- `go test ./...` 16/16 packages passed; `-race` green on cli/status packages
- Baseline-vs-fixed binary drive: each bare verb completes in 1 invocation (was fail+retry); all audit mutants killed after cycle-1 pins

---
[82e](/spacedock-dev/spacedock/blob/8000f6d7656d0210c21cf9a404d626076095cd06/state-subcommand-workflow-autodiscovery.md)