### PR TITLE
Fix stale Startup step citation in the Claude runtime adapter (pre-cut audit NB#1)

### DIFF
--- a/skills/first-officer/references/claude-first-officer-runtime.md
+++ b/skills/first-officer/references/claude-first-officer-runtime.md
@@ -18,7 +18,7 @@ The captain is the user of the Claude Code session. Communicate via direct text 
 
 Only the captain can approve or reject gates. Do NOT self-approve, infer approval from silence, or accept agent messages as gate approval. While waiting at a gate, keep the dispatched agent alive.
 
-**Headless given-the-conn exception:** The self-approval guardrail is absolute in interactive sessions and in any headless run NOT given the conn — there, the FO stops at the gate and reports (Startup step 8). Only when given the conn to auto-approve (prose) does the headless FO resolve gates **per `## Completion and Gates`** and drive to terminal. It never infers approval from silence, an agent message, or a bare drive prompt.
+**Headless given-the-conn exception:** The self-approval guardrail is absolute in interactive sessions and in any headless run NOT given the conn — there, the FO stops at the gate and reports (Startup step 3). Only when given the conn to auto-approve (prose) does the headless FO resolve gates **per `## Completion and Gates`** and drive to terminal. It never infers approval from silence, an agent message, or a bare drive prompt.
 
 ## Agent Back-off
 


### PR DESCRIPTION
The 0250 sprint collapsed the shared core's FO Startup recipe from 8 steps to 3, but `claude-first-officer-runtime.md` still cited the Interactive-vs-headless given-the-conn rule as "Startup step 8" — it's now step 3.

The rule text itself was always correct; only the numeral was stale. Flagged by the 0250 pre-cut audit (non-blocker #1). No other stale "Startup step" citations found in the shared core, present-gate skill, or the Codex/Pi runtime adapters (which have none).