### PR TITLE
Edge channel survives the stable-cut window (no binary/skills minor skew between a stable tag and the first prerelease)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,14 @@ jobs:
           # GITHUB_TOKEN cannot write to another repository).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # Defensive pin of the version goreleaser stamps into the binary. On the
+          # auto-cut vX.(Y+1).0-pre0 run the commit carries BOTH that pre0 tag and
+          # the stable vX.Y.0 tag; goreleaser 2.16 already picks the highest-semver
+          # tag pointing at HEAD (the pre0 tag) with no override, so this only makes
+          # the choice explicit — harmless on a single-tag run, deterministic on the
+          # dual-tagged one. Not load-bearing (measured with AND without in the CI
+          # dry-run spike); belt-and-suspenders against a future resolution change.
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       # AC-4: stamp the plugin manifests' `version` to the release so the host
       # plugin panel (`claude plugin list --json`) displays a version that tracks
@@ -301,11 +309,33 @@ jobs:
         with:
           go-version: "1.22"
 
+      # Decide whether this tag advances the edge line AT ALL, gating the whole
+      # job. edge-advance-decision computes the tag's target edge version
+      # (dev-preversion for a stable tag; the tag's own version for a -pre tag)
+      # and prints `advance` only when that is STRICTLY greater than origin/next's
+      # current manifest version. An old-line / patch tag prints `skip`, and EVERY
+      # downstream step gates on this output, so the whole job no-ops: no
+      # `-X theirs` clobber of next's newer content, no manifest/gate-line rewind,
+      # no marketplace calendar re-pull, and no colliding pre0 auto-tag.
+      - name: Decide whether this tag advances the edge line
+        id: decision
+        run: |
+          set -euo pipefail
+          git fetch origin next
+          NEXT_PLUGIN="$(mktemp)"
+          git show origin/next:.claude-plugin/plugin.json > "$NEXT_PLUGIN"
+          if [ "$(go run ./cmd/spacedock-release edge-advance-decision "$GITHUB_REF_NAME" "$NEXT_PLUGIN")" = "advance" ]; then
+            echo "advance=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "advance=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::edge-advance SKIPPED for $GITHUB_REF_NAME: its target edge version is not strictly greater than next's current manifest version (an old-line/patch tag); next's tip is left untouched"
+          fi
+
       # Prerelease (`-pre`) tag: reconcile `next` to the tagged commit's content,
       # favoring the release over whatever `next` drifted to. The manifests inherit
       # the tag's version; the calendar bump below makes installers re-pull.
       - name: Reconcile the edge line to the prerelease commit
-        if: "contains(github.ref, '-')"
+        if: "contains(github.ref, '-') && steps.decision.outputs.advance == 'true'"
         run: |
           set -euo pipefail
           RELEASE_COMMIT="$(git rev-list -1 "$GITHUB_REF_NAME")"
@@ -320,7 +350,7 @@ jobs:
       # PAST the release to the post-release dev pre-version (X.(Y+1).0-pre1), so
       # the edge line never masquerades as the stable version it just shipped.
       - name: Reconcile the edge line past the stable release
-        if: "!contains(github.ref, '-')"
+        if: "!contains(github.ref, '-') && steps.decision.outputs.advance == 'true'"
         run: |
           set -euo pipefail
           RELEASE_COMMIT="$(git rev-list -1 "$GITHUB_REF_NAME")"
@@ -338,11 +368,15 @@ jobs:
           git commit -m "next: bump dev pre-version to $DEV_VERSION" \
             -- .claude-plugin/plugin.json .codex-plugin/plugin.json "$FO_PROSE"
 
-      # Both paths end here: bump the marketplace calendar key (the moving-branch
-      # re-pull key `claude plugin update` / `codex` read) and fast-forward `next`.
-      # Exactly one reconcile step above ran, so `edge-advance` already carries the
-      # merge (plus, on a stable tag, the dev-preversion stamp).
+      # On an advancing tag both reconcile paths end here: bump the marketplace
+      # calendar key (the moving-branch re-pull key `claude plugin update` /
+      # `codex` read) and fast-forward `next`. Exactly one reconcile step above
+      # ran, so `edge-advance` already carries the merge (plus, on a stable tag,
+      # the dev-preversion stamp). Gated on the same advance decision: an old-line
+      # / patch tag skips this bump too, so the calendar key — the thing every edge
+      # installer polls — is left untouched and no re-pull is triggered (AC-2d).
       - name: Bump the marketplace calendar key and push the edge line
+        if: "steps.decision.outputs.advance == 'true'"
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -351,3 +385,35 @@ jobs:
           git commit -m "next: bump marketplace calendar version" \
             -- .claude-plugin/marketplace.json
           git push origin edge-advance:next
+
+      # Always-cut-pre0 (latest-line stable tag only, same advance gate): auto-cut
+      # an ANNOTATED vX.(Y+1).0-pre0 tag ON THE GREENED RELEASE COMMIT (the SHA
+      # e2e-gate already greened and the stable stamp resolved) and push it via the
+      # re-triggering PAT. That tag's own release run resolves the SAME green e2e
+      # run (same commit), builds+publishes the X.(Y+1)-minor edge binary, and
+      # bumps the spacedock@next cask — closing the post-stable-cut window in
+      # minutes instead of waiting for the next hand-cut prerelease. The tag MUST be
+      # annotated with a non-empty body: the release-notes extraction step
+      # (above, in goreleaser) hard-errors on a lightweight/empty-body tag before
+      # the binary builds. The push MUST use the PAT: a push authenticated with the
+      # default GITHUB_TOKEN deliberately does NOT trigger further workflow runs, so
+      # the pre0 build would never start. Recursion terminates at one level — the
+      # pre0 tag routes to the prerelease path, whose edge-advance-decision skips
+      # (pre0 < next's pre1), so it neither re-tags nor rewinds `next`.
+      - name: Auto-cut the edge prerelease tag on the greened release commit
+        if: "!contains(github.ref, '-') && steps.decision.outputs.advance == 'true'"
+        env:
+          # PAT (HOMEBREW_TAP_TOKEN-class) so the tag push RE-TRIGGERS release.yml;
+          # the default GITHUB_TOKEN cannot fire a workflow from within a run.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          RELEASE_COMMIT="$(git rev-list -1 "$GITHUB_REF_NAME")"
+          RELEASE_VERSION="${GITHUB_REF_NAME#v}"
+          PRE0_VERSION="$(go run ./cmd/spacedock-release edge-pre0-version "$RELEASE_VERSION")"
+          PRE0_TAG="v$PRE0_VERSION"
+          PRE0_BODY="Edge prerelease auto-cut with stable $GITHUB_REF_NAME: publishes the ${PRE0_VERSION%.*}-line edge binary so spacedock@next realigns with next's post-release skills. No standalone changes."
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$PRE0_TAG" "$RELEASE_COMMIT" -m "$PRE0_BODY"
+          git push "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PRE0_TAG"

--- a/cmd/spacedock-release/edge_advance_decision.go
+++ b/cmd/spacedock-release/edge_advance_decision.go
@@ -1,0 +1,69 @@
+// ABOUTME: `edge-advance-decision` prints advance/skip gating the whole edge-advance
+// ABOUTME: job; `edge-pre0-version` prints the auto-cut edge prerelease version.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spacedock-dev/spacedock/internal/release"
+)
+
+// edgeAdvanceDecision decides whether a tag advances the edge line or skips the
+// whole edge-advance job, given `next`'s current manifest. It prints `advance`
+// or `skip` to stdout (exit 0 for BOTH — a skip is a normal outcome, not an
+// error) so release.yml's decision step can write advance=true|false to
+// $GITHUB_OUTPUT and gate every downstream step on it. A missing/unparseable
+// manifest or a malformed tag/version is a real error (non-zero), so a miswiring
+// fails loud rather than silently skipping and leaving the edge channel broken.
+func edgeAdvanceDecision(args []string) int {
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "spacedock-release edge-advance-decision: need <tag> <next-plugin.json>")
+		return 2
+	}
+	tag, manifestPath := args[0], args[1]
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read %s: %v\n", manifestPath, err)
+		return 1
+	}
+	nextVersion, err := release.ManifestVersion(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse %s: %v\n", manifestPath, err)
+		return 1
+	}
+	if nextVersion == "" {
+		fmt.Fprintf(os.Stderr, "edge-advance-decision: %s carries no top-level version\n", manifestPath)
+		return 1
+	}
+	advance, target, err := release.EdgeAdvanceDecision(tag, nextVersion)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "edge-advance-decision: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "tag %s target edge version %s vs next %s\n", tag, target, nextVersion)
+	if advance {
+		fmt.Println("advance")
+	} else {
+		fmt.Println("skip")
+	}
+	return 0
+}
+
+// edgePre0Version prints the auto-cut edge prerelease version (X.(Y+1).0-pre0)
+// for a bare stable version, so release.yml's always-cut-pre0 step forms the
+// `vX.(Y+1).0-pre0` annotated tag. It errors on a hyphenated/malformed input,
+// since it runs only on the stable path that already guarantees a bare X.Y.Z.
+func edgePre0Version(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "spacedock-release edge-pre0-version: need exactly one <stable-version> (e.g. 0.25.0)")
+		return 2
+	}
+	version, err := release.Pre0EdgeVersion(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "edge-pre0-version: %v\n", err)
+		return 1
+	}
+	fmt.Println(version)
+	return 0
+}

--- a/cmd/spacedock-release/edge_advance_decision_test.go
+++ b/cmd/spacedock-release/edge_advance_decision_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeNextPlugin writes a plugin.json carrying version to a temp file and
+// returns its path — the `<next-plugin.json>` the decision subcommand reads (the
+// workflow pipes `git show origin/next:.claude-plugin/plugin.json` into it).
+func writeNextPlugin(t *testing.T, version string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "plugin.json")
+	body := "{\n  \"name\": \"spacedock\",\n  \"version\": \"" + version + "\"\n}\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write next plugin.json: %v", err)
+	}
+	return path
+}
+
+// TestEdgeAdvanceDecisionCommandPrintsVerdict — the subcommand's contract IS its
+// stdout: release.yml's decision step captures `advance`/`skip` and writes
+// advance=true|false to $GITHUB_OUTPUT. A forward stable cut advances; an
+// old-line patch whose target edge version is not strictly greater than next's
+// manifest skips. Exit is 0 for BOTH verdicts (a skip is a normal outcome).
+func TestEdgeAdvanceDecisionCommandPrintsVerdict(t *testing.T) {
+	cases := []struct {
+		name string
+		tag  string
+		next string
+		want string
+	}{
+		{"forward stable advances", "v0.26.0", "0.26.0-pre1", "advance"},
+		{"old-line patch skips", "v0.25.1", "0.27.0-pre1", "skip"},
+		{"patch-equality skips", "v0.25.1", "0.26.0-pre1", "skip"},
+		{"pre0 vs next pre1 skips", "v0.26.0-pre0", "0.26.0-pre1", "skip"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			plugin := writeNextPlugin(t, c.next)
+			out, code := captureStdout(t, func() int { return edgeAdvanceDecision([]string{c.tag, plugin}) })
+			if code != 0 {
+				t.Fatalf("edge-advance-decision exit = %d, want 0", code)
+			}
+			if got := strings.TrimSpace(out); got != c.want {
+				t.Fatalf("edge-advance-decision(%q, next=%q) stdout = %q, want %q", c.tag, c.next, got, c.want)
+			}
+		})
+	}
+}
+
+// TestEdgeAdvanceDecisionCommandRejectsBadArgs — a missing manifest path or a
+// wrong arg count is a usage/IO error (non-zero), so a release.yml miswiring
+// fails loud rather than silently defaulting to skip (which would leave the edge
+// channel broken with no signal).
+func TestEdgeAdvanceDecisionCommandRejectsBadArgs(t *testing.T) {
+	if code := edgeAdvanceDecision([]string{"v0.26.0"}); code == 0 {
+		t.Fatalf("edge-advance-decision exit = 0 with one argument; want non-zero")
+	}
+	if code := edgeAdvanceDecision([]string{"v0.26.0", filepath.Join(t.TempDir(), "missing.json")}); code == 0 {
+		t.Fatalf("edge-advance-decision exit = 0 on a missing manifest; want non-zero")
+	}
+}
+
+// TestEdgePre0VersionCommandPrintsComputedVersion — the subcommand prints exactly
+// X.(Y+1).0-pre0, so release.yml's always-cut-pre0 step forms `vX.(Y+1).0-pre0`
+// as the annotated auto-tag, whose minor matches the required minor next's skills
+// were stamped to.
+func TestEdgePre0VersionCommandPrintsComputedVersion(t *testing.T) {
+	out, code := captureStdout(t, func() int { return edgePre0Version([]string{"0.25.0"}) })
+	if code != 0 {
+		t.Fatalf("edge-pre0-version exit = %d, want 0 on a bare stable semver", code)
+	}
+	if got := strings.TrimSpace(out); got != "0.26.0-pre0" {
+		t.Fatalf("edge-pre0-version stdout = %q, want 0.26.0-pre0", got)
+	}
+	if code := edgePre0Version([]string{"0.25.0-pre1"}); code == 0 {
+		t.Fatalf("edge-pre0-version exit = 0 on a hyphenated input; want non-zero")
+	}
+}

--- a/cmd/spacedock-release/main.go
+++ b/cmd/spacedock-release/main.go
@@ -32,7 +32,13 @@ import (
 // erroring unless the literal appears exactly once. bump-calendar advances the
 // marketplace plugin entry's calendar key to today's `0.0.YYYYMMDDNN` (AC-2d).
 // All rewrite in place. dev-preversion prints the post-release dev pre-version
-// (X.(Y+1).0-pre1) the stable-tag edge advance stamps onto `next`. journey-delta
+// (X.(Y+1).0-pre1) the stable-tag edge advance stamps onto `next`.
+// edge-advance-decision prints `advance` or `skip` (exit 0 either way) deciding
+// whether a tag advances the edge line: it computes the tag's target edge
+// version and skips unless that is strictly greater than `next`'s current
+// manifest, so the whole edge-advance job no-ops on an old-line/patch tag.
+// edge-pre0-version prints the auto-cut edge prerelease version (X.(Y+1).0-pre0)
+// the stable path tags on the greened release commit. journey-delta
 // renders and posts the per-PR journey-cost delta against the previously
 // published release ledger's latest-by-captured_at baseline per scenario/model,
 // updating a single sticky PR comment found by its HTML marker. The AC-4
@@ -63,6 +69,10 @@ func main() {
 		os.Exit(bumpCalendar(os.Args[2:]))
 	case "dev-preversion":
 		os.Exit(devPreversion(os.Args[2:]))
+	case "edge-advance-decision":
+		os.Exit(edgeAdvanceDecision(os.Args[2:]))
+	case "edge-pre0-version":
+		os.Exit(edgePre0Version(os.Args[2:]))
 	case "journey-costs":
 		os.Exit(journeyCosts(os.Args[2:]))
 	case "journey-delta":
@@ -374,6 +384,8 @@ Usage:
   spacedock-release stamp-version <release-version> <manifest-or-prose> [<manifest-or-prose> ...]
   spacedock-release bump-calendar <marketplace.json>
   spacedock-release dev-preversion <stable-version>
+  spacedock-release edge-advance-decision <tag> <next-plugin.json>
+  spacedock-release edge-pre0-version <stable-version>
   spacedock-release journey-costs <release-version> --metrics-dir <dir> --out <path>
   spacedock-release journey-delta <previous-ledger.json> --metrics-dir <dir> --pr <number>
   spacedock-release e2e-gate <release-commit-sha>

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -168,11 +168,38 @@ rare conflict here cannot unwind or block the release that already published):
   re-pull. This is the automated form of the manual reconcile the 0.24.0-pre1
   cut required (`next` had drifted 40 commits behind `main`, hard-blocking
   `spacedock codex` on a binary/plugin version-compat check).
-- **Stable (`vX.Y.Z`) tag:** `next` is reconciled the same way, then stamped
-  PAST the release to the post-release dev pre-version
-  (`spacedock-release dev-preversion X.Y.Z` → `X.(Y+1).0-pre1`), so the edge
-  line never masquerades as the stable version it just shipped, then the
-  calendar key is bumped.
+- **Stable (`vX.Y.Z`) tag, latest line:** `next` is reconciled the same way,
+  stamped PAST the release to `X.(Y+1).0-pre1`
+  (`spacedock-release dev-preversion X.Y.Z`) so the edge line never masquerades
+  as the stable version it just shipped, and the calendar key is bumped — then an
+  ANNOTATED `vX.(Y+1).0-pre0` tag is auto-created **on the greened release commit**
+  and pushed (via the re-triggering tap PAT). That prerelease tag's own release
+  run reuses the greened commit's e2e-gate pass, builds+publishes the `X.(Y+1)`-minor
+  edge binary, and bumps the `spacedock@next` cask — so the edge binary's minor
+  catches up to the skills' gate line within minutes instead of waiting for the
+  next hand-cut prerelease. The auto-tag MUST be annotated with a non-empty body
+  (the release-notes extraction step rejects a lightweight tag), and MUST be
+  pushed with the PAT (a `GITHUB_TOKEN` push does not fire the pre0 build). Expect
+  two GitHub releases per stable cut.
+- **Old-line / patch (`vX.Y.1`, or any tag whose target edge version is not
+  strictly greater than `next`'s current manifest version):** the whole
+  `edge-advance` job SKIPS (`spacedock-release edge-advance-decision` prints
+  `skip`, logged as a `::notice::`; every downstream step is gated on the
+  decision). `next`'s tip — content, manifests, gate line, and the marketplace
+  calendar key — is left untouched, so no edge installer re-pulls. The patch
+  updates only the stable cask; its fix reaches edge through the normal
+  `main`→`next` flow, never through a `-X theirs` reconcile that would clobber
+  `next`'s newer `(Y+1)`-line content or rewind its manifest/gate line. The
+  auto-pre0 step is stable-latest-line-only and decision-gated, so a patch never
+  attempts a colliding pre0 tag.
+
+The `vX.(Y+1).0-pre0` release run does not recurse: its `-pre0` tag routes to the
+prerelease path, whose `edge-advance-decision` skips (`pre0 < next`'s `pre1`), and
+the auto-pre0 step runs only on the stable path — so it neither re-tags nor
+rewinds `next`. goreleaser stamps the edge binary from the highest tag pointing at
+the commit (`git tag --points-at HEAD --sort -version:refname`), which is the
+`-pre0` tag, so the `X.(Y+1)` binary version is correct without an override; a
+`GORELEASER_CURRENT_TAG` pin is set on the goreleaser step as belt-and-suspenders.
 
 The reconcile is a merge, never a reset or force-push: the previous `next` tip
 is always a first-parent ancestor of the new commit, so `git push origin

--- a/internal/release/edge_advance_decision.go
+++ b/internal/release/edge_advance_decision.go
@@ -1,0 +1,173 @@
+// ABOUTME: Edge-advance line-ordering guard — orders X.Y.Z / X.Y.Z-preN versions
+// ABOUTME: and decides whether a tag advances `next` or skips the whole job.
+package release
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// preVersionRe matches X.Y.Z with an optional semver prerelease suffix
+// (`-<identifiers>`). The prerelease is captured whole and ordered per semver
+// §11 by comparePrerelease; build metadata is not part of the release scheme
+// this tool cuts, so `+meta` is not accepted.
+var preVersionRe = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$`)
+
+// parsePreVersion splits a version into its X.Y.Z core and its prerelease string
+// (empty for a plain stable). It errors on anything that is not X.Y.Z or
+// X.Y.Z-<prerelease>, so the decision guard fails loudly on a malformed version
+// rather than treating it as equal (which would silently skip).
+func parsePreVersion(v string) (core [3]int, pre string, err error) {
+	m := preVersionRe.FindStringSubmatch(v)
+	if m == nil {
+		return core, "", fmt.Errorf("version %q is not X.Y.Z or X.Y.Z-preN", v)
+	}
+	for i := 0; i < 3; i++ {
+		core[i], _ = strconv.Atoi(m[i+1])
+	}
+	return core, m[4], nil
+}
+
+// ComparePreVersion orders two release versions of the shape X.Y.Z or
+// X.Y.Z-<prerelease>, returning -1, 0, or 1 (a<b, a==b, a>b). The X.Y.Z core
+// dominates; when cores are equal a version WITHOUT a prerelease outranks one
+// WITH it (0.26.0 > 0.26.0-pre1, semver §11), and two prereleases compare by
+// their dot-separated identifiers with numeric identifiers ordered numerically
+// (so pre0 < pre1 and pre2 < pre10 — the exact distinction the recursion-skip
+// needs and contract.semverCompare, dotted-int only, cannot make). Errors on a
+// version neither side can parse.
+func ComparePreVersion(a, b string) (int, error) {
+	ca, pa, err := parsePreVersion(a)
+	if err != nil {
+		return 0, err
+	}
+	cb, pb, err := parsePreVersion(b)
+	if err != nil {
+		return 0, err
+	}
+	for i := 0; i < 3; i++ {
+		if ca[i] != cb[i] {
+			return sign(ca[i] - cb[i]), nil
+		}
+	}
+	return comparePrerelease(pa, pb), nil
+}
+
+// comparePrerelease orders two prerelease strings. An absent prerelease outranks
+// a present one (a stable release is greater than its own prereleases, semver
+// §11), so the empty string ranks highest. Two present prereleases compare
+// naturally: embedded digit runs order NUMERICALLY, so this scheme's `preN`
+// labels sort pre0 < pre1 < pre2 < pre10 rather than lexically (`pre10 < pre2`),
+// which is the exact distinction the recursion-skip needs and would silently
+// break past pre9 under a plain ASCII compare.
+func comparePrerelease(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a == "" {
+		return 1 // stable release > any prerelease
+	}
+	if b == "" {
+		return -1
+	}
+	return naturalCompare(a, b)
+}
+
+// naturalCompare orders two strings chunk by chunk, where a chunk is a maximal
+// run of digits or of non-digits: two digit runs compare numerically, two
+// non-digit runs by ASCII, and a shorter string ranks below a longer one when
+// all shared chunks are equal. A digit run and a non-digit run at the same
+// position fall back to a byte compare of the remaining strings (a shape this
+// scheme's `preN` prereleases never produce).
+func naturalCompare(a, b string) int {
+	for a != "" && b != "" {
+		aDigit, bDigit := isDigit(a[0]), isDigit(b[0])
+		if aDigit != bDigit {
+			return strings.Compare(a, b)
+		}
+		aChunk, aRest := splitChunk(a, aDigit)
+		bChunk, bRest := splitChunk(b, bDigit)
+		if aDigit {
+			an, _ := strconv.Atoi(aChunk)
+			bn, _ := strconv.Atoi(bChunk)
+			if an != bn {
+				return sign(an - bn)
+			}
+		} else if c := strings.Compare(aChunk, bChunk); c != 0 {
+			return c
+		}
+		a, b = aRest, bRest
+	}
+	return sign(len(a) - len(b))
+}
+
+// splitChunk peels the leading maximal run of digits (or of non-digits, per
+// digit) off s, returning the chunk and the remainder.
+func splitChunk(s string, digit bool) (chunk, rest string) {
+	i := 0
+	for i < len(s) && isDigit(s[i]) == digit {
+		i++
+	}
+	return s[:i], s[i:]
+}
+
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+
+func sign(n int) int {
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// EdgeAdvanceDecision decides whether the edge-advance job should ADVANCE `next`
+// (reconcile + stamp + calendar bump + auto-cut pre0) or SKIP the whole job for
+// the given tag, given `next`'s current manifest version. It computes the tag's
+// TARGET EDGE VERSION — the version `next` would carry after this tag's
+// reconcile: dev-preversion(tag) for a bare stable vX.Y.Z (`next` is stamped
+// PAST the release), or the tag's own version for a `-pre` tag (`next` inherits
+// it through the `-X theirs` reconcile) — and returns advance iff that target is
+// STRICTLY GREATER than nextVersion. A patch cut from an older line yields a
+// target at or below `next`'s current line, so it skips, leaving `next`'s tip
+// untouched: no `-X theirs` clobber, no manifest/gate-line rewind, no colliding
+// pre0 tag, no calendar re-pull. The boundary is strict `>`, not `>=`: a patch
+// whose target exactly equals `next` (dev-preversion(vX.Y.1) == next) must skip.
+func EdgeAdvanceDecision(tag, nextVersion string) (advance bool, targetEdge string, err error) {
+	version := strings.TrimPrefix(tag, "v")
+	if strings.Contains(version, "-") {
+		// A prerelease tag: `next` would inherit the tag's own version.
+		targetEdge = version
+	} else {
+		// A bare stable tag: `next` is stamped PAST it to the dev pre-version.
+		targetEdge, err = DevPreVersion(version)
+		if err != nil {
+			return false, "", err
+		}
+	}
+	cmp, err := ComparePreVersion(targetEdge, nextVersion)
+	if err != nil {
+		return false, "", err
+	}
+	return cmp > 0, targetEdge, nil
+}
+
+// Pre0EdgeVersion computes the auto-cut edge prerelease version for a latest-line
+// stable cut — X.(Y+1).0-pre0 — derived from the SAME dev-preversion the stable
+// path stamps into `next` (X.(Y+1).0-pre1), swapping only the trailing label. So
+// the pre0 tag's minor equals the required binary minor next's skills demand BY
+// CONSTRUCTION, and the pre0 edge binary passes the minor-exact boot gate under
+// the pre1-stamped skills (AC-1). release.yml's stable path prepends `v` to form
+// the annotated auto-tag.
+func Pre0EdgeVersion(stableVersion string) (string, error) {
+	dev, err := DevPreVersion(stableVersion)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(dev, "-pre1") + "-pre0", nil
+}

--- a/internal/release/edge_advance_decision_test.go
+++ b/internal/release/edge_advance_decision_test.go
@@ -1,0 +1,135 @@
+// ABOUTME: Unit proof for the edge-advance line-ordering guard — ComparePreVersion
+// ABOUTME: ordering, the advance/skip decision table, and the pre0/required-minor algebra.
+package release
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestComparePreVersionOrders locks the prerelease-aware ordering the decision
+// guard needs and contract.semverCompare cannot give (it is dotted-int only and
+// fails to parse `-preN`). Core X.Y.Z dominates; a release outranks the same
+// core's prerelease (semver §11); two `-preN` order by NUMERIC N, so pre0 < pre1
+// and pre2 < pre10 (a lexical compare would wrongly put pre10 before pre2).
+func TestComparePreVersionOrders(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"0.26.0-pre1", "0.26.0", -1}, // release > prerelease of same core
+		{"0.26.0", "0.26.0-pre1", 1},
+		{"0.26.0-pre1", "0.26.0-pre2", -1},  // pre1 < pre2
+		{"0.26.0-pre0", "0.26.0-pre1", -1},  // the recursion-skip's pre0 < pre1
+		{"0.26.0-pre2", "0.26.0-pre10", -1}, // numeric, not lexical
+		{"0.27.0-pre1", "0.26.0", 1},        // core dominates the prerelease label
+		{"0.26.0", "0.27.0-pre1", -1},
+		{"1.0.0", "0.27.0-pre1", 1}, // major dominates
+		{"0.26.0-pre1", "0.26.0-pre1", 0},
+		{"0.26.0", "0.26.0", 0},
+	}
+	for _, c := range cases {
+		got, err := ComparePreVersion(c.a, c.b)
+		if err != nil {
+			t.Errorf("ComparePreVersion(%q, %q) errored: %v", c.a, c.b, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ComparePreVersion(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+		// Antisymmetry: swapping the operands negates the sign.
+		rev, err := ComparePreVersion(c.b, c.a)
+		if err != nil {
+			t.Errorf("ComparePreVersion(%q, %q) errored: %v", c.b, c.a, err)
+			continue
+		}
+		if rev != -c.want {
+			t.Errorf("ComparePreVersion(%q, %q) = %d, want %d (antisymmetry)", c.b, c.a, rev, -c.want)
+		}
+	}
+}
+
+// TestComparePreVersionRejectsMalformed proves a version that is not X.Y.Z or
+// X.Y.Z-<prerelease> errors rather than silently comparing as 0 (which would
+// make the decision guard skip on garbage instead of failing loudly).
+func TestComparePreVersionRejectsMalformed(t *testing.T) {
+	for _, bad := range []string{"", "0.26", "0.26.0.1", "v0.26.0", "garbage", "0.x.0"} {
+		if _, err := ComparePreVersion(bad, "0.26.0"); err == nil {
+			t.Errorf("ComparePreVersion(%q, …) accepted a malformed version", bad)
+		}
+		if _, err := ComparePreVersion("0.26.0", bad); err == nil {
+			t.Errorf("ComparePreVersion(…, %q) accepted a malformed version", bad)
+		}
+	}
+}
+
+// TestEdgeAdvanceDecision locks the guard's forward-fires / backward-skips table,
+// including the three patch-equality skip-cases: a patch cut whose target edge
+// version (dev-preversion of the patch) EQUALS next's current manifest must SKIP,
+// because the boundary is strict `>` (an `>=` boundary would fire on that
+// equality and clobber next via the `-X theirs` reconcile).
+func TestEdgeAdvanceDecision(t *testing.T) {
+	cases := []struct {
+		name        string
+		tag         string
+		next        string
+		wantAdvance bool
+		wantTarget  string
+	}{
+		{"forward stable", "v0.26.0", "0.26.0-pre1", true, "0.27.0-pre1"},
+		{"forward prerelease", "v0.26.0-pre2", "0.26.0-pre1", true, "0.26.0-pre2"},
+		{"major bump", "v1.0.0", "0.27.0-pre1", true, "1.1.0-pre1"},
+		{"old-line patch, next ahead", "v0.25.1", "0.27.0-pre1", false, "0.26.0-pre1"},
+		{"pre0 vs next pre1", "v0.26.0-pre0", "0.26.0-pre1", false, "0.26.0-pre0"},
+		// The three patch-equality skip-cases: dev-preversion(tag) == next.
+		{"equality skip: v0.25.1 vs 0.26.0-pre1", "v0.25.1", "0.26.0-pre1", false, "0.26.0-pre1"},
+		{"equality skip: v0.26.1 vs 0.27.0-pre1", "v0.26.1", "0.27.0-pre1", false, "0.27.0-pre1"},
+		{"equality skip: v1.0.9 vs 1.1.0-pre1", "v1.0.9", "1.1.0-pre1", false, "1.1.0-pre1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			advance, target, err := EdgeAdvanceDecision(c.tag, c.next)
+			if err != nil {
+				t.Fatalf("EdgeAdvanceDecision(%q, %q) errored: %v", c.tag, c.next, err)
+			}
+			if advance != c.wantAdvance {
+				t.Errorf("EdgeAdvanceDecision(%q, %q) advance = %v, want %v", c.tag, c.next, advance, c.wantAdvance)
+			}
+			if target != c.wantTarget {
+				t.Errorf("EdgeAdvanceDecision(%q, %q) target = %q, want %q", c.tag, c.next, target, c.wantTarget)
+			}
+		})
+	}
+}
+
+// TestAutoPre0MinorEqualsRequiredMinor is AC-1's version-algebra proof: for a
+// latest-line stable cut vX.Y.0, the required binary minor stamped into next's
+// prose (dev-preversion → X.(Y+1)) and the auto-cut pre0 tag's own minor
+// (Pre0EdgeVersion → X.(Y+1)) are EQUAL BY CONSTRUCTION — they share the same
+// X.(Y+1).0 core, differing only in the -pre1/-pre0 label. So a pre0 edge binary
+// under pre1-stamped skills passes the minor-exact boot gate. No goreleaser tag
+// resolution is modeled here — the real binary-version measurement is the CI
+// dry-run spike; this pins only the algebra.
+func TestAutoPre0MinorEqualsRequiredMinor(t *testing.T) {
+	for _, stable := range []string{"0.25.0", "0.26.0", "1.0.0", "2.9.0", "0.99.0"} {
+		dev, err := DevPreVersion(stable)
+		if err != nil {
+			t.Fatalf("DevPreVersion(%q): %v", stable, err)
+		}
+		pre0, err := Pre0EdgeVersion(stable)
+		if err != nil {
+			t.Fatalf("Pre0EdgeVersion(%q): %v", stable, err)
+		}
+		if !strings.HasSuffix(dev, "-pre1") {
+			t.Errorf("DevPreVersion(%q) = %q, want a -pre1 suffix", stable, dev)
+		}
+		if !strings.HasSuffix(pre0, "-pre0") {
+			t.Errorf("Pre0EdgeVersion(%q) = %q, want a -pre0 suffix", stable, pre0)
+		}
+		devCore := strings.TrimSuffix(dev, "-pre1")
+		pre0Core := strings.TrimSuffix(pre0, "-pre0")
+		if devCore != pre0Core {
+			t.Errorf("stable %q: required-minor core %q != pre0 core %q — the boot gate would mismatch", stable, devCore, pre0Core)
+		}
+	}
+}

--- a/internal/release/edge_advance_noregress_test.go
+++ b/internal/release/edge_advance_noregress_test.go
@@ -1,0 +1,318 @@
+// ABOUTME: AC-3 proof — an old-line patch cut leaves `next`'s tip byte-identical
+// ABOUTME: under the real decision guard, and clobbers it once the gate is removed.
+package release
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// patchNoRegressFixture builds the AC-3 scenario in a temp git repo: `next` has
+// advanced to the 0.27 dev line with exclusive content (manifest 0.27.0-pre1,
+// FO-prose required minor 0.27, a bumped calendar key), while an OLDER line cuts
+// a vX.Y.1 patch (0.25.1) whose tree would clobber `next` if reconciled. It
+// returns the repo dir, the patch tag, and `next`'s pristine tip so the subtests
+// can prove the guard's decision leaves that tip untouched — and that removing
+// the gate rewinds it.
+type patchNoRegressFixture struct {
+	dir           string
+	patchTag      string
+	releaseCommit string
+	nextTip       string
+	nextVersion   string
+}
+
+func newPatchNoRegressFixture(t *testing.T) patchNoRegressFixture {
+	t.Helper()
+	dir := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		return string(out)
+	}
+	write := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pluginJSON := func(version string) string {
+		return "{\n  \"name\": \"spacedock\",\n  \"version\": \"" + version + "\"\n}\n"
+	}
+	codexJSON := func(version string) string {
+		return "{\n  \"name\": \"spacedock-codex\",\n  \"version\": \"" + version + "\"\n}\n"
+	}
+	prose := func(minor string) string {
+		return "# FO shared core\n\nThese skills require binary minor " + minor + " to boot.\n"
+	}
+	marketplaceJSON := func(cal string) string {
+		return "{\n  \"name\": \"spacedock-edge\",\n  \"plugins\": [\n    {\n      \"name\": \"spacedock\",\n      \"version\": \"" + cal + "\"\n    }\n  ]\n}\n"
+	}
+	const foProse = "skills/first-officer/references/first-officer-shared-core.md"
+
+	git("init", "-q")
+	git("config", "user.email", "test@example.com")
+	git("config", "user.name", "test")
+
+	// Shared ancestor both the old release line and `next` descend from.
+	write(".claude-plugin/plugin.json", pluginJSON("0.24.0-pre1"))
+	write(".codex-plugin/plugin.json", codexJSON("0.24.0-pre1"))
+	write(foProse, prose("0.24"))
+	write(".claude-plugin/marketplace.json", marketplaceJSON("0.0.2026050101"))
+	write("app.txt", "base\n")
+	git("add", "-A")
+	git("commit", "-q", "-m", "seed")
+	git("branch", "-M", "main")
+	git("branch", "next")
+
+	// The OLD line advances to a vX.Y.1 patch (0.25.1) with its own content on the
+	// same files `next` also touches — a genuine divergence a -X theirs reconcile
+	// would resolve in the OLD release's favor.
+	patchVersion := "0.25.1"
+	write("app.txt", "old-line-patch\n")
+	write(".claude-plugin/plugin.json", pluginJSON(patchVersion))
+	write(".codex-plugin/plugin.json", codexJSON(patchVersion))
+	write(foProse, prose("0.25"))
+	git("commit", "-q", "-am", "release: stamp "+patchVersion)
+	releaseCommit := strings.TrimSpace(git("rev-parse", "HEAD"))
+	patchTag := "v" + patchVersion
+	git("tag", "-a", patchTag, releaseCommit, "-m", "patch "+patchVersion)
+
+	// `next` advances PAST the release to the 0.27 dev line with exclusive content.
+	git("switch", "-q", "next")
+	nextVersion := "0.27.0-pre1"
+	write("app.txt", "next-0.27-exclusive\n")
+	write(".claude-plugin/plugin.json", pluginJSON(nextVersion))
+	write(".codex-plugin/plugin.json", codexJSON(nextVersion))
+	write(foProse, prose("0.27"))
+	write(".claude-plugin/marketplace.json", marketplaceJSON("0.0.2026060101"))
+	git("commit", "-q", "-am", "next: advance to 0.27 dev line")
+	nextTip := strings.TrimSpace(git("rev-parse", "HEAD"))
+
+	return patchNoRegressFixture{
+		dir:           dir,
+		patchTag:      patchTag,
+		releaseCommit: releaseCommit,
+		nextTip:       nextTip,
+		nextVersion:   nextVersion,
+	}
+}
+
+// runGuardedEdgeAdvance mirrors release.yml's decision-gated stable path against
+// the fixture repo: it computes the REAL EdgeAdvanceDecision for the tag, and
+// runs the reconcile+stamp+bump ONLY when it says advance. gateRemoved=true drops
+// the gate (the adversarial twin), running the reconcile unconditionally to show
+// the damage the gate prevents. It returns the decision so the caller can assert
+// the guard's verdict.
+func runGuardedEdgeAdvance(t *testing.T, f patchNoRegressFixture, branch string, gateRemoved bool) (advance bool) {
+	t.Helper()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = f.dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		return string(out)
+	}
+	advance, _, err := EdgeAdvanceDecision(f.patchTag, f.nextVersion)
+	if err != nil {
+		t.Fatalf("EdgeAdvanceDecision(%q, %q): %v", f.patchTag, f.nextVersion, err)
+	}
+	if !advance && !gateRemoved {
+		// The gate skips the whole job: `next` is left byte-identical.
+		return advance
+	}
+
+	// The reconcile the stable path runs (guarded), or the ungated adversarial run.
+	git("switch", "-q", "-c", branch, "next")
+	git("merge", "-X", "theirs", "--no-edit", f.releaseCommit, "-m", "next: reconcile edge line to "+f.patchTag)
+	dev, err := DevPreVersion(strings.TrimPrefix(f.patchTag, "v"))
+	if err != nil {
+		t.Fatalf("DevPreVersion: %v", err)
+	}
+	const foProse = "skills/first-officer/references/first-officer-shared-core.md"
+	for _, rel := range []string{".claude-plugin/plugin.json", ".codex-plugin/plugin.json", foProse} {
+		path := filepath.Join(f.dir, rel)
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			t.Fatal(rerr)
+		}
+		var out []byte
+		if strings.HasSuffix(rel, ".md") {
+			out, err = StampProseVersion(data, dev)
+		} else {
+			out, err = StampVersion(data, dev)
+		}
+		if err != nil {
+			t.Fatalf("stamp %s: %v", rel, err)
+		}
+		if werr := os.WriteFile(path, out, 0o644); werr != nil {
+			t.Fatal(werr)
+		}
+	}
+	git("commit", "-q", "-m", "next: bump dev pre-version to "+dev,
+		"--", ".claude-plugin/plugin.json", ".codex-plugin/plugin.json", foProse)
+	mktPath := filepath.Join(f.dir, ".claude-plugin/marketplace.json")
+	mktData, rerr := os.ReadFile(mktPath)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	bumped, berr := BumpCalendarVersion(mktData, time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC))
+	if berr != nil {
+		t.Fatalf("BumpCalendarVersion: %v", berr)
+	}
+	if werr := os.WriteFile(mktPath, bumped, 0o644); werr != nil {
+		t.Fatal(werr)
+	}
+	git("commit", "-q", "-m", "next: bump marketplace calendar version",
+		"--", ".claude-plugin/marketplace.json")
+	return advance
+}
+
+func gitRevParse(t *testing.T, dir, rev string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", rev)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse %s: %v\n%s", rev, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitShow returns the bytes of path as committed on branch (never the working
+// tree), so a branch-scoped read is unaffected by whatever branch is checked out.
+func gitShow(t *testing.T, dir, branch, path string) []byte {
+	t.Helper()
+	cmd := exec.Command("git", "show", branch+":"+path)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git show %s:%s: %v\n%s", branch, path, err, out)
+	}
+	return out
+}
+
+func readEdgeVersionOnBranch(t *testing.T, dir, branch, rel string) string {
+	t.Helper()
+	v, err := ManifestVersion(gitShow(t, dir, branch, rel))
+	if err != nil {
+		t.Fatalf("parse %s on %s: %v", rel, branch, err)
+	}
+	return v
+}
+
+func readEdgeCalendarOnBranch(t *testing.T, dir, branch string) string {
+	t.Helper()
+	var doc struct {
+		Plugins []struct {
+			Version string `json:"version"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(gitShow(t, dir, branch, ".claude-plugin/marketplace.json"), &doc); err != nil {
+		t.Fatalf("parse marketplace.json on %s: %v", branch, err)
+	}
+	if len(doc.Plugins) == 0 {
+		t.Fatalf("marketplace.json on %s has no plugin entry", branch)
+	}
+	return doc.Plugins[0].Version
+}
+
+func gitTagList(t *testing.T, dir string) []string {
+	t.Helper()
+	cmd := exec.Command("git", "tag", "--list")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git tag --list: %v\n%s", err, out)
+	}
+	var tags []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			tags = append(tags, line)
+		}
+	}
+	return tags
+}
+
+func proseMinorOnBranch(t *testing.T, dir, branch string) string {
+	t.Helper()
+	minor, err := ProseMinor(gitShow(t, dir, branch, "skills/first-officer/references/first-officer-shared-core.md"))
+	if err != nil {
+		t.Fatalf("ProseMinor on %s: %v", branch, err)
+	}
+	return minor
+}
+
+// TestEdgeAdvancePatchDoesNotRegressNext (AC-3) proves the decision guard is
+// load-bearing on all four regress counts. Under the real guard an old-line
+// vX.Y.1 patch is decided `skip`, so `next`'s tip is left byte-identical — same
+// commit; no manifest/gate-line rewind; the marketplace calendar key unchanged —
+// and no colliding pre0 tag is cut. The adversarial half removes the gate and
+// runs the same reconcile: `-X theirs` clobbers `next`'s newer content, the stamp
+// rewinds the manifest (0.27.0-pre1 → 0.26.0-pre1) and the prose minor
+// (0.27 → 0.26), and the calendar key advances — the exact damage the gate
+// prevents.
+func TestEdgeAdvancePatchDoesNotRegressNext(t *testing.T) {
+	t.Run("guarded patch skips, next byte-identical", func(t *testing.T) {
+		f := newPatchNoRegressFixture(t)
+		advance := runGuardedEdgeAdvance(t, f, "edge-advance", false)
+		if advance {
+			t.Fatalf("EdgeAdvanceDecision advanced for old-line patch %q vs next %q; want skip", f.patchTag, f.nextVersion)
+		}
+		// next's tip is untouched: same commit, same manifest, prose, calendar.
+		if got := gitRevParse(t, f.dir, "next"); got != f.nextTip {
+			t.Fatalf("next tip moved on a skip: %s != pristine %s", got, f.nextTip)
+		}
+		if got := readEdgeVersionOnBranch(t, f.dir, "next", ".claude-plugin/plugin.json"); got != "0.27.0-pre1" {
+			t.Fatalf("next manifest rewound on a skip: %q, want 0.27.0-pre1", got)
+		}
+		if got := proseMinorOnBranch(t, f.dir, "next"); got != "0.27" {
+			t.Fatalf("next prose minor rewound on a skip: %q, want 0.27", got)
+		}
+		if got := readEdgeCalendarOnBranch(t, f.dir, "next"); got != "0.0.2026060101" {
+			t.Fatalf("next calendar key churned on a skip: %q, want 0.0.2026060101", got)
+		}
+		// No colliding vX.(Y+1).0-pre0 tag was cut.
+		tags := gitTagList(t, f.dir)
+		for _, tag := range tags {
+			if strings.HasSuffix(tag, "-pre0") {
+				t.Fatalf("a pre0 tag %q was cut on a skip; want none", tag)
+			}
+		}
+	})
+
+	t.Run("gate removed clobbers next", func(t *testing.T) {
+		f := newPatchNoRegressFixture(t)
+		runGuardedEdgeAdvance(t, f, "edge-advance-ungated", true)
+		branch := "edge-advance-ungated"
+		if got := gitRevParse(t, f.dir, branch); got == f.nextTip {
+			t.Fatal("ungated reconcile left next's tip unchanged; the adversarial twin proved nothing")
+		}
+		if got := readEdgeVersionOnBranch(t, f.dir, branch, ".claude-plugin/plugin.json"); got != "0.26.0-pre1" {
+			t.Fatalf("ungated reconcile manifest = %q, want the rewound 0.26.0-pre1 (proof the gate matters)", got)
+		}
+		if got := proseMinorOnBranch(t, f.dir, branch); got != "0.26" {
+			t.Fatalf("ungated reconcile prose minor = %q, want the rewound 0.26", got)
+		}
+		if got := readEdgeCalendarOnBranch(t, f.dir, branch); got == "0.0.2026060101" {
+			t.Fatal("ungated reconcile left the calendar key unchanged; it should have churned")
+		}
+	})
+}

--- a/internal/release/edge_advance_wiring_test.go
+++ b/internal/release/edge_advance_wiring_test.go
@@ -1,0 +1,311 @@
+// ABOUTME: Structure guards for the edge-advance line-ordering decision gate (AC-2)
+// ABOUTME: and the always-cut-pre0 auto-tag (AC-4), each with adversarial twins.
+package release
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// ifHasDecisionGate reports whether an `if:` guard conjoins the edge-advance
+// decision output (`steps.decision.outputs.advance == 'true'`), the gate every
+// mutating step in the job must carry so an old-line/patch tag skips the whole
+// job.
+func ifHasDecisionGate(ifCond string) bool {
+	return strings.Contains(strings.ReplaceAll(ifCond, " ", ""), "steps.decision.outputs.advance=='true'")
+}
+
+// edgeAdvanceDecisionStep returns the step that runs the edge-advance-decision
+// subcommand (the job's first, gating step), or nil when none does.
+func edgeAdvanceDecisionStep(job workflowJob) *workflowStep {
+	for i := range job.steps {
+		for _, command := range executableShellCommands(job.steps[i].run) {
+			if strings.Contains(command, "edge-advance-decision") {
+				return &job.steps[i]
+			}
+		}
+	}
+	return nil
+}
+
+// edgeAdvanceAutoPre0Step returns the always-cut-pre0 step (the one running
+// edge-pre0-version to auto-create the vX.(Y+1).0-pre0 tag), or nil when none.
+func edgeAdvanceAutoPre0Step(job workflowJob) *workflowStep {
+	for i := range job.steps {
+		for _, command := range executableShellCommands(job.steps[i].run) {
+			if strings.Contains(command, "edge-pre0-version") {
+				return &job.steps[i]
+			}
+		}
+	}
+	return nil
+}
+
+// assertEdgeAdvanceDecisionGating (AC-2) binds the line-ordering guard's job-level
+// wiring: a `decision` step runs edge-advance-decision and writes BOTH
+// advance=true and advance=false to $GITHUB_OUTPUT, and EVERY mutating step —
+// both reconcile steps, the calendar-bump+push step, and the auto-pre0 step —
+// gates on `steps.decision.outputs.advance == 'true'`. The calendar-bump gate is
+// the one ASK 2 added: previously unconditional, an old-line patch would
+// otherwise still churn every edge installer's re-pull (AC-2d / AC-3d).
+func assertEdgeAdvanceDecisionGating(workflow string) error {
+	job := edgeAdvanceJob(workflow)
+	if job == nil {
+		return fmt.Errorf("release.yml has no edge-advance job")
+	}
+	decision := edgeAdvanceDecisionStep(*job)
+	if decision == nil {
+		return fmt.Errorf("edge-advance has no step running edge-advance-decision")
+	}
+	if decision.id != "decision" {
+		return fmt.Errorf("edge-advance decision step has id %q, want \"decision\" (else steps.decision.outputs.advance does not resolve)", decision.id)
+	}
+	emitsTrue, emitsFalse := false, false
+	for _, command := range executableShellCommands(decision.run) {
+		if strings.Contains(command, "advance=true") && strings.Contains(command, `"$GITHUB_OUTPUT"`) {
+			emitsTrue = true
+		}
+		if strings.Contains(command, "advance=false") && strings.Contains(command, `"$GITHUB_OUTPUT"`) {
+			emitsFalse = true
+		}
+	}
+	if !emitsTrue || !emitsFalse {
+		return fmt.Errorf("edge-advance decision step does not write both advance=true and advance=false to $GITHUB_OUTPUT (true=%v false=%v)", emitsTrue, emitsFalse)
+	}
+	for _, step := range edgeAdvanceReconcileSteps(*job) {
+		if !ifHasDecisionGate(step.ifCond) {
+			return fmt.Errorf("edge-advance reconcile step %q does not gate on the decision output; if: %q", step.name, step.ifCond)
+		}
+	}
+	bump := edgeAdvanceBumpCalendarStep(*job)
+	if bump == nil {
+		return fmt.Errorf("edge-advance has no bump-calendar step")
+	}
+	if !ifHasDecisionGate(bump.ifCond) {
+		return fmt.Errorf("edge-advance bump-calendar step is not decision-gated; if: %q — an old-line patch would still churn every edge installer's re-pull", bump.ifCond)
+	}
+	pre0 := edgeAdvanceAutoPre0Step(*job)
+	if pre0 == nil {
+		return fmt.Errorf("edge-advance has no auto-cut pre0 step")
+	}
+	if !ifHasDecisionGate(pre0.ifCond) {
+		return fmt.Errorf("edge-advance auto-pre0 step is not decision-gated; if: %q", pre0.ifCond)
+	}
+	return nil
+}
+
+// TestReleaseWorkflowEdgeAdvanceDecisionGates locks AC-2 against the on-disk
+// release.yml: the whole job gates on the line-ordering decision. The adversarial
+// twins ungate the calendar-bump step, ungate the stable reconcile step, and
+// break the decision step's advance=false emission; each must red, so the green
+// is not vacuous.
+func TestReleaseWorkflowEdgeAdvanceDecisionGates(t *testing.T) {
+	workflow := readWorkflow(t, "release.yml")
+	if err := assertEdgeAdvanceDecisionGating(workflow); err != nil {
+		t.Fatalf("real release.yml edge-advance decision gating failed: %v", err)
+	}
+
+	// Ungate the calendar bump — an old-line patch would churn every edge
+	// installer's re-pull (the AC-2d / AC-3d regression ASK 2 closed).
+	ungatedBump := strings.Replace(workflow,
+		"      - name: Bump the marketplace calendar key and push the edge line\n        if: \"steps.decision.outputs.advance == 'true'\"\n",
+		"      - name: Bump the marketplace calendar key and push the edge line\n",
+		1)
+	if ungatedBump == workflow {
+		t.Fatal("fixture workflow missing the decision-gated bump-calendar step to ungate")
+	}
+	if err := assertEdgeAdvanceDecisionGating(ungatedBump); err == nil {
+		t.Fatal("decision-gating guard accepted an ungated calendar-bump step")
+	}
+
+	// Ungate the stable reconcile step — an old-line patch would `-X theirs`
+	// clobber next's newer content.
+	ungatedReconcile := strings.Replace(workflow,
+		"      - name: Reconcile the edge line past the stable release\n        if: \"!contains(github.ref, '-') && steps.decision.outputs.advance == 'true'\"\n",
+		"      - name: Reconcile the edge line past the stable release\n        if: \"!contains(github.ref, '-')\"\n",
+		1)
+	if ungatedReconcile == workflow {
+		t.Fatal("fixture workflow missing the decision-gated stable reconcile step to ungate")
+	}
+	if err := assertEdgeAdvanceDecisionGating(ungatedReconcile); err == nil {
+		t.Fatal("decision-gating guard accepted an ungated stable reconcile step")
+	}
+
+	// Break the decision step's advance=false emission — downstream gates would
+	// never see a skip signal.
+	brokenDecision := strings.Replace(workflow,
+		"            echo \"advance=false\" >> \"$GITHUB_OUTPUT\"\n",
+		"            echo \"skipped the edge line\"\n",
+		1)
+	if brokenDecision == workflow {
+		t.Fatal("fixture workflow missing the decision step advance=false emission to break")
+	}
+	if err := assertEdgeAdvanceDecisionGating(brokenDecision); err == nil {
+		t.Fatal("decision-gating guard accepted a decision step that never emits advance=false")
+	}
+}
+
+// assertAlwaysCutPre0 (AC-4) binds the always-cut-pre0 auto-tag's wiring: the
+// step runs ONLY on the stable path (a `-pre` tag must not recurse), is
+// decision-gated, tags the GREENED release commit (`RELEASE_COMMIT` from
+// `git rev-list -1 "$GITHUB_REF_NAME"`, not next's tip — so the pre0 run reuses
+// the existing green e2e run), creates an ANNOTATED tag with a non-empty body (a
+// lightweight/empty-body tag reds the release-notes extraction step before the
+// binary builds), and pushes via the re-triggering PAT (a GITHUB_TOKEN push does
+// not fire the pre0 build).
+func assertAlwaysCutPre0(workflow string) error {
+	job := edgeAdvanceJob(workflow)
+	if job == nil {
+		return fmt.Errorf("release.yml has no edge-advance job")
+	}
+	pre0 := edgeAdvanceAutoPre0Step(*job)
+	if pre0 == nil {
+		return fmt.Errorf("edge-advance has no auto-cut pre0 step (none runs edge-pre0-version)")
+	}
+	if !ifSelectsStable(pre0.ifCond) {
+		return fmt.Errorf("auto-pre0 step must run only on the stable path (!contains(github.ref, '-')); if: %q would let a prerelease tag recurse", pre0.ifCond)
+	}
+	if !ifHasDecisionGate(pre0.ifCond) {
+		return fmt.Errorf("auto-pre0 step is not decision-gated; if: %q — a non-advancing patch would attempt a colliding pre0 tag", pre0.ifCond)
+	}
+
+	var tagCmd, pushCmd string
+	derivesGreenedSHA, assignsBody := false, false
+	for _, command := range executableShellCommands(pre0.run) {
+		switch {
+		case strings.HasPrefix(command, "git tag "):
+			tagCmd = command
+		case strings.HasPrefix(command, "git push"):
+			pushCmd = command
+		case command == `RELEASE_COMMIT="$(git rev-list -1 "$GITHUB_REF_NAME")"`:
+			derivesGreenedSHA = true
+		case strings.HasPrefix(command, `PRE0_BODY="`) && command != `PRE0_BODY=""`:
+			assignsBody = true
+		}
+	}
+	if tagCmd == "" {
+		return fmt.Errorf("auto-pre0 step runs no `git tag` command")
+	}
+	if !tagCmdIsAnnotatedWithBody(tagCmd) {
+		return fmt.Errorf("auto-pre0 `git tag` is not annotated (-a) with a non-empty -m body: %q", tagCmd)
+	}
+	if !assignsBody {
+		return fmt.Errorf("auto-pre0 step does not assign a non-empty PRE0_BODY — the annotated tag body must be non-empty or the release-notes extraction hard-errors")
+	}
+	if !derivesGreenedSHA {
+		return fmt.Errorf("auto-pre0 step does not derive RELEASE_COMMIT from `git rev-list -1 \"$GITHUB_REF_NAME\"` (the e2e-gate-greened SHA)")
+	}
+	if tagCmdTarget(tagCmd) != `"$RELEASE_COMMIT"` {
+		return fmt.Errorf("auto-pre0 `git tag` targets %q, want \"$RELEASE_COMMIT\" (the greened SHA); tagging next's tip places the pre0 on an ungreened commit e2e-gate would block", tagCmdTarget(tagCmd))
+	}
+	if pushCmd == "" {
+		return fmt.Errorf("auto-pre0 step runs no `git push` command")
+	}
+	if !strings.Contains(pushCmd, "HOMEBREW_TAP_TOKEN") {
+		return fmt.Errorf("auto-pre0 push does not use the re-triggering PAT (HOMEBREW_TAP_TOKEN); a GITHUB_TOKEN push would not fire the pre0 build: %q", pushCmd)
+	}
+	return nil
+}
+
+// tagCmdIsAnnotatedWithBody reports whether a normalized `git tag …` command is
+// annotated (`-a`) with a non-empty `-m` body (the first field after `-m` is not
+// an empty quote). A lightweight tag (no `-a`) or an empty body both fail.
+func tagCmdIsAnnotatedWithBody(tagCmd string) bool {
+	fields := strings.Fields(tagCmd)
+	hasA := false
+	for _, f := range fields {
+		if f == "-a" {
+			hasA = true
+		}
+	}
+	if !hasA {
+		return false
+	}
+	for i, f := range fields {
+		if f == "-m" && i+1 < len(fields) {
+			body := fields[i+1]
+			return body != `""` && body != `''` && body != ""
+		}
+	}
+	return false
+}
+
+// tagCmdTarget returns the commit-ish positional argument of a `git tag -a
+// <tagname> <commit> -m …` command (the SECOND positional, after the tag name),
+// or "" when it carries fewer than two positionals before `-m`.
+func tagCmdTarget(tagCmd string) string {
+	fields := strings.Fields(tagCmd)
+	var positional []string
+	for i := 2; i < len(fields); i++ { // skip "git" "tag"
+		f := fields[i]
+		if f == "-m" {
+			break
+		}
+		if strings.HasPrefix(f, "-") {
+			continue
+		}
+		positional = append(positional, f)
+	}
+	if len(positional) < 2 {
+		return ""
+	}
+	return positional[1]
+}
+
+// TestReleaseWorkflowAlwaysCutPre0 locks AC-4 against the on-disk release.yml.
+// The adversarial twins: (a) retarget the tag from the greened RELEASE_COMMIT to
+// next's tip; (b) drop -a/-m to make it a lightweight tag; (c) move the step to
+// the prerelease path (recursion); (d) push via GITHUB_TOKEN instead of the PAT.
+// Each must red.
+func TestReleaseWorkflowAlwaysCutPre0(t *testing.T) {
+	workflow := readWorkflow(t, "release.yml")
+	if err := assertAlwaysCutPre0(workflow); err != nil {
+		t.Fatalf("real release.yml always-cut-pre0 guard failed: %v", err)
+	}
+
+	const realTag = `git tag -a "$PRE0_TAG" "$RELEASE_COMMIT" -m "$PRE0_BODY"`
+
+	// (a) tag next's tip instead of the greened release commit → ungreened SHA.
+	nextTip := strings.Replace(workflow, realTag,
+		`git tag -a "$PRE0_TAG" origin/next -m "$PRE0_BODY"`, 1)
+	if nextTip == workflow {
+		t.Fatal("fixture workflow missing the auto-pre0 `git tag` line to retarget")
+	}
+	if err := assertAlwaysCutPre0(nextTip); err == nil {
+		t.Fatal("always-cut-pre0 guard accepted a pre0 tag on next's tip (ungreened SHA)")
+	}
+
+	// (b) lightweight tag (no -a, no -m) → reds the release-notes extraction.
+	lightweight := strings.Replace(workflow, realTag,
+		`git tag "$PRE0_TAG" "$RELEASE_COMMIT"`, 1)
+	if lightweight == workflow {
+		t.Fatal("fixture workflow missing the auto-pre0 `git tag` line to make lightweight")
+	}
+	if err := assertAlwaysCutPre0(lightweight); err == nil {
+		t.Fatal("always-cut-pre0 guard accepted a lightweight (non-annotated) pre0 tag")
+	}
+
+	// (c) move the auto-pre0 step to the prerelease path → recursion.
+	recursion := strings.Replace(workflow,
+		"      - name: Auto-cut the edge prerelease tag on the greened release commit\n        if: \"!contains(github.ref, '-') && steps.decision.outputs.advance == 'true'\"\n",
+		"      - name: Auto-cut the edge prerelease tag on the greened release commit\n        if: \"contains(github.ref, '-') && steps.decision.outputs.advance == 'true'\"\n",
+		1)
+	if recursion == workflow {
+		t.Fatal("fixture workflow missing the auto-pre0 step guard to flip to the prerelease path")
+	}
+	if err := assertAlwaysCutPre0(recursion); err == nil {
+		t.Fatal("always-cut-pre0 guard accepted an auto-pre0 step on the prerelease path (recursion)")
+	}
+
+	// (d) push via GITHUB_TOKEN instead of the re-triggering PAT.
+	wrongToken := strings.Replace(workflow,
+		`git push "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PRE0_TAG"`,
+		`git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PRE0_TAG"`, 1)
+	if wrongToken == workflow {
+		t.Fatal("fixture workflow missing the auto-pre0 PAT push line to swap")
+	}
+	if err := assertAlwaysCutPre0(wrongToken); err == nil {
+		t.Fatal("always-cut-pre0 guard accepted a pre0 tag pushed via GITHUB_TOKEN (would not re-trigger)")
+	}
+}

--- a/internal/release/edge_reconcile_test.go
+++ b/internal/release/edge_reconcile_test.go
@@ -512,29 +512,34 @@ func mergeStrategyOption(command string) string {
 
 // ifSelectsPrerelease reports whether an `if:` guard fires on a prerelease
 // (hyphenated) tag and not a stable one — the un-negated `contains(github.ref,
-// '-')` form.
+// '-')` form, optionally conjoined with the edge-advance decision gate
+// (`&& steps.decision.outputs.advance == 'true'`), which every reconcile step
+// now carries so an old-line tag skips the whole job.
 func ifSelectsPrerelease(ifCond string) bool {
-	return strings.ReplaceAll(ifCond, " ", "") == "contains(github.ref,'-')"
+	c := strings.ReplaceAll(ifCond, " ", "")
+	return c == "contains(github.ref,'-')" || strings.HasPrefix(c, "contains(github.ref,'-')&&")
 }
 
 // ifSelectsStable reports whether an `if:` guard fires on a stable tag and not a
-// prerelease — the negated `!contains(github.ref, '-')` form. It is the exact
-// logical complement of ifSelectsPrerelease, so a step pair carrying both fires
-// on exactly one tag shape each.
+// prerelease — the negated `!contains(github.ref, '-')` form, optionally
+// conjoined with the decision gate. It is the exact logical complement of
+// ifSelectsPrerelease on the tag-shape axis (the `!` prefix distinguishes them),
+// so a step pair carrying both fires on exactly one tag shape each.
 func ifSelectsStable(ifCond string) bool {
-	return strings.ReplaceAll(ifCond, " ", "") == "!contains(github.ref,'-')"
+	c := strings.ReplaceAll(ifCond, " ", "")
+	return c == "!contains(github.ref,'-')" || strings.HasPrefix(c, "!contains(github.ref,'-')&&")
 }
 
 // TestReleaseWorkflowEdgeAdvanceWiring locks the edge-advance job's step-level
 // wiring against the on-disk release.yml, closing the coupling gaps the detached
 // audit found: both reconcile steps must merge with `-X theirs` (favor the
-// release — the `-X ours` flip is the exact 0.24.0-pre1 divergence incident),
-// their `if:` guards must be complementary so EXACTLY one fires per tag
-// (prerelease `contains(github.ref, '-')`, stable `!contains(...)`), and the
-// calendar-bump step must carry no `if:` so it always runs. The adversarial twins
-// flip the strategy to `-X ours`, widen the stable guard to `always()`, copy the
-// prerelease guard onto the stable step, and gate the bump-calendar step; each
-// must red, so a green result is not vacuous.
+// release — the `-X ours` flip is the exact 0.24.0-pre1 divergence incident) and
+// their `if:` guards must be complementary on the tag-shape axis so EXACTLY one
+// fires per tag (prerelease `contains(github.ref, '-')`, stable `!contains(...)`,
+// each conjoined with the decision gate). The adversarial twins flip the strategy
+// to `-X ours`, widen the stable guard to `always()`, and copy the prerelease
+// guard onto the stable step; each must red, so a green result is not vacuous.
+// The decision-gate conjunct itself is guarded by TestReleaseWorkflowEdgeAdvanceDecisionGates.
 func TestReleaseWorkflowEdgeAdvanceWiring(t *testing.T) {
 	workflow := readWorkflow(t, "release.yml")
 	if err := assertEdgeAdvanceWiring(workflow); err != nil {
@@ -554,7 +559,7 @@ func TestReleaseWorkflowEdgeAdvanceWiring(t *testing.T) {
 	// stable dev-preversion stamp wrongly runs on a `-pre` cut. Anchored to the
 	// stable step's name so it does not mutate the other `!contains(...)` guards.
 	always := strings.Replace(workflow,
-		"      - name: Reconcile the edge line past the stable release\n        if: \"!contains(github.ref, '-')\"\n",
+		"      - name: Reconcile the edge line past the stable release\n        if: \"!contains(github.ref, '-') && steps.decision.outputs.advance == 'true'\"\n",
 		"      - name: Reconcile the edge line past the stable release\n        if: \"always()\"\n",
 		1)
 	if always == workflow {
@@ -567,8 +572,8 @@ func TestReleaseWorkflowEdgeAdvanceWiring(t *testing.T) {
 	// Copy-paste: the stable step reuses the prerelease `contains(...)` guard, so
 	// the stable dev-preversion path would never fire on any tag.
 	copyPaste := strings.Replace(workflow,
-		"      - name: Reconcile the edge line past the stable release\n        if: \"!contains(github.ref, '-')\"\n",
-		"      - name: Reconcile the edge line past the stable release\n        if: \"contains(github.ref, '-')\"\n",
+		"      - name: Reconcile the edge line past the stable release\n        if: \"!contains(github.ref, '-') && steps.decision.outputs.advance == 'true'\"\n",
+		"      - name: Reconcile the edge line past the stable release\n        if: \"contains(github.ref, '-') && steps.decision.outputs.advance == 'true'\"\n",
 		1)
 	if copyPaste == workflow {
 		t.Fatal("fixture workflow missing the stable reconcile step guard to copy-paste")
@@ -576,25 +581,15 @@ func TestReleaseWorkflowEdgeAdvanceWiring(t *testing.T) {
 	if err := assertEdgeAdvanceWiring(copyPaste); err == nil {
 		t.Fatal("wiring guard accepted two reconcile steps with the same non-complementary if: guard")
 	}
-
-	// A conditional bump-calendar step — it must run unconditionally on both paths.
-	gatedBump := strings.Replace(workflow,
-		"      - name: Bump the marketplace calendar key and push the edge line\n",
-		"      - name: Bump the marketplace calendar key and push the edge line\n        if: \"!contains(github.ref, '-')\"\n",
-		1)
-	if gatedBump == workflow {
-		t.Fatal("fixture workflow missing the bump-calendar step name to gate")
-	}
-	if err := assertEdgeAdvanceWiring(gatedBump); err == nil {
-		t.Fatal("wiring guard accepted a conditional bump-calendar step")
-	}
 }
 
 // assertEdgeAdvanceWiring consolidates the edge-advance job's step-level wiring
 // invariants against the parsed workflow: it is a force-free `needs: goreleaser`
 // sibling (assertEdgeAdvanceIsForceFreeSibling), both reconcile steps merge with
-// `-X theirs`, their `if:` guards are complementary (exactly one fires per tag),
-// and the calendar-bump step runs unconditionally.
+// `-X theirs`, and their `if:` guards are complementary on the tag-shape axis
+// (exactly one fires per tag). The decision-gate conjunct each step now also
+// carries — and the calendar-bump/auto-pre0 gating — is asserted separately by
+// assertEdgeAdvanceDecisionGating.
 func assertEdgeAdvanceWiring(workflow string) error {
 	if err := assertEdgeAdvanceIsForceFreeSibling(workflow); err != nil {
 		return err
@@ -624,14 +619,6 @@ func assertEdgeAdvanceWiring(workflow string) error {
 	}
 	if !prereleaseGuarded || !stableGuarded {
 		return fmt.Errorf("edge-advance reconcile steps are not complementary (prerelease-guarded=%v stable-guarded=%v); exactly one must fire per tag", prereleaseGuarded, stableGuarded)
-	}
-
-	bump := edgeAdvanceBumpCalendarStep(*job)
-	if bump == nil {
-		return fmt.Errorf("edge-advance has no bump-calendar step")
-	}
-	if strings.TrimSpace(bump.ifCond) != "" {
-		return fmt.Errorf("edge-advance bump-calendar step carries if: %q, want unconditional (no if:)", bump.ifCond)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes the edge-channel stable-cut window: a stable tag can no longer ship skills demanding a binary minor that doesn't exist — and old-line patch releases can no longer regress or rewind the edge line.

## What changed
- Add a job-level line-ordering decision (strict `>` via `ComparePreVersion`) gating every edge-advance step, calendar bump included
- Auto-cut the annotated `X.(Y+1).0-pre0` edge tag on the greened release commit at latest-line stable cuts
- Add `GORELEASER_CURRENT_TAG` as a defensive pin; document the flow in docs/releasing.md

## Evidence
- Real goreleaser 2.16 dry-runs: pre0 stamps correctly in all four pin×order combos; notes-extraction green on annotated, red on lightweight; e2e-gate SHA-reuse confirmed
- Decision table covers all three equality skip-cases; byte-identical-tip fixture incl. calendar; every structure guard's adversarial twin red-under-violation; detached audit refuted nothing material; 16 pkgs green

## Review guidance
Deploy condition (not code): the pre0 push PAT needs contents:write on THIS repo — a tap-only fine-grained PAT 403s and the window stays open. Spike-4's re-trigger confirms end-to-end on the first real cut.

---
[zr2](/spacedock-dev/spacedock/blob/1622e6cdf1fc400f6b5acfdfcea5fd92f1d2c22f/edge-channel-stable-cut-gap.md)
