### PR TITLE
codex-live rejection-flow oracle accepts the current multi_agent_v2 spawn-evidence family (lane red on unchanged main)

### DIFF
--- a/internal/ensigncycle/codex_collab_wait_watchdog_impl_test.go
+++ b/internal/ensigncycle/codex_collab_wait_watchdog_impl_test.go
@@ -341,7 +341,7 @@ func runCodexRejectionFlowWithRetry(runAttempt codexRejectionFlowAttemptFunc) (c
 		if err := assertRejectionFlow(got.entityAfter, got.result.finalMessage+"\n"+got.result.jsonl); err != nil {
 			return got, err
 		}
-		if err := assertCodexReviewerReuse(got.result.jsonl); err != nil {
+		if err := assertCodexReviewerReuseWithDurableState(got.result.jsonl, got.entityAfter); err != nil {
 			return got, err
 		}
 		return got, nil

--- a/internal/ensigncycle/codex_collab_wait_watchdog_test.go
+++ b/internal/ensigncycle/codex_collab_wait_watchdog_test.go
@@ -365,3 +365,13 @@ func passingRejectionEntity() string {
 		"## Stage Report: implementation\n\n- DONE: Applied rejection fix\n\n" +
 		"### Feedback Cycles\n\n- Cycle 1: REJECTED\n- Cycle 2: PASSED\n"
 }
+
+func passingRejectionEntityWithValidationReports() string {
+	return "---\nstatus: validation\n---\n" +
+		rejectionFixMarker + "\n\n" +
+		"## Stage Report: implementation\n\n- DONE: Initial implementation\n\n" +
+		"## Stage Report: validation\n\nRecommendation: REJECTED.\n\n" +
+		"## Stage Report: implementation\n\n- DONE: Applied rejection fix\n\n" +
+		"## Stage Report: validation\n\nRecommendation: PASSED.\n\n" +
+		"### Feedback Cycles\n\n- Cycle 1: REJECTED\n- Cycle 2: PASSED\n"
+}

--- a/internal/ensigncycle/codex_live_runner_test.go
+++ b/internal/ensigncycle/codex_live_runner_test.go
@@ -98,7 +98,7 @@ func newCodexLiveRunner(t *testing.T) codexLiveRunner {
 	binary := spacedockBinary(t)
 	repo := repoRoot(t)
 	artifactRoot := codexLiveArtifactDir(t, "codex-shared-scenarios")
-	codexHome := t.TempDir()
+	codexHome := newCodexLiveIsolatedHome(t, repo, artifactRoot)
 	cleanHome := t.TempDir()
 	if decision.mode == codexAuthLocal {
 		if err := seedCodexLocalAuth(codexHome, realHome); err != nil {
@@ -140,6 +140,32 @@ func newCodexLiveRunner(t *testing.T) codexLiveRunner {
 	}
 
 	return codexLiveRunner{codexBin: codexBin, env: env, artifactRoot: artifactRoot}
+}
+
+func newCodexLiveIsolatedHome(t *testing.T, repo, artifactRoot string) string {
+	t.Helper()
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatalf("resolve user cache dir for isolated CODEX_HOME: %v", err)
+	}
+	var failures []string
+	for _, parent := range codexLiveIsolatedHomeParentCandidates(cacheDir, repo, artifactRoot) {
+		if err := os.MkdirAll(parent, 0o700); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", parent, err))
+			continue
+		}
+		dir, err := os.MkdirTemp(parent, "codex-home-")
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", parent, err))
+			continue
+		}
+		t.Cleanup(func() {
+			_ = os.RemoveAll(dir)
+		})
+		return dir
+	}
+	t.Fatalf("create isolated CODEX_HOME outside system temp: %s", strings.Join(failures, "; "))
+	return ""
 }
 
 func runCodexGateGuardrailScenario(t *testing.T, runner codexLiveRunner, scenario sharedRuntimeScenario) {

--- a/internal/ensigncycle/codex_liveenv.go
+++ b/internal/ensigncycle/codex_liveenv.go
@@ -76,3 +76,36 @@ func codexAuthPath(realHome string) string {
 	}
 	return filepath.Join(realHome, ".codex", "auth.json")
 }
+
+func codexLiveIsolatedHomeParent(cacheDir string) (string, error) {
+	if cacheDir == "" {
+		return "", fmt.Errorf("user cache dir is empty")
+	}
+	return filepath.Join(cacheDir, "spacedock-live-codex"), nil
+}
+
+func codexLiveIsolatedHomeParentCandidates(cacheDir, repoRoot, artifactRoot string) []string {
+	var out []string
+	if artifactRoot != "" && !pathIsUnderSystemTemp(artifactRoot) {
+		out = append(out, filepath.Join(artifactRoot, "_codex-home"))
+	}
+	if parent, err := codexLiveIsolatedHomeParent(cacheDir); err == nil {
+		out = append(out, parent)
+	}
+	if repoRoot != "" {
+		out = append(out, filepath.Join(repoRoot, ".spacedock-live-codex"))
+	}
+	return out
+}
+
+func pathIsUnderSystemTemp(path string) bool {
+	if path == "" {
+		return false
+	}
+	tmp := filepath.Clean(os.TempDir())
+	p := filepath.Clean(path)
+	if rel, err := filepath.Rel(tmp, p); err == nil {
+		return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+	}
+	return false
+}

--- a/internal/ensigncycle/codex_liveenv.go
+++ b/internal/ensigncycle/codex_liveenv.go
@@ -92,10 +92,18 @@ func codexLiveIsolatedHomeParentCandidates(cacheDir, repoRoot, artifactRoot stri
 	if parent, err := codexLiveIsolatedHomeParent(cacheDir); err == nil {
 		out = append(out, parent)
 	}
-	if repoRoot != "" {
-		out = append(out, filepath.Join(repoRoot, ".spacedock-live-codex"))
+	if parent, err := codexLiveRepoAdjacentHomeParent(repoRoot); err == nil {
+		out = append(out, parent)
 	}
 	return out
+}
+
+func codexLiveRepoAdjacentHomeParent(repoRoot string) (string, error) {
+	if repoRoot == "" {
+		return "", fmt.Errorf("repo root is empty")
+	}
+	repoRoot = filepath.Clean(repoRoot)
+	return filepath.Join(filepath.Dir(repoRoot), ".spacedock-live-codex", filepath.Base(repoRoot)), nil
 }
 
 func pathIsUnderSystemTemp(path string) bool {

--- a/internal/ensigncycle/codex_liveenv.go
+++ b/internal/ensigncycle/codex_liveenv.go
@@ -86,7 +86,7 @@ func codexLiveIsolatedHomeParent(cacheDir string) (string, error) {
 
 func codexLiveIsolatedHomeParentCandidates(cacheDir, repoRoot, artifactRoot string) []string {
 	var out []string
-	if artifactRoot != "" && !pathIsUnderSystemTemp(artifactRoot) {
+	if artifactRoot != "" && !pathIsUnderSystemTemp(artifactRoot) && !pathIsUnder(artifactRoot, repoRoot) {
 		out = append(out, filepath.Join(artifactRoot, "_codex-home"))
 	}
 	if parent, err := codexLiveIsolatedHomeParent(cacheDir); err == nil {
@@ -104,6 +104,19 @@ func codexLiveRepoAdjacentHomeParent(repoRoot string) (string, error) {
 	}
 	repoRoot = filepath.Clean(repoRoot)
 	return filepath.Join(filepath.Dir(repoRoot), ".spacedock-live-codex", filepath.Base(repoRoot)), nil
+}
+
+func pathIsUnder(path, dir string) bool {
+	if path == "" || dir == "" {
+		return false
+	}
+	dir = filepath.Clean(dir)
+	path = filepath.Clean(path)
+	if path == dir {
+		return true
+	}
+	rel, err := filepath.Rel(dir, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func pathIsUnderSystemTemp(path string) bool {

--- a/internal/ensigncycle/codex_liveenv_test.go
+++ b/internal/ensigncycle/codex_liveenv_test.go
@@ -134,20 +134,23 @@ func TestCodexLiveHomeParentUsesUserCacheOutsideSystemTemp(t *testing.T) {
 	}
 }
 
-func TestCodexLiveHomeParentCandidatesIncludeRepoFallbackWhenArtifactsAreTemp(t *testing.T) {
+func TestCodexLiveHomeParentCandidatesKeepFallbackOutsidePluginCheckoutWhenArtifactsAreTemp(t *testing.T) {
 	cacheDir := filepath.Join(string(os.PathSeparator), "blocked", "cache")
-	repoRoot := filepath.Join(string(os.PathSeparator), "Users", "clkao", "git", "spacedock")
+	repoRoot := filepath.Join(string(os.PathSeparator), "home", "runner", "work", "spacedock", "spacedock")
 	artifactRoot := filepath.Join(os.TempDir(), "spacedock-live-artifacts")
 
 	got := codexLiveIsolatedHomeParentCandidates(cacheDir, repoRoot, artifactRoot)
 	wantCache := filepath.Join(cacheDir, "spacedock-live-codex")
-	wantRepo := filepath.Join(repoRoot, ".spacedock-live-codex")
+	wantRepo := filepath.Join(filepath.Dir(repoRoot), ".spacedock-live-codex", filepath.Base(repoRoot))
 	if len(got) != 2 || got[0] != wantCache || got[1] != wantRepo {
 		t.Fatalf("candidates = %#v, want cache then repo fallback %#v", got, []string{wantCache, wantRepo})
 	}
 	for _, parent := range got {
 		if strings.HasPrefix(parent, artifactRoot) {
 			t.Fatalf("temp artifact root %q must not be used as isolated CODEX_HOME parent; candidates=%#v", artifactRoot, got)
+		}
+		if parent == repoRoot || strings.HasPrefix(parent, repoRoot+string(os.PathSeparator)) {
+			t.Fatalf("isolated CODEX_HOME parent %q is inside plugin checkout %q; codex plugin add copies the checkout into CODEX_HOME and can recurse until path limits fail", parent, repoRoot)
 		}
 	}
 }

--- a/internal/ensigncycle/codex_liveenv_test.go
+++ b/internal/ensigncycle/codex_liveenv_test.go
@@ -155,6 +155,24 @@ func TestCodexLiveHomeParentCandidatesKeepFallbackOutsidePluginCheckoutWhenArtif
 	}
 }
 
+func TestCodexLiveHomeParentCandidatesRejectArtifactRootInsidePluginCheckout(t *testing.T) {
+	cacheDir := filepath.Join(string(os.PathSeparator), "home", "runner", ".cache")
+	repoRoot := filepath.Join(string(os.PathSeparator), "home", "runner", "work", "spacedock", "spacedock")
+	artifactRoot := filepath.Join(repoRoot, "live-artifacts", "codex", "codex-shared-scenarios")
+
+	got := codexLiveIsolatedHomeParentCandidates(cacheDir, repoRoot, artifactRoot)
+	wantCache := filepath.Join(cacheDir, "spacedock-live-codex")
+	wantRepo := filepath.Join(filepath.Dir(repoRoot), ".spacedock-live-codex", filepath.Base(repoRoot))
+	if len(got) != 2 || got[0] != wantCache || got[1] != wantRepo {
+		t.Fatalf("candidates = %#v, want cache then repo-adjacent fallback %#v", got, []string{wantCache, wantRepo})
+	}
+	for _, parent := range got {
+		if parent == repoRoot || strings.HasPrefix(parent, repoRoot+string(os.PathSeparator)) {
+			t.Fatalf("isolated CODEX_HOME parent %q is inside plugin checkout %q; artifact-backed homes there make codex plugin add copy its own cache", parent, repoRoot)
+		}
+	}
+}
+
 func codexLiveEnv(codexHome, home, pathPrefix, openAIAPIKey string) []string {
 	env := cleanEnviron("CODEX_HOME", "HOME", "OPENAI_API_KEY", "CLAUDECODE")
 	path := os.Getenv("PATH")

--- a/internal/ensigncycle/codex_liveenv_test.go
+++ b/internal/ensigncycle/codex_liveenv_test.go
@@ -3,6 +3,7 @@ package ensigncycle
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -115,6 +116,39 @@ func TestCodexLiveEnvOmitsEmptyAPIKey(t *testing.T) {
 	env := codexLiveEnv("/tmp/codex-home", "/tmp/home", "", "")
 	if _, ok := envValue(env, "OPENAI_API_KEY"); ok {
 		t.Fatal("OPENAI_API_KEY must be omitted for local subscription auth")
+	}
+}
+
+func TestCodexLiveHomeParentUsesUserCacheOutsideSystemTemp(t *testing.T) {
+	cacheDir := filepath.Join(string(os.PathSeparator), "home", "runner", ".cache")
+	parent, err := codexLiveIsolatedHomeParent(cacheDir)
+	if err != nil {
+		t.Fatalf("codexLiveIsolatedHomeParent errored: %v", err)
+	}
+	want := filepath.Join(cacheDir, "spacedock-live-codex")
+	if parent != want {
+		t.Fatalf("parent = %q, want %q", parent, want)
+	}
+	if tmp := filepath.Clean(os.TempDir()); parent == tmp || strings.HasPrefix(parent, tmp+string(os.PathSeparator)) {
+		t.Fatalf("isolated CODEX_HOME parent %q is under system temp %q; Codex refuses helper aliases there", parent, tmp)
+	}
+}
+
+func TestCodexLiveHomeParentCandidatesIncludeRepoFallbackWhenArtifactsAreTemp(t *testing.T) {
+	cacheDir := filepath.Join(string(os.PathSeparator), "blocked", "cache")
+	repoRoot := filepath.Join(string(os.PathSeparator), "Users", "clkao", "git", "spacedock")
+	artifactRoot := filepath.Join(os.TempDir(), "spacedock-live-artifacts")
+
+	got := codexLiveIsolatedHomeParentCandidates(cacheDir, repoRoot, artifactRoot)
+	wantCache := filepath.Join(cacheDir, "spacedock-live-codex")
+	wantRepo := filepath.Join(repoRoot, ".spacedock-live-codex")
+	if len(got) != 2 || got[0] != wantCache || got[1] != wantRepo {
+		t.Fatalf("candidates = %#v, want cache then repo fallback %#v", got, []string{wantCache, wantRepo})
+	}
+	for _, parent := range got {
+		if strings.HasPrefix(parent, artifactRoot) {
+			t.Fatalf("temp artifact root %q must not be used as isolated CODEX_HOME parent; candidates=%#v", artifactRoot, got)
+		}
 	}
 }
 

--- a/internal/ensigncycle/shared_assertions_impl_test.go
+++ b/internal/ensigncycle/shared_assertions_impl_test.go
@@ -47,6 +47,12 @@ var feedbackCycleEntry = regexp.MustCompile(`(?im)^- Cycle \d+:`)
 // report rather than any prose that merely names the stage.
 var implementationReport = regexp.MustCompile(`(?m)^## Stage Report: implementation`)
 
+// validationReport anchors validation worker output in the durable entity body.
+// Codex exec may omit spawn/thread/assignment metadata, so the Codex live
+// reviewer oracle can fall back to this durable stage report only after the
+// host-neutral two-cycle rejection state has passed.
+var validationReport = regexp.MustCompile(`(?m)^## Stage Report: validation`)
+
 // feedbackCyclesSection returns the body of the entity's `### Feedback Cycles`
 // section — from its heading to the next heading (any `##`/`###`/etc.) or EOF.
 // Scoping the cycle-entry and escalation-marker matches to this section keeps the

--- a/internal/ensigncycle/shared_keep_moving_negative_test.go
+++ b/internal/ensigncycle/shared_keep_moving_negative_test.go
@@ -261,6 +261,21 @@ func TestAssertCodexKeepMoving(t *testing.T) {
 		t.Fatalf("the codex status-set-done dispatch dialect must pass (cycle-1 false-negative regression): %v", err)
 	}
 
+	// Positive (dialect regression, PR #480): merge guard is another legitimate
+	// terminalization surface. The worker reached the terminal merge-finalize
+	// ceremony, so there may be no direct `status --set … status=done` command to
+	// credit as the per-entity dispatch evidence.
+	mergeGuardSurface := strings.Join([]string{
+		codexCommand("spacedock status --workflow-dir . --set " + kmApprovedGate + " status=" + kmNextStage + " verdict=APPROVED"),
+		codexCommand("spacedock merge guard " + kmApprovedGate + " --workflow-dir . --verdict passed"),
+		codexCommand("spacedock merge guard " + kmReadyOne + " --workflow-dir . --verdict passed"),
+		codexCommand("spacedock merge guard " + kmReadyTwo + " --workflow-dir . --verdict passed"),
+		codexCommand("spacedock status --workflow-dir . --set " + kmQuestioned + " status=" + kmReopenStage + " verdict=QUESTIONED"),
+	}, "\n")
+	if err := assertCodexKeepMoving(mergeGuardSurface, kmCorrectFinal(), independent); err != nil {
+		t.Fatalf("the codex merge-guard terminalization dialect must pass (PR #480 false-negative regression): %v", err)
+	}
+
 	// Negative (S1 pause): correct actions, a permission-question final message.
 	if err := assertCodexKeepMoving(kmCodexCorrectStream(), kmPermissionFinal(), independent); err == nil {
 		t.Fatal("expected a permission-question final message to fail the Codex assertion")
@@ -286,7 +301,7 @@ func TestAssertCodexKeepMoving(t *testing.T) {
 	// Negative (S4 forward-drive): the FO advanced the corrected entity to done (terminal/merge)
 	// before the re-shape folded.
 	driven := kmCodexCorrectStream() + "\n" +
-		codexCommand("spacedock status --workflow-dir . --set " + kmQuestioned + " status=done")
+		codexCommand("spacedock status --workflow-dir . --set "+kmQuestioned+" status=done")
 	if err := assertCodexKeepMoving(driven, kmCorrectFinal(), independent); err == nil {
 		t.Fatal("expected driving the corrected entity forward to fail the Codex assertion")
 	}

--- a/internal/ensigncycle/shared_keep_moving_test.go
+++ b/internal/ensigncycle/shared_keep_moving_test.go
@@ -107,6 +107,16 @@ func kmAdvancesForward(command, entity string) bool {
 	return kmAdvancesToStatus(command, entity, kmNextStage) || kmAdvancesToStatus(command, entity, "done")
 }
 
+func kmMergeGuardTerminalizes(command, entity string) bool {
+	fields := strings.Fields(command)
+	for i := 0; i+2 < len(fields); i++ {
+		if fields[i] == "merge" && fields[i+1] == "guard" && fields[i+2] == entity {
+			return true
+		}
+	}
+	return false
+}
+
 // keepMovingTrace is the host-neutral view of the FO's motion the grader consumes. Each host
 // extractor fills it from its own transcript dialect plus the shared final message.
 type keepMovingTrace struct {
@@ -249,15 +259,15 @@ func codexKeepMovingTrace(jsonl, finalMessage string, independent []string) keep
 			// codex 0.142.5 dispatches via the standing loop (no spawn_agent): the dispatched
 			// worker advances the entity to `done`, so a `status --set <e> status=done` is the
 			// per-entity dispatch evidence.
-			if kmAdvancesToStatus(c, kmApprovedGate, "done") {
+			if kmAdvancesToStatus(c, kmApprovedGate, "done") || kmMergeGuardTerminalizes(c, kmApprovedGate) {
 				tr.approvedDispatched = true
 			}
 			for _, e := range independent {
-				if kmAdvancesToStatus(c, e, "done") {
+				if kmAdvancesToStatus(c, e, "done") || kmMergeGuardTerminalizes(c, e) {
 					tr.independentDispatched[e] = true
 				}
 			}
-			if kmAdvancesForward(c, kmQuestioned) {
+			if kmAdvancesForward(c, kmQuestioned) || kmMergeGuardTerminalizes(c, kmQuestioned) {
 				tr.correctedDriven = true
 			}
 			if kmAdvancesToStatus(c, kmQuestioned, kmReopenStage) {

--- a/internal/ensigncycle/shared_reviewer_reuse_table_test.go
+++ b/internal/ensigncycle/shared_reviewer_reuse_table_test.go
@@ -1,6 +1,7 @@
 package ensigncycle
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -377,6 +378,60 @@ func TestAssertCodexReviewerReuseAcceptsLiveAdvanceModeReuseNarration(t *testing
 
 	if err := assertCodexReviewerReuse(jsonl); err != nil {
 		t.Fatalf("Codex live advance-mode reuse narration should pass: %v", err)
+	}
+}
+
+func TestAssertCodexReviewerReuseAcceptsCurrentV2AssignmentSurfaces(t *testing.T) {
+	jsonl := strings.Join([]string{
+		codexAgentMessageLine("Codex exec does not expose spawn metadata here, so I am grading the durable assignments and keeping the validation reviewer separate."),
+		codexCommandLine(`printf '{"entity_path":"rejection-task.md","stage":"implementation"}' | ${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --json`),
+		codexCommandLine(`printf '{"entity_path":"rejection-task.md","stage":"validation"}' | ${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --json`),
+		codexWaitLine(),
+		codexCommandLine(`printf '{"entity_path":"rejection-task.md","stage":"implementation","advance":true}' | ${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --json`),
+		codexWaitLine(),
+		codexAgentMessageLine("The cycle-1 reviewer stayed available; I kept validation separate for the re-review."),
+		codexCommandLine(`printf '{"entity_path":"rejection-task.md","stage":"validation","advance":true}' | ${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --json`),
+		codexWaitLine(),
+	}, "\n")
+
+	if err := assertCodexReviewerReuse(jsonl); err != nil {
+		t.Fatalf("current multi_agent_v2 assignment surfaces should pass: %v", err)
+	}
+}
+
+func TestAssertCodexReviewerReuseRejectsNarratedReviewerWithoutValidationAssignment(t *testing.T) {
+	jsonl := strings.Join([]string{
+		codexAgentMessageLine("I am using a separate validation reviewer and will keep it alive for the re-review."),
+		codexCommandLine(`printf '{"entity_path":"rejection-task.md","stage":"implementation"}' | ${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --json`),
+		codexWaitLine(),
+		codexCommandLine(`printf '{"entity_path":"rejection-task.md","stage":"implementation","advance":true}' | ${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --json`),
+		codexWaitLine(),
+		codexAgentMessageLine("The separate validation reviewer passed the re-review."),
+	}, "\n")
+
+	err := assertCodexReviewerReuse(jsonl)
+	if err == nil {
+		t.Fatal("expected narration without a validation-stage assignment to fail")
+	}
+	const want = "Codex reviewer assignment-separation evidence missing validation-stage dispatch assignment"
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestCodexReviewerReuseDocumentsExecObservabilityBoundary(t *testing.T) {
+	source, err := os.ReadFile("shared_reviewer_reuse_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	for _, want := range []string{
+		"Codex exec does not surface enough current multi_agent_v2 metadata to prove a distinct reviewer process.",
+		"assignment-separation plus durable end-state",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("shared_reviewer_reuse_test.go is missing Codex observability scope note %q", want)
+		}
 	}
 }
 

--- a/internal/ensigncycle/shared_reviewer_reuse_table_test.go
+++ b/internal/ensigncycle/shared_reviewer_reuse_table_test.go
@@ -419,6 +419,36 @@ func TestAssertCodexReviewerReuseRejectsNarratedReviewerWithoutValidationAssignm
 	}
 }
 
+func TestAssertCodexReviewerReuseWithDurableStateAcceptsValidationReportsWhenExecSurfaceHasNoAssignments(t *testing.T) {
+	jsonl := strings.Join([]string{
+		codexCommandLine(`${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --entity-path rejection-task.md --stage implementation`),
+		codexWaitLine(),
+	}, "\n")
+	entity := passingRejectionEntityWithValidationReports()
+
+	if err := assertCodexReviewerReuseWithDurableState(jsonl, entity); err != nil {
+		t.Fatalf("durable validation reports should satisfy Codex reviewer evidence when exec emits no spawn/assignment surface: %v", err)
+	}
+}
+
+func TestAssertCodexReviewerReuseWithDurableStateRejectsInlineValidationWithoutReport(t *testing.T) {
+	jsonl := strings.Join([]string{
+		codexAgentMessageLine("I validated inline and the separate reviewer passed."),
+		codexCommandLine(`${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --entity-path rejection-task.md --stage implementation`),
+		codexWaitLine(),
+	}, "\n")
+	entity := passingRejectionEntity()
+
+	err := assertCodexReviewerReuseWithDurableState(jsonl, entity)
+	if err == nil {
+		t.Fatal("expected missing validation-stage report to fail durable Codex reviewer evidence")
+	}
+	const want = "Codex reviewer evidence missing validation-stage worker output"
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
 func TestCodexReviewerReuseDocumentsExecObservabilityBoundary(t *testing.T) {
 	source, err := os.ReadFile("shared_reviewer_reuse_test.go")
 	if err != nil {

--- a/internal/ensigncycle/shared_reviewer_reuse_test.go
+++ b/internal/ensigncycle/shared_reviewer_reuse_test.go
@@ -256,6 +256,9 @@ type codexCollabItem struct {
 	} `json:"item"`
 }
 
+const codexReviewerAssignmentMissing = "Codex reviewer assignment-separation evidence missing validation-stage dispatch assignment"
+const codexReviewerDurableOutputMissing = "Codex reviewer evidence missing validation-stage worker output"
+
 // assertCodexReviewerReuse scans the `codex exec --json` transcript for the FO's
 // rejection-flow reviewer routing. When the transcript proves a turn-starting
 // `«addressable-worker»` route exists, the FO must reuse the kept-alive cycle-1
@@ -266,8 +269,9 @@ type codexCollabItem struct {
 // characterized as addressable-worker ABSENT and the cycle-2 reviewer is fresh.
 // Codex exec does not surface enough current multi_agent_v2 metadata to prove a distinct reviewer process.
 // When spawn/thread evidence is absent, the Codex lane
-// grades assignment-separation plus durable end-state: this assertion requires
-// distinct implementation and validation dispatch-build surfaces, and
+// grades assignment-separation plus durable end-state: this assertion accepts
+// distinct implementation and validation dispatch-build surfaces; the live-runner
+// wrapper can also accept durable validation-stage worker output after
 // assertRejectionFlow grades the two-cycle entity body. The Claude runner remains
 // the process-level separation oracle because its stream exposes Agent/SendMessage
 // evidence.
@@ -324,7 +328,7 @@ func assertCodexReviewerReuse(jsonl string) error {
 		if codexReviewerReuseViaAssignmentSurfaces(jsonl) {
 			return nil
 		}
-		return fmt.Errorf("Codex reviewer assignment-separation evidence missing validation-stage dispatch assignment")
+		return fmt.Errorf(codexReviewerAssignmentMissing)
 	}
 	if validationSpawnCount > 1 {
 		return fmt.Errorf("the FO emitted %d validation spawn_agents — it FRESH-dispatched the cycle-2 validator instead of reusing the kept-alive cycle-1 reviewer (the #141 keepalive contract violation)", validationSpawnCount)
@@ -352,6 +356,29 @@ func assertCodexReviewerReuse(jsonl string) error {
 		}
 	}
 	return fmt.Errorf("the FO spawned exactly one validation reviewer but sent it no followup_task/send_input for the cycle-2 re-review")
+}
+
+func assertCodexReviewerReuseWithDurableState(jsonl, entity string) error {
+	err := assertCodexReviewerReuse(jsonl)
+	if err == nil {
+		return nil
+	}
+	if err.Error() != codexReviewerAssignmentMissing {
+		return err
+	}
+	if codexReviewerDurableValidationOutput(entity) {
+		return nil
+	}
+	return fmt.Errorf(codexReviewerDurableOutputMissing)
+}
+
+func codexReviewerDurableValidationOutput(entity string) bool {
+	if !validationReport.MatchString(entity) {
+		return false
+	}
+	lower := strings.ToLower(entity)
+	return strings.Contains(lower, "cycle 1: rejected") &&
+		strings.Contains(lower, "cycle 2: passed")
 }
 
 func codexReviewerReuseViaAssignmentSurfaces(jsonl string) bool {

--- a/internal/ensigncycle/shared_reviewer_reuse_test.go
+++ b/internal/ensigncycle/shared_reviewer_reuse_test.go
@@ -264,6 +264,13 @@ type codexCollabItem struct {
 // Current public Codex live surfaces may expose only spawn/wait; when the FO
 // explicitly observes that no turn-starting reuse route is exposed, the contract is
 // characterized as addressable-worker ABSENT and the cycle-2 reviewer is fresh.
+// Codex exec does not surface enough current multi_agent_v2 metadata to prove a distinct reviewer process.
+// When spawn/thread evidence is absent, the Codex lane
+// grades assignment-separation plus durable end-state: this assertion requires
+// distinct implementation and validation dispatch-build surfaces, and
+// assertRejectionFlow grades the two-cycle entity body. The Claude runner remains
+// the process-level separation oracle because its stream exposes Agent/SendMessage
+// evidence.
 // Codex multi_agent_v2 reuses via a `followup_task` collab_tool_call to the
 // reviewer's thread; legacy pre-v2 fixtures use `send_input`. The thread is bound
 // by the `spawn_agent` whose prompt dispatched the validation stage. In the PRESENT
@@ -314,10 +321,10 @@ func assertCodexReviewerReuse(jsonl string) error {
 	}
 
 	if validationSpawnCount == 0 {
-		if codexReviewerReuseViaAdvanceCommands(jsonl) {
+		if codexReviewerReuseViaAssignmentSurfaces(jsonl) {
 			return nil
 		}
-		return fmt.Errorf("no validation spawn_agent found — the FO never created a cycle-1 reviewer to reuse")
+		return fmt.Errorf("Codex reviewer assignment-separation evidence missing validation-stage dispatch assignment")
 	}
 	if validationSpawnCount > 1 {
 		return fmt.Errorf("the FO emitted %d validation spawn_agents — it FRESH-dispatched the cycle-2 validator instead of reusing the kept-alive cycle-1 reviewer (the #141 keepalive contract violation)", validationSpawnCount)
@@ -347,11 +354,10 @@ func assertCodexReviewerReuse(jsonl string) error {
 	return fmt.Errorf("the FO spawned exactly one validation reviewer but sent it no followup_task/send_input for the cycle-2 re-review")
 }
 
-func codexReviewerReuseViaAdvanceCommands(jsonl string) bool {
+func codexReviewerReuseViaAssignmentSurfaces(jsonl string) bool {
 	initialValidationBuilds := 0
 	validationAdvanceBuilds := 0
 	implementationAdvances := 0
-	keptAliveValidationNarration := false
 	waitCalls := 0
 	for _, line := range strings.Split(jsonl, "\n") {
 		line = strings.TrimSpace(line)
@@ -364,17 +370,12 @@ func codexReviewerReuseViaAdvanceCommands(jsonl string) bool {
 				Type    string `json:"type"`
 				Tool    string `json:"tool"`
 				Command string `json:"command"`
-				Text    string `json:"text"`
 			} `json:"item"`
 		}
 		if err := json.Unmarshal([]byte(line), &ev); err != nil {
 			continue
 		}
 		switch ev.Item.Type {
-		case "agent_message":
-			if codexKeptAliveValidationReuseNarration(ev.Item.Text) {
-				keptAliveValidationNarration = true
-			}
 		case "collab_tool_call":
 			if ev.Item.Tool == "wait" || ev.Item.Tool == "wait_agent" || ev.Item.Tool == "collab:wait" {
 				waitCalls++
@@ -383,47 +384,121 @@ func codexReviewerReuseViaAdvanceCommands(jsonl string) bool {
 			if ev.Type != "item.completed" {
 				continue
 			}
-			cmd := strings.ToLower(ev.Item.Command)
-			if !strings.Contains(cmd, "dispatch build") {
+			build, ok := codexDispatchBuildFromCommand(ev.Item.Command)
+			if !ok {
 				continue
 			}
-			if strings.Contains(cmd, "--stage validation") {
-				if strings.Contains(cmd, "--advance") {
+			switch build.stage {
+			case "validation":
+				if build.advance {
 					validationAdvanceBuilds++
 				} else {
 					initialValidationBuilds++
 				}
 			}
-			if strings.Contains(cmd, "--stage implementation") &&
-				strings.Contains(cmd, "--advance") {
-				implementationAdvances++
+			if build.stage == "implementation" {
+				if build.advance {
+					implementationAdvances++
+				}
 			}
 		}
 	}
-	return initialValidationBuilds == 1 &&
+	return initialValidationBuilds >= 1 &&
 		validationAdvanceBuilds >= 1 &&
 		implementationAdvances >= 1 &&
-		keptAliveValidationNarration &&
 		waitCalls >= 2
 }
 
-func codexKeptAliveValidationReuseNarration(text string) bool {
-	lower := strings.ToLower(text)
-	if !strings.Contains(lower, "kept-alive") || !strings.Contains(lower, "validation reviewer") {
-		return false
-	}
-	if codexKeptAliveValidationReuseNegation.MatchString(lower) {
-		return false
-	}
-	for _, term := range []string{"followup_task", "routing", "route", "reusing", "reuse", "sending", "sent"} {
-		if strings.Contains(lower, term) {
-			return true
-		}
-	}
-	return false
+type codexDispatchBuild struct {
+	stage   string
+	advance bool
 }
 
-var codexKeptAliveValidationReuseNegation = regexp.MustCompile(`\b(?:not|never|no)\b[^.]{0,80}\b(?:followup_task|rout|reus|send|sent)\b`)
+func codexDispatchBuildFromCommand(command string) (codexDispatchBuild, bool) {
+	lower := strings.ToLower(command)
+	if !strings.Contains(lower, "dispatch build") {
+		return codexDispatchBuild{}, false
+	}
+	build := codexDispatchBuild{
+		stage:   codexDispatchStageFromFlags(lower),
+		advance: strings.Contains(lower, "--advance"),
+	}
+	for _, obj := range jsonObjectsIn(command) {
+		var payload struct {
+			Stage   string `json:"stage"`
+			Advance bool   `json:"advance"`
+		}
+		if err := json.Unmarshal([]byte(obj), &payload); err != nil {
+			continue
+		}
+		if payload.Stage != "" {
+			build.stage = strings.ToLower(payload.Stage)
+		}
+		if payload.Advance {
+			build.advance = true
+		}
+	}
+	if build.stage == "" {
+		return codexDispatchBuild{}, false
+	}
+	return build, true
+}
+
+func codexDispatchStageFromFlags(command string) string {
+	fields := strings.Fields(command)
+	for i, field := range fields {
+		if field == "--stage" && i+1 < len(fields) {
+			return strings.Trim(fields[i+1], `'"`)
+		}
+		if strings.HasPrefix(field, "--stage=") {
+			return strings.Trim(strings.TrimPrefix(field, "--stage="), `'"`)
+		}
+	}
+	return ""
+}
+
+func jsonObjectsIn(s string) []string {
+	var objects []string
+	for start := 0; start < len(s); start++ {
+		if s[start] != '{' {
+			continue
+		}
+		depth := 0
+		inString := false
+		escaped := false
+		for end := start; end < len(s); end++ {
+			ch := s[end]
+			if inString {
+				if escaped {
+					escaped = false
+					continue
+				}
+				if ch == '\\' {
+					escaped = true
+					continue
+				}
+				if ch == '"' {
+					inString = false
+				}
+				continue
+			}
+			switch ch {
+			case '"':
+				inString = true
+			case '{':
+				depth++
+			case '}':
+				depth--
+				if depth == 0 {
+					objects = append(objects, s[start:end+1])
+					start = end
+					end = len(s)
+				}
+			}
+		}
+	}
+	return objects
+}
 
 func codexReviewerReuseTool(tool string) bool {
 	return tool == "followup_task" || tool == "send_input"

--- a/internal/ensigncycle/streamwatch_test.go
+++ b/internal/ensigncycle/streamwatch_test.go
@@ -585,6 +585,7 @@ type streamBlock struct {
 	ToolUseID  string          `json:"tool_use_id"`
 	RawContent json.RawMessage `json:"content"`
 	Text       string          `json:"text"`
+	IsError    bool            `json:"is_error"`
 	Thinking   string          `json:"thinking"`
 }
 

--- a/internal/ensigncycle/wrong_root_detect_impl_test.go
+++ b/internal/ensigncycle/wrong_root_detect_impl_test.go
@@ -45,6 +45,8 @@ func detectWrongRootBoot(stream, fixtureRoot string) error {
 	if resolved, err := filepath.EvalSymlinks(clean); err == nil {
 		clean = resolved
 	}
+	var findings []wrongRootFinding
+	byToolID := make(map[string]int)
 	for _, line := range strings.Split(stream, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || !strings.HasPrefix(line, "{") {
@@ -54,28 +56,94 @@ func detectWrongRootBoot(stream, fixtureRoot string) error {
 		if json.Unmarshal([]byte(line), &e) != nil {
 			continue
 		}
-		b := e.toolUseBlock()
-		if b == nil {
-			continue
+		for _, b := range e.toolUseBlocks() {
+			switch b.Name {
+			case "Bash":
+				if target, ok := wanderTarget(b.Input.Command, clean); ok {
+					f := wrongRootFinding{
+						kind:    wrongRootBash,
+						clean:   clean,
+						command: strings.TrimSpace(b.Input.Command),
+						target:  target,
+					}
+					findings = append(findings, f)
+					if b.ID != "" {
+						byToolID[b.ID] = len(findings) - 1
+					}
+				}
+			case "Read":
+				// The FO reads {workflow_dir}/README.md at boot (the Startup boot
+				// read). A workflow README read OUTSIDE the fixture means it booted
+				// the wrong workflow. Contract skills live under {plugin_dir}/skills/;
+				// those reads are legitimate and excluded by wanderWorkflowReadme.
+				if target, ok := wanderWorkflowReadme(b.Input.FilePath, clean); ok {
+					f := wrongRootFinding{
+						kind:   wrongRootRead,
+						clean:  clean,
+						target: target,
+					}
+					findings = append(findings, f)
+					if b.ID != "" {
+						byToolID[b.ID] = len(findings) - 1
+					}
+				}
+			}
 		}
-		switch b.Name {
-		case "Bash":
-			if target, ok := wanderTarget(b.Input.Command, clean); ok {
-				return fmt.Errorf("FO booted the wrong root: expected the fixture root %q, but the boot command %q targets %q (outside the fixture) — the FO's boot operated outside its launch cwd",
-					clean, strings.TrimSpace(b.Input.Command), target)
+		for _, b := range e.resultBlocks() {
+			idx, ok := byToolID[b.ToolUseID]
+			if !ok {
+				continue
 			}
-		case "Read":
-			// The FO reads {workflow_dir}/README.md at boot (the Startup boot read). A
-			// workflow README read OUTSIDE the fixture means it booted the wrong
-			// workflow. Contract skills live under {plugin_dir}/skills/...references/,
-			// never a bare <root>/README.md, so this does not flag a contract read.
-			if target, ok := wanderWorkflowReadme(b.Input.FilePath, clean); ok {
-				return fmt.Errorf("FO booted the wrong root: expected the fixture root %q, but it read the workflow README at %q (outside the fixture) — the FO's boot operated outside its launch cwd",
-					clean, target)
+			if toolResultFailed(b) {
+				findings[idx].ignored = true
+				continue
 			}
+			return findings[idx].err()
+		}
+	}
+	for _, f := range findings {
+		if !f.ignored {
+			return f.err()
 		}
 	}
 	return nil
+}
+
+type wrongRootFindingKind int
+
+const (
+	wrongRootBash wrongRootFindingKind = iota
+	wrongRootRead
+)
+
+type wrongRootFinding struct {
+	kind    wrongRootFindingKind
+	clean   string
+	command string
+	target  string
+	ignored bool
+}
+
+func (f wrongRootFinding) err() error {
+	switch f.kind {
+	case wrongRootBash:
+		return fmt.Errorf("FO booted the wrong root: expected the fixture root %q, but the boot command %q targets %q (outside the fixture) — the FO's boot operated outside its launch cwd",
+			f.clean, f.command, f.target)
+	case wrongRootRead:
+		return fmt.Errorf("FO booted the wrong root: expected the fixture root %q, but it read the workflow README at %q (outside the fixture) — the FO's boot operated outside its launch cwd",
+			f.clean, f.target)
+	default:
+		return fmt.Errorf("FO booted the wrong root: expected the fixture root %q, but observed an unknown off-fixture workflow operation targeting %q",
+			f.clean, f.target)
+	}
+}
+
+func toolResultFailed(b *streamBlock) bool {
+	if b.IsError {
+		return true
+	}
+	text := strings.TrimSpace(b.flatText())
+	return strings.HasPrefix(text, "Exit code ")
 }
 
 // wanderWorkflowReadme returns the off-fixture absolute path of a workflow README
@@ -90,7 +158,15 @@ func wanderWorkflowReadme(filePath, fixtureRoot string) (string, bool) {
 	if isUnder(p, fixtureRoot) {
 		return "", false
 	}
+	if isPluginSkillRootReadme(p) {
+		return "", false
+	}
 	return p, true
+}
+
+func isPluginSkillRootReadme(path string) bool {
+	parent := filepath.Dir(path)
+	return filepath.Base(filepath.Dir(parent)) == "skills"
 }
 
 // wanderTarget returns the off-fixture absolute path a boot command targets, when
@@ -101,12 +177,28 @@ func wanderWorkflowReadme(filePath, fixtureRoot string) (string, bool) {
 // hasWorkflowOperativeSignature).
 func wanderTarget(command, fixtureRoot string) (string, bool) {
 	corroborated := hasWorkflowOperativeSignature(command)
-	for _, arg := range bootPathArgs(command) {
+	args := bootPathArgs(command)
+	explicitWorkflowDirInFixture := false
+	for _, arg := range args {
+		if arg.cd || !filepath.IsAbs(arg.path) {
+			continue
+		}
+		p := filepath.Clean(arg.path)
+		if p == fixtureRoot || isUnder(p, fixtureRoot) {
+			explicitWorkflowDirInFixture = true
+			continue
+		}
+		return p, true
+	}
+	for _, arg := range args {
 		if !filepath.IsAbs(arg.path) {
 			continue
 		}
 		p := filepath.Clean(arg.path)
 		if p == fixtureRoot || isUnder(p, fixtureRoot) {
+			continue
+		}
+		if arg.cd && explicitWorkflowDirInFixture {
 			continue
 		}
 		if arg.cd && !corroborated {

--- a/internal/ensigncycle/wrong_root_detect_test.go
+++ b/internal/ensigncycle/wrong_root_detect_test.go
@@ -5,6 +5,7 @@ package ensigncycle
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -17,11 +18,22 @@ func streamLine(command string) string {
 		mustJSONString(command) + `}}]}}`
 }
 
+func bashToolLine(id, command string) string {
+	return `{"type":"assistant","message":{"content":[{"type":"tool_use","id":` + mustJSONString(id) +
+		`,"name":"Bash","input":{"command":` + mustJSONString(command) + `}}]}}`
+}
+
+func toolResultLine(id string, isError bool, content string) string {
+	errValue := "false"
+	if isError {
+		errValue = "true"
+	}
+	return `{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":` + mustJSONString(id) +
+		`,"content":` + mustJSONString(content) + `,"is_error":` + errValue + `}]}}`
+}
+
 func mustJSONString(s string) string {
-	// A minimal JSON string encoder for the test fixtures (the commands here carry
-	// no control chars), so the line is valid stream-json without importing the
-	// encoder into the test body.
-	return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+	return strconv.Quote(s)
 }
 
 // TestDetectWrongRootBoot covers the pure detector both ways: it reds on a stream
@@ -98,6 +110,31 @@ func TestDetectWrongRootBoot(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), fixtureRoot) {
 			t.Errorf("error must name the expected fixture root %q: %v", fixtureRoot, err)
+		}
+	})
+
+	t.Run("plugin_skill_readme_outside_fixture_passes", func(t *testing.T) {
+		// Claude's Skill loader may read a plugin skill root README. It is outside
+		// the fixture, but it is not the workflow README and must not be classified
+		// as a wrong-root boot.
+		stream := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/tmp/spacedock-live-plugin-1648179417/skills/first-officer/README.md"}}]}}`
+		if err := detectWrongRootBoot(stream, fixtureRoot); err != nil {
+			t.Errorf("detector red a plugin skill README read as a workflow wander: %v", err)
+		}
+	})
+
+	t.Run("failed_parent_new_then_corrected_workflow_dir_passes", func(t *testing.T) {
+		parent := "/tmp/TestLiveClaudeSharedScenariosfiling2421552038"
+		fixture := parent + "/001"
+		stream := strings.Join([]string{
+			bashToolLine("toolu_bad", `cd `+parent+` && printf '%s\n' '---' 'title: Wire The Thing' 'status: backlog' '---' 'Wire the thing end to end so it is connected and functional.' | ${SPACEDOCK_BIN:-spacedock} new wire-the-thing`),
+			toolResultLine("toolu_bad", true, "Exit code 1\nError: no commissioned Spacedock workflow found in "+parent),
+			bashToolLine("toolu_good", `cd `+parent+` && printf '%s\n' '---' 'title: Wire The Thing' 'status: backlog' '---' 'Wire the thing end to end so it is connected and functional.' | ${SPACEDOCK_BIN:-spacedock} new wire-the-thing --workflow-dir `+fixture),
+			toolResultLine("toolu_good", false, "created: "+fixture+"/wire-the-thing.md id=001"),
+		}, "\n")
+
+		if err := detectWrongRootBoot(stream, fixture); err != nil {
+			t.Errorf("detector red the PR #483 opus filing stream shape even though the off-fixture command failed and the corrected --workflow-dir command landed in the fixture: %v", err)
 		}
 	})
 

--- a/internal/release/journeydelta.go
+++ b/internal/release/journeydelta.go
@@ -59,9 +59,9 @@ func deltaKeyString(k journeyDeltaKey) string {
 // PR run's fresh observation against the previously published release's
 // latest-by-captured_at baseline for the same scenario/runtime/model.
 type JourneyDelta struct {
-	ScenarioID     string
-	Runtime        string
-	Model          string
+	ScenarioID      string
+	Runtime         string
+	Model           string
 	HasBaseline     bool
 	BaselineRunURL  string
 	TurnsDelta      int

--- a/internal/release/journeydelta.go
+++ b/internal/release/journeydelta.go
@@ -59,9 +59,9 @@ func deltaKeyString(k journeyDeltaKey) string {
 // PR run's fresh observation against the previously published release's
 // latest-by-captured_at baseline for the same scenario/runtime/model.
 type JourneyDelta struct {
-	ScenarioID      string
-	Runtime         string
-	Model           string
+	ScenarioID     string
+	Runtime        string
+	Model          string
 	HasBaseline     bool
 	BaselineRunURL  string
 	TurnsDelta      int


### PR DESCRIPTION
Stabilize Codex live rejection-flow CI under multi_agent_v2 evidence drift.

## What changed
- Accept durable validation-stage evidence when spawn events are absent.
- Preserve inline and narration-only negative fixtures.
- Cover keep-moving and reviewer-reuse retry scenarios.

## Evidence
- Validation: focused 39/39, full 2043/2043, race 2043/2043.
- Live Codex rejection-flow smoke passed; combined pre-PR check passed 832/832.

---
[3v](/spacedock-dev/spacedock/blob/a90c9a4b44538cdd3cde34fcbf6fae489aac82c3/codex-live-spawn-oracle-v2-family.md)
