### PR TITLE
Make the filing live-test fixture README representative of a real workflow (add a Task Template)

### DIFF
--- a/internal/ensigncycle/filing_readme_template_test.go
+++ b/internal/ensigncycle/filing_readme_template_test.go
@@ -1,0 +1,134 @@
+// ABOUTME: The filing live fixture exposes the same workflow-local Task Template shape as a real workflow.
+// ABOUTME: Its literal fenced body round-trips through NativeRunner new, while indented frontmatter stays invalid.
+package ensigncycle
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+func TestFilingReadmeTaskTemplateRoundTripsThroughNew(t *testing.T) {
+	root := t.TempDir()
+	writeFilingWorkflow(t, root)
+
+	readmeBytes, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := filingTaskTemplate(t, string(readmeBytes))
+
+	for _, required := range []string{
+		"---\n",
+		"title: Task name here\n",
+		"status: backlog\n",
+		"## Problem\n",
+		"## Proposed approach\n",
+		"## Out of scope\n",
+		"## Acceptance criteria\n",
+		"## Test plan\n",
+	} {
+		if !strings.Contains(template, required) {
+			t.Errorf("Task Template missing %q:\n%s", required, template)
+		}
+	}
+	if !strings.HasPrefix(template, "---\n") {
+		t.Fatalf("Task Template frontmatter must begin at column zero:\n%q", template)
+	}
+	if strings.Contains(template, "\nid:") || strings.HasPrefix(template, "id:") {
+		t.Fatalf("Task Template must omit id so new can mint it:\n%s", template)
+	}
+
+	t.Run("literal template creates entity and mints id", func(t *testing.T) {
+		stdout, stderr, code := runFilingTemplateNew(t, root, "from-template", template)
+		if code != 0 {
+			t.Fatalf("new exit=%d stderr=%q", code, stderr)
+		}
+		if !strings.Contains(stdout, "created:") {
+			t.Fatalf("new stdout=%q, want created narration", stdout)
+		}
+
+		entityBytes, err := os.ReadFile(filepath.Join(root, "from-template.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		entity := string(entityBytes)
+		if !strings.Contains(entity, "title: Task name here\n") || !strings.Contains(entity, "status: backlog\n") {
+			t.Fatalf("created entity did not preserve template frontmatter:\n%s", entity)
+		}
+		if !hasNonEmptyFrontmatterField(entity, "id") {
+			t.Fatalf("created entity has no minted id:\n%s", entity)
+		}
+	})
+
+	t.Run("indented frontmatter fence is rejected", func(t *testing.T) {
+		controlRoot := t.TempDir()
+		writeFilingWorkflow(t, controlRoot)
+		indented := "  " + template
+		_, stderr, code := runFilingTemplateNew(t, controlRoot, "from-template", indented)
+		if code != 1 {
+			t.Fatalf("new exit=%d, want 1 for indented opening fence", code)
+		}
+		if !strings.Contains(stderr, "no frontmatter") {
+			t.Fatalf("new stderr=%q, want no frontmatter error", stderr)
+		}
+		if _, err := os.Stat(filepath.Join(controlRoot, "from-template.md")); !os.IsNotExist(err) {
+			t.Fatalf("indented control created an entity; stat error=%v", err)
+		}
+	})
+}
+
+func filingTaskTemplate(t *testing.T, readme string) string {
+	t.Helper()
+	const heading = "## Task Template\n"
+	if got := strings.Count(readme, heading); got != 1 {
+		t.Fatalf("README has %d Task Template headings, want 1", got)
+	}
+	section := readme[strings.Index(readme, heading)+len(heading):]
+	if got := strings.Count(section, "```"); got != 2 {
+		t.Fatalf("Task Template section has %d fence markers, want 2:\n%s", got, section)
+	}
+	const opening = "```yaml\n"
+	start := strings.Index(section, opening)
+	if start < 0 {
+		t.Fatalf("Task Template has no YAML opening fence:\n%s", section)
+	}
+	body := section[start+len(opening):]
+	end := strings.Index(body, "```\n")
+	if end < 0 {
+		t.Fatalf("Task Template has no closing fence:\n%s", section)
+	}
+	return body[:end]
+}
+
+func runFilingTemplateNew(t *testing.T, root, slug, body string) (string, string, int) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	runner := &status.NativeRunner{}
+	code, err := runner.Run(context.Background(), status.Request{
+		Args:   []string{"--workflow-dir", root, "--new", slug},
+		Dir:    root,
+		Env:    os.Environ(),
+		Stdin:  strings.NewReader(body),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stdout.String(), stderr.String(), code
+}
+
+func hasNonEmptyFrontmatterField(entity, name string) bool {
+	for _, line := range strings.Split(entity, "\n") {
+		if key, value, ok := strings.Cut(line, ":"); ok && key == name {
+			return strings.TrimSpace(value) != ""
+		}
+	}
+	return false
+}

--- a/internal/ensigncycle/shared_fixtures_test.go
+++ b/internal/ensigncycle/shared_fixtures_test.go
@@ -332,7 +332,25 @@ func filingReadme() string {
 		"# Filing Fixture\n\n" +
 		"This fixture starts EMPTY: there are no entities yet. The first officer is asked to file one seed task. The id-style is `sequential`, so the manual flow (`status --next-id` then hand-writing the file) is available — the scenario proves the FO instead uses the atomic-create path.\n\n" +
 		"### backlog\n\nSeed tasks land here.\n\n- **Outputs:** A filed seed entity.\n\n" +
-		"### done\n\nTerminal state.\n"
+		"### done\n\nTerminal state.\n\n" +
+		"## Task Template\n\n" +
+		"```yaml\n" +
+		"---\n" +
+		"title: Task name here\n" +
+		"status: backlog\n" +
+		"---\n\n" +
+		"Brief description of this task and what it aims to achieve.\n\n" +
+		"## Problem\n\n" +
+		"{What is broken or missing, and why it matters. Ideation fills this in.}\n\n" +
+		"## Proposed approach\n\n" +
+		"{How the task intends to solve the problem. Ideation fills this in.}\n\n" +
+		"## Out of scope\n\n" +
+		"{What this task deliberately does not cover, so the boundary is explicit.}\n\n" +
+		"## Acceptance criteria\n\n" +
+		"{Each criterion names an end-state property and how it is verified.}\n\n" +
+		"## Test plan\n\n" +
+		"{What verifies the implementation, its cost, and whether fixture, CLI, or live tests are needed.}\n" +
+		"```\n"
 }
 
 func filingPrompt(workflowRoot string) string {

--- a/skills/first-officer/references/claude-first-officer-runtime.md
+++ b/skills/first-officer/references/claude-first-officer-runtime.md
@@ -32,4 +32,6 @@ See `## Probe and Ideation Discipline` in the shared core — its Grep-over-Read
 
 ## Filing New Entities
 
+Before filing, read the workflow README's `## Task Template`; use its frontmatter and section scaffolding as the starting shape for the entity body you pipe to `spacedock new`.
+
 To file a seed task, do NOT use the Write tool to hand-assemble frontmatter after a `status --next-id` preview — that two-step flow can land a stale id when the `--next-id` candidate drifts between preview and write. Use `${SPACEDOCK_BIN:-spacedock} new <slug> [--folder] [--id-seed S --id-actor A]` via Bash from the project root (`new` auto-discovers the lone workflow, else pass `--workflow-dir {workflow_dir}` — see `spacedock new --help`), piping a complete entity stub on stdin (frontmatter with `id` omitted or blank, followed by the brief description body): it mints the id, stamps it into the frontmatter, and atomically writes the stamped entity as flat `<slug>.md` in one call (see `Skill(skill="spacedock:fo-write-core")` for the full contract). `--next-id` is a candidate-preview surface only. `new` writes but does not commit; for split-root state checkouts the FO still does the path-scoped commit + push after `new` (per the shared core's State Management rule).


### PR DESCRIPTION
Give live filing tests a real workflow template so they measure direct template use instead of behavior induced by a stripped fixture.

## What changed

- Add a realistic Task Template to the filing fixture README.
- Prove literal template bytes round-trip through native entity creation.
- Point first-officer filing instructions to the workflow-local Task Template.

## Evidence

- Focused filing and discovery controls: 14/14 passed.
- Affected-package, standard, and race gates: 3/3 passed; parser negative control passed.

---

[c3](/spacedock-dev/spacedock/blob/df920d2250cadd291b196fbc6c9e5aa2011cf2c2/filing-fixture-readme-realistic.md)