### PR TITLE
Restore opaque Codex post-fence passthrough

### DIFF
--- a/docs/site/reference/command-reference.md
+++ b/docs/site/reference/command-reference.md
@@ -24,7 +24,7 @@ The `Sandbox:` line is one of `enabled (safehouse)`, `available, not enabled (no
 spacedock claude [task] [spacedock-flags] [-- host-flags]
 ```
 
-The task comes first and becomes the launch prompt. Anything after `--` forwards verbatim to the host (`--model`, `--resume`, and the like). When no plugin is installed, the launcher auto-installs it and launches, so the single command yields a working session; a contract mismatch fails fast. The sandbox flags (`--safehouse` and its knobs) and the contract-gate flags are listed by `spacedock claude --help`.
+The task comes first and becomes the launch prompt. Anything after `--` forwards verbatim to the host (`--model`, `--resume`, and the like); for Codex, this includes `spacedock codex -- --model <model> resume <session>`. When no plugin is installed, the launcher auto-installs it and launches, so the single command yields a working session; a contract mismatch fails fast. The sandbox flags (`--safehouse` and its knobs) and the contract-gate flags are listed by `spacedock claude --help`.
 
 An unsandboxed launch carries no safehouse isolation, so per-action permission prompting is friction without a matching safety gain: `spacedock claude` starts in `--permission-mode auto` and `spacedock codex` in `--ask-for-approval on-request`. A sandboxed launch instead skips/bypasses approvals (`--dangerously-skip-permissions` for claude, `--dangerously-bypass-approvals-and-sandbox` for codex) since the sandbox is the gate. Either posture is suppressed when you pass your own mode or a resume.
 

--- a/docs/site/reference/command-reference.md
+++ b/docs/site/reference/command-reference.md
@@ -24,9 +24,9 @@ The `Sandbox:` line is one of `enabled (safehouse)`, `available, not enabled (no
 spacedock claude [task] [spacedock-flags] [-- host-flags]
 ```
 
-The task comes first and becomes the launch prompt. Anything after `--` forwards verbatim to the host (`--model`, `--resume`, and the like); for Codex, this includes `spacedock codex -- --model <model> resume <session>`. When no plugin is installed, the launcher auto-installs it and launches, so the single command yields a working session; a contract mismatch fails fast. The sandbox flags (`--safehouse` and its knobs) and the contract-gate flags are listed by `spacedock claude --help`.
+The task comes first and becomes the launch prompt. Anything after `--` forwards verbatim to the host (`--model`, `--resume`, and the like). For Codex, any nonempty post-fence argv is an opaque host-directed launch: Spacedock adds no launch banner, default approval mode, or bootstrap prompt. Use bare `spacedock codex` to start the first officer. When no plugin is installed, the launcher auto-installs it and launches, so the single command yields a working session; a contract mismatch fails fast. The sandbox flags (`--safehouse` and its knobs) and the contract-gate flags are listed by `spacedock claude --help`.
 
-An unsandboxed launch carries no safehouse isolation, so per-action permission prompting is friction without a matching safety gain: `spacedock claude` starts in `--permission-mode auto` and `spacedock codex` in `--ask-for-approval on-request`. A sandboxed launch instead skips/bypasses approvals (`--dangerously-skip-permissions` for claude, `--dangerously-bypass-approvals-and-sandbox` for codex) since the sandbox is the gate. Either posture is suppressed when you pass your own mode or a resume.
+An unsandboxed bootstrap launch carries no safehouse isolation, so per-action permission prompting is friction without a matching safety gain: `spacedock claude` starts in `--permission-mode auto` and bare `spacedock codex` in `--ask-for-approval on-request`. A sandboxed bootstrap launch instead skips/bypasses approvals (`--dangerously-skip-permissions` for claude, `--dangerously-bypass-approvals-and-sandbox` for codex) since the sandbox is the gate. Claude suppresses its defaults when you pass your own mode or a resume; Codex suppresses them for any nonempty post-fence passthrough.
 
 ## Setup
 

--- a/internal/cli/codex_plugin_dir_test.go
+++ b/internal/cli/codex_plugin_dir_test.go
@@ -73,6 +73,26 @@ func TestRunCodexPluginDirInstallsThenLaunchesWithoutTheFlag(t *testing.T) {
 	}
 }
 
+func TestRunCodexPluginDirOptionBeforeResumePreservesInnerArgv(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir()) // isolate the persistent local marketplace
+	checkout := t.TempDir()
+	host := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runCodex(context.Background(), []string{"--plugin-dir", checkout, "--", "--model", "gpt-x", "resume", "abc123"}, t.TempDir(), host, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	want := []string{"codex", "--model", "gpt-x", "resume", "abc123"}
+	if !equalArgv(host.launchedArg, want) {
+		t.Fatalf("launch argv = %v, want %v", host.launchedArg, want)
+	}
+	if strings.Contains(stderr.String(), "· launching codex") {
+		t.Fatalf("option-before-resume printed a launch banner: %q", stderr.String())
+	}
+}
+
 // TestCodexPluginDirAdvisoryPresenceAndAbsence is AC-3: every --plugin-dir codex
 // install prints the version-masquerade advisory; a plain (non---plugin-dir) launch
 // prints none. The pair (not a presence-only check) means the test cannot pass by

--- a/internal/cli/codex_plugin_dir_test.go
+++ b/internal/cli/codex_plugin_dir_test.go
@@ -73,7 +73,7 @@ func TestRunCodexPluginDirInstallsThenLaunchesWithoutTheFlag(t *testing.T) {
 	}
 }
 
-func TestRunCodexPluginDirOptionBeforeResumePreservesInnerArgv(t *testing.T) {
+func TestRunCodexPluginDirPostFenceExamplePreservesInnerArgv(t *testing.T) {
 	t.Setenv("CODEX_HOME", t.TempDir()) // isolate the persistent local marketplace
 	checkout := t.TempDir()
 	host := &fakeHost{manifest: compatibleManifest(t)}
@@ -89,7 +89,52 @@ func TestRunCodexPluginDirOptionBeforeResumePreservesInnerArgv(t *testing.T) {
 		t.Fatalf("launch argv = %v, want %v", host.launchedArg, want)
 	}
 	if strings.Contains(stderr.String(), "· launching codex") {
-		t.Fatalf("option-before-resume printed a launch banner: %q", stderr.String())
+		t.Fatalf("opaque post-fence argv produced Spacedock output: %q", stderr.String())
+	}
+}
+
+func TestRunCodexPluginDirOpaquePostFencePreservesInnerArgv(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir()) // isolate the persistent local marketplace
+	checkout := t.TempDir()
+	host := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	args := []string{"--plugin-dir", checkout, "--", "--future-codex-flag=handoff", "opaque-argument"}
+	code := runCodex(context.Background(), args, t.TempDir(), host, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	want := []string{"codex", "--future-codex-flag=handoff", "opaque-argument"}
+	if !equalArgv(host.launchedArg, want) {
+		t.Fatalf("launch argv = %v, want %v", host.launchedArg, want)
+	}
+	if strings.Contains(stderr.String(), "· launching codex") || strings.Contains(stderr.String(), "warning: positional") {
+		t.Fatalf("opaque post-fence argv produced Spacedock launch output: %q", stderr.String())
+	}
+}
+
+func TestRunCodexPostFencePluginDirRemainsOpaque(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	postFenceCheckout := t.TempDir()
+	host := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	args := []string{"--", "--plugin-dir", postFenceCheckout}
+	code := runCodex(context.Background(), args, t.TempDir(), host, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	want := []string{"codex", "--plugin-dir", postFenceCheckout}
+	if !equalArgv(host.launchedArg, want) {
+		t.Fatalf("launch argv = %v, want %v", host.launchedArg, want)
+	}
+	if len(host.installCmds) != 0 {
+		t.Fatalf("post-fence --plugin-dir invoked the local-install seam: %v", host.installCmds)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("opaque post-fence argv produced Spacedock output: %q", stderr.String())
 	}
 }
 

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -375,7 +375,7 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 			return 1
 		}
 	}
-	warnStrayPromptAfterDash(fd, "claude", "spacedock claude", stderr)
+	warnStrayPromptAfterDash(fd, "spacedock claude", stderr)
 
 	wrap := safehouse.Present(dir) || fd.forceSafehouse || len(fd.safehouseFlags) > 0
 	resume := containsResume(fd.passthrough)
@@ -429,9 +429,9 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 // prepended to it. The warning names the stray positional and the corrected form
 // (put the prompt BEFORE `--`). It does NOT alter the assembled host argv; the
 // launch is byte-identical with or without this call. `name` is the front-door
-// verb (`spacedock claude` / `spacedock codex`) so the message names a runnable fix.
-func warnStrayPromptAfterDash(fd frontDoorArgs, host, name string, stderr io.Writer) {
-	pos, ok := strayPromptAfterDash(fd, host)
+// verb so the message names a runnable fix.
+func warnStrayPromptAfterDash(fd frontDoorArgs, name string, stderr io.Writer) {
+	pos, ok := strayPromptAfterDash(fd)
 	if !ok {
 		return
 	}
@@ -443,8 +443,8 @@ func warnStrayPromptAfterDash(fd frontDoorArgs, host, name string, stderr io.Wri
 }
 
 // launchPrompt returns the inner-argv launch prompt: `base + " " + task` when the
-// operator fenced a task after `--`, otherwise the bare base prompt. Callers
-// suppress it entirely on a resume (which carries its own session intent).
+// operator fenced a task after `--`, otherwise the bare base prompt. Claude
+// suppresses it on a resume; Codex suppresses it for any nonempty post-fence argv.
 func launchPrompt(base string, fd frontDoorArgs) string {
 	if fd.hasTask {
 		return base + " " + fd.task
@@ -452,9 +452,9 @@ func launchPrompt(base string, fd frontDoorArgs) string {
 	return base
 }
 
-// hasPluginDir reports whether the host passthrough carries a `--plugin-dir`
-// flag (either `--plugin-dir P` or `--plugin-dir=P`). Its presence relaxes the
-// version gate (the local checkout supersedes the installed plugin).
+// hasPluginDir reports whether the Claude passthrough carries a `--plugin-dir`
+// flag (either `--plugin-dir P` or `--plugin-dir=P`). Its presence relaxes
+// Claude's version gate because the local checkout supersedes the installed plugin.
 func hasPluginDir(passthrough []string) bool {
 	for _, a := range passthrough {
 		if a == "--plugin-dir" || strings.HasPrefix(a, "--plugin-dir=") {
@@ -464,32 +464,24 @@ func hasPluginDir(passthrough []string) bool {
 	return false
 }
 
-// takeCodexPluginDir splits a `--plugin-dir <dir>` (or `--plugin-dir=<dir>`) out of
-// the codex passthrough, returning the checkout dir, the passthrough with EVERY
-// --plugin-dir token removed, and whether any was found. codex's own CLI has no
-// --plugin-dir flag — it hard-rejects the token — so spacedock must consume it here
-// and turn it into a local-marketplace install rather than forward it. When
-// repeated, the last dir wins.
-func takeCodexPluginDir(passthrough []string) (dir string, rest []string, found bool) {
-	rest = make([]string, 0, len(passthrough))
-	for i := 0; i < len(passthrough); i++ {
-		a := passthrough[i]
-		if a == "--plugin-dir" {
-			found = true
-			if i+1 < len(passthrough) {
-				dir = passthrough[i+1]
-				i++ // consume the value token too
-			}
-			continue
-		}
-		if strings.HasPrefix(a, "--plugin-dir=") {
-			found = true
-			dir = strings.TrimPrefix(a, "--plugin-dir=")
-			continue
-		}
-		rest = append(rest, a)
+// takeCodexPluginDir consumes only the declared pre-fence --plugin-dir pairs
+// parseFrontDoorArgs injected at the front of passthrough. Codex itself rejects
+// that Spacedock-owned flag, so those owned pairs become a local-marketplace
+// install. Tokens written after the fence are opaque host argv, even if they spell
+// `--plugin-dir`, and are never consumed here.
+func takeCodexPluginDir(passthrough []string, ownedPairs int) (dir string, rest []string, found bool) {
+	if ownedPairs == 0 {
+		return "", passthrough, false
 	}
-	return dir, rest, found
+	rest = passthrough
+	for range ownedPairs {
+		if len(rest) < 2 || rest[0] != "--plugin-dir" {
+			return "", passthrough, false
+		}
+		dir = rest[1] // the last declared pre-fence checkout wins
+		rest = rest[2:]
+	}
+	return dir, rest, true
 }
 
 // passthroughHasFlag reports whether the operator already supplied any of the
@@ -543,11 +535,11 @@ const codexBootstrapPrompt = "You totally got this. Take your time. I love you. 
 // `--safehouse-*` knob} is given — safehouse is the sandbox, so codex's own
 // sandbox is bypassed. Otherwise the launch is plain `codex …` keeping codex's own
 // sandbox (the bypass flag is omitted: it is safe only when safehouse provides the
-// sandbox). The FO-skill bootstrap prompt is appended last (base, or base + " " +
-// task when a task is fenced after `--`) unless the passthrough begins with the
-// `resume` subcommand. The gate is bypassed by `--skip-compat-check` or by any
-// `--plugin-dir`. `lookPath` resolves the safehouse binary (default exec.LookPath;
-// injected so tests pin not-found).
+// sandbox). A nonempty post-`--` Codex argv is opaque host passthrough: it gets no
+// Spacedock banner, default approval mode, or bootstrap prompt. A declared
+// pre-fence `--plugin-dir` installs its local checkout before the normal gate;
+// `--skip-compat-check` alone bypasses that gate. `lookPath` resolves the safehouse
+// binary (default exec.LookPath; injected so tests pin not-found).
 func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookPath func(string) (string, error), stdout, stderr io.Writer) int {
 	fd, err := parseFrontDoorArgs(args)
 	if err != nil {
@@ -562,12 +554,11 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 	// `spacedock codex --plugin-dir <checkout>` has no codex-native flag to forward
 	// — codex's CLI hard-rejects `--plugin-dir` — so consume it here: strip it from
 	// the passthrough so the real codex never sees it, build a local marketplace
-	// from the checkout, and install it under the binary's own channel. With the
-	// flag stripped, hasPluginDir reads false below and the normal gate runs against
-	// the just-installed plugin. Unlike claude's ephemeral --plugin-dir bypass, a
-	// codex --plugin-dir is a real on-disk install, so gate-checking it is
-	// meaningful rather than redundant.
-	if dir, rest, found := takeCodexPluginDir(fd.passthrough); found {
+	// from the checkout, and install it under the binary's own channel. The normal
+	// gate then runs against the just-installed plugin. Unlike Claude's ephemeral
+	// --plugin-dir bypass, a Codex --plugin-dir is a real on-disk install. It is
+	// gate-checked rather than treated as redundant.
+	if dir, rest, found := takeCodexPluginDir(fd.passthrough, fd.pluginDirPairs); found {
 		fd.passthrough = rest
 		if dir == "" {
 			fmt.Fprintln(stderr, "spacedock codex: --plugin-dir requires a checkout path")
@@ -578,21 +569,22 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 			return 1
 		}
 	}
+	// Once Spacedock-owned plugin-dir handling has been consumed, any remaining
+	// post-fence argv belongs wholly to Codex. Do not inspect its option or command
+	// grammar: new Codex forms must retain the same no-injection posture.
+	opaquePassthrough := len(fd.passthrough) > 0
 	// The gate fails fast on too-old-binary, but the two healable verdicts
 	// (NoPluginFound, TooOldPlugin) auto-install the codex plugin and proceed to
 	// launch so the single command the user typed yields a working session —
 	// `--no-install` opts out, preserving the refuse-and-instruct behavior. This
 	// mirrors runClaude.
-	if !fd.skipCheck && !hasPluginDir(fd.passthrough) {
+	if !fd.skipCheck {
 		if !resolveHealableGate(ops, "codex", fd.noInstall, stderr) {
 			return 1
 		}
 	}
-	warnStrayPromptAfterDash(fd, "codex", "spacedock codex", stderr)
-
 	wrap := safehouse.Present(dir) || fd.forceSafehouse || len(fd.safehouseFlags) > 0
-	resume := codexResume(fd.passthrough)
-	if !resume {
+	if !opaquePassthrough {
 		launchBanner("codex", dir, wrap, lookPath, stderr)
 	}
 	inner := []string{"codex"}
@@ -602,14 +594,13 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 	// An unsandboxed launch has no safehouse isolation; codex has no single
 	// auto-mode flag, so its nearest analog to claude's auto permission-mode is
 	// `--ask-for-approval on-request` (the model decides when to escalate).
-	// Suppressed when the operator already chose an approval policy and on a resume
-	// (which rides its own session intent). The sandboxed arm's bypass flag above
-	// already covers its posture, so this is the !wrap counterpart.
-	if !wrap && !resume && !passthroughHasFlag(fd.passthrough, "--ask-for-approval", "-a") {
+	// The sandboxed arm's bypass flag above already covers its posture, so this is
+	// the !wrap counterpart. Opaque post-fence argv receives no launcher defaults.
+	if !wrap && !opaquePassthrough {
 		inner = append(inner, "--ask-for-approval", "on-request")
 	}
 	inner = append(inner, fd.passthrough...)
-	if !resume {
+	if !opaquePassthrough {
 		inner = append(inner, launchPrompt(codexBootstrapPrompt, fd))
 	}
 
@@ -635,127 +626,30 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 	return code
 }
 
-// codexResume reports whether `resume` is the first Codex command token after
-// known global options. A resume carries its own session intent, so the bootstrap
-// prompt is suppressed. The scan is classification-only: it never rewrites the
-// forwarded passthrough argv.
-func codexResume(passthrough []string) bool {
-	command, ok := codexCommandToken(passthrough)
-	return ok && command == "resume"
-}
-
-// codexCommandToken returns the first Codex command token after known global
-// options. Unknown options stop the scan so an unknown option's value cannot be
-// mistaken for a command. The returned token remains in passthrough unchanged.
-func codexCommandToken(passthrough []string) (string, bool) {
-	valueFlags := valueTakingHostFlags["codex"]
-	flagOnly := flagOnlyHostFlags["codex"]
-	for len(passthrough) > 0 {
-		tok := passthrough[0]
-		if !strings.HasPrefix(tok, "-") || tok == "-" {
-			return tok, true
-		}
-		if flag, _, hasEqualsValue := strings.Cut(tok, "="); hasEqualsValue {
-			if !valueFlags[flag] {
-				return "", false
-			}
-			passthrough = passthrough[1:]
-			continue
-		}
-		if len(tok) > 2 && tok[0] == '-' && tok[1] != '-' && valueFlags[tok[:2]] {
-			passthrough = passthrough[1:] // compact short form, such as -mmodel
-			continue
-		}
-		if valueFlags[tok] {
-			if len(passthrough) < 2 {
-				return "", false
-			}
-			passthrough = passthrough[2:]
-			continue
-		}
-		if flagOnly[tok] {
-			passthrough = passthrough[1:]
-			continue
-		}
-		return "", false
-	}
-	return "", false
-}
-
-// valueTakingHostFlags is the per-host set of host flags whose successor token is
-// the flag's value (space form), so that successor is NOT a stray positional. The
-// assembled argv is unchanged regardless of membership; the set tunes the
-// advisory and Codex command classifiers. The spacedock-injected `--plugin-dir
-// <dir>` prefix is NOT handled here — skipInjectedPrefix strips it structurally
-// before any scan — so the prefix interaction stays in one place rather than
-// threaded through this set.
-var valueTakingHostFlags = map[string]map[string]bool{
-	"claude": {
-		"-p": true, "--print": true,
-		"--model":                true,
-		"--mcp-config":           true,
-		"--permission-mode":      true,
-		"--add-dir":              true,
-		"--append-system-prompt": true,
-		"--settings":             true,
-		"--session-id":           true,
-		"--output-format":        true,
-	},
-	"codex": {
-		"-m": true, "--model": true,
-		"--config":                true,
-		"-c":                      true,
-		"--enable":                true,
-		"--disable":               true,
-		"--remote":                true,
-		"--remote-auth-token-env": true,
-		"--cd":                    true,
-		"-C":                      true,
-		"--image":                 true,
-		"-i":                      true,
-		"--local-provider":        true,
-		"--sandbox":               true,
-		"-s":                      true,
-		"--profile":               true,
-		"-p":                      true,
-		"--add-dir":               true,
-		"--ask-for-approval":      true,
-		"-a":                      true,
-	},
-}
-
-// flagOnlyHostFlags complements valueTakingHostFlags for the known global host
-// flags that consume no following token. Keeping arity here lets codexResume
-// stop safely at an unknown option instead of mistaking its value for `resume`.
-var flagOnlyHostFlags = map[string]map[string]bool{
-	"codex": {
-		"--oss":           true,
-		"--strict-config": true,
-		"--dangerously-bypass-approvals-and-sandbox": true,
-		"--dangerously-bypass-hook-trust":            true,
-		"--search":                                   true,
-		"--no-alt-screen":                            true,
-	},
-}
-
-// leadingHostSubcommands is the per-host set of known leading subcommands whose
-// positional arguments are legitimate (e.g. `codex exec <prompt>`,
-// `codex resume <id>`). When the passthrough leads with one, no after-`--`
-// positional is treated as stray.
-var leadingHostSubcommands = map[string]map[string]bool{
-	"codex": {"exec": true, "resume": true},
+// claudeValueTakingHostFlags identifies Claude's space-form values for its
+// advisory-only stray-prompt scan. Codex has no corresponding grammar table:
+// its nonempty post-fence argv is opaque.
+var claudeValueTakingHostFlags = map[string]bool{
+	"-p": true, "--print": true,
+	"--model":                true,
+	"--mcp-config":           true,
+	"--permission-mode":      true,
+	"--add-dir":              true,
+	"--append-system-prompt": true,
+	"--settings":             true,
+	"--session-id":           true,
+	"--output-format":        true,
 }
 
 // skipInjectedPrefix returns the passthrough slice past the spacedock-injected
 // leading `--plugin-dir <dir>` pairs. parseFrontDoorArgs re-prepends each
 // before-`--` `--plugin-dir` as a `--plugin-dir <dir>` pair at the FRONT of
 // fd.passthrough; that prefix is spacedock-owned, not operator after-`--` tokens,
-// so the classifier's subcommand and value-flag checks must run against the real
-// after-`--` tokens BEHIND it. `--plugin-dir` is the only flag parseFrontDoorArgs
-// re-prepends (the safehouse knobs live in fd.safehouseFlags, the booleans are
-// consumed), so it is the complete injected-prefix set. Skipping a leading
-// `--plugin-dir <dir>` pair is correct regardless of origin: the dir is the flag's
-// value, never a stray prompt.
+// so Claude's advisory scan runs against the real after-`--` tokens. `--plugin-dir`
+// is the only flag parseFrontDoorArgs re-prepends (the safehouse knobs live in
+// fd.safehouseFlags, the booleans are consumed), so it is the complete injected
+// prefix set. Skipping a leading `--plugin-dir <dir>` pair is correct regardless of
+// origin: the dir is the flag's value, never a stray prompt.
 func skipInjectedPrefix(passthrough []string) []string {
 	for len(passthrough) >= 2 && passthrough[0] == "--plugin-dir" {
 		passthrough = passthrough[2:]
@@ -771,13 +665,10 @@ func skipInjectedPrefix(passthrough []string) []string {
 //
 // It fires only when the operator gave no task before `--` (hasTask == false): a
 // task before `--` means the operator already placed their prompt, so a positional
-// after `--` is a deliberate host positional. The classifier first skips the
+// after `--` is a deliberate host positional. The scan first skips the
 // spacedock-injected leading `--plugin-dir <dir>` prefix, then runs every check
-// against the real after-`--` tokens — so the subcommand exemption, the value-flag
-// scan, and any future per-token rule all see the operator's actual grammar
-// regardless of the injected prefix. A token is a candidate when it is non-flag
-// (does not start with `-`, and is not the bare `--` separator) AND the real tokens
-// do not lead with a known host subcommand whose arguments are legitimate. A
+// against the real Claude after-`--` tokens. A token is a candidate when it is
+// non-flag (does not start with `-`, and is not the bare `--` separator). A
 // candidate is reported as stray only when we can be confident it is NOT a host
 // flag's value:
 //   - preceding a recognized value-taking host flag → it is that flag's value, skip;
@@ -786,29 +677,20 @@ func skipInjectedPrefix(passthrough []string) []string {
 //   - otherwise (first token, or preceded by a positional or recognized boolean
 //     flag) → confidently stray.
 //
-// The check never alters the assembled argv — runClaude/runCodex only write the
-// warning to stderr.
-func strayPromptAfterDash(fd frontDoorArgs, host string) (positional string, ok bool) {
+// The check never alters the assembled argv — runClaude only writes the warning to
+// stderr.
+func strayPromptAfterDash(fd frontDoorArgs) (positional string, ok bool) {
 	if fd.hasTask {
 		return "", false
 	}
 	tokens := skipInjectedPrefix(fd.passthrough)
-	subcommands := leadingHostSubcommands[host]
-	if host == "codex" {
-		if command, found := codexCommandToken(tokens); found && subcommands[command] {
-			return "", false
-		}
-	} else if len(tokens) > 0 && subcommands[tokens[0]] {
-		return "", false
-	}
-	valueFlags := valueTakingHostFlags[host]
 	for i, tok := range tokens {
 		if tok == "--" || strings.HasPrefix(tok, "-") {
 			continue
 		}
 		if i > 0 {
 			prev := tokens[i-1]
-			if valueFlags[prev] {
+			if claudeValueTakingHostFlags[prev] {
 				continue // the value of a recognized value-taking host flag (space form)
 			}
 			// An equals-form flag (`--flag=value`) carries its own value, so it never
@@ -829,6 +711,10 @@ func strayPromptAfterDash(fd frontDoorArgs, host string) (positional string, ok 
 type frontDoorArgs struct {
 	// passthrough is the host-only argv (claude/codex flags), in operator order.
 	passthrough []string
+	// pluginDirPairs counts the pre-fence --plugin-dir pairs re-injected at the
+	// front of passthrough. It lets Codex consume only Spacedock-owned flags while
+	// preserving opaque post-fence argv.
+	pluginDirPairs int
 	// task is the launch-prompt override (the bare text after the `--` fence);
 	// hasTask distinguishes an explicit empty task from "no fence given".
 	task    string
@@ -934,10 +820,11 @@ func parseFrontDoorArgs(args []string) (fd frontDoorArgs, err error) {
 	// --plugin-dir is the one host flag spacedock parses before `--`: pflag knows
 	// its arity (one value, repeatable), so the dirs are captured correctly in
 	// space/equals/repeated forms. Re-inject each as a `--plugin-dir <dir>` pair at
-	// the FRONT of passthrough so it forwards to the host and hasPluginDir sees it,
-	// ahead of any after-`--` tokens. This keeps the spacedock prompt the always-last
-	// assembled token and hasPluginDir the single gate-relax reader (D4).
+	// the FRONT of passthrough, ahead of any after-`--` tokens, and record that owned
+	// prefix separately. Claude forwards it; Codex consumes only this declared prefix
+	// into its local marketplace while preserving all post-fence argv verbatim.
 	if dirs := *flags.pluginDir; len(dirs) > 0 {
+		fd.pluginDirPairs = len(dirs)
 		front := make([]string, 0, len(dirs)*2+len(fd.passthrough))
 		for _, d := range dirs {
 			front = append(front, "--plugin-dir", d)

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -635,20 +635,60 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 	return code
 }
 
-// codexResume reports whether the codex passthrough begins with the `resume`
-// subcommand (codex's resume is a leading subcommand, not a flag like claude's
-// `--resume`). A resume carries its own session intent, so the bootstrap prompt
-// is suppressed.
+// codexResume reports whether `resume` is the first Codex command token after
+// known global options. A resume carries its own session intent, so the bootstrap
+// prompt is suppressed. The scan is classification-only: it never rewrites the
+// forwarded passthrough argv.
 func codexResume(passthrough []string) bool {
-	return len(passthrough) > 0 && passthrough[0] == "resume"
+	command, ok := codexCommandToken(passthrough)
+	return ok && command == "resume"
+}
+
+// codexCommandToken returns the first Codex command token after known global
+// options. Unknown options stop the scan so an unknown option's value cannot be
+// mistaken for a command. The returned token remains in passthrough unchanged.
+func codexCommandToken(passthrough []string) (string, bool) {
+	valueFlags := valueTakingHostFlags["codex"]
+	flagOnly := flagOnlyHostFlags["codex"]
+	for len(passthrough) > 0 {
+		tok := passthrough[0]
+		if !strings.HasPrefix(tok, "-") || tok == "-" {
+			return tok, true
+		}
+		if flag, _, hasEqualsValue := strings.Cut(tok, "="); hasEqualsValue {
+			if !valueFlags[flag] {
+				return "", false
+			}
+			passthrough = passthrough[1:]
+			continue
+		}
+		if len(tok) > 2 && tok[0] == '-' && tok[1] != '-' && valueFlags[tok[:2]] {
+			passthrough = passthrough[1:] // compact short form, such as -mmodel
+			continue
+		}
+		if valueFlags[tok] {
+			if len(passthrough) < 2 {
+				return "", false
+			}
+			passthrough = passthrough[2:]
+			continue
+		}
+		if flagOnly[tok] {
+			passthrough = passthrough[1:]
+			continue
+		}
+		return "", false
+	}
+	return "", false
 }
 
 // valueTakingHostFlags is the per-host set of host flags whose successor token is
 // the flag's value (space form), so that successor is NOT a stray positional. The
-// assembled argv is unchanged regardless of membership; the set only tunes the
-// advisory's accuracy. The spacedock-injected `--plugin-dir <dir>` prefix is NOT
-// handled here — skipInjectedPrefix strips it structurally before any scan — so
-// the prefix interaction stays in one place rather than threaded through this set.
+// assembled argv is unchanged regardless of membership; the set tunes the
+// advisory and Codex command classifiers. The spacedock-injected `--plugin-dir
+// <dir>` prefix is NOT handled here — skipInjectedPrefix strips it structurally
+// before any scan — so the prefix interaction stays in one place rather than
+// threaded through this set.
 var valueTakingHostFlags = map[string]map[string]bool{
 	"claude": {
 		"-p": true, "--print": true,
@@ -663,14 +703,38 @@ var valueTakingHostFlags = map[string]map[string]bool{
 	},
 	"codex": {
 		"-m": true, "--model": true,
-		"--config":           true,
-		"-c":                 true,
-		"--cd":               true,
-		"--image":            true,
-		"--sandbox":          true,
-		"--profile":          true,
-		"--ask-for-approval": true,
-		"-a":                 true,
+		"--config":                true,
+		"-c":                      true,
+		"--enable":                true,
+		"--disable":               true,
+		"--remote":                true,
+		"--remote-auth-token-env": true,
+		"--cd":                    true,
+		"-C":                      true,
+		"--image":                 true,
+		"-i":                      true,
+		"--local-provider":        true,
+		"--sandbox":               true,
+		"-s":                      true,
+		"--profile":               true,
+		"-p":                      true,
+		"--add-dir":               true,
+		"--ask-for-approval":      true,
+		"-a":                      true,
+	},
+}
+
+// flagOnlyHostFlags complements valueTakingHostFlags for the known global host
+// flags that consume no following token. Keeping arity here lets codexResume
+// stop safely at an unknown option instead of mistaking its value for `resume`.
+var flagOnlyHostFlags = map[string]map[string]bool{
+	"codex": {
+		"--oss":           true,
+		"--strict-config": true,
+		"--dangerously-bypass-approvals-and-sandbox": true,
+		"--dangerously-bypass-hook-trust":            true,
+		"--search":                                   true,
+		"--no-alt-screen":                            true,
 	},
 }
 
@@ -730,7 +794,11 @@ func strayPromptAfterDash(fd frontDoorArgs, host string) (positional string, ok 
 	}
 	tokens := skipInjectedPrefix(fd.passthrough)
 	subcommands := leadingHostSubcommands[host]
-	if len(tokens) > 0 && subcommands[tokens[0]] {
+	if host == "codex" {
+		if command, found := codexCommandToken(tokens); found && subcommands[command] {
+			return "", false
+		}
+	} else if len(tokens) > 0 && subcommands[tokens[0]] {
 		return "", false
 	}
 	valueFlags := valueTakingHostFlags[host]

--- a/internal/cli/frontdoor_permission_mode_test.go
+++ b/internal/cli/frontdoor_permission_mode_test.go
@@ -195,9 +195,9 @@ func TestOperatorPermissionFlagSuppressesInjection(t *testing.T) {
 	})
 }
 
-// AC-4: the injected flag rides the non-resume gate — a resumed unsandboxed
-// launch is NOT forced into the auto/approval mode. Mirrors the resume-suppression
-// oracle: the bootstrap prompt and the injected flag share the same gate.
+// AC-4: the injected flag rides the non-bootstrap gate — Claude resume and every
+// nonempty Codex post-fence argv are not forced into their default permission/
+// approval mode. The bootstrap prompt and injected flag share the same gate.
 func TestResumeUnsandboxedSuppressesInjection(t *testing.T) {
 	t.Run("claude-resume", func(t *testing.T) {
 		dir := t.TempDir() // no .safehouse
@@ -215,7 +215,7 @@ func TestResumeUnsandboxedSuppressesInjection(t *testing.T) {
 			}
 		}
 	})
-	t.Run("codex-resume", func(t *testing.T) {
+	t.Run("codex-post-fence", func(t *testing.T) {
 		dir := t.TempDir() // no .safehouse
 		fake := &fakeHost{manifest: compatibleManifest(t)}
 		var stdout, stderr bytes.Buffer
@@ -227,7 +227,7 @@ func TestResumeUnsandboxedSuppressesInjection(t *testing.T) {
 		}
 		for _, tok := range fake.launchedArg {
 			if tok == "--ask-for-approval" {
-				t.Fatalf("resumed codex launch carried injected --ask-for-approval: %v", fake.launchedArg)
+				t.Fatalf("Codex post-fence launch carried injected --ask-for-approval: %v", fake.launchedArg)
 			}
 		}
 	})

--- a/internal/cli/frontdoor_stray_prompt_test.go
+++ b/internal/cli/frontdoor_stray_prompt_test.go
@@ -227,6 +227,11 @@ func TestStrayPromptAfterDashClassifier(t *testing.T) {
 			host:        "codex",
 		},
 		{
+			name:        "option-before-resume command is not stray",
+			passthrough: []string{"--model", "gpt-x", "resume", "abc-123"},
+			host:        "codex",
+		},
+		{
 			name:           "equals-form successor positional is stray",
 			passthrough:    []string{"--model=gpt-x", "@/tmp/handoff.md"},
 			host:           "claude",

--- a/internal/cli/frontdoor_stray_prompt_test.go
+++ b/internal/cli/frontdoor_stray_prompt_test.go
@@ -73,35 +73,6 @@ func TestClaudeStrayPromptSession12Shape(t *testing.T) {
 	}
 }
 
-// TestCodexStrayPromptAfterDashWarns (AC-1 positive, codex): the subcommand-less
-// passthrough leading with a value-taking flag still surfaces the stray prompt,
-// and the codex inner argv is unchanged.
-func TestCodexStrayPromptAfterDashWarns(t *testing.T) {
-	dir := safehouseFixtureDir(t)
-	bin := executableFixture(t)
-	withExecutablePath(t, bin, nil)
-	fake := &fakeHost{manifest: compatibleManifest(t)}
-	var stdout, stderr bytes.Buffer
-
-	code := runCodex(context.Background(), []string{"--", "-m", "gpt-x", "@/tmp/handoff.md"}, dir, fake, lookFound, &stdout, &stderr)
-
-	if code != 0 {
-		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
-	}
-	warn := stderr.String()
-	if !strings.Contains(warn, strayWarnMarker) {
-		t.Fatalf("stderr missing the stray-positional warning marker %q: %q", strayWarnMarker, warn)
-	}
-	if !strings.Contains(warn, "@/tmp/handoff.md") {
-		t.Fatalf("warning does not name the stray positional: %q", warn)
-	}
-	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
-		"codex", "--dangerously-bypass-approvals-and-sandbox", "-m", "gpt-x", "@/tmp/handoff.md", wantCodexBootstrapPrompt}
-	if !equalArgv(fake.launchedArg, want) {
-		t.Fatalf("launch argv = %v, want %v (warn must not change the argv)", fake.launchedArg, want)
-	}
-}
-
 // TestStrayPromptGuardNegatives (AC-2): a legitimate host positional after `--`
 // does NOT trip the guard, and the argv is unchanged in each case. The three
 // negatives are the value of a value-taking flag (`-p <prompt>`), the argument of
@@ -121,15 +92,6 @@ func TestStrayPromptGuardNegatives(t *testing.T) {
 			},
 			args: []string{"--", "-p", "do the thing"},
 			want: []string{"claude", "--agent", "spacedock:first-officer", "--permission-mode", "auto", "-p", "do the thing", wantBootstrapPrompt},
-		},
-		{
-			name: "codex exec subcommand-arg",
-			run: func(args []string, dir string, fake *fakeHost, stderr *bytes.Buffer) int {
-				var stdout bytes.Buffer
-				return runCodex(context.Background(), args, dir, fake, lookFound, &stdout, stderr)
-			},
-			args: []string{"--", "exec", "do the thing"},
-			want: []string{"codex", "--ask-for-approval", "on-request", "exec", "do the thing", wantCodexBootstrapPrompt},
 		},
 		{
 			name: "claude hasTask short-circuit",
@@ -152,30 +114,6 @@ func TestStrayPromptGuardNegatives(t *testing.T) {
 			args: []string{"--", "--some-new-flag", "the-value"},
 			want: []string{"claude", "--agent", "spacedock:first-officer", "--permission-mode", "auto", "--some-new-flag", "the-value", wantBootstrapPrompt},
 		},
-		{
-			// codex consumes `--plugin-dir <dir>` into a local install (its CLI has no
-			// such flag), so the flag never reaches the launch argv; the `exec`
-			// subcommand that follows still exempts its args from the stray guard.
-			name: "codex --plugin-dir then exec subcommand",
-			run: func(args []string, dir string, fake *fakeHost, stderr *bytes.Buffer) int {
-				var stdout bytes.Buffer
-				return runCodex(context.Background(), args, dir, fake, lookFound, &stdout, stderr)
-			},
-			args: []string{"--plugin-dir", "/co", "--", "exec", "do the thing"},
-			want: []string{"codex", "--ask-for-approval", "on-request", "exec", "do the thing", wantCodexBootstrapPrompt},
-		},
-		{
-			// Same consumption for the codex `resume` subcommand: --plugin-dir is
-			// stripped and installed, resume leads the passthrough (so no approval flag
-			// or bootstrap prompt), and the guard stays silent.
-			name: "codex --plugin-dir then resume subcommand",
-			run: func(args []string, dir string, fake *fakeHost, stderr *bytes.Buffer) int {
-				var stdout bytes.Buffer
-				return runCodex(context.Background(), args, dir, fake, lookFound, &stdout, stderr)
-			},
-			args: []string{"--plugin-dir", "/co", "--", "resume", "abc123"},
-			want: []string{"codex", "resume", "abc123"},
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -196,45 +134,30 @@ func TestStrayPromptGuardNegatives(t *testing.T) {
 	}
 }
 
-// TestStrayPromptAfterDashClassifier (AC-3): the classifier over the after-`--`
-// token grammar, independent of launch. Pins the boundary logic directly so a
-// regression in flag-set membership or subcommand recognition fails a fast unit
-// test, not only the launch-seam tests.
+// TestStrayPromptAfterDashClassifier (AC-3) pins Claude's advisory-only after-`--`
+// token grammar directly, so a value-flag regression fails a fast unit test rather
+// than only a launch-seam test.
 func TestStrayPromptAfterDashClassifier(t *testing.T) {
 	cases := []struct {
 		name           string
 		passthrough    []string
 		hasTask        bool
-		host           string
 		wantPositional string
 		wantOK         bool
 	}{
 		{
 			name:           "stray after value-flag pair",
 			passthrough:    []string{"--model", "gpt-x", "@/tmp/handoff.md"},
-			host:           "claude",
 			wantPositional: "@/tmp/handoff.md",
 			wantOK:         true,
 		},
 		{
 			name:        "value of value-taking flag is not stray",
 			passthrough: []string{"-p", "do the thing"},
-			host:        "claude",
-		},
-		{
-			name:        "leading subcommand arg is not stray",
-			passthrough: []string{"exec", "do the thing"},
-			host:        "codex",
-		},
-		{
-			name:        "option-before-resume command is not stray",
-			passthrough: []string{"--model", "gpt-x", "resume", "abc-123"},
-			host:        "codex",
 		},
 		{
 			name:           "equals-form successor positional is stray",
 			passthrough:    []string{"--model=gpt-x", "@/tmp/handoff.md"},
-			host:           "claude",
 			wantPositional: "@/tmp/handoff.md",
 			wantOK:         true,
 		},
@@ -242,46 +165,29 @@ func TestStrayPromptAfterDashClassifier(t *testing.T) {
 			name:        "hasTask short-circuit suppresses",
 			passthrough: []string{"@/tmp/handoff.md"},
 			hasTask:     true,
-			host:        "claude",
 		},
 		{
 			// skipInjectedPrefix strips the leading `--plugin-dir <dir>` pair so the
 			// dir is NOT named and the operator's real prompt after it IS.
 			name:           "spacedock-injected --plugin-dir prefix does not shadow the real prompt",
 			passthrough:    []string{"--plugin-dir", "/co", "--model", "gpt-x", "@/tmp/handoff.md"},
-			host:           "claude",
 			wantPositional: "@/tmp/handoff.md",
 			wantOK:         true,
-		},
-		{
-			// A leading subcommand BEHIND the injected `--plugin-dir <dir>` prefix must
-			// still be recognized as a subcommand (its args legitimate). This reds if
-			// skipInjectedPrefix is removed — the bare index-0 check then names `exec`.
-			name:        "subcommand behind injected --plugin-dir prefix is not stray",
-			passthrough: []string{"--plugin-dir", "/co", "exec", "do the thing"},
-			host:        "codex",
-		},
-		{
-			// Multiple injected `--plugin-dir <dir>` pairs are all skipped.
-			name:        "multiple injected --plugin-dir pairs all skipped before subcommand",
-			passthrough: []string{"--plugin-dir", "/a", "--plugin-dir", "/b", "exec", "p"},
-			host:        "codex",
 		},
 		{
 			// A value of an UNRECOGNIZED `-`-prefixed flag is ambiguous; the
 			// conservative fallback suppresses rather than prescribe wrong advice.
 			name:        "value of unrecognized flag suppresses (no wrong advice)",
 			passthrough: []string{"--some-new-flag", "the-value"},
-			host:        "claude",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			fd := frontDoorArgs{passthrough: tc.passthrough, hasTask: tc.hasTask}
-			pos, ok := strayPromptAfterDash(fd, tc.host)
+			pos, ok := strayPromptAfterDash(fd)
 			if ok != tc.wantOK || pos != tc.wantPositional {
-				t.Fatalf("strayPromptAfterDash(%v, %q) = (%q, %v), want (%q, %v)",
-					tc.passthrough, tc.host, pos, ok, tc.wantPositional, tc.wantOK)
+				t.Fatalf("strayPromptAfterDash(%v) = (%q, %v), want (%q, %v)",
+					tc.passthrough, pos, ok, tc.wantPositional, tc.wantOK)
 			}
 		})
 	}

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -802,9 +802,8 @@ func TestClaudeFrontDoorSkipCompatCheckBootstrap(t *testing.T) {
 }
 
 // TestCodexFrontDoorLaunchesOnCompatible: on a compatible contract the codex
-// front door invokes the launch seam with argv beginning `codex
-// --dangerously-bypass-approvals-and-sandbox` (under .safehouse) and passes
-// through the operator's trailing args before the FO-skill prompt.
+// front door preserves nonempty post-fence argv exactly, with safehouse owning
+// only its outer wrapping and bypass flag.
 func TestCodexFrontDoorLaunchesOnCompatible(t *testing.T) {
 	withVersion(t, testBinaryVersion)
 	dir := safehouseFixtureDir(t)
@@ -819,7 +818,7 @@ func TestCodexFrontDoorLaunchesOnCompatible(t *testing.T) {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
-		"codex", "--dangerously-bypass-approvals-and-sandbox", "-m", "gpt-x", wantCodexBootstrapPrompt}
+		"codex", "--dangerously-bypass-approvals-and-sandbox", "-m", "gpt-x"}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
 	}
@@ -852,7 +851,7 @@ func TestCodexFrontDoorInjectsLauncherBinThroughSafehouseResume(t *testing.T) {
 	}
 }
 
-func TestCodexFrontDoorRecognizesOptionBeforeResumeThroughSafehouse(t *testing.T) {
+func TestCodexFrontDoorForwardsPostFenceExampleThroughSafehouse(t *testing.T) {
 	withVersion(t, testBinaryVersion)
 	bin := executableFixture(t)
 	withExecutablePath(t, bin, nil)
@@ -871,7 +870,31 @@ func TestCodexFrontDoorRecognizesOptionBeforeResumeThroughSafehouse(t *testing.T
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, wantArgv)
 	}
 	if stderr.Len() != 0 {
-		t.Fatalf("option-before-resume printed a launch banner: %q", stderr.String())
+		t.Fatalf("opaque post-fence argv produced Spacedock output: %q", stderr.String())
+	}
+}
+
+func TestCodexFrontDoorPreservesOpaquePostFenceThroughSafehouse(t *testing.T) {
+	withVersion(t, testBinaryVersion)
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
+	dir := safehouseFixtureDir(t)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	args := []string{"--", "--future-codex-flag=handoff", "opaque-argument"}
+	code := runCodex(context.Background(), args, dir, fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	wantArgv := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
+		"codex", "--dangerously-bypass-approvals-and-sandbox", "--future-codex-flag=handoff", "opaque-argument"}
+	if !equalArgv(fake.launchedArg, wantArgv) {
+		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, wantArgv)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("opaque post-fence argv produced Spacedock output: %q", stderr.String())
 	}
 }
 

--- a/internal/cli/frontdoor_test.go
+++ b/internal/cli/frontdoor_test.go
@@ -852,6 +852,29 @@ func TestCodexFrontDoorInjectsLauncherBinThroughSafehouseResume(t *testing.T) {
 	}
 }
 
+func TestCodexFrontDoorRecognizesOptionBeforeResumeThroughSafehouse(t *testing.T) {
+	withVersion(t, testBinaryVersion)
+	bin := executableFixture(t)
+	withExecutablePath(t, bin, nil)
+	dir := safehouseFixtureDir(t)
+	fake := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runCodex(context.Background(), []string{"--", "--model", "gpt-x", "resume", "abc123"}, dir, fake, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	wantArgv := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
+		"codex", "--dangerously-bypass-approvals-and-sandbox", "--model", "gpt-x", "resume", "abc123"}
+	if !equalArgv(fake.launchedArg, wantArgv) {
+		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, wantArgv)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("option-before-resume printed a launch banner: %q", stderr.String())
+	}
+}
+
 // TestCodexFrontDoorDoesNotEnableAgentTeams: the agent-teams flag is a
 // claude-only concern; the codex launch path must NOT inject it (scope guard).
 func TestCodexFrontDoorDoesNotEnableAgentTeams(t *testing.T) {

--- a/internal/cli/launch_banner_test.go
+++ b/internal/cli/launch_banner_test.go
@@ -205,8 +205,8 @@ func TestLaunchBannerReachesStderrBeforeLaunch(t *testing.T) {
 
 // TestLaunchBannerSuppressedOnResume (AC-B polish): a resume continues an
 // existing session, not a fresh launch, so the banner is suppressed — its
-// version line must NOT appear on stderr. claude's resume is a flag; codex's is
-// the leading `resume` subcommand.
+// version line must NOT appear on stderr. Claude's resume is a flag; any nonempty
+// Codex post-fence argv is opaque and has the same no-banner posture.
 func TestLaunchBannerSuppressedOnResume(t *testing.T) {
 	t.Run("claude --resume", func(t *testing.T) {
 		fake := &fakeHost{manifest: compatibleManifest(t)}
@@ -219,7 +219,7 @@ func TestLaunchBannerSuppressedOnResume(t *testing.T) {
 		}
 	})
 
-	t.Run("codex resume subcommand", func(t *testing.T) {
+	t.Run("codex post-fence passthrough", func(t *testing.T) {
 		dir := safehouseFixtureDir(t)
 		fake := &fakeHost{manifest: compatibleManifest(t)}
 		var stdout, stderr bytes.Buffer
@@ -227,7 +227,7 @@ func TestLaunchBannerSuppressedOnResume(t *testing.T) {
 			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 		}
 		if strings.Contains(stderr.String(), "spacedock "+displayVersion()) {
-			t.Fatalf("banner emitted on codex resume (should be suppressed): %q", stderr.String())
+			t.Fatalf("banner emitted on codex post-fence passthrough: %q", stderr.String())
 		}
 	})
 }

--- a/internal/cli/launch_parity_test.go
+++ b/internal/cli/launch_parity_test.go
@@ -240,9 +240,10 @@ func TestFenceTaskPromptOverride(t *testing.T) {
 	})
 }
 
-// LP-AC-2: codex resume subcommand suppresses the prompt; bare codex gets base.
-func TestCodexResumeSubcommandSuppressesPrompt(t *testing.T) {
-	t.Run("resume-no-prompt", func(t *testing.T) {
+// LP-AC-2: any nonempty Codex post-fence argv suppresses the prompt; bare Codex
+// gets the bootstrap prompt.
+func TestCodexPostFenceSuppressesPrompt(t *testing.T) {
+	t.Run("post-fence-argv-no-prompt", func(t *testing.T) {
 		fake := &fakeHost{manifest: compatibleManifest(t)}
 		var stdout, stderr bytes.Buffer
 		code := runCodex(context.Background(), []string{"--", "resume", "abc-123"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
@@ -251,11 +252,11 @@ func TestCodexResumeSubcommandSuppressesPrompt(t *testing.T) {
 		}
 		want := []string{"codex", "resume", "abc-123"}
 		if !equalArgv(fake.launchedArg, want) {
-			t.Fatalf("launch argv = %v, want %v (resume forwards verbatim, no prompt)", fake.launchedArg, want)
+			t.Fatalf("launch argv = %v, want %v (post-fence argv forwards verbatim, no prompt)", fake.launchedArg, want)
 		}
 		for _, tok := range fake.launchedArg {
 			if tok == wantCodexBootstrapPrompt {
-				t.Fatalf("codex resume carried the bootstrap prompt: %v", fake.launchedArg)
+				t.Fatalf("codex post-fence argv carried the bootstrap prompt: %v", fake.launchedArg)
 			}
 		}
 	})
@@ -273,61 +274,53 @@ func TestCodexResumeSubcommandSuppressesPrompt(t *testing.T) {
 	})
 }
 
-// LP-AC-2 extension: Codex global options may precede its first command token.
-// A recognized option-before-resume form still carries its own session intent,
-// while the first non-option command token decides the fresh-vs-resume posture.
-func TestCodexOptionBeforeResumeSuppressesPrompt(t *testing.T) {
+// Every nonempty Codex post-fence example receives the same opaque passthrough
+// posture, without classifying its options or command tokens.
+func TestCodexPostFenceExamplesSuppressPrompt(t *testing.T) {
 	tests := []struct {
 		name        string
 		passthrough []string
 		want        []string
-		resume      bool
 	}{
 		{
 			name:        "model space form",
 			passthrough: []string{"--model", "gpt-x", "resume", "abc-123"},
 			want:        []string{"codex", "--model", "gpt-x", "resume", "abc-123"},
-			resume:      true,
 		},
 		{
 			name:        "model equals form",
 			passthrough: []string{"--model=gpt-x", "resume", "abc-123"},
 			want:        []string{"codex", "--model=gpt-x", "resume", "abc-123"},
-			resume:      true,
 		},
 		{
 			name:        "model short form",
 			passthrough: []string{"-m", "gpt-x", "resume", "abc-123"},
 			want:        []string{"codex", "-m", "gpt-x", "resume", "abc-123"},
-			resume:      true,
 		},
 		{
 			name:        "model short attached value",
 			passthrough: []string{"-mgpt-x", "resume", "abc-123"},
 			want:        []string{"codex", "-mgpt-x", "resume", "abc-123"},
-			resume:      true,
 		},
 		{
 			name:        "shared value-taking option",
 			passthrough: []string{"--config", "model=\"gpt-x\"", "resume", "abc-123"},
 			want:        []string{"codex", "--config", "model=\"gpt-x\"", "resume", "abc-123"},
-			resume:      true,
 		},
 		{
 			name:        "known valueless option",
 			passthrough: []string{"--oss", "resume", "abc-123"},
 			want:        []string{"codex", "--oss", "resume", "abc-123"},
-			resume:      true,
 		},
 		{
-			name:        "model only remains fresh",
+			name:        "model only remains opaque",
 			passthrough: []string{"--model", "gpt-x"},
-			want:        []string{"codex", "--ask-for-approval", "on-request", "--model", "gpt-x", wantCodexBootstrapPrompt},
+			want:        []string{"codex", "--model", "gpt-x"},
 		},
 		{
-			name:        "first command wins over later resume text",
+			name:        "arbitrary command with later resume text remains opaque",
 			passthrough: []string{"--model", "gpt-x", "exec", "resume", "abc-123"},
-			want:        []string{"codex", "--ask-for-approval", "on-request", "--model", "gpt-x", "exec", "resume", "abc-123", wantCodexBootstrapPrompt},
+			want:        []string{"codex", "--model", "gpt-x", "exec", "resume", "abc-123"},
 		},
 	}
 
@@ -343,8 +336,47 @@ func TestCodexOptionBeforeResumeSuppressesPrompt(t *testing.T) {
 			if !equalArgv(fake.launchedArg, tt.want) {
 				t.Fatalf("launch argv = %v, want %v", fake.launchedArg, tt.want)
 			}
-			if tt.resume && stderr.Len() != 0 {
-				t.Fatalf("option-before-resume printed a launch banner: %q", stderr.String())
+			if stderr.Len() != 0 {
+				t.Fatalf("opaque post-fence argv produced Spacedock output: %q", stderr.String())
+			}
+		})
+	}
+}
+
+// A nonempty post-fence Codex argv belongs entirely to Codex. Spacedock must not
+// parse its tokens to decide whether to add its own launch defaults.
+func TestCodexPostFencePassthroughIsOpaque(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		want       []string
+		wantSilent bool
+	}{
+		{
+			name:       "future option and positional remain opaque",
+			args:       []string{"--", "--future-codex-flag=handoff", "opaque-argument"},
+			want:       []string{"codex", "--future-codex-flag=handoff", "opaque-argument"},
+			wantSilent: true,
+		},
+		{
+			name: "bare codex still boots the first officer",
+			want: []string{"codex", "--ask-for-approval", "on-request", wantCodexBootstrapPrompt},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeHost{manifest: compatibleManifest(t)}
+			var stdout, stderr bytes.Buffer
+			code := runCodex(context.Background(), tt.args, t.TempDir(), fake, lookFound, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+			}
+			if !equalArgv(fake.launchedArg, tt.want) {
+				t.Fatalf("launch argv = %v, want %v", fake.launchedArg, tt.want)
+			}
+			if tt.wantSilent && stderr.Len() != 0 {
+				t.Fatalf("opaque post-fence argv produced Spacedock output: %q", stderr.String())
 			}
 		})
 	}

--- a/internal/cli/launch_parity_test.go
+++ b/internal/cli/launch_parity_test.go
@@ -273,6 +273,83 @@ func TestCodexResumeSubcommandSuppressesPrompt(t *testing.T) {
 	})
 }
 
+// LP-AC-2 extension: Codex global options may precede its first command token.
+// A recognized option-before-resume form still carries its own session intent,
+// while the first non-option command token decides the fresh-vs-resume posture.
+func TestCodexOptionBeforeResumeSuppressesPrompt(t *testing.T) {
+	tests := []struct {
+		name        string
+		passthrough []string
+		want        []string
+		resume      bool
+	}{
+		{
+			name:        "model space form",
+			passthrough: []string{"--model", "gpt-x", "resume", "abc-123"},
+			want:        []string{"codex", "--model", "gpt-x", "resume", "abc-123"},
+			resume:      true,
+		},
+		{
+			name:        "model equals form",
+			passthrough: []string{"--model=gpt-x", "resume", "abc-123"},
+			want:        []string{"codex", "--model=gpt-x", "resume", "abc-123"},
+			resume:      true,
+		},
+		{
+			name:        "model short form",
+			passthrough: []string{"-m", "gpt-x", "resume", "abc-123"},
+			want:        []string{"codex", "-m", "gpt-x", "resume", "abc-123"},
+			resume:      true,
+		},
+		{
+			name:        "model short attached value",
+			passthrough: []string{"-mgpt-x", "resume", "abc-123"},
+			want:        []string{"codex", "-mgpt-x", "resume", "abc-123"},
+			resume:      true,
+		},
+		{
+			name:        "shared value-taking option",
+			passthrough: []string{"--config", "model=\"gpt-x\"", "resume", "abc-123"},
+			want:        []string{"codex", "--config", "model=\"gpt-x\"", "resume", "abc-123"},
+			resume:      true,
+		},
+		{
+			name:        "known valueless option",
+			passthrough: []string{"--oss", "resume", "abc-123"},
+			want:        []string{"codex", "--oss", "resume", "abc-123"},
+			resume:      true,
+		},
+		{
+			name:        "model only remains fresh",
+			passthrough: []string{"--model", "gpt-x"},
+			want:        []string{"codex", "--ask-for-approval", "on-request", "--model", "gpt-x", wantCodexBootstrapPrompt},
+		},
+		{
+			name:        "first command wins over later resume text",
+			passthrough: []string{"--model", "gpt-x", "exec", "resume", "abc-123"},
+			want:        []string{"codex", "--ask-for-approval", "on-request", "--model", "gpt-x", "exec", "resume", "abc-123", wantCodexBootstrapPrompt},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeHost{manifest: compatibleManifest(t)}
+			var stdout, stderr bytes.Buffer
+			args := append([]string{"--"}, tt.passthrough...)
+			code := runCodex(context.Background(), args, t.TempDir(), fake, lookFound, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+			}
+			if !equalArgv(fake.launchedArg, tt.want) {
+				t.Fatalf("launch argv = %v, want %v", fake.launchedArg, tt.want)
+			}
+			if tt.resume && stderr.Len() != 0 {
+				t.Fatalf("option-before-resume printed a launch banner: %q", stderr.String())
+			}
+		})
+	}
+}
+
 // LP-AC-3: for claude, --plugin-dir passes through (multiplicity, order) AND
 // relaxes the gate (launches even on a failing manifest); without it the gate
 // still fails. Codex is the exception: its CLI has no --plugin-dir flag, so the

--- a/internal/cli/safehouse_frontdoor_test.go
+++ b/internal/cli/safehouse_frontdoor_test.go
@@ -234,8 +234,8 @@ func TestClaudeSafehousePresentButBinaryMissing(t *testing.T) {
 const wantCodexBootstrapPrompt = "You totally got this. Take your time. I love you. And tell all subagents and team members you love them too. Assume $spacedock:first-officer for the entire session."
 
 // codex AC-2: .safehouse present → canonical safehouse-wrapped codex argv with
-// codex's own sandbox bypassed and the FO-skill prompt appended LAST, after the
-// operator passthrough. Mirrors runClaude's dir+lookPath threading. The wrap
+// codex's own sandbox bypassed and opaque post-fence argv forwarded unchanged.
+// Mirrors runClaude's dir+lookPath threading. The wrap
 // carries `--env-pass SPACEDOCK_BIN` among the safehouse flags (before `--`); the
 // inner program is `codex` directly after `--` (NO /usr/bin/env, NO SPACEDOCK_BIN=
 // argv token).
@@ -253,7 +253,7 @@ func TestCodexSafehousePresentWrapsArgv(t *testing.T) {
 	}
 	want := []string{"safehouse", "--trust-workdir-config", "--env-pass", spacedockBinEnv, "--",
 		"codex", "--dangerously-bypass-approvals-and-sandbox",
-		"--foo", wantCodexBootstrapPrompt}
+		"--foo"}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
 	}
@@ -301,9 +301,8 @@ func TestCodexSafehousePromptNamesFirstOfficerSkill(t *testing.T) {
 	}
 }
 
-// codex no-`.safehouse` = captain option (b): plain `codex <fo-prompt>` with NO
-// --dangerously-bypass-approvals-and-sandbox (bypass is safehouse-path-only); the
-// token `safehouse` appears nowhere; the FO-skill prompt is still appended last.
+// codex no-`.safehouse`: a nonempty post-fence argv is plain `codex <argv>` with
+// no bypass flag and no Spacedock launch defaults.
 func TestCodexNoSafehouseLaunchesPlainNoBypass(t *testing.T) {
 	dir := t.TempDir() // no .safehouse
 	fake := &fakeHost{manifest: compatibleManifest(t)}
@@ -314,7 +313,7 @@ func TestCodexNoSafehouseLaunchesPlainNoBypass(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	want := []string{"codex", "--ask-for-approval", "on-request", "--foo", wantCodexBootstrapPrompt}
+	want := []string{"codex", "--foo"}
 	if !equalArgv(fake.launchedArg, want) {
 		t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
 	}


### PR DESCRIPTION
Nonempty `spacedock codex -- …` argv is now forwarded unchanged, so explicit Codex commands never receive a Spacedock bootstrap prompt.

## What changed

- Remove Codex option and subcommand grammar parsing.
- Forward direct, Safehouse, and local-plugin argv unchanged.
- Consume only Spacedock-owned pre-fence plugin directories.
- Document opaque post-fence passthrough.

## Evidence

- Focused, full, and race suites: 471 / 2,164 / 2,164 tests passed.
- NUL-argv probes passed across all paths; a false predicate broke five tests.

---
[xv](https://github.com/spacedock-dev/spacedock/blob/3a6bce44a74cadcf042c2a9cd8126408a84faf62/codex-resume-no-bootstrap-prompt/index.md)