### PR TITLE
spacedock state ready resolves init paths relative to cwd and requires an origin remote

### DIFF
--- a/docs/site/advanced/split-root-state.md
+++ b/docs/site/advanced/split-root-state.md
@@ -2,7 +2,7 @@
 
 A busy workflow generates constant small state commits. Split-root keeps them off your code branch. The README and stage declarations stay on your main branch; the mutable entity state (frontmatter updates, stage reports, archive moves) lives in a separate state checkout. Your code history stays clean, and several agents or operators can drive the same workflow at once.
 
-The README [opts in with one `state:` field](../concepts/workflows-and-entities.md#keep-workflow-state-off-your-code-branch); the split is transparent, and you read the workflow exactly as you would any other. On a fresh clone the state checkout is absent; run `spacedock state init` to restore it. The shipped [`docs/dev` workflow](https://github.com/spacedock-dev/spacedock/tree/main/docs/dev) runs split-root, a live example.
+The README [opts in with one `state:` field](../concepts/workflows-and-entities.md#keep-workflow-state-off-your-code-branch); the split is transparent, and you read the workflow exactly as you would any other. On a fresh clone the state checkout is absent; run `spacedock state init` to restore it. The checkout always lands at the workflow's declared path under the repository's main worktree, wherever the command runs from; a repo with no `origin` remote resumes from the local state branch. The shipped [`docs/dev` workflow](https://github.com/spacedock-dev/spacedock/tree/main/docs/dev) runs split-root, a live example.
 
 ## Concurrent writers
 

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -47,7 +47,7 @@ func runStateInit(ctx context.Context, args []string, env []string, dir string, 
 		fmt.Fprintf(stderr, "spacedock state init: %v\n", err)
 		return 1
 	}
-	statePath := filepath.Join(workflowDir, relPath)
+	statePath := resolveSplitRootCheckout(workflowDir, relPath)
 
 	// Path-exists guard: a present state checkout is a no-op. Refresh it from
 	// origin so a resume sees peers' commits, then report. Never re-`worktree add`
@@ -60,20 +60,82 @@ func runStateInit(ctx context.Context, args []string, env []string, dir string, 
 		return 0
 	}
 
-	// Fresh resume: fetch the orphan branch, then add it as a linked worktree.
-	if ok, out := runGit(workflowDir, "fetch", "origin", branch); !ok {
-		fmt.Fprintf(stderr, "spacedock state init: git fetch origin %s failed:\n%s\n"+
-			"Manual fallback: git fetch origin %s && git worktree add %s %s\n",
-			branch, out, branch, statePath, branch)
-		return 1
+	code, _ = resumeAbsentSplitRootCheckout(workflowDir, branch, statePath, stdout, stderr)
+	return code
+}
+
+// resumeAbsentSplitRootCheckout implements the RESUME half of `state init`,
+// shared with `state ready`'s absent-checkout resume. Callers confirm statePath's
+// directory is ABSENT before calling. It repairs a stale worktree registration —
+// necessarily stale here, since a live registration's directory would exist (e.g.
+// issue #484's deleted-checkout-but-registered-worktree repro, where a raw `git
+// worktree add` at that path fatals exit 128 "missing but already registered
+// worktree") — then adds statePath as a linked worktree on branch, preferring a
+// fresh fetch from origin and falling back to the local branch when origin is
+// absent or unreachable (mirrors `state commit`'s local-only carve-out). Neither
+// fetchable nor local is a hard failure (exit 1).
+//
+// originReached reports whether this resume actually fetched from origin — false
+// for a local-only or fallback resume. `state ready` uses this to skip its own
+// follow-up network pull against a checkout it just proved can't reach origin
+// (rather than immediately failing that pull and defeating the fallback).
+func resumeAbsentSplitRootCheckout(workflowDir, branch, statePath string, stdout, stderr io.Writer) (code int, originReached bool) {
+	if err := repairStaleWorktreeRegistration(workflowDir, statePath, stdout); err != nil {
+		fmt.Fprintf(stderr, "spacedock state init: %v\n", err)
+		return 1, false
 	}
-	if ok, out := runGit(workflowDir, "worktree", "add", statePath, branch); !ok {
-		fmt.Fprintf(stderr, "spacedock state init: git worktree add %s %s failed:\n%s\n",
-			statePath, branch, out)
-		return 1
+
+	hasOrigin := stateHasOrigin(workflowDir)
+	var fetchOK bool
+	var fetchOut string
+	if hasOrigin {
+		fetchOK, fetchOut = runGit(workflowDir, "fetch", "origin", branch)
 	}
-	fmt.Fprintf(stdout, "Initialized state checkout at %s (branch %s).\n", statePath, branch)
-	return 0
+	localBranchExists, _ := runGit(workflowDir, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
+
+	switch {
+	case fetchOK:
+		if ok, out := runGit(workflowDir, "worktree", "add", statePath, branch); !ok {
+			fmt.Fprintf(stderr, "spacedock state init: git worktree add %s %s failed:\n%s\n", statePath, branch, out)
+			return 1, false
+		}
+		fmt.Fprintf(stdout, "Initialized state checkout at %s (branch %s).\n", statePath, branch)
+		return 0, true
+
+	case localBranchExists:
+		if ok, out := runGit(workflowDir, "worktree", "add", statePath, branch); !ok {
+			fmt.Fprintf(stderr, "spacedock state init: git worktree add %s %s failed:\n%s\n", statePath, branch, out)
+			return 1, false
+		}
+		if !hasOrigin {
+			fmt.Fprintf(stdout, "Initialized state checkout at %s (branch %s) — no origin remote, state is local-only.\n", statePath, branch)
+		} else {
+			fmt.Fprintf(stdout, "Warning: git fetch origin %s failed; resumed from the local branch — peers' state may be missing:\n%s\n", branch, fetchOut)
+			fmt.Fprintf(stdout, "Initialized state checkout at %s (branch %s).\n", statePath, branch)
+		}
+		return 0, false
+
+	default:
+		// Neither a fetchable origin branch nor a local branch. Disambiguate
+		// "never birthed" (no way the branch exists anywhere) from "origin
+		// unreachable" (indeterminate — the branch may exist, we just can't see
+		// it) so the hint doesn't send an operator to `state new` when a peer's
+		// birth is merely unreachable right now.
+		reachable, found := false, false
+		if hasOrigin {
+			reachable, found = remoteBranchStatus(workflowDir, branch)
+		}
+		neverBirthed := !found && (!hasOrigin || reachable)
+		if neverBirthed {
+			fmt.Fprintf(stderr, "spacedock state init: state branch %s not found locally or on origin at %s — the workflow has not been birthed here. Run `spacedock state new --workflow-dir %s`.\n",
+				branch, statePath, workflowDir)
+		} else {
+			fmt.Fprintf(stderr, "spacedock state init: git fetch origin %s failed:\n%s\n"+
+				"Manual fallback: git fetch origin %s && git worktree add %s %s\n",
+				branch, fetchOut, branch, statePath, branch)
+		}
+		return 1, false
+	}
 }
 
 // parseStateInitArgs reads `--workflow-dir DIR`, resolving a relative path
@@ -132,7 +194,7 @@ func runStateNew(ctx context.Context, args []string, env []string, dir string, s
 		fmt.Fprintf(stderr, "spacedock state new: %v\n", err)
 		return 1
 	}
-	statePath := filepath.Join(workflowDir, relPath)
+	statePath := resolveSplitRootCheckout(workflowDir, relPath)
 
 	// Refusal prechecks (AC-3): an occupied path or an existing orphan (local or
 	// remote) means the workflow is already birthed; refuse with a tailored message
@@ -176,6 +238,21 @@ func runStateNew(ctx context.Context, args []string, env []string, dir string, s
 func orphanOnRemote(workflowDir, branch string) bool {
 	ok, out := runGit(workflowDir, "ls-remote", "--heads", "origin", branch)
 	return ok && lsRemoteHasBranch(out, branch)
+}
+
+// remoteBranchStatus reports whether `git ls-remote --heads origin {branch}`
+// could reach origin at all (reachable) and, if so, whether branch was found
+// there (found). Unlike orphanOnRemote, an unreachable origin is distinguished
+// from a reachable one with no matching branch: `ls-remote` exits non-zero on an
+// unreachable/misconfigured remote but exits 0 with empty output when reachable
+// with no such branch — so reachable=false means the caller cannot conclude
+// anything about the branch's existence, only that it couldn't check.
+func remoteBranchStatus(workflowDir, branch string) (reachable, found bool) {
+	ok, out := runGit(workflowDir, "ls-remote", "--heads", "origin", branch)
+	if !ok {
+		return false, false
+	}
+	return true, lsRemoteHasBranch(out, branch)
 }
 
 // lsRemoteHasBranch reports whether `git ls-remote --heads` output names branch.
@@ -365,4 +442,39 @@ func fileExists(path string) bool {
 func dirExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
+}
+
+// repairStaleWorktreeRegistration removes a stale `git worktree` registration for
+// statePath before a fresh resume adds it. Callers only reach this after
+// confirming statePath's directory is ABSENT, so any registration found for it is
+// necessarily stale (a live registration's directory would exist) — e.g. issue
+// #484's deleted-checkout-but-registered-worktree repro, where a raw `git
+// worktree add` at that path fatals exit 128 "missing but already registered
+// worktree". Comparisons are realpath-normalized (macOS `/var` -> `/private/var`).
+// Never runs `git worktree prune` (would touch unrelated registrations) and never
+// removes a registration whose directory exists (the caller's dirExists guard
+// already routes that case to the present-checkout no-op instead).
+func repairStaleWorktreeRegistration(workflowDir, statePath string, stdout io.Writer) error {
+	ok, out := runGit(workflowDir, "worktree", "list", "--porcelain")
+	if !ok {
+		// Best-effort: a listing failure just skips the repair; the subsequent
+		// `worktree add` will surface any real problem.
+		return nil
+	}
+	target := status.RealpathOf(statePath)
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "worktree ") {
+			continue
+		}
+		registered := strings.TrimSpace(line[len("worktree "):])
+		if status.RealpathOf(registered) != target {
+			continue
+		}
+		if ok, out := runGit(workflowDir, "worktree", "remove", "--force", statePath); !ok {
+			return fmt.Errorf("repairing stale worktree registration for %s failed:\n%s", statePath, out)
+		}
+		fmt.Fprintf(stdout, "Repaired stale worktree registration for %s.\n", statePath)
+		return nil
+	}
+	return nil
 }

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -47,7 +47,11 @@ func runStateInit(ctx context.Context, args []string, env []string, dir string, 
 		fmt.Fprintf(stderr, "spacedock state init: %v\n", err)
 		return 1
 	}
-	statePath := resolveSplitRootCheckout(workflowDir, relPath)
+	statePath, err := resolveSplitRootCheckout(workflowDir, relPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock state init: cannot resolve state checkout: %v\n", err)
+		return 1
+	}
 
 	// Path-exists guard: a present state checkout is a no-op. Refresh it from
 	// origin so a resume sees peers' commits, then report. Never re-`worktree add`
@@ -80,62 +84,75 @@ func runStateInit(ctx context.Context, args []string, env []string, dir string, 
 // follow-up network pull against a checkout it just proved can't reach origin
 // (rather than immediately failing that pull and defeating the fallback).
 func resumeAbsentSplitRootCheckout(workflowDir, branch, statePath string, stdout, stderr io.Writer) (code int, originReached bool) {
-	if err := repairStaleWorktreeRegistration(workflowDir, statePath, stdout); err != nil {
-		fmt.Fprintf(stderr, "spacedock state init: %v\n", err)
-		return 1, false
-	}
-
-	hasOrigin := stateHasOrigin(workflowDir)
-	var fetchOK bool
-	var fetchOut string
-	if hasOrigin {
-		fetchOK, fetchOut = runGit(workflowDir, "fetch", "origin", branch)
-	}
-	localBranchExists, _ := runGit(workflowDir, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
-
-	switch {
-	case fetchOK:
-		if ok, out := runGit(workflowDir, "worktree", "add", statePath, branch); !ok {
-			fmt.Fprintf(stderr, "spacedock state init: git worktree add %s %s failed:\n%s\n", statePath, branch, out)
+	code, originReached, err := withStateResumeLock(workflowDir, func() (int, bool) {
+		// Another process may have completed the resume while this caller waited.
+		// Re-check while holding the same repository-scoped lock that guards repair
+		// and creation; never remove a checkout that appeared after the outer check.
+		if dirExists(statePath) {
+			return 0, stateHasOrigin(statePath)
+		}
+		if err := repairStaleWorktreeRegistration(workflowDir, statePath, stdout); err != nil {
+			fmt.Fprintf(stderr, "spacedock state init: %v\n", err)
 			return 1, false
 		}
-		fmt.Fprintf(stdout, "Initialized state checkout at %s (branch %s).\n", statePath, branch)
-		return 0, true
 
-	case localBranchExists:
-		if ok, out := runGit(workflowDir, "worktree", "add", statePath, branch); !ok {
-			fmt.Fprintf(stderr, "spacedock state init: git worktree add %s %s failed:\n%s\n", statePath, branch, out)
-			return 1, false
-		}
-		if !hasOrigin {
-			fmt.Fprintf(stdout, "Initialized state checkout at %s (branch %s) — no origin remote, state is local-only.\n", statePath, branch)
-		} else {
-			fmt.Fprintf(stdout, "Warning: git fetch origin %s failed; resumed from the local branch — peers' state may be missing:\n%s\n", branch, fetchOut)
-			fmt.Fprintf(stdout, "Initialized state checkout at %s (branch %s).\n", statePath, branch)
-		}
-		return 0, false
-
-	default:
-		// Neither a fetchable origin branch nor a local branch. Disambiguate
-		// "never birthed" (no way the branch exists anywhere) from "origin
-		// unreachable" (indeterminate — the branch may exist, we just can't see
-		// it) so the hint doesn't send an operator to `state new` when a peer's
-		// birth is merely unreachable right now.
-		reachable, found := false, false
+		hasOrigin := stateHasOrigin(workflowDir)
+		var fetchOK bool
+		var fetchOut string
 		if hasOrigin {
-			reachable, found = remoteBranchStatus(workflowDir, branch)
+			fetchOK, fetchOut = runGit(workflowDir, "fetch", "origin", branch)
 		}
-		neverBirthed := !found && (!hasOrigin || reachable)
-		if neverBirthed {
-			fmt.Fprintf(stderr, "spacedock state init: state branch %s not found locally or on origin at %s — the workflow has not been birthed here. Run `spacedock state new --workflow-dir %s`.\n",
-				branch, statePath, workflowDir)
-		} else {
-			fmt.Fprintf(stderr, "spacedock state init: git fetch origin %s failed:\n%s\n"+
-				"Manual fallback: git fetch origin %s && git worktree add %s %s\n",
-				branch, fetchOut, branch, statePath, branch)
+		localBranchExists, _ := runGit(workflowDir, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
+
+		switch {
+		case fetchOK:
+			if ok, out := runGit(workflowDir, "worktree", "add", statePath, branch); !ok {
+				fmt.Fprintf(stderr, "spacedock state init: git worktree add %s %s failed:\n%s\n", statePath, branch, out)
+				return 1, false
+			}
+			fmt.Fprintf(stdout, "Initialized state checkout at %s (branch %s).\n", statePath, branch)
+			return 0, true
+
+		case localBranchExists:
+			if ok, out := runGit(workflowDir, "worktree", "add", statePath, branch); !ok {
+				fmt.Fprintf(stderr, "spacedock state init: git worktree add %s %s failed:\n%s\n", statePath, branch, out)
+				return 1, false
+			}
+			if !hasOrigin {
+				fmt.Fprintf(stdout, "Initialized state checkout at %s (branch %s) — no origin remote, state is local-only.\n", statePath, branch)
+			} else {
+				fmt.Fprintf(stdout, "Warning: git fetch origin %s failed; resumed from the local branch — peers' state may be missing:\n%s\n", branch, fetchOut)
+				fmt.Fprintf(stdout, "Initialized state checkout at %s (branch %s).\n", statePath, branch)
+			}
+			return 0, false
+
+		default:
+			// Neither a fetchable origin branch nor a local branch. Disambiguate
+			// "never birthed" (no way the branch exists anywhere) from "origin
+			// unreachable" (indeterminate — the branch may exist, we just can't see
+			// it) so the hint doesn't send an operator to `state new` when a peer's
+			// birth is merely unreachable right now.
+			reachable, found := false, false
+			if hasOrigin {
+				reachable, found = remoteBranchStatus(workflowDir, branch)
+			}
+			neverBirthed := !found && (!hasOrigin || reachable)
+			if neverBirthed {
+				fmt.Fprintf(stderr, "spacedock state init: state branch %s not found locally or on origin at %s — the workflow has not been birthed here. Run `spacedock state new --workflow-dir %s`.\n",
+					branch, statePath, workflowDir)
+			} else {
+				fmt.Fprintf(stderr, "spacedock state init: git fetch origin %s failed:\n%s\n"+
+					"Manual fallback: git fetch origin %s && git worktree add %s %s\n",
+					branch, fetchOut, branch, statePath, branch)
+			}
+			return 1, false
 		}
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock state init: cannot lock state resume: %v\n", err)
 		return 1, false
 	}
+	return code, originReached
 }
 
 // parseStateInitArgs reads `--workflow-dir DIR`, resolving a relative path
@@ -194,7 +211,11 @@ func runStateNew(ctx context.Context, args []string, env []string, dir string, s
 		fmt.Fprintf(stderr, "spacedock state new: %v\n", err)
 		return 1
 	}
-	statePath := resolveSplitRootCheckout(workflowDir, relPath)
+	statePath, err := resolveSplitRootCheckout(workflowDir, relPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock state new: cannot resolve state checkout: %v\n", err)
+		return 1
+	}
 
 	// Refusal prechecks (AC-3): an occupied path or an existing orphan (local or
 	// remote) means the workflow is already birthed; refuse with a tailored message
@@ -282,6 +303,10 @@ func appendGitignoreEntry(workflowDir, relPath string) error {
 	if err != nil {
 		return err
 	}
+	placement, err := status.ResolveRepositoryPlacement(workflowDir)
+	if err != nil {
+		return err
+	}
 	// The .gitignore entry is the workflow's repo-relative prefix + the state
 	// relPath, so a docs/dev workflow ignores docs/dev/.spacedock-state/. Derive the
 	// prefix from git's `--show-prefix` rather than filepath.Rel against the
@@ -293,9 +318,27 @@ func appendGitignoreEntry(workflowDir, relPath string) error {
 		return err
 	}
 	entry := filepath.ToSlash(filepath.Join(prefix, relPath)) + "/"
+	// The checkout is physically created under the main worktree even when this
+	// command runs from a linked worktree. The tracked .gitignore edit belongs to
+	// the invoking code branch, but until that edit is merged the main worktree
+	// would otherwise see the state checkout as untracked content. Mirror the
+	// physical path into the shared repository exclude before creating it.
+	if placement.InGit {
+		exclude := filepath.Join(placement.CommonGitDir, "info", "exclude")
+		if err := appendIgnoreEntry(exclude, "/"+entry); err != nil {
+			return fmt.Errorf("updating repository exclude: %w", err)
+		}
+	}
 
 	gitignore := filepath.Join(root, ".gitignore")
-	existing, err := os.ReadFile(gitignore)
+	return appendIgnoreEntry(gitignore, entry)
+}
+
+func appendIgnoreEntry(path, entry string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	existing, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -309,7 +352,7 @@ func appendGitignoreEntry(workflowDir, relPath string) error {
 		body += "\n"
 	}
 	body += entry + "\n"
-	return os.WriteFile(gitignore, []byte(body), 0o644)
+	return os.WriteFile(path, []byte(body), 0o644)
 }
 
 // birthOrphanState creates the orphan branch in a temp detached worktree (clearing

--- a/internal/cli/state_checkout.go
+++ b/internal/cli/state_checkout.go
@@ -1,0 +1,68 @@
+// ABOUTME: Split-root checkout path resolution — anchors the checkout at the
+// ABOUTME: repository's main worktree regardless of the invoking cwd.
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// resolveSplitRootCheckout maps (workflowDir, relPath) to the split-root state
+// checkout's absolute path. The checkout is a process-wide singleton that only
+// ever exists at the repository's MAIN worktree — its directory is gitignored, so
+// a linked (agent) worktree's copy of the same relative path never exists. When
+// workflowDir sits inside a linked worktree, the checkout is re-anchored at
+// <main-worktree-root>/<repo-relative-prefix>/<relPath>. Outside a linked
+// worktree — the main worktree itself, or workflowDir not inside a git repository
+// at all (the standalone test fixtures) — this is a plain
+// filepath.Join(workflowDir, relPath).
+func resolveSplitRootCheckout(workflowDir, relPath string) string {
+	if !isLinkedWorktree(workflowDir) {
+		return filepath.Join(workflowDir, relPath)
+	}
+	mainRoot, err := mainWorktreeRoot(workflowDir)
+	if err != nil {
+		return filepath.Join(workflowDir, relPath)
+	}
+	prefix, err := repoRelPrefix(workflowDir)
+	if err != nil {
+		return filepath.Join(workflowDir, relPath)
+	}
+	return filepath.Join(mainRoot, prefix, relPath)
+}
+
+// isLinkedWorktree reports whether dir sits inside a linked (non-main) git
+// worktree. `--git-dir` and `--git-common-dir` agree only in the main worktree
+// (both resolve to the repo's single `.git`); a linked worktree's git-dir is
+// `.git/worktrees/<name>` while its git-common-dir stays the shared `.git`. Both
+// are read with `--path-format=absolute` and realpath-normalized (macOS `/var` ->
+// `/private/var`) so the comparison never depends on cwd-relative spelling. A
+// non-git dir (the standalone test fixtures) reports false — the caller's
+// fallback is the historical unanchored join.
+func isLinkedWorktree(dir string) bool {
+	gitDirOK, gitDirOut := runGit(dir, "rev-parse", "--path-format=absolute", "--git-dir")
+	commonDirOK, commonDirOut := runGit(dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if !gitDirOK || !commonDirOK {
+		return false
+	}
+	return status.RealpathOf(strings.TrimSpace(gitDirOut)) != status.RealpathOf(strings.TrimSpace(commonDirOut))
+}
+
+// mainWorktreeRoot returns the absolute path of the repository's main worktree,
+// as seen from any linked worktree — `git worktree list --porcelain`'s first
+// entry is always the main worktree, regardless of which worktree invokes it.
+func mainWorktreeRoot(dir string) (string, error) {
+	ok, out := runGit(dir, "worktree", "list", "--porcelain")
+	if !ok {
+		return "", fmt.Errorf("git worktree list --porcelain failed:\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "worktree ") {
+			return strings.TrimSpace(line[len("worktree "):]), nil
+		}
+	}
+	return "", fmt.Errorf("git worktree list --porcelain returned no worktree entries")
+}

--- a/internal/cli/state_checkout.go
+++ b/internal/cli/state_checkout.go
@@ -2,13 +2,7 @@
 // ABOUTME: repository's main worktree regardless of the invoking cwd.
 package cli
 
-import (
-	"fmt"
-	"path/filepath"
-	"strings"
-
-	"github.com/spacedock-dev/spacedock/internal/status"
-)
+import "github.com/spacedock-dev/spacedock/internal/status"
 
 // resolveSplitRootCheckout maps (workflowDir, relPath) to the split-root state
 // checkout's absolute path. The checkout is a process-wide singleton that only
@@ -19,50 +13,6 @@ import (
 // worktree — the main worktree itself, or workflowDir not inside a git repository
 // at all (the standalone test fixtures) — this is a plain
 // filepath.Join(workflowDir, relPath).
-func resolveSplitRootCheckout(workflowDir, relPath string) string {
-	if !isLinkedWorktree(workflowDir) {
-		return filepath.Join(workflowDir, relPath)
-	}
-	mainRoot, err := mainWorktreeRoot(workflowDir)
-	if err != nil {
-		return filepath.Join(workflowDir, relPath)
-	}
-	prefix, err := repoRelPrefix(workflowDir)
-	if err != nil {
-		return filepath.Join(workflowDir, relPath)
-	}
-	return filepath.Join(mainRoot, prefix, relPath)
-}
-
-// isLinkedWorktree reports whether dir sits inside a linked (non-main) git
-// worktree. `--git-dir` and `--git-common-dir` agree only in the main worktree
-// (both resolve to the repo's single `.git`); a linked worktree's git-dir is
-// `.git/worktrees/<name>` while its git-common-dir stays the shared `.git`. Both
-// are read with `--path-format=absolute` and realpath-normalized (macOS `/var` ->
-// `/private/var`) so the comparison never depends on cwd-relative spelling. A
-// non-git dir (the standalone test fixtures) reports false — the caller's
-// fallback is the historical unanchored join.
-func isLinkedWorktree(dir string) bool {
-	gitDirOK, gitDirOut := runGit(dir, "rev-parse", "--path-format=absolute", "--git-dir")
-	commonDirOK, commonDirOut := runGit(dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
-	if !gitDirOK || !commonDirOK {
-		return false
-	}
-	return status.RealpathOf(strings.TrimSpace(gitDirOut)) != status.RealpathOf(strings.TrimSpace(commonDirOut))
-}
-
-// mainWorktreeRoot returns the absolute path of the repository's main worktree,
-// as seen from any linked worktree — `git worktree list --porcelain`'s first
-// entry is always the main worktree, regardless of which worktree invokes it.
-func mainWorktreeRoot(dir string) (string, error) {
-	ok, out := runGit(dir, "worktree", "list", "--porcelain")
-	if !ok {
-		return "", fmt.Errorf("git worktree list --porcelain failed:\n%s", out)
-	}
-	for _, line := range strings.Split(out, "\n") {
-		if strings.HasPrefix(line, "worktree ") {
-			return strings.TrimSpace(line[len("worktree "):]), nil
-		}
-	}
-	return "", fmt.Errorf("git worktree list --porcelain returned no worktree entries")
+func resolveSplitRootCheckout(workflowDir, relPath string) (string, error) {
+	return status.ResolveSplitRootCheckout(workflowDir, relPath)
 }

--- a/internal/cli/state_checkout_test.go
+++ b/internal/cli/state_checkout_test.go
@@ -5,11 +5,15 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/spacedock-dev/spacedock/internal/dispatch"
 	"github.com/spacedock-dev/spacedock/internal/status"
 )
 
@@ -209,6 +213,260 @@ func TestStateReadyNoOriginResumeFromRoot(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "local-only") {
 		t.Fatalf("no-origin resume output should say local-only; got stdout=%q", out.String())
+	}
+}
+
+func TestStateReadyJSONAbsentCheckoutIsAtomic(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T) (root, workflowDir, statePath string)
+	}{
+		{
+			name: "local-only with stale registration",
+			setup: func(t *testing.T) (string, string, string) {
+				root, workflowDir, statePath := noOriginSplitWorkflow(t)
+				if err := os.RemoveAll(statePath); err != nil {
+					t.Fatal(err)
+				}
+				return root, workflowDir, statePath
+			},
+		},
+		{
+			name: "origin-backed fresh clone",
+			setup: func(t *testing.T) (string, string, string) {
+				bare := filepath.Join(t.TempDir(), "origin.git")
+				git(t, t.TempDir(), "init", "-q", "--bare", bare)
+				hostA := filepath.Join(t.TempDir(), "host-a")
+				git(t, t.TempDir(), "clone", "-q", bare, hostA)
+				git(t, hostA, "config", "user.email", "a@t")
+				git(t, hostA, "config", "user.name", "a")
+				commissionSplitWorkflow(t, hostA)
+				git(t, hostA, "push", "-q", "origin", "HEAD")
+				fresh := filepath.Join(t.TempDir(), "fresh")
+				git(t, t.TempDir(), "clone", "-q", bare, fresh)
+				return fresh, filepath.Join(fresh, "docs", "dev"), filepath.Join(fresh, "docs", "dev", ".spacedock-state")
+			},
+		},
+		{
+			name: "unreachable origin local fallback warning suppressed",
+			setup: func(t *testing.T) (string, string, string) {
+				bare := filepath.Join(t.TempDir(), "origin.git")
+				git(t, t.TempDir(), "init", "-q", "--bare", bare)
+				host := filepath.Join(t.TempDir(), "host")
+				git(t, t.TempDir(), "clone", "-q", bare, host)
+				git(t, host, "config", "user.email", "t@t")
+				git(t, host, "config", "user.name", "t")
+				workflowDir, _, _ := commissionSplitWorkflow(t, host)
+				statePath := filepath.Join(workflowDir, ".spacedock-state")
+				if err := os.RemoveAll(statePath); err != nil {
+					t.Fatal(err)
+				}
+				git(t, host, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "missing.git"))
+				return host, workflowDir, statePath
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			root, workflowDir, statePath := tc.setup(t)
+			var out, errBuf strings.Builder
+			code := run(context.Background(), []string{"state", "ready", "--workflow-dir", workflowDir, "--json"},
+				os.Environ(), root, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+			if code != 0 {
+				t.Fatalf("state ready --json exit=%d stderr=%q stdout=%q", code, errBuf.String(), out.String())
+			}
+			if errBuf.String() != "" {
+				t.Fatalf("successful state ready --json wrote stderr=%q", errBuf.String())
+			}
+			if !json.Valid([]byte(out.String())) {
+				t.Fatalf("stdout is not one atomic JSON document: %q", out.String())
+			}
+			var envelope map[string]any
+			if err := json.Unmarshal([]byte(out.String()), &envelope); err != nil {
+				t.Fatal(err)
+			}
+			if envelope["command"] != "state ready" || envelope["result"] != "ready" {
+				t.Fatalf("unexpected envelope: %#v", envelope)
+			}
+			if _, err := os.Stat(statePath); err != nil {
+				t.Fatalf("state checkout not restored: %v", err)
+			}
+		})
+	}
+}
+
+func TestConcurrentStateReadySerializesRepairAndCreation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root, workflowDir, statePath := noOriginSplitWorkflow(t)
+	entity := filepath.Join(statePath, "race-task.md")
+	if err := os.WriteFile(entity, []byte("---\nstatus: implementation\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, statePath, "add", "race-task.md")
+	git(t, statePath, "commit", "-q", "-m", "seed race task")
+	wantHead := strings.TrimSpace(git(t, statePath, "rev-parse", "HEAD"))
+	if err := os.RemoveAll(statePath); err != nil {
+		t.Fatal(err)
+	}
+
+	const callers = 12
+	start := make(chan struct{})
+	results := make(chan string, callers)
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			var out, errBuf strings.Builder
+			code := run(context.Background(), []string{"state", "ready", "--workflow-dir", workflowDir},
+				os.Environ(), root, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+			results <- strings.Join([]string{fmt.Sprint(code), out.String(), errBuf.String()}, "|")
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for result := range results {
+		if !strings.HasPrefix(result, "0|") {
+			t.Fatalf("concurrent state ready failed: %q", result)
+		}
+	}
+	if got := strings.TrimSpace(git(t, statePath, "rev-parse", "HEAD")); got != wantHead {
+		t.Fatalf("state HEAD changed: got %s want %s", got, wantHead)
+	}
+	if _, err := os.Stat(entity); err != nil {
+		t.Fatalf("entity missing after concurrent resume: %v", err)
+	}
+	registrations := 0
+	for _, line := range strings.Split(git(t, root, "worktree", "list", "--porcelain"), "\n") {
+		if strings.HasPrefix(line, "worktree ") && status.RealpathOf(strings.TrimSpace(strings.TrimPrefix(line, "worktree "))) == status.RealpathOf(statePath) {
+			registrations++
+		}
+	}
+	if registrations != 1 {
+		t.Fatalf("state checkout registrations=%d, want exactly 1", registrations)
+	}
+}
+
+func TestLinkedWorktreeMetadataFailureFailsClosed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root, _, statePath := noOriginSplitWorkflow(t)
+	wantHead := strings.TrimSpace(git(t, statePath, "rev-parse", "HEAD"))
+	wtRoot := addAgentWorktree(t, root, "broken-metadata")
+	wtWorkflow := filepath.Join(wtRoot, "docs", "dev")
+	if err := os.WriteFile(filepath.Join(wtRoot, ".git"), []byte("gitdir: /definitely/missing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "ready", "--workflow-dir", wtWorkflow},
+		os.Environ(), wtRoot, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 1 || !strings.Contains(errBuf.String(), "cannot resolve state checkout") {
+		t.Fatalf("metadata failure must fail closed; exit=%d stdout=%q stderr=%q", code, out.String(), errBuf.String())
+	}
+	if _, err := os.Stat(filepath.Join(wtWorkflow, ".spacedock-state")); !os.IsNotExist(err) {
+		t.Fatalf("metadata failure created nested state path: %v", err)
+	}
+	if got := strings.TrimSpace(git(t, statePath, "rev-parse", "HEAD")); got != wantHead {
+		t.Fatalf("main state checkout mutated: got HEAD %s want %s", got, wantHead)
+	}
+}
+
+func TestStatusAndSweepFromLinkedWorktreeUseMainState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root, _, statePath := noOriginSplitWorkflow(t)
+	entity := filepath.Join(statePath, "placement-task.md")
+	if err := os.WriteFile(entity, []byte("---\nid: placement\ntitle: Placement\nstatus: implementation\npr: '#42'\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, statePath, "add", "placement-task.md")
+	git(t, statePath, "commit", "-q", "-m", "seed placement task")
+	wtRoot := addAgentWorktree(t, root, "placement")
+	wtWorkflow := filepath.Join(wtRoot, "docs", "dev")
+
+	var statusOut, statusErr strings.Builder
+	code := run(context.Background(), []string{"status", "--workflow-dir", wtWorkflow, "--set", "placement-task", "status=ideation"},
+		os.Environ(), wtRoot, nil, &statusOut, &statusErr, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("linked-worktree status mutation exit=%d stderr=%q", code, statusErr.String())
+	}
+	if got := status.ParseFrontmatter(entity)["status"]; got != "ideation" {
+		t.Fatalf("main state entity status=%q, want ideation", got)
+	}
+	if _, err := os.Stat(filepath.Join(wtWorkflow, ".spacedock-state")); !os.IsNotExist(err) {
+		t.Fatalf("status created or used nested checkout: %v", err)
+	}
+	var bootOut, bootErr strings.Builder
+	code = run(context.Background(), []string{"status", "--workflow-dir", wtWorkflow, "--boot", "--json"},
+		os.Environ(), wtRoot, nil, &bootOut, &bootErr, &status.NativeRunner{}, nil)
+	if code != 0 || !json.Valid([]byte(bootOut.String())) {
+		t.Fatalf("linked-worktree boot exit=%d stdout=%q stderr=%q", code, bootOut.String(), bootErr.String())
+	}
+	if !strings.Contains(bootOut.String(), statePath) || strings.Contains(bootOut.String(), filepath.Join(wtWorkflow, ".spacedock-state")) {
+		t.Fatalf("boot did not report exact main-root entity directory: %s", bootOut.String())
+	}
+
+	var sweepOut, sweepErr strings.Builder
+	code = dispatch.Sweep(wtWorkflow, func(string) (string, error) { return "MERGED", nil }, true, &sweepOut, &sweepErr)
+	if code != 0 || !json.Valid([]byte(sweepOut.String())) {
+		t.Fatalf("linked-worktree sweep exit=%d stdout=%q stderr=%q", code, sweepOut.String(), sweepErr.String())
+	}
+	if !strings.Contains(sweepOut.String(), `"slug": "placement-task"`) {
+		t.Fatalf("sweep did not read main state checkout: %s", sweepOut.String())
+	}
+}
+
+func TestStateNewFromLinkedWorktreeIgnoresPhysicalMainCheckout(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	git(t, root, "init", "-q")
+	git(t, root, "config", "user.email", "t@t")
+	git(t, root, "config", "user.name", "t")
+	workflowDir := filepath.Join(root, "docs", "dev")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "README.md"), []byte(splitWorkflowReadme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(".worktrees/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, root, "add", "docs/dev/README.md", ".gitignore")
+	git(t, root, "commit", "-q", "-m", "add workflow")
+	wtRoot := addAgentWorktree(t, root, "birth")
+	wtWorkflow := filepath.Join(wtRoot, "docs", "dev")
+
+	code, _, stderr := execStateNew(t, wtRoot, wtWorkflow)
+	if code != 0 {
+		t.Fatalf("state new from linked worktree exit=%d stderr=%q", code, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(workflowDir, ".spacedock-state")); err != nil {
+		t.Fatalf("main-anchored state checkout absent: %v", err)
+	}
+	exclude, err := os.ReadFile(filepath.Join(root, ".git", "info", "exclude"))
+	if err != nil || !strings.Contains(string(exclude), "/docs/dev/.spacedock-state/") {
+		t.Fatalf("shared exclude does not protect physical checkout: err=%v body=%q", err, string(exclude))
+	}
+	trackedIgnore, err := os.ReadFile(filepath.Join(wtRoot, ".gitignore"))
+	if err != nil || !strings.Contains(string(trackedIgnore), "docs/dev/.spacedock-state/") {
+		t.Fatalf("tracked ignore missing on invoking branch: err=%v body=%q", err, string(trackedIgnore))
+	}
+	if got := strings.TrimSpace(git(t, root, "status", "--porcelain", "--untracked-files=all")); got != "" {
+		t.Fatalf("main worktree sees physical state checkout as dirty: %q", got)
+	}
+	if got := strings.TrimSpace(git(t, wtRoot, "status", "--porcelain", "--untracked-files=all")); got != "M .gitignore" && got != " M .gitignore" {
+		t.Fatalf("linked worktree should carry only the intentional .gitignore edit, got %q", got)
+	}
+	git(t, wtRoot, "add", ".gitignore")
+	git(t, wtRoot, "commit", "-q", "-m", "ignore state checkout")
+	if got := strings.TrimSpace(git(t, root, "status", "--porcelain", "--untracked-files=all")); got != "" {
+		t.Fatalf("main worktree dirty after linked ignore commit: %q", got)
+	}
+	if got := strings.TrimSpace(git(t, wtRoot, "status", "--porcelain", "--untracked-files=all")); got != "" {
+		t.Fatalf("linked worktree dirty after ignore commit: %q", got)
 	}
 }
 

--- a/internal/cli/state_checkout_test.go
+++ b/internal/cli/state_checkout_test.go
@@ -1,0 +1,413 @@
+// ABOUTME: Real-git e2e for main-worktree-anchored split-root checkout resolution
+// ABOUTME: (issue #484) — worktree-cwd anchoring, no-origin/unreachable-origin
+// ABOUTME: resume fallback, and targeted stale-worktree-registration repair.
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+// addAgentWorktree adds a linked git worktree at hostRoot/.worktrees/<name>, on a
+// new branch off HEAD — the shape a Spacedock agent dispatch creates
+// (`.worktrees/<worker>-<entity>/`). Returns the worktree's absolute root, whose
+// docs/dev carries the same commissioned README as the main worktree (same repo
+// content, a different checkout location) — the setup issue #484 observed the
+// cwd-relative bug from.
+func addAgentWorktree(t *testing.T, hostRoot, name string) string {
+	t.Helper()
+	wtRoot := filepath.Join(hostRoot, ".worktrees", name)
+	git(t, hostRoot, "worktree", "add", "-q", "-b", "agent/"+name, wtRoot, "HEAD")
+	return wtRoot
+}
+
+// noOriginSplitWorkflow births a standalone (no `origin` remote at all) split-root
+// workflow at root/docs/dev via the real `state new` command, matching the
+// no-origin carve-out `state commit`/`state new` already document. Returns the
+// workflow dir and its state checkout path (present after birth).
+func noOriginSplitWorkflow(t *testing.T) (root, workflowDir, statePath string) {
+	t.Helper()
+	root = t.TempDir()
+	git(t, root, "init", "-q")
+	git(t, root, "config", "user.email", "t@t")
+	git(t, root, "config", "user.name", "t")
+	workflowDir = filepath.Join(root, "docs", "dev")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "README.md"), []byte(splitWorkflowReadme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, root, "add", "docs/dev/README.md")
+	git(t, root, "commit", "-q", "-m", "add split-root README")
+
+	code, _, stderr := execStateNew(t, root, workflowDir)
+	if code != 0 {
+		t.Fatalf("noOriginSplitWorkflow: state new failed; exit=%d stderr=%q", code, stderr)
+	}
+	statePath = filepath.Join(workflowDir, ".spacedock-state")
+	return root, workflowDir, statePath
+}
+
+// TestStateReadyFromWorktreeCwdPresentCheckoutResolvesMain pins test-plan item 1 /
+// AC-2: `state ready`, invoked with cwd inside an agent worktree, resolves the
+// checkout ALREADY PRESENT at the main worktree — no nested copy appears under
+// the worktree. Cwd variant: bare discovery (no --workflow-dir); the process cwd
+// (the worktree root, mirroring where an ensign's dispatch actually starts) walks
+// up/scans down to the worktree's own copy of docs/dev.
+func TestStateReadyFromWorktreeCwdPresentCheckoutResolvesMain(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+
+	hostClone := filepath.Join(t.TempDir(), "host")
+	git(t, t.TempDir(), "clone", "-q", bare, hostClone)
+	git(t, hostClone, "config", "user.email", "t@t")
+	git(t, hostClone, "config", "user.name", "t")
+	workflowDir, _, _ := commissionSplitWorkflow(t, hostClone)
+	git(t, hostClone, "push", "-q", "origin", "HEAD")
+	mainCheckout := filepath.Join(workflowDir, ".spacedock-state")
+
+	wtRoot := addAgentWorktree(t, hostClone, "w1")
+	nestedCheckout := filepath.Join(wtRoot, "docs", "dev", ".spacedock-state")
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "ready"},
+		os.Environ(), wtRoot, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("state ready from worktree cwd (checkout present) should exit 0; got exit=%d stderr=%q", code, errBuf.String())
+	}
+	if _, err := os.Stat(mainCheckout); err != nil {
+		t.Fatalf("main checkout should still be present at %s: %v", mainCheckout, err)
+	}
+	if _, err := os.Stat(nestedCheckout); !os.IsNotExist(err) {
+		t.Fatalf("state ready must NOT create a nested checkout under the worktree; found at %s", nestedCheckout)
+	}
+}
+
+// TestStateReadyFromWorktreeCwdAbsentCheckoutResumesMain pins test-plan item 2 /
+// AC-2: `state ready` with the checkout ABSENT (fresh clone), invoked with cwd
+// inside an agent worktree, resumes the checkout at the MAIN-anchored path, never
+// under the worktree. Cwd variant: bare discovery from the worktree root, same as
+// the present-checkout test above.
+func TestStateReadyFromWorktreeCwdAbsentCheckoutResumesMain(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+
+	hostA := filepath.Join(t.TempDir(), "hostA")
+	git(t, t.TempDir(), "clone", "-q", bare, hostA)
+	git(t, hostA, "config", "user.email", "a@t")
+	git(t, hostA, "config", "user.name", "a")
+	commissionSplitWorkflow(t, hostA)
+	git(t, hostA, "push", "-q", "origin", "HEAD")
+
+	fresh := filepath.Join(t.TempDir(), "fresh")
+	git(t, t.TempDir(), "clone", "-q", bare, fresh)
+	git(t, fresh, "config", "user.email", "f@t")
+	git(t, fresh, "config", "user.name", "f")
+	mainCheckout := filepath.Join(fresh, "docs", "dev", ".spacedock-state")
+
+	wtRoot := addAgentWorktree(t, fresh, "w1")
+	nestedCheckout := filepath.Join(wtRoot, "docs", "dev", ".spacedock-state")
+
+	if _, err := os.Stat(mainCheckout); !os.IsNotExist(err) {
+		t.Fatalf("precondition: fresh clone should NOT yet have the state checkout (err=%v)", err)
+	}
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "ready"},
+		os.Environ(), wtRoot, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("state ready from worktree cwd (checkout absent) should resume (exit 0); got exit=%d stderr=%q", code, errBuf.String())
+	}
+	if _, err := os.Stat(mainCheckout); err != nil {
+		t.Fatalf("state ready should have resumed the checkout at the MAIN-anchored path %s: %v", mainCheckout, err)
+	}
+	if _, err := os.Stat(nestedCheckout); !os.IsNotExist(err) {
+		t.Fatalf("state ready must NOT resume a nested checkout under the worktree; found at %s", nestedCheckout)
+	}
+}
+
+// TestStateReadyIssue484Repro pins test-plan item 3, AC-1 (the value-measure
+// baseline) and AC-5: the full issue #484 repro — a no-origin repo whose split-root
+// checkout directory was deleted while its worktree registration survived —
+// converges from a worktree cwd. Cwd variant: bare discovery from the worktree
+// root. Where 0.24.0-pre2 exits non-zero and proposes a worktree-nested path, this
+// must exit 0 and restore the checkout at the main-root state path with the
+// pre-existing entity still readable, and no `.spacedock-state` anywhere under
+// `.worktrees/`.
+func TestStateReadyIssue484Repro(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root, _, statePath := noOriginSplitWorkflow(t)
+
+	// Seed an entity in the checkout so AC-1's "entity file readable" has
+	// something concrete to assert on, then delete the checkout dir while
+	// leaving the worktree registration behind (the reported repro: `git
+	// worktree list --porcelain` still names the now-missing directory).
+	entity := filepath.Join(statePath, "first-task.md")
+	if err := os.WriteFile(entity, []byte("---\nstatus: ideation\n---\n# First Task\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, statePath, "add", "-A")
+	git(t, statePath, "commit", "-q", "-m", "seed first-task")
+	if err := os.RemoveAll(statePath); err != nil {
+		t.Fatal(err)
+	}
+	if out := git(t, root, "worktree", "list", "--porcelain"); !strings.Contains(out, statePath) {
+		t.Fatalf("precondition: worktree registration for %s should survive the directory deletion; list=%q", statePath, out)
+	}
+
+	wtRoot := addAgentWorktree(t, root, "w1")
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "ready"},
+		os.Environ(), wtRoot, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("issue #484 repro should converge (exit 0); got exit=%d stdout=%q stderr=%q", code, out.String(), errBuf.String())
+	}
+	if _, err := os.Stat(filepath.Join(statePath, "first-task.md")); err != nil {
+		t.Fatalf("restored checkout should carry the pre-existing entity: %v", err)
+	}
+
+	worktreesDir := filepath.Join(root, ".worktrees")
+	walkErr := filepath.Walk(worktreesDir, func(path string, info os.FileInfo, err error) error {
+		if err == nil && info.IsDir() && info.Name() == ".spacedock-state" {
+			t.Fatalf("no .spacedock-state may appear anywhere under .worktrees/; found %s", path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking %s failed: %v", worktreesDir, walkErr)
+	}
+}
+
+// TestStateReadyNoOriginResumeFromRoot pins test-plan item 4, AC-3: a no-origin
+// repo resumes an absent checkout from the local state branch when invoked from
+// the repo root (no worktree involved) — exit 0, entities present, local-only
+// wording in the output.
+func TestStateReadyNoOriginResumeFromRoot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root, workflowDir, statePath := noOriginSplitWorkflow(t)
+	if err := os.RemoveAll(statePath); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "ready", "--workflow-dir", workflowDir},
+		os.Environ(), root, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("no-origin resume from root should exit 0; got exit=%d stderr=%q", code, errBuf.String())
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("no-origin resume should have restored the checkout: %v", err)
+	}
+	if !strings.Contains(out.String(), "local-only") {
+		t.Fatalf("no-origin resume output should say local-only; got stdout=%q", out.String())
+	}
+}
+
+// TestStateReadyUnreachableOriginFallsBackToLocalBranch pins test-plan item 5
+// (with-local-branch half), AC-4: origin is CONFIGURED but unreachable (a bad
+// local path, never a real remote); resume falls back to the local state branch,
+// exits 0, and warns that the fetch failed.
+func TestStateReadyUnreachableOriginFallsBackToLocalBranch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+
+	hostClone := filepath.Join(t.TempDir(), "host")
+	git(t, t.TempDir(), "clone", "-q", bare, hostClone)
+	git(t, hostClone, "config", "user.email", "t@t")
+	git(t, hostClone, "config", "user.name", "t")
+	workflowDir, _, _ := commissionSplitWorkflow(t, hostClone)
+	git(t, hostClone, "push", "-q", "origin", "HEAD")
+	statePath := filepath.Join(workflowDir, ".spacedock-state")
+
+	if err := os.RemoveAll(statePath); err != nil {
+		t.Fatal(err)
+	}
+	git(t, hostClone, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "does-not-exist.git"))
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "ready", "--workflow-dir", workflowDir},
+		os.Environ(), hostClone, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("unreachable-origin resume with a local branch should exit 0; got exit=%d stdout=%q stderr=%q", code, out.String(), errBuf.String())
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("resume should have restored the checkout from the local branch: %v", err)
+	}
+	if !strings.Contains(out.String(), "Warning") || !strings.Contains(out.String(), "fetch") {
+		t.Fatalf("resume should warn that the fetch failed; got stdout=%q", out.String())
+	}
+}
+
+// TestStateReadyUnreachableOriginNoLocalBranchHintsMainAnchoredPath pins test-plan
+// item 5 (without-local-branch half), AC-4: origin is configured but unreachable
+// AND no local branch exists — resume cannot fall back to anything, exits
+// non-zero, and the hint names the main-anchored checkout path via the generic
+// manual-fallback wording (NOT the "state new" never-birthed wording — an
+// unreachable origin is indeterminate, not proof the branch was never birthed).
+func TestStateReadyUnreachableOriginNoLocalBranchHintsMainAnchoredPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	git(t, root, "init", "-q")
+	git(t, root, "config", "user.email", "t@t")
+	git(t, root, "config", "user.name", "t")
+	workflowDir := filepath.Join(root, "docs", "dev")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "README.md"), []byte(splitWorkflowReadme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, root, "add", "docs/dev/README.md")
+	git(t, root, "commit", "-q", "-m", "add split-root README")
+	git(t, root, "remote", "add", "origin", filepath.Join(t.TempDir(), "does-not-exist.git"))
+	statePath := filepath.Join(workflowDir, ".spacedock-state")
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "ready", "--workflow-dir", workflowDir},
+		os.Environ(), root, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code == 0 {
+		t.Fatalf("unreachable origin with no local branch must fail, not silently succeed; stdout=%q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "Manual fallback") {
+		t.Fatalf("hint should carry the manual-fallback wording; stderr=%q", errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), statePath) {
+		t.Fatalf("hint should name the main-anchored checkout path %s; stderr=%q", statePath, errBuf.String())
+	}
+	if strings.Contains(errBuf.String(), "spacedock state new") {
+		t.Fatalf("indeterminate (unreachable) origin must NOT claim the branch was never birthed; stderr=%q", errBuf.String())
+	}
+}
+
+// TestStateReadyNeverBirthedFromWorktreeCwdHintsStateNewAtMainPath pins test-plan
+// item 6 (AC-4) AND the ideation-gate-flagged AC-2 requirement: "one test forces
+// the manual-fallback hint from a worktree cwd and asserts the hinted path." Cwd
+// variant: EXPLICIT --workflow-dir naming a path physically inside the linked
+// worktree (distinct from the bare-discovery-from-worktree-cwd variant exercised
+// by the Present/Absent tests above) — the shape of a hook or script passing
+// --workflow-dir explicitly from inside an agent worktree, issue #484's second
+// named trigger ("hooks/scripts may invoke it from anywhere"). No origin and no
+// local branch exist anywhere, so the branch was genuinely never birthed; the
+// hint must name `spacedock state new` AND the MAIN-anchored path, never the
+// worktree-nested one.
+func TestStateReadyNeverBirthedFromWorktreeCwdHintsStateNewAtMainPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	git(t, root, "init", "-q")
+	git(t, root, "config", "user.email", "t@t")
+	git(t, root, "config", "user.name", "t")
+	workflowDir := filepath.Join(root, "docs", "dev")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "README.md"), []byte(splitWorkflowReadme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, root, "add", "docs/dev/README.md")
+	git(t, root, "commit", "-q", "-m", "add split-root README")
+	mainStatePath := filepath.Join(workflowDir, ".spacedock-state")
+
+	wtRoot := addAgentWorktree(t, root, "w1")
+	wtWorkflowDir := filepath.Join(wtRoot, "docs", "dev")
+	nestedStatePath := filepath.Join(wtWorkflowDir, ".spacedock-state")
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "ready", "--workflow-dir", wtWorkflowDir},
+		os.Environ(), wtRoot, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code == 0 {
+		t.Fatalf("never-birthed branch must fail, not silently succeed; stdout=%q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "spacedock state new") {
+		t.Fatalf("never-birthed hint should name `spacedock state new`; stderr=%q", errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), mainStatePath) {
+		t.Fatalf("never-birthed hint should name the main-anchored path %s; stderr=%q", mainStatePath, errBuf.String())
+	}
+	if strings.Contains(errBuf.String(), nestedStatePath) {
+		t.Fatalf("never-birthed hint must NOT name the worktree-nested path %s; stderr=%q", nestedStatePath, errBuf.String())
+	}
+}
+
+// TestStateReadyPresentCheckoutRegressionUntouched pins test-plan item 7, AC-5's
+// regression half: a PRESENT checkout's worktree registration and HEAD are
+// untouched by `state ready` — the stale-registration repair must never fire when
+// the directory already exists (dirExists guards it before repair runs).
+func TestStateReadyPresentCheckoutRegressionUntouched(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+
+	hostClone := filepath.Join(t.TempDir(), "host")
+	git(t, t.TempDir(), "clone", "-q", bare, hostClone)
+	git(t, hostClone, "config", "user.email", "t@t")
+	git(t, hostClone, "config", "user.name", "t")
+	workflowDir, _, _ := commissionSplitWorkflow(t, hostClone)
+	git(t, hostClone, "push", "-q", "origin", "HEAD")
+	statePath := filepath.Join(workflowDir, ".spacedock-state")
+
+	worktreesBefore := git(t, hostClone, "worktree", "list", "--porcelain")
+	headBefore := strings.TrimSpace(git(t, statePath, "rev-parse", "HEAD"))
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "ready", "--workflow-dir", workflowDir},
+		os.Environ(), hostClone, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("state ready on a present, up-to-date checkout should exit 0; got exit=%d stderr=%q", code, errBuf.String())
+	}
+	worktreesAfter := git(t, hostClone, "worktree", "list", "--porcelain")
+	headAfter := strings.TrimSpace(git(t, statePath, "rev-parse", "HEAD"))
+	if worktreesBefore != worktreesAfter {
+		t.Fatalf("present-checkout state ready must not touch worktree registrations; before=%q after=%q", worktreesBefore, worktreesAfter)
+	}
+	if headBefore != headAfter {
+		t.Fatalf("present-checkout state ready must not move HEAD; before=%s after=%s", headBefore, headAfter)
+	}
+}
+
+// TestStateCommitFromWorktreeCwdLandsInMainCheckout pins test-plan item 8, AC-2:
+// `state commit` (a second verb through the same shared resolver, not just
+// `ready`) invoked with cwd inside an agent worktree lands its commit in the MAIN
+// checkout, never a nested one. Cwd variant: bare discovery from the worktree
+// root, matching TestStateReadyFromWorktreeCwd{Present,Absent}CheckoutResolvesMain.
+func TestStateCommitFromWorktreeCwdLandsInMainCheckout(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+
+	hostClone := filepath.Join(t.TempDir(), "host")
+	git(t, t.TempDir(), "clone", "-q", bare, hostClone)
+	git(t, hostClone, "config", "user.email", "t@t")
+	git(t, hostClone, "config", "user.name", "t")
+	workflowDir, _, _ := commissionSplitWorkflow(t, hostClone)
+	git(t, hostClone, "push", "-q", "origin", "HEAD")
+	mainCheckout := filepath.Join(workflowDir, ".spacedock-state")
+
+	writeEntity(t, workflowDir, "first-task", "---\nstatus: implementation\n---\n# First Task\n")
+
+	wtRoot := addAgentWorktree(t, hostClone, "w1")
+	nestedCheckout := filepath.Join(wtRoot, "docs", "dev", ".spacedock-state")
+
+	var out, errBuf strings.Builder
+	code := run(context.Background(), []string{"state", "commit", "first-task", "-m", "from worktree cwd"},
+		os.Environ(), wtRoot, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("state commit from worktree cwd should exit 0; got exit=%d stderr=%q", code, errBuf.String())
+	}
+	names := git(t, mainCheckout, "log", "--name-only", "--pretty=format:", "-1")
+	if !strings.Contains(names, "first-task.md") {
+		t.Fatalf("commit from worktree cwd should land in the main checkout's log; log:\n%s", names)
+	}
+	if _, err := os.Stat(nestedCheckout); !os.IsNotExist(err) {
+		t.Fatalf("state commit must NOT create a nested checkout under the worktree; found at %s", nestedCheckout)
+	}
+}

--- a/internal/cli/state_resume_lock_other.go
+++ b/internal/cli/state_resume_lock_other.go
@@ -1,0 +1,15 @@
+// ABOUTME: In-process fallback for platforms without Unix advisory locks.
+//go:build !unix
+
+package cli
+
+import "sync"
+
+var stateResumeMu sync.Mutex
+
+func withStateResumeLock(_ string, fn func() (int, bool)) (int, bool, error) {
+	stateResumeMu.Lock()
+	defer stateResumeMu.Unlock()
+	code, reached := fn()
+	return code, reached, nil
+}

--- a/internal/cli/state_resume_lock_unix.go
+++ b/internal/cli/state_resume_lock_unix.go
@@ -1,0 +1,35 @@
+// ABOUTME: Repository-scoped advisory lock for atomic split-root resume.
+//go:build unix
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
+)
+
+func withStateResumeLock(workflowDir string, fn func() (int, bool)) (int, bool, error) {
+	placement, err := status.ResolveRepositoryPlacement(workflowDir)
+	if err != nil {
+		return 0, false, err
+	}
+	if !placement.InGit {
+		return 0, false, fmt.Errorf("not a git repository at %s", workflowDir)
+	}
+	lockPath := filepath.Join(placement.CommonGitDir, "spacedock-state-resume.lock")
+	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return 0, false, fmt.Errorf("open resume lock: %w", err)
+	}
+	defer lock.Close()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		return 0, false, fmt.Errorf("acquire resume lock: %w", err)
+	}
+	defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+	code, reached := fn()
+	return code, reached, nil
+}

--- a/internal/cli/state_sync.go
+++ b/internal/cli/state_sync.go
@@ -152,10 +152,11 @@ func runStateReady(ctx context.Context, args []string, env []string, dir string,
 		}, 0)
 	}
 
-	// Absent checkout → resume it (reuse `state init`'s fetch + worktree-add path).
+	// Absent checkout → resume it (shares `state init`'s fetch + worktree-add path).
 	if !dirExists(checkout) {
-		if code := runStateInit(ctx, []string{"--workflow-dir", workflowDir}, env, dir, stdout, stderr); code != 0 {
-			return code
+		resumeCode, originReached := resumeAbsentSplitRootCheckout(workflowDir, branch, checkout, stdout, stderr)
+		if resumeCode != 0 {
+			return resumeCode
 		}
 		// The re-boot-after-resume sequencing the «state.ensure-ready» prose used to
 		// own: a just-linked checkout means the boot read the FO already did (if any)
@@ -163,6 +164,16 @@ func runStateReady(ctx context.Context, args []string, env []string, dir string,
 		// Prose-only (not --json) — it is FO guidance, not part of the result envelope.
 		if !jsonOut {
 			fmt.Fprintln(stdout, "checkout resumed — re-run `spacedock status --boot` before the greet.")
+		}
+		if !originReached {
+			// The resume already fell back to the local branch (no origin, or an
+			// unreachable one) and said so on stdout — there is no reachable origin
+			// to integrate from, so skip the network pull below rather than
+			// immediately failing it and defeating the fallback just taken.
+			return emitSync(stdout, jsonOut, syncResult{
+				Command: "state ready", Result: "ready", StateBranch: branch,
+				Reason: "State checkout ready (resumed from the local branch — no reachable origin to integrate from).",
+			}, 0)
 		}
 	}
 
@@ -377,7 +388,7 @@ func resolveStateCheckout(command, workflowDir string, stderr io.Writer) (checko
 		fmt.Fprintf(stderr, "spacedock %s: %v\n", command, err)
 		return "", "", status.StateInline, 1
 	}
-	return filepath.Join(workflowDir, relPath), b, status.StateSplitRoot, 0
+	return resolveSplitRootCheckout(workflowDir, relPath), b, status.StateSplitRoot, 0
 }
 
 // parseStateCommitArgs reads the positional <slug> plus `--workflow-dir DIR`,

--- a/internal/cli/state_sync.go
+++ b/internal/cli/state_sync.go
@@ -154,7 +154,14 @@ func runStateReady(ctx context.Context, args []string, env []string, dir string,
 
 	// Absent checkout → resume it (shares `state init`'s fetch + worktree-add path).
 	if !dirExists(checkout) {
-		resumeCode, originReached := resumeAbsentSplitRootCheckout(workflowDir, branch, checkout, stdout, stderr)
+		resumeOut := stdout
+		if jsonOut {
+			// The resume helper's initialization/warning narration is prose. JSON
+			// mode owns stdout atomically: exactly one document, with diagnostics on
+			// stderr and no prefix bytes that make the envelope undecodable.
+			resumeOut = io.Discard
+		}
+		resumeCode, originReached := resumeAbsentSplitRootCheckout(workflowDir, branch, checkout, resumeOut, stderr)
 		if resumeCode != 0 {
 			return resumeCode
 		}
@@ -388,7 +395,12 @@ func resolveStateCheckout(command, workflowDir string, stderr io.Writer) (checko
 		fmt.Fprintf(stderr, "spacedock %s: %v\n", command, err)
 		return "", "", status.StateInline, 1
 	}
-	return resolveSplitRootCheckout(workflowDir, relPath), b, status.StateSplitRoot, 0
+	checkout, err = resolveSplitRootCheckout(workflowDir, relPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock %s: cannot resolve state checkout: %v\n", command, err)
+		return "", "", status.StateInline, 1
+	}
+	return checkout, b, status.StateSplitRoot, 0
 }
 
 // parseStateCommitArgs reads the positional <slug> plus `--workflow-dir DIR`,

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -473,7 +473,10 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 	// isolates CODE only — the entity body stays at the FO-passed entity_path.
 	// stateCheckout is the resolved absolute state-checkout dir (workflowDir/<state>),
 	// the git repo where the entity body lives; "" when the workflow is single-root.
-	stateCheckout := splitRootStateCheckout(workflowDir)
+	stateCheckout, err := splitRootStateCheckout(workflowDir)
+	if err != nil {
+		return buildError(stderr, 1, "cannot resolve split-root state checkout: %v", err)
+	}
 	splitRoot := stateCheckout != ""
 
 	// stateBranch is the orphan state branch peers push/pull on a split-root

--- a/internal/dispatch/helpers.go
+++ b/internal/dispatch/helpers.go
@@ -120,14 +120,14 @@ func isFile(path string) bool {
 // resolved state checkout is workflowDir/<state> — NOT workflowDir itself (which
 // is the definition dir where the state checkout is git-excluded). Returns "" when
 // the README is unreadable or carries no non-empty state: field.
-func splitRootStateCheckout(workflowDir string) string {
+func splitRootStateCheckout(workflowDir string) (string, error) {
 	readmePath := filepath.Join(workflowDir, "README.md")
 	fm := status.ParseFrontmatter(readmePath)
 	mode, relPath, err := status.ClassifyState(fm["state"])
 	if err != nil || mode != status.StateSplitRoot {
-		return ""
+		return "", err
 	}
-	return filepath.Join(workflowDir, relPath)
+	return status.ResolveSplitRootCheckout(workflowDir, relPath)
 }
 
 // pyRelpath returns path relative to base the way os.path.relpath does for the

--- a/internal/dispatch/inline_sentinel_checkout_test.go
+++ b/internal/dispatch/inline_sentinel_checkout_test.go
@@ -29,7 +29,10 @@ func TestSplitRootStateCheckoutInlineSentinel(t *testing.T) {
 			fm += "---\n\n# WF\n"
 			writeFile(t, filepath.Join(wf, "README.md"), fm)
 
-			got := splitRootStateCheckout(wf)
+			got, err := splitRootStateCheckout(wf)
+			if err != nil {
+				t.Fatalf("splitRootStateCheckout: %v", err)
+			}
 			if got != "" {
 				t.Fatalf("splitRootStateCheckout = %q, want \"\" (inline has no state checkout)", got)
 			}

--- a/internal/dispatch/reconcile.go
+++ b/internal/dispatch/reconcile.go
@@ -231,7 +231,11 @@ func Reconcile(opts reconcileOpts, stdout, stderr io.Writer) int {
 			"note: no session-scoped team resolved; reporting git/filesystem drift only (roster reconciliation needs a team identity — pass --team-name)")
 	}
 
-	stateRoot := splitRootStateCheckout(opts.workflowDir)
+	stateRoot, err := splitRootStateCheckout(opts.workflowDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: cannot resolve split-root state checkout: %v\n", err)
+		return 1
+	}
 	if stateRoot == "" {
 		stateRoot = opts.workflowDir
 	}
@@ -688,7 +692,11 @@ func Sweep(workflowDir string, gh GhRunner, jsonOut bool, stdout, stderr io.Writ
 		fmt.Fprintf(stderr, "spacedock state sweep: workflow directory not found: %s\n", workflowDir)
 		return 1
 	}
-	stateRoot := splitRootStateCheckout(workflowDir)
+	stateRoot, err := splitRootStateCheckout(workflowDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "spacedock state sweep: cannot resolve state checkout: %v\n", err)
+		return 1
+	}
 	if stateRoot == "" {
 		stateRoot = workflowDir
 	}

--- a/internal/status/path.go
+++ b/internal/status/path.go
@@ -8,6 +8,13 @@ import (
 	"strings"
 )
 
+// RealpathOf is the exported form of realpathOf, for callers outside this
+// package (e.g. internal/cli's worktree-registration path comparisons) that need
+// the same symlink-resolving, nonexistent-leaf-tolerant canonicalization.
+func RealpathOf(p string) string {
+	return realpathOf(p)
+}
+
 // realpathOf resolves symlinks the way os.path.realpath does: it returns the
 // canonical absolute path, resolving symlinks in the existing prefix and
 // appending the remaining (non-existent) components. EvalSymlinks alone errors

--- a/internal/status/repository_placement.go
+++ b/internal/status/repository_placement.go
@@ -1,0 +1,91 @@
+// ABOUTME: Shared Git repository placement for split-root workflow state.
+// ABOUTME: Keeps status, dispatch, and state verbs anchored to the main worktree.
+package status
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// RepositoryPlacement describes where repository-wide files belong when dir is
+// inside either the main worktree or a linked worktree. Prefix is dir's
+// repository-relative path and CommonGitDir is the shared Git administration
+// directory. InGit is false only when no enclosing .git entry exists.
+type RepositoryPlacement struct {
+	MainWorktreeRoot string
+	Prefix           string
+	CommonGitDir     string
+	InGit            bool
+	Linked           bool
+}
+
+// ResolveRepositoryPlacement resolves Git's authoritative worktree metadata.
+// A conclusively non-Git directory is not an error. Once an enclosing .git entry
+// exists, however, every metadata failure is returned: silently treating a
+// broken linked worktree as a standalone directory could redirect mutations into
+// a worktree-local copy.
+func ResolveRepositoryPlacement(dir string) (RepositoryPlacement, error) {
+	gitRoot := FindGitRoot(dir)
+	if !hasGitEntry(gitRoot) {
+		return RepositoryPlacement{}, nil
+	}
+
+	gitDirOut, err := runGitCmd(dir, "rev-parse", "--path-format=absolute", "--git-dir")
+	if err != nil {
+		return RepositoryPlacement{}, fmt.Errorf("resolve git directory for %s: %w", dir, err)
+	}
+	commonDirOut, err := runGitCmd(dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		return RepositoryPlacement{}, fmt.Errorf("resolve git common directory for %s: %w", dir, err)
+	}
+	prefixOut, err := runGitCmd(dir, "rev-parse", "--show-prefix")
+	if err != nil {
+		return RepositoryPlacement{}, fmt.Errorf("resolve repository prefix for %s: %w", dir, err)
+	}
+	topOut, err := runGitCmd(dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return RepositoryPlacement{}, fmt.Errorf("resolve worktree root for %s: %w", dir, err)
+	}
+
+	gitDir := RealpathOf(strings.TrimSpace(gitDirOut))
+	commonDir := RealpathOf(strings.TrimSpace(commonDirOut))
+	placement := RepositoryPlacement{
+		MainWorktreeRoot: strings.TrimSpace(topOut),
+		Prefix:           strings.TrimSpace(prefixOut),
+		CommonGitDir:     commonDir,
+		InGit:            true,
+		Linked:           gitDir != commonDir,
+	}
+	if !placement.Linked {
+		return placement, nil
+	}
+
+	worktreesOut, err := runGitCmd(dir, "worktree", "list", "--porcelain")
+	if err != nil {
+		return RepositoryPlacement{}, fmt.Errorf("resolve main worktree for %s: %w", dir, err)
+	}
+	for _, line := range strings.Split(worktreesOut, "\n") {
+		if strings.HasPrefix(line, "worktree ") {
+			placement.MainWorktreeRoot = strings.TrimSpace(strings.TrimPrefix(line, "worktree "))
+			if placement.MainWorktreeRoot == "" {
+				break
+			}
+			return placement, nil
+		}
+	}
+	return RepositoryPlacement{}, fmt.Errorf("resolve main worktree for %s: git worktree list returned no worktree entries", dir)
+}
+
+// ResolveSplitRootCheckout anchors a workflow's state checkout under the main
+// worktree. Standalone non-Git fixtures retain the historical plain join.
+func ResolveSplitRootCheckout(workflowDir, relPath string) (string, error) {
+	placement, err := ResolveRepositoryPlacement(workflowDir)
+	if err != nil {
+		return "", err
+	}
+	if !placement.InGit || !placement.Linked {
+		return filepath.Join(workflowDir, relPath), nil
+	}
+	return filepath.Join(placement.MainWorktreeRoot, placement.Prefix, relPath), nil
+}

--- a/internal/status/roots.go
+++ b/internal/status/roots.go
@@ -61,8 +61,16 @@ func resolveRoots(workflowDir, baseDir string) (roots, error) {
 		return r, nil
 	}
 
-	r.entityDir = filepath.Join(abs, relPath)
-	r.entityDirSpelling = PyJoin(spellingOr(workflowDir, abs), relPath)
+	entityDir, err := ResolveSplitRootCheckout(abs, relPath)
+	if err != nil {
+		return roots{}, fmt.Errorf("resolve split-root state checkout: %w", err)
+	}
+	r.entityDir = entityDir
+	if entityDir != filepath.Join(abs, relPath) {
+		r.entityDirSpelling = entityDir
+	} else {
+		r.entityDirSpelling = PyJoin(spellingOr(workflowDir, abs), relPath)
+	}
 	return r, nil
 }
 


### PR DESCRIPTION
Restore missing split-root checkouts from any working directory without creating nested state roots or requiring a reachable origin.

## What changed
- Anchor state checkout discovery in the main worktree.
- Repair stale worktree registrations before restoring checkouts.
- Preserve local-only operation when origin is unavailable.
- Distinguish never-created checkouts from unreachable remotes.
- Document cwd-independent split-root recovery.

## Evidence
- 2/2 full and focused Go test suites passed.
- 3/3 adversarial mutations produced the predicted failures.

---
[e6j](/spacedock-dev/spacedock/blob/abb36cb8a773b199728a86e2836f6784fb016530/state-ready-cwd-path-resolution.md)
Closes spacedock-dev/spacedock#484
