### PR TITLE
Install the checked-out candidate into a neutral bin for Claude live E2E

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -155,11 +155,69 @@ jobs:
           curl -fsSL https://claude.ai/install.sh | bash -s -- "$VERSION"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Build spacedock binary
+      - name: Install spacedock candidate
         run: |
-          go build -o ./spacedock ./cmd/spacedock
-          echo "SPACEDOCK_BIN=$(pwd)/spacedock" >> "$GITHUB_ENV"
-          echo "$(pwd)" >> "$GITHUB_PATH"
+          set -euo pipefail
+
+          candidate_dir="$RUNNER_TEMP/spacedock-live-bin"
+          candidate_bin="$candidate_dir/spacedock"
+          if [ -e "$candidate_bin" ] || [ -L "$candidate_bin" ]; then
+            echo "candidate output already exists: $candidate_bin" >&2
+            exit 1
+          fi
+          if [ -e "$candidate_dir" ] || [ -L "$candidate_dir" ]; then
+            if [ ! -d "$candidate_dir" ] || [ -L "$candidate_dir" ]; then
+              echo "candidate directory is not a physical directory: $candidate_dir" >&2
+              exit 1
+            fi
+            if find "$candidate_dir" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+              echo "candidate directory is not empty: $candidate_dir" >&2
+              exit 1
+            fi
+          else
+            mkdir -p "$candidate_dir"
+          fi
+
+          GOBIN="$candidate_dir" go install ./cmd/spacedock
+          if [ ! -f "$candidate_bin" ] || [ ! -x "$candidate_bin" ] || [ -L "$candidate_bin" ]; then
+            echo "installed candidate is not a physical executable: $candidate_bin" >&2
+            exit 1
+          fi
+
+          candidate_canonical_path="$(realpath "$candidate_bin")"
+          checkout_canonical_path="$(realpath "$(git rev-parse --show-toplevel)")"
+          case "$candidate_canonical_path" in
+            "$checkout_canonical_path"|"$checkout_canonical_path"/*)
+              echo "candidate resolves inside checkout: $candidate_canonical_path" >&2
+              exit 1
+              ;;
+          esac
+
+          checkout_revision="$(git rev-parse HEAD)"
+          build_metadata="$(go version -m "$candidate_bin")"
+          embedded_revision="$(printf '%s\n' "$build_metadata" | awk '$1 == "build" && $2 ~ /^vcs.revision=/ { sub(/^vcs.revision=/, "", $2); print $2; exit }')"
+          vcs_modified="$(printf '%s\n' "$build_metadata" | awk '$1 == "build" && $2 ~ /^vcs.modified=/ { sub(/^vcs.modified=/, "", $2); print $2; exit }')"
+          if [ -z "$embedded_revision" ] || [ "$embedded_revision" != "$checkout_revision" ]; then
+            echo "embedded revision does not match checkout: embedded=${embedded_revision:-missing} checkout=$checkout_revision" >&2
+            exit 1
+          fi
+          if [ "$vcs_modified" != "false" ]; then
+            echo "candidate build reports vcs.modified=${vcs_modified:-missing}" >&2
+            exit 1
+          fi
+
+          mkdir -p "$SPACEDOCK_LIVE_ARTIFACT_DIR"
+          provenance="$SPACEDOCK_LIVE_ARTIFACT_DIR/candidate-binary-provenance.txt"
+          {
+            printf 'candidate_path=%s\n' "$candidate_bin"
+            printf 'candidate_canonical_path=%s\n' "$candidate_canonical_path"
+            printf 'checkout_revision=%s\n' "$checkout_revision"
+            printf 'embedded_revision=%s\n' "$embedded_revision"
+            printf 'vcs_modified=%s\n' "$vcs_modified"
+          } > "$provenance"
+
+          printf 'SPACEDOCK_BIN=%s\n' "$candidate_bin" >> "$GITHUB_ENV"
+          printf '%s\n' "$candidate_dir" >> "$GITHUB_PATH"
 
       # gotestsum renders the live test run as a CLEAN step log (a per-package
       # progress view + an `=== Failed` recap listing each failing test with
@@ -301,7 +359,7 @@ jobs:
         with:
           name: runtime-live-e2e-claude-live-${{ matrix.model }}
           path: |
-            ./spacedock
+            ${{ runner.temp }}/spacedock-live-bin/spacedock
             ./live-e2e-detail.jsonl
             ./claude-shared-scenarios-detail.jsonl
             ./pty-team-mode-detail.jsonl

--- a/internal/release/claude_candidate_binary_workflow_test.go
+++ b/internal/release/claude_candidate_binary_workflow_test.go
@@ -1,0 +1,208 @@
+package release
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestClaudeLiveInstallsExactCandidateOutsideCheckout(t *testing.T) {
+	workflow := readWorkflow(t, "runtime-live-e2e.yml")
+	script := extractStepRun(t, workflow, "Install spacedock candidate")
+	checkout, revision := candidateFixture(t)
+	runnerTemp := t.TempDir()
+	artifactDir := filepath.Join(t.TempDir(), "artifacts")
+	githubEnv := filepath.Join(t.TempDir(), "github-env")
+	githubPath := filepath.Join(t.TempDir(), "github-path")
+
+	output, err := runCandidateInstall(t, script, checkout, runnerTemp, artifactDir, githubEnv, githubPath, "")
+	if err != nil {
+		t.Fatalf("candidate install failed: %v\n%s", err, output)
+	}
+
+	candidate := filepath.Join(runnerTemp, "spacedock-live-bin", executableName("spacedock"))
+	info, err := os.Lstat(candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode()&0o111 == 0 {
+		t.Fatalf("candidate is not a physical executable: mode=%s", info.Mode())
+	}
+	realCandidate, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	realCheckout, err := filepath.EvalSymlinks(checkout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if realCandidate == realCheckout || strings.HasPrefix(realCandidate, realCheckout+string(os.PathSeparator)) {
+		t.Fatalf("candidate %q resolves inside checkout %q", realCandidate, realCheckout)
+	}
+
+	envBytes, err := os.ReadFile(githubEnv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(envBytes), "SPACEDOCK_BIN="+candidate+"\n"; got != want {
+		t.Fatalf("GITHUB_ENV = %q, want %q", got, want)
+	}
+	pathBytes, err := os.ReadFile(githubPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(pathBytes), filepath.Dir(candidate)+"\n"; got != want {
+		t.Fatalf("GITHUB_PATH = %q, want %q", got, want)
+	}
+
+	provenanceBytes, err := os.ReadFile(filepath.Join(artifactDir, "candidate-binary-provenance.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	provenance := string(provenanceBytes)
+	for _, want := range []string{
+		"candidate_path=" + candidate,
+		"candidate_canonical_path=" + realCandidate,
+		"checkout_revision=" + revision,
+		"embedded_revision=" + revision,
+		"vcs_modified=false",
+	} {
+		if !strings.Contains(provenance, want+"\n") {
+			t.Errorf("provenance missing %q:\n%s", want, provenance)
+		}
+	}
+
+	claudeJob := workflow[strings.Index(workflow, "  claude-live:"):strings.Index(workflow, "  codex-live:")]
+	if !strings.Contains(claudeJob, `${{ runner.temp }}/spacedock-live-bin/spacedock`) {
+		t.Error("Claude artifact upload does not retain the installed candidate")
+	}
+	if strings.Contains(claudeJob, "            ./spacedock\n") {
+		t.Error("Claude artifact upload still retains the obsolete checkout-root binary")
+	}
+}
+
+func TestClaudeCandidateInstallFailsClosed(t *testing.T) {
+	workflow := readWorkflow(t, "runtime-live-e2e.yml")
+	script := extractStepRun(t, workflow, "Install spacedock candidate")
+
+	t.Run("dangling symlink", func(t *testing.T) {
+		checkout, _ := candidateFixture(t)
+		runnerTemp := t.TempDir()
+		candidateDir := filepath.Join(runnerTemp, "spacedock-live-bin")
+		if err := os.MkdirAll(candidateDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(filepath.Join(runnerTemp, "missing"), filepath.Join(candidateDir, executableName("spacedock"))); err != nil {
+			t.Fatal(err)
+		}
+		output, err := runCandidateInstall(t, script, checkout, runnerTemp, filepath.Join(t.TempDir(), "artifacts"), filepath.Join(t.TempDir(), "env"), filepath.Join(t.TempDir(), "path"), "")
+		if err == nil || !strings.Contains(output, "candidate output already exists") {
+			t.Fatalf("dangling symlink was not rejected: err=%v\n%s", err, output)
+		}
+	})
+
+	t.Run("inside checkout", func(t *testing.T) {
+		checkout, _ := candidateFixture(t)
+		runnerTemp := filepath.Join(checkout, "runner-temp")
+		if err := os.Mkdir(runnerTemp, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		output, err := runCandidateInstall(t, script, checkout, runnerTemp, filepath.Join(t.TempDir(), "artifacts"), filepath.Join(t.TempDir(), "env"), filepath.Join(t.TempDir(), "path"), "")
+		if err == nil || !strings.Contains(output, "candidate resolves inside checkout") {
+			t.Fatalf("inside-checkout candidate was not rejected: err=%v\n%s", err, output)
+		}
+	})
+
+	t.Run("modified checkout", func(t *testing.T) {
+		checkout, _ := candidateFixture(t)
+		mainFile := filepath.Join(checkout, "cmd", "spacedock", "main.go")
+		if err := os.WriteFile(mainFile, []byte("package main\nfunc main() { println(\"modified\") }\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		output, err := runCandidateInstall(t, script, checkout, t.TempDir(), filepath.Join(t.TempDir(), "artifacts"), filepath.Join(t.TempDir(), "env"), filepath.Join(t.TempDir(), "path"), "")
+		if err == nil || !strings.Contains(output, "candidate build reports vcs.modified=true") {
+			t.Fatalf("modified checkout was not rejected: err=%v\n%s", err, output)
+		}
+	})
+
+	t.Run("revision mismatch", func(t *testing.T) {
+		checkout, _ := candidateFixture(t)
+		realGit, err := exec.LookPath("git")
+		if err != nil {
+			t.Fatal(err)
+		}
+		fakeBin := t.TempDir()
+		wrapper := fmt.Sprintf("#!/bin/sh\nif [ \"$*\" = \"rev-parse HEAD\" ]; then\n  printf '0000000000000000000000000000000000000000\\n'\nelse\n  exec %q \"$@\"\nfi\n", realGit)
+		if err := os.WriteFile(filepath.Join(fakeBin, executableName("git")), []byte(wrapper), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		output, err := runCandidateInstall(t, script, checkout, t.TempDir(), filepath.Join(t.TempDir(), "artifacts"), filepath.Join(t.TempDir(), "env"), filepath.Join(t.TempDir(), "path"), fakeBin)
+		if err == nil || !strings.Contains(output, "embedded revision does not match checkout") {
+			t.Fatalf("revision mismatch was not rejected: err=%v\n%s", err, output)
+		}
+	})
+}
+
+func candidateFixture(t *testing.T) (string, string) {
+	t.Helper()
+	checkout := t.TempDir()
+	mainDir := filepath.Join(checkout, "cmd", "spacedock")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(checkout, "go.mod"), []byte("module example.com/candidate\n\ngo 1.22\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = checkout
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-q")
+	git("add", ".")
+	git("commit", "-qm", "fixture")
+	return checkout, git("rev-parse", "HEAD")
+}
+
+func runCandidateInstall(t *testing.T, script, checkout, runnerTemp, artifactDir, githubEnv, githubPath, pathPrefix string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("bash", "-eu", "-o", "pipefail", "-c", script)
+	cmd.Dir = checkout
+	path := os.Getenv("PATH")
+	if pathPrefix != "" {
+		path = pathPrefix + string(os.PathListSeparator) + path
+	}
+	cmd.Env = append(os.Environ(),
+		"PATH="+path,
+		"RUNNER_TEMP="+runnerTemp,
+		"GITHUB_WORKSPACE="+checkout,
+		"SPACEDOCK_LIVE_ARTIFACT_DIR="+artifactDir,
+		"GITHUB_ENV="+githubEnv,
+		"GITHUB_PATH="+githubPath,
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func executableName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}


### PR DESCRIPTION
Neutral candidate installation prevents Claude from mistaking checkout-shaped binary paths for workflow roots while preserving exact-SHA live provenance.

## What changed

- Install Claude live candidates in a neutral temporary bin directory.
- Upload neutral-path executables with exact build provenance.
- Verify installation, permissions, and retained artifact behavior.

## Evidence

- Roborev exact-range review: 1/1 passed on `557f8df3..5ff92f9b`.
- Claude live variants: 2/2 passed with retained Sonnet and Opus executables.

---
[2h](/spacedock-dev/spacedock/blob/c6b70ce0cec866f67206f4e00197a38fc9d3f772/claude-live-installed-candidate-binary/index.md)
