### PR TITLE
spacedock merge guard: entity not found from a foreign cwd even with --workflow-dir

### DIFF
--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -187,7 +187,10 @@ Re-run guard after invoking the hook: it resumes from the entity's current state
 
 Flags:
   --verdict passed|rejected   The merge decision (required; a verdict-less finalize is refused)
-  --workflow-dir DIR          Target this workflow explicitly (skips auto-discovery)
+  --workflow-dir DIR          Target this workflow explicitly (skips auto-discovery).
+                              A relative DIR resolves against the current directory;
+                              from anywhere else (e.g. an agent worktree) pass an
+                              absolute path.
   --json                      Emit the phase signal as JSON
   --quiet                     Emit a terse machine-readable phase signal
 

--- a/internal/cli/merge_test.go
+++ b/internal/cli/merge_test.go
@@ -82,6 +82,19 @@ func TestMergeGuardHelpRenders(t *testing.T) {
 	}
 }
 
+// TestMergeGuardHelpDocumentsWorkflowDirResolution is AC-6: the merge help text
+// states the cwd-relative --workflow-dir resolution rule, so an operator reads
+// the fix before hitting the issue-#485 foreign-cwd confusion.
+func TestMergeGuardHelpDocumentsWorkflowDirResolution(t *testing.T) {
+	out, errOut, code := runMergeCLI(t, t.TempDir(), "merge", "guard", "--help")
+	if code != 0 {
+		t.Fatalf("merge guard --help exit=%d stderr=%q", code, errOut)
+	}
+	if !strings.Contains(out, "resolves against the current directory") || !strings.Contains(out, "absolute path") {
+		t.Fatalf("merge guard --help missing cwd-relative --workflow-dir resolution rule:\n%s", out)
+	}
+}
+
 // TestMergeGuardInGroupedHelp (AC-7): `merge guard <slug>` appears in the
 // top-level grouped help workflow group.
 func TestMergeGuardInGroupedHelp(t *testing.T) {

--- a/internal/status/merge.go
+++ b/internal/status/merge.go
@@ -84,6 +84,10 @@ func MergeGuard(args []string, dir string, stdout, stderr io.Writer) int {
 		return errExit(stderr, err.Error())
 	}
 
+	if rc := mergeRootsGuard(workflowDir, roots, dir, stderr); rc != 0 {
+		return rc
+	}
+
 	resolved, rc := resolveMutationEntity(roots, slug, stderr)
 	if rc != 0 {
 		return rc
@@ -164,6 +168,83 @@ func MergeGuard(args []string, dir string, stdout, stderr io.Writer) int {
 		// that state — so the merge-hook guard cannot strand a finalize.
 		return finalize(roots, slug, modBlock, pr, verdict, worktree, hookRegistered, quiet, asJSON, stdout, stderr)
 	}
+}
+
+// mergeRootsGuard fails MergeGuard closed, before entity resolution, when the
+// resolved roots cannot possibly hold entities: the resolved definition dir does
+// not exist, or a declared split-root state checkout is missing. Either shape
+// today ends at the same misleading "entity not found: <slug>" — this names the
+// real problem instead. workflowDirSpelling is the --workflow-dir value as
+// literally passed (before defaulting via ResolveWorkflowDir), used both to name
+// the as-passed spelling in the refusal and to gate the did-you-mean hint, which
+// only fires for a relative spelling. A resolvable roots pair (or an inline
+// workflow, which can never suffer the split-root shape) returns 0.
+func mergeRootsGuard(workflowDirSpelling string, roots roots, dir string, stderr io.Writer) int {
+	hint := didYouMeanHint(workflowDirSpelling, dir)
+
+	if info, statErr := os.Stat(roots.definitionDir); statErr != nil || !info.IsDir() {
+		msg := fmt.Sprintf(
+			"merge guard: --workflow-dir %s resolves to %s (a relative --workflow-dir resolves against the current directory), which does not exist",
+			workflowDirSpelling, roots.definitionDir)
+		return errExit(stderr, appendHint(msg, hint))
+	}
+
+	mode, relPath, _ := ClassifyState(ParseFrontmatter(filepath.Join(roots.definitionDir, "README.md"))["state"])
+	if mode != StateSplitRoot {
+		return 0
+	}
+	if info, statErr := os.Stat(roots.entityDir); statErr != nil || !info.IsDir() {
+		msg := fmt.Sprintf(
+			"merge guard: workflow at %s declares state: %s but the state checkout is missing at %s",
+			roots.definitionDir, relPath, roots.entityDir)
+		return errExit(stderr, appendHint(msg, hint))
+	}
+	return 0
+}
+
+// didYouMeanHint computes the merge-guard corrective hint named in the roots
+// guard's refusals: when workflowDirSpelling is a relative --workflow-dir, derive
+// the enclosing main-checkout root as the parent of `git rev-parse
+// --git-common-dir` run from dir, re-join the as-passed spelling there, and
+// return the hint sentence only if that candidate validates as a resolvable
+// workflow (via the same check --validate uses). A relative `--git-common-dir`
+// output (the main-checkout-cwd case) resolves against dir, since git prints it
+// relative to the invocation dir itself. Returns "" when the spelling is
+// absent/absolute, git fails (non-repo cwd, bare), or the candidate does not
+// validate — the refusal then stands without naming an unproven recovery path.
+func didYouMeanHint(workflowDirSpelling, dir string) string {
+	if workflowDirSpelling == "" || filepath.IsAbs(workflowDirSpelling) {
+		return ""
+	}
+	out, err := runGitCmd(dir, "rev-parse", "--git-common-dir")
+	if err != nil {
+		return ""
+	}
+	commonDir := strings.TrimSpace(out)
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(dir, commonDir)
+	}
+	mainRoot := filepath.Dir(commonDir)
+
+	candidate, rerr := resolveRoots(workflowDirSpelling, mainRoot)
+	if rerr != nil {
+		return ""
+	}
+	if rc := validateRootsOrExit(candidate, "", io.Discard); rc != 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"did you mean --workflow-dir %s? (the current directory is a linked git worktree; a relative --workflow-dir resolves against it)",
+		candidate.definitionDir)
+}
+
+// appendHint appends a did-you-mean hint on its own line when non-empty, else
+// returns msg unchanged.
+func appendHint(msg, hint string) string {
+	if hint == "" {
+		return msg
+	}
+	return msg + "\n" + hint
 }
 
 // prIndicatesMerged reports whether the pr field carries a WELL-FORMED merge

--- a/internal/status/merge_guard_foreign_cwd_test.go
+++ b/internal/status/merge_guard_foreign_cwd_test.go
@@ -116,6 +116,32 @@ func TestMergeGuardForeignCwdRefusalNamesWorkingFix(t *testing.T) {
 	}
 }
 
+// TestMergeGuardForeignCwdSuppressesHintWhenCandidateInvalid closes the
+// negative-hint-suppression gap found by a detached adversarial audit (cycle 1):
+// removing didYouMeanHint's validateRootsOrExit check made the hint fire for a
+// syntactically-joined main-root candidate that does not actually resolve to a
+// workflow, suggesting a corrected invocation that itself would not work. From a
+// linked-worktree cwd, a relative --workflow-dir whose main-root-joined
+// candidate does not exist in either checkout must refuse WITHOUT a "did you
+// mean" line — the refusal stands on its own per the Proposed approach.
+func TestMergeGuardForeignCwdSuppressesHintWhenCandidateInvalid(t *testing.T) {
+	_, _, wtDir := buildMergeGuardForeignCwdFixture(t)
+
+	var out, errBuf bytes.Buffer
+	code := MergeGuard([]string{"010-repro", "--verdict", "passed", "--workflow-dir", "docs/bogus"}, wtDir, &out, &errBuf)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 (out=%q stderr=%q)", code, out.String(), errBuf.String())
+	}
+	stderr := errBuf.String()
+	resolved := filepath.Join(wtDir, "docs", "bogus")
+	if !strings.Contains(stderr, resolved) {
+		t.Fatalf("refusal must still name the nonexistent resolved dir %q, got %q", resolved, stderr)
+	}
+	if strings.Contains(stderr, "did you mean") {
+		t.Fatalf("refusal must NOT suggest a did-you-mean hint when the main-root-joined candidate does not validate, got %q", stderr)
+	}
+}
+
 // TestMergeGuardRefusesNonexistentWorkflowDir is AC-2: a --workflow-dir
 // resolving to a nonexistent directory is refused with a diagnostic naming the
 // as-passed spelling and the resolved absolute path — never falling through to

--- a/internal/status/merge_guard_foreign_cwd_test.go
+++ b/internal/status/merge_guard_foreign_cwd_test.go
@@ -1,0 +1,178 @@
+// ABOUTME: mergeRootsGuard coverage (issue #485) — a --workflow-dir that cannot
+// ABOUTME: possibly hold entities refuses with a named, actionable diagnostic.
+package status
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// mergeGuardWorktreeReadme declares a split-root workflow whose terminal
+// transition finalizes directly (no merge hook, no worktree-bearing stage) so
+// the AC-1 real-worktree repro's corrected re-run finalizes in one MergeGuard
+// call, matching the no-hook Phase C default path other merge_guard_test.go
+// fixtures already exercise.
+const mergeGuardWorktreeReadme = `---
+commissioned-by: spacedock@1
+id-style: sequential
+state: .spacedock-state
+stages:
+  states:
+    - name: implementation
+      initial: true
+    - name: done
+      terminal: true
+---
+
+# Merge Guard Foreign-Cwd Fixture Workflow
+`
+
+// buildMergeGuardForeignCwdFixture materializes the issue-#485 repro topology: a
+// code repo whose docs/dev declares a split-root state checkout, with
+// docs/dev/README.md tracked in the code repo (so it appears in a linked
+// worktree) and docs/dev/.spacedock-state its OWN separate git checkout (so it
+// does NOT appear in a linked worktree — matching the live topology where the
+// state checkout is a separate checkout that exists only under the main working
+// copy), plus a real linked agent worktree of the code repo. Returns the
+// main-checkout root, the definition dir, and the worktree dir.
+func buildMergeGuardForeignCwdFixture(t *testing.T) (coderoot, defDir, wtDir string) {
+	t.Helper()
+	coderoot = t.TempDir()
+	gitC(t, coderoot, "init")
+	gitC(t, coderoot, "config", "user.email", "test@example.com")
+	gitC(t, coderoot, "config", "user.name", "spacedock-test")
+
+	defDir = filepath.Join(coderoot, "docs", "dev")
+	writeFile(t, filepath.Join(defDir, "README.md"), mergeGuardWorktreeReadme)
+	gitC(t, coderoot, "add", "docs/dev/README.md")
+	gitC(t, coderoot, "commit", "-q", "-m", "seed")
+
+	state := filepath.Join(defDir, ".spacedock-state")
+	writeFile(t, filepath.Join(state, "010-repro.md"),
+		"---\nid: \"010\"\nstatus: implementation\n---\n# Repro entity\n")
+	gitC(t, state, "init")
+	gitC(t, state, "config", "user.email", "test@example.com")
+	gitC(t, state, "config", "user.name", "spacedock-test")
+	gitC(t, state, "add", "010-repro.md")
+	gitC(t, state, "commit", "-q", "-m", "seed")
+
+	wtDir = filepath.Join(coderoot, ".worktrees", "agent-x")
+	gitC(t, coderoot, "worktree", "add", "--detach", wtDir)
+	return coderoot, defDir, wtDir
+}
+
+// TestMergeGuardForeignCwdRefusalNamesWorkingFix is AC-1 (measures the
+// end-value): from a linked-worktree cwd, the issue-#485 repro invocation
+// (`merge guard <slug> --verdict passed --workflow-dir docs/dev`, with the
+// split-root state checkout absent in the worktree) produces a refusal whose
+// suggested corrected invocation actually works.
+func TestMergeGuardForeignCwdRefusalNamesWorkingFix(t *testing.T) {
+	coderoot, defDir, wtDir := buildMergeGuardForeignCwdFixture(t)
+
+	var out, errBuf bytes.Buffer
+	code := MergeGuard([]string{"010-repro", "--verdict", "passed", "--workflow-dir", "docs/dev"}, wtDir, &out, &errBuf)
+	if code != 1 {
+		t.Fatalf("foreign-cwd repro: exit = %d, want 1 (out=%q stderr=%q)", code, out.String(), errBuf.String())
+	}
+	stderr := errBuf.String()
+	resolvedDefDir := filepath.Join(wtDir, "docs", "dev")
+	missingState := filepath.Join(resolvedDefDir, ".spacedock-state")
+	if !strings.Contains(stderr, resolvedDefDir) {
+		t.Fatalf("refusal must name the resolved absolute path %q, got %q", resolvedDefDir, stderr)
+	}
+	if !strings.Contains(stderr, missingState) {
+		t.Fatalf("refusal must name the missing state-checkout path %q, got %q", missingState, stderr)
+	}
+	// git rev-parse --git-common-dir resolves symlinks (e.g. macOS's /var ->
+	// /private/var), so compare via realpathOf rather than raw string equality —
+	// the same normalization TestDiscoverWorkflowDirWalksUp uses.
+	hintFlag := "--workflow-dir " + realpathOf(defDir)
+	if !strings.Contains(stderr, hintFlag) {
+		t.Fatalf("refusal must name the corrected invocation %q, got %q", hintFlag, stderr)
+	}
+	if strings.Contains(stderr, "entity not found") {
+		t.Fatalf("refusal must not fall through to the misleading entity-not-found message, got %q", stderr)
+	}
+
+	// Re-run with the suggested absolute --workflow-dir: the corrected invocation
+	// must actually succeed and land the mutation in the main checkout's state dir.
+	var out2, errBuf2 bytes.Buffer
+	code2 := MergeGuard([]string{"010-repro", "--verdict", "passed", "--workflow-dir", defDir}, wtDir, &out2, &errBuf2)
+	if code2 != 0 {
+		t.Fatalf("corrected invocation: exit = %d, want 0 (stderr=%q)", code2, errBuf2.String())
+	}
+	archived := filepath.Join(coderoot, "docs", "dev", ".spacedock-state", "_archive", "010-repro.md")
+	if !fileExists(archived) {
+		t.Fatalf("corrected invocation must finalize+archive the entity at %q", archived)
+	}
+	if got := frontmatterField(t, archived, "status"); got != "done" {
+		t.Fatalf("archived entity status = %q, want done", got)
+	}
+	if got := frontmatterField(t, archived, "verdict"); got != "passed" {
+		t.Fatalf("archived entity verdict = %q, want passed", got)
+	}
+}
+
+// TestMergeGuardRefusesNonexistentWorkflowDir is AC-2: a --workflow-dir
+// resolving to a nonexistent directory is refused with a diagnostic naming the
+// as-passed spelling and the resolved absolute path — never falling through to
+// "entity not found".
+func TestMergeGuardRefusesNonexistentWorkflowDir(t *testing.T) {
+	dir := t.TempDir()
+	var out, errBuf bytes.Buffer
+	code := MergeGuard([]string{"my-task", "--verdict", "passed", "--workflow-dir", "does/not/exist"}, dir, &out, &errBuf)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 (stderr=%q)", code, errBuf.String())
+	}
+	stderr := errBuf.String()
+	if !strings.Contains(stderr, "does/not/exist") {
+		t.Fatalf("refusal must name the as-passed spelling, got %q", stderr)
+	}
+	resolved := filepath.Join(dir, "does/not/exist")
+	if !strings.Contains(stderr, resolved) {
+		t.Fatalf("refusal must name the resolved absolute path %q, got %q", resolved, stderr)
+	}
+	if strings.Contains(stderr, "entity not found") {
+		t.Fatalf("must not fall through to entity not found, got %q", stderr)
+	}
+}
+
+// TestMergeGuardRefusesMissingStateCheckout is AC-3: a resolved split-root
+// workflow whose declared state checkout is missing is refused before entity
+// resolution, naming the missing state-checkout path.
+func TestMergeGuardRefusesMissingStateCheckout(t *testing.T) {
+	def, state := buildSplitRoot(t, splitRootReadme, map[string]string{
+		"add-login.md": "---\nstatus: ideation\n---\n",
+	})
+	if err := os.RemoveAll(state); err != nil {
+		t.Fatal(err)
+	}
+	var out, errBuf bytes.Buffer
+	code := MergeGuard([]string{"add-login", "--verdict", "passed", "--workflow-dir", def}, def, &out, &errBuf)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 (stderr=%q)", code, errBuf.String())
+	}
+	stderr := errBuf.String()
+	if !strings.Contains(stderr, state) {
+		t.Fatalf("refusal must name the missing state-checkout path %q, got %q", state, stderr)
+	}
+	if strings.Contains(stderr, "entity not found") {
+		t.Fatalf("must not fall through to entity not found, got %q", stderr)
+	}
+}
+
+// TestMergeGuardWrongSlugKeepsEntityNotFound is AC-4: a wrong slug against a
+// valid, resolvable workflow still reports the plain entity-not-found error —
+// the roots guard does not shadow it.
+func TestMergeGuardWrongSlugKeepsEntityNotFound(t *testing.T) {
+	root, _, errOut, code := driveMergeGuard(t, "merge-local-workflow", "does-not-exist", "--verdict", "passed")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 (root=%q stderr=%q)", code, root, errOut)
+	}
+	if !strings.Contains(errOut, "Error: entity not found: does-not-exist") {
+		t.Fatalf("stderr = %q, want entity not found", errOut)
+	}
+}


### PR DESCRIPTION
Foreign-worktree merge guards now explain invalid relative workflow paths and provide a verified absolute path, letting operators recover safely.

## What changed

- Fail closed when merge guard resolves an unusable workflow or state checkout.
- Suggest the validated main-checkout workflow path from linked worktrees.
- Document current-directory resolution for relative merge workflow paths.
- Cover positive, negative, and unchanged entity-lookup behavior with regression tests.

## Evidence

- Focused merge-guard checks: 6/6 passed.
- Full and race suites: 15/15 packages passed in each.

## Review guidance

Focus on `didYouMeanHint` candidate validation and its negative regression test.

---

[bme](/spacedock-dev/spacedock/blob/c7900ba579b20056a3fb54bf0515e59f69f70b45/merge-guard-foreign-cwd-entity-lookup.md)
Closes spacedock-dev/spacedock#485
