### PR TITLE
Wrong-root boot detector false-positives on macOS: observed path not symlink-resolved before comparison

### DIFF
--- a/internal/ensigncycle/wrong_root_detect_impl_test.go
+++ b/internal/ensigncycle/wrong_root_detect_impl_test.go
@@ -37,14 +37,13 @@ import (
 // only the WORKFLOW root (where it boots / cd's / reads the workflow README) must
 // stay under the fixture.
 func detectWrongRootBoot(stream, fixtureRoot string) error {
-	clean := filepath.Clean(fixtureRoot)
 	// On macOS the fixture root is a `/var/folders/...` symlink while the FO, having
 	// cd'd in, reports the EvalSymlinks-resolved `/private/var/...` form — the same
-	// directory. Resolve the fixture root so an under-fixture path in either form is
-	// recognized, matching the EvalSymlinks guard the sibling live runners use.
-	if resolved, err := filepath.EvalSymlinks(clean); err == nil {
-		clean = resolved
-	}
+	// directory. canonicalizeWrongRootPath resolves the fixture root AND (at the two
+	// wander call sites below) the FO's observed path through the SAME function, so
+	// an under-fixture path in either spelling is recognized — isUnder only holds the
+	// under-relationship when both operands are canonicalized consistently.
+	clean := canonicalizeWrongRootPath(fixtureRoot)
 	var findings []wrongRootFinding
 	byToolID := make(map[string]int)
 	for _, line := range strings.Split(stream, "\n") {
@@ -154,7 +153,7 @@ func wanderWorkflowReadme(filePath, fixtureRoot string) (string, bool) {
 	if filePath == "" || filepath.Base(filePath) != "README.md" || !filepath.IsAbs(filePath) {
 		return "", false
 	}
-	p := filepath.Clean(filePath)
+	p := canonicalizeWrongRootPath(filePath)
 	if isUnder(p, fixtureRoot) {
 		return "", false
 	}
@@ -183,7 +182,7 @@ func wanderTarget(command, fixtureRoot string) (string, bool) {
 		if arg.cd || !filepath.IsAbs(arg.path) {
 			continue
 		}
-		p := filepath.Clean(arg.path)
+		p := canonicalizeWrongRootPath(arg.path)
 		if p == fixtureRoot || isUnder(p, fixtureRoot) {
 			explicitWorkflowDirInFixture = true
 			continue
@@ -194,7 +193,7 @@ func wanderTarget(command, fixtureRoot string) (string, bool) {
 		if !filepath.IsAbs(arg.path) {
 			continue
 		}
-		p := filepath.Clean(arg.path)
+		p := canonicalizeWrongRootPath(arg.path)
 		if p == fixtureRoot || isUnder(p, fixtureRoot) {
 			continue
 		}
@@ -300,4 +299,35 @@ func isUnder(p, dir string) bool {
 		return false
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// canonicalizeWrongRootPath resolves p to its deepest-existing-ancestor form: if p
+// itself resolves via EvalSymlinks, that resolution is returned; otherwise the walk
+// climbs to the deepest EXISTING ancestor, resolves THAT, and rejoins the
+// non-existent tail onto it. This is what lets a stream-extracted observed path —
+// which may not exist on disk at check-time, e.g. a Read the FO's boot stream
+// captured for a file that was since removed — still canonicalize to the same
+// symlink-resolved spelling as the fixture root: a plain "EvalSymlinks, else use
+// the unresolved Clean'd path" fallback leaves such a path in its unresolved form
+// and the wrong-root comparison still mismatches. Falls back to Clean(p) only when
+// nothing up to the filesystem root resolves.
+func canonicalizeWrongRootPath(p string) string {
+	p = filepath.Clean(p)
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	dir := p
+	var tail []string
+	for {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		tail = append([]string{filepath.Base(dir)}, tail...)
+		dir = parent
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			return filepath.Join(append([]string{resolved}, tail...)...)
+		}
+	}
+	return p
 }

--- a/internal/ensigncycle/wrong_root_detect_test.go
+++ b/internal/ensigncycle/wrong_root_detect_test.go
@@ -243,6 +243,84 @@ func TestDetectWrongRootBootRealPR446Commands(t *testing.T) {
 	}
 }
 
+// TestDetectWrongRootBootSymlinkMismatch proves the observed-path canonicalizer
+// fix: a fixture root and an FO-observed path that are the SAME directory but
+// spelled through a symlink vs its resolved target must not false-flag as a
+// wander, whether the observed path exists on disk (existing variant) or not
+// (ghost variant — the FO's stream captured a path that no longer exists by the
+// time the detector runs). Builds a REAL on-disk symlink divergence in
+// t.TempDir() so this reproduces deterministically on macOS AND Linux CI, unlike
+// the underlying macOS-only `/var` -> `/private/var` bug this guards.
+func TestDetectWrongRootBootSymlinkMismatch(t *testing.T) {
+	parent := t.TempDir()
+	real := filepath.Join(parent, "real")
+	if err := os.Mkdir(real, 0o755); err != nil {
+		t.Fatalf("mkdir real target: %v", err)
+	}
+	link := filepath.Join(parent, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// fixtureRoot mirrors t.TempDir()'s unresolved spelling; detectWrongRootBoot
+	// resolves it internally, so `clean` inside the detector becomes `real`'s
+	// resolved form.
+	fixtureRoot := link
+
+	t.Run("existing_readme_passes", func(t *testing.T) {
+		readmePath := filepath.Join(link, "README.md")
+		if err := os.WriteFile(readmePath, []byte("# fixture\n"), 0o644); err != nil {
+			t.Fatalf("write README: %v", err)
+		}
+		stream := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"` + readmePath + `"}}]}}`
+		if err := detectWrongRootBoot(stream, fixtureRoot); err != nil {
+			t.Errorf("detector false-flagged a workflow README read through the SAME directory's symlink spelling as the (internally resolved) fixture root: %v", err)
+		}
+	})
+
+	t.Run("ghost_readme_passes", func(t *testing.T) {
+		// This README was never written — the observed path does not exist on disk
+		// at check-time. EvalSymlinks errors on the full path; only the
+		// deepest-existing-ancestor walk (resolving through `link`) closes this.
+		ghostPath := filepath.Join(link, "does", "not", "exist", "README.md")
+		stream := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"` + ghostPath + `"}}]}}`
+		if err := detectWrongRootBoot(stream, fixtureRoot); err != nil {
+			t.Errorf("detector false-flagged a workflow README read at a NON-EXISTENT path under the SAME directory's symlink spelling as the fixture root: %v", err)
+		}
+	})
+
+	t.Run("workflow_dir_bash_passes", func(t *testing.T) {
+		stream := streamLine(`spacedock status --boot --workflow-dir ` + link)
+		if err := detectWrongRootBoot(stream, fixtureRoot); err != nil {
+			t.Errorf("detector false-flagged a --workflow-dir boot through the SAME directory's symlink spelling as the fixture root: %v", err)
+		}
+	})
+
+	t.Run("genuine_wander_still_reds", func(t *testing.T) {
+		// Positive control: an observed path outside BOTH the link and its resolved
+		// target must still be flagged, even with the symlinked fixture root.
+		elsewhere := filepath.Join(parent, "elsewhere")
+		if err := os.Mkdir(elsewhere, 0o755); err != nil {
+			t.Fatalf("mkdir elsewhere: %v", err)
+		}
+		readmePath := filepath.Join(elsewhere, "README.md")
+		if err := os.WriteFile(readmePath, []byte("# elsewhere\n"), 0o644); err != nil {
+			t.Fatalf("write README: %v", err)
+		}
+		wantRoot, err := filepath.EvalSymlinks(real)
+		if err != nil {
+			t.Fatalf("EvalSymlinks(real): %v", err)
+		}
+		stream := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"` + readmePath + `"}}]}}`
+		gotErr := detectWrongRootBoot(stream, fixtureRoot)
+		if gotErr == nil {
+			t.Fatal("detector passed a workflow README read from a genuinely unrelated directory — want a wrong-root error")
+		}
+		if !strings.Contains(gotErr.Error(), wantRoot) {
+			t.Errorf("error must name the resolved fixture root %q: %v", wantRoot, gotErr)
+		}
+	})
+}
+
 // TestDetectWrongRootBootRealPR446Streams replays the two full captured sonnet
 // streams from PR #446 (run 28466995641, artifact
 // runtime-live-e2e-claude-live-sonnet, `claude-shared-scenarios/feedback-3-cycle-escalation/claude-stream.jsonl`)


### PR DESCRIPTION
Canonicalizing both fixture and observed paths prevents macOS symlink spellings from falsely reporting correct workflow boots as wrong-root failures.

## What changed

- Centralize wrong-root path normalization in a deepest-existing-ancestor canonicalizer.
- Route fixture roots, README reads, and Bash path observations through the canonicalizer.
- Add deterministic symlink tests for existing, ghost, and genuine-wander paths.

## Evidence

- Focused symlink and detector suites: 5/5 and 25/25 passed.
- Repository gates: 2/2 passed; live macOS probe: 1/1 passed with zero false flags.

---

[5q](/spacedock-dev/spacedock/blob/c7900ba579b20056a3fb54bf0515e59f69f70b45/wrong-root-detector-symlink-false-positive.md)
