### PR TITLE
feat(contract): draft Ledger gate-binding boundary

### DIFF
--- a/docs/schema/gate-binding.v1.schema.json
+++ b/docs/schema/gate-binding.v1.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.spacedock.dev/gate-binding.v1.schema.json",
+  "title": "Spacedock gate binding v1 (Draft)",
+  "description": "Spacedock-owned provider target stored in a Helm Ledger gate binding slot. The binding exists before a Resolution or application obligation, so later gate, Resolution, application, attestation, and projection fields remain outside this payload. This review draft does not imply a shipped writer, projector, watcher, command, or endpoint.",
+  "type": "object",
+  "required": [
+    "ns",
+    "entity_ref"
+  ],
+  "properties": {
+    "ns": {
+      "const": "spacedock.gate-binding.v1",
+      "description": "The Spacedock-owned provider namespace. The containing Ledger gate attaches this binding to its gat_ identity."
+    },
+    "entity_ref": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
+      "description": "Stable Spacedock entity reference used to locate the workflow-owned target."
+    },
+    "stage": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
+      "description": "Optional expected current stage before the authorized transition."
+    },
+    "target_stage": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
+      "description": "Optional stage the Spacedock apply coordinator may enter after validating the selected Resolution."
+    },
+    "workflow_ref": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
+      "description": "Optional explicit workflow reference when entity_ref alone is not sufficient for provider routing."
+    },
+    "provider_instance_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
+      "description": "Optional immutable Spacedock installation or service identity used for multi-instance routing."
+    },
+    "expected_revision": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
+      "description": "Optional provider-owned optimistic concurrency pin checked before mutation."
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/site/contributing/architecture-notes.md
+++ b/docs/site/contributing/architecture-notes.md
@@ -18,10 +18,11 @@ The division is deliberate: a behavior that can be guarded by the binary or a fa
 
 ## Design contracts under `docs/specs/`
 
-`docs/specs/` holds the contracts downstream code cites instead of re-deriving. Two are current.
+`docs/specs/` holds the contracts downstream code cites instead of re-deriving. Two are current, and one is a ratification Draft.
 
 - **`state-behavior-extension.md`** defines the split-root storage profile. A development workflow keeps its README in the main repo and its mutable entities in a per-workflow `.spacedock-state` checkout, so shared issues advance without noisy state commits on the code branch. The README's `state: .spacedock-state` frontmatter field names the checkout, resolved relative to the README directory. The spec fixes the v0 layout (entities directly under `.spacedock-state`, no `entities/` directory; `_archive/` and `_debriefs/` siblings) and the mutation rules: reads compose the main README's stages with the checkout's entities, while `--set` and `--archive` write only inside the checkout.
 - **`scenario-testing-principles.md`** sets out the semantic model for scenario testing. A *scenario* is a natural-language behavioral spec graded on **durable outcomes** (entity state before → after, archive state, on-disk artifacts, durable user-facing output), never transcript phrasing. An *executor* is a pluggable implementation of that check: a **codified** executor (a deterministic Go fixture/unit test, proving the modeled consumer) or an **LLM** executor (a real Claude/Codex run, proving the real producer). The two check the same scenario at different fidelity, which dissolves the recurring failure mode where an offline proof passes while the live run fails. The four seed scenario IDs declared in this spec must equal the `sharedRuntimeScenarios()` table in `internal/ensigncycle`; a lock test reds on drift in either direction.
+- **`ledger-gate-binding.md`** proposes the Spacedock-owned provider boundary for one Helm Ledger gate Resolution and application obligation. The Draft pins identity and recovery without moving gate or application authority into Spacedock. Its schema and fixtures are review material; no writer, projector, watcher, command, or endpoint ships with the proposal.
 
 ## Runtime live CI model
 

--- a/docs/specs/ledger-gate-binding.md
+++ b/docs/specs/ledger-gate-binding.md
@@ -64,6 +64,14 @@ Committed and observed facts use the same `application_id` but remain separate.
 Missing observation does not undo an applied gate. Observation arriving first does
 not apply a gate.
 
+For a Git target, the committed fact names `tree_or_blob_kind` (`tree` or `blob`), the
+full 40/64 lowercase-hex `tree_or_blob_oid`, and `tree_or_blob_digest`. The digest is
+`sha256:` plus lowercase SHA-256 over the exact raw Git object payload bytes named by
+that kind and OID. It excludes the loose-object header `<kind> <size>\0` and forbids
+pretty-printed/text-normalized output such as `git cat-file -p`. The empty-blob golden
+vector uses OID `e69de29bb2d1d6434b8b29ae775ad8c2e48c5391` and payload digest
+`sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
+
 ## Apply lifecycle
 
 1. Ledger opens the gate with the Spacedock binding, then records an authorized
@@ -72,8 +80,9 @@ not apply a gate.
    Ledger capabilities before mutation.
 3. Spacedock writes its workflow state and commits durable references to
    `application_id`, `resolution_id`, and `gate_id`.
-4. The same coordinator records `helm.application.committed.v1` with the original
-   idempotency material.
+4. The same coordinator records `helm.application.committed.v1`; idempotency is scoped
+   by `(application_id, idempotency_key)`, and response-loss replay reuses that tuple
+   with the byte-identical fact/body digest.
 5. Ledger acceptance changes the gate from `pending_apply` to `applied`.
 6. A publisher or watcher may later record `helm.application.observed.v1`.
 
@@ -139,6 +148,11 @@ digest path. Contract vectors cover UTF-16 property ordering, string escaping, a
 numeric representation. Reprojection cannot silently mint a new application
 obligation or redirect an existing one.
 
+An applied application never enters rewrite_quarantined. Its committed receipt remains
+append-only proof; later binding/source changes append supersession or reconciliation
+evidence and, if needed, create a new application obligation. Quarantine is only for an
+uncommitted projection whose candidate differs from the frozen exposed binding.
+
 ## Orphan observations
 
 An observation without `application_id` is not a binding and cannot apply a gate.
@@ -196,7 +210,7 @@ They recursively walk every Helm `$ref` and reject an incomplete vendored schema
 closure, including a reference reachable only through an optional property.
 
 The manifest uses `provenance_status: complete` and pins Helm source revision
-`3d39fcdc67cc6aac22d51f4abcc2dfdadf56c838`. Every schema entry records its exact
+`e852f31e0ae6c5f06c44b51b5c7a82d0edc7da7a`. Every schema entry records its exact
 source path, Git blob ID, and raw SHA-256 so consumers can independently reproduce
 the vendored bytes from the immutable source commit.
 
@@ -210,8 +224,11 @@ A consumer of `spacedock.gate-binding.v1` must:
   never by requiring them inside the binding;
 - validate target state and required capabilities before mutation;
 - persist `application_id` in durable mutation evidence;
+- recompute Git tree/blob evidence from the declared kind, full object OID, and raw
+  payload bytes without a loose-object header or text conversion;
 - treat committed acceptance as the only apply fold and observation as audit only;
-- recover a lost response by application read or same-key, same-body replay;
+- recover a lost response by application read or replay of the same
+  `(application_id, idempotency_key)` tuple and byte-identical body;
 - preserve unknown additive fields;
 - stop on projection invalidation or rewrite quarantine.
 

--- a/docs/specs/ledger-gate-binding.md
+++ b/docs/specs/ledger-gate-binding.md
@@ -1,0 +1,231 @@
+# Ledger gate binding contract
+
+> **Draft for CL and Jared ratification.** This document and
+> [`gate-binding.v1.schema.json`](../schema/gate-binding.v1.schema.json) propose the
+> Spacedock-owned boundary. They do not claim a shipped writer, projector, watcher,
+> command, or endpoint.
+
+Spacedock needs one stable way to bind a portable Ledger gate to workflow state
+without taking ownership of the gate or Ledger facts. `spacedock.gate-binding.v1`
+does that. It identifies the Spacedock target before a Resolution or application
+exists. Later Ledger facts link through the containing gate; they do not expand the
+binding payload.
+
+## Ownership
+
+| Fact or responsibility | Owner | Contract consequence |
+|---|---|---|
+| Portable Review & Gate semantics | Subspace R&G | Spacedock does not redefine the Resolution object. |
+| `gat_`, `resolution_id`, and `application_id` | Helm Ledger | Spacedock treats these as immutable external identities. |
+| `spacedock.gate-binding.v1` | Spacedock | Helm may pin and preserve the schema but does not redefine it. |
+| Workflow and entity state | Spacedock | Only the Spacedock-owned writer mutates and commits this state. |
+| Apply coordination for an SD-bound gate | Spacedock | The coordinator owns every post-mutation uncertainty until Ledger acceptance is known. |
+| Application facts and the apply fold | Helm Ledger | Ledger accepts idempotent attestations and owns `pending_apply -> applied`. |
+| Missed-attestation and observation recovery | Reconciliation lane | Recovery can append evidence but cannot invent a Resolution or change authority. |
+
+There is no synchronous transaction across Git and Ledger. The boundary makes each
+uncertain window observable and assigns one recovery owner.
+
+## Binding identity
+
+The minimal provider pin is the existing Helm opaque binding slot:
+
+```json
+{
+  "ns": "spacedock.gate-binding.v1",
+  "entity_ref": "docs/ship-flow/m4.13"
+}
+```
+
+`ns` selects the Spacedock-owned vocabulary. `entity_ref` identifies the provider
+target. Optional `stage`, `target_stage`, `workflow_ref`, `provider_instance_id`, and
+`expected_revision` fields can tighten transition checks, routing, and optimistic
+concurrency without changing the real two-field Helm slot.
+
+The containing Ledger gate attaches this provider pin to `gate_id`; the binding never
+replaces or rekeys the gate. `resolution_id` and `application_id` do not exist when the
+gate is opened, so they are forbidden as required binding fields. They appear only in
+later Ledger-owned Resolution and application facts. A later authorized application
+uses a new `application_id` and may name `supersedes_application_id` in the Helm
+application contract.
+
+## Application contracts
+
+The boundary uses these Helm-owned wire contracts after Resolution:
+
+| Reference | Meaning | Fold effect |
+|---|---|---|
+| `helm.application.committed.v1` | The Spacedock-local canonical state commit and its before/after evidence | Ledger acceptance is the sole `pending_apply -> applied` input. |
+| `helm.application.observed.v1` | Later observation of the application on a named ref or remote | Audit and divergence evidence only. |
+| `helm.application.view.v1` | Stable read model for response-lost recovery | No new fact; reports the current application state. |
+
+Spacedock consumes these contracts and does not copy their fields into its binding schema.
+Committed and observed facts use the same `application_id` but remain separate.
+Missing observation does not undo an applied gate. Observation arriving first does
+not apply a gate.
+
+## Apply lifecycle
+
+1. Ledger opens the gate with the Spacedock binding, then records an authorized
+   Resolution and exposes a stable `application_id` for required apply.
+2. The Spacedock coordinator verifies the provider pin, target state, and required
+   Ledger capabilities before mutation.
+3. Spacedock writes its workflow state and commits durable references to
+   `application_id`, `resolution_id`, and `gate_id`.
+4. The same coordinator records `helm.application.committed.v1` with the original
+   idempotency material.
+5. Ledger acceptance changes the gate from `pending_apply` to `applied`.
+6. A publisher or watcher may later record `helm.application.observed.v1`.
+
+The coordinator must refuse before mutation when application commit or application
+recovery is unsupported. An observation capability may be absent without blocking
+the committed apply.
+
+A Git hook may wake reconciliation. Correctness must remain the same when hooks are
+missing, bypassed, duplicated, or replayed. A hook never mints a Resolution, chooses
+authority, or makes Ledger availability part of Git commit success.
+
+## Failure and recovery
+
+| Window | Reported state | Recovery owner and action |
+|---|---|---|
+| Binding validation fails before mutation | `binding_refused` | Spacedock refuses closed and returns the typed Ledger or provider validation error. |
+| Provider version or digest differs from the pinned contract | `helm.provider_binding.unsupported_version.v1` | Spacedock refuses before mutation and waits for an explicitly supported pin. |
+| Spacedock exits before commit | Ledger remains `pending_apply` | Spacedock cleans or reconciles its own worktree, then retries by `application_id`. |
+| Commit succeeds and Ledger definitively refuses the attestation | `commit_succeeded_attestation_pending` | Spacedock detects the existing commit and replays the same request after the refusal is addressed. |
+| Commit succeeds and the Ledger response is lost | `commit_succeeded_attestation_outcome_unknown` | Spacedock reads `helm.application.view.v1` or replays the same key and body. It does not report a false failure. |
+| Observation arrives before committed attestation | `observed_without_attestation` | Spacedock or trusted reconciliation validates durable metadata and supplies the missing committed fact. The gate stays pending until acceptance. |
+| Ledger accepts committed attestation but no observation arrives | `applied`, publication evidence absent | No apply recovery is needed. Observation may arrive later. |
+| The same idempotency key carries a changed body | `helm.application.idempotency_conflict.v1` | Spacedock refuses the changed replay and reads the current application view. |
+
+The Helm boundary supplies these stable error codes to the coordinator:
+
+- `helm.application.not_found.v1`
+- `helm.application.attestation_invalid.v1`
+- `helm.application.idempotency_conflict.v1`
+- `helm.application.observation_unlinked.v1`
+- `helm.provider_binding.unsupported_version.v1`
+- `helm.projection.cursor_invalidated.v1`
+- `helm.projection.rewrite_quarantined.v1`
+
+Unknown error details are additive and must survive forwarding. An unknown error code
+is never interpreted as success.
+
+Helm pins the supported provider namespace and schema digest outside the binding
+payload. A different `ns` version or a digest mismatch returns
+`helm.provider_binding.unsupported_version.v1` before mutation. Spacedock must not
+guess fields, fall back to a nearby version, or fetch live upstream canon. The same
+typed refusal covers version and digest mismatch so consumers have one fail-closed
+recovery branch.
+
+## Projection rewrites
+
+The Ledger projection that exposes a binding records `projection_epoch` and
+`exposed_binding_digest` outside the binding payload. Event cursors are valid only
+inside their epoch. An epoch mismatch returns
+`helm.projection.cursor_invalidated.v1` with restart guidance; it must not look like
+a successful empty page.
+
+If reprojection selects a different binding, the old exposed binding stays frozen.
+The projection enters `rewrite_quarantined`, records the exact
+`candidate_binding_digest`, and waits for explicit reconciliation. Both binding
+digests are `"sha256:"` followed by the lowercase hexadecimal SHA-256 of the
+UTF-8 bytes produced by the RFC 8785 JSON Canonicalization Scheme (JCS) for their
+corresponding binding objects. Producers and consumers must use a compliant JCS
+implementation; ordinary JSON serialization, including Go `encoding/json` or
+JavaScript `JSON.stringify`, is not a substitute. A binding value that cannot be
+represented as RFC 8785 I-JSON fails closed before any mutation, with no fallback
+digest path. Contract vectors cover UTF-16 property ordering, string escaping, and
+numeric representation. Reprojection cannot silently mint a new application
+obligation or redirect an existing one.
+
+## Orphan observations
+
+An observation without `application_id` is not a binding and cannot apply a gate.
+Helm may expose readable `helm.application.orphan_observed.v1` evidence keyed by
+immutable source identity. Its writer remains a typed, reconciliation-internal
+operation for trusted watcher or backfill adapters.
+
+Spacedock must not advertise the orphan writer as a CLI, HTTP endpoint, or public
+capability. The public capability set remains application commit, linked observation,
+application recovery, and projection epoch support.
+
+## Operation without Spacedock
+
+When Spacedock is absent, this binding is absent. Helm keeps the existing Ledger path:
+
+- a gate with `apply_requirement: none` ends at `decided`;
+- an action gate can bind to its session executor and use the provider-neutral Helm
+  attestation contract;
+- Helm does not create synthetic Spacedock workflow state or a fake provider pin.
+
+This keeps Spacedock optional without creating a second decision or application
+model.
+
+## Compatibility rules
+
+The schema follows JSON Schema 2020-12 and accepts the existing minimal Helm binding
+slot. It permits additive fields so a consumer can preserve extensions it does not
+understand. Consumers must validate known required fields and constants, retain
+unknown fields on read/write round trips, and ignore unknown optional fields unless
+another negotiated capability assigns them meaning.
+
+`entity_ref` and every known optional string routing field must contain at least one
+non-whitespace character. A present whitespace-only field fails validation; omission
+remains valid for optional fields.
+
+An additive optional field is compatible within v1. Removing or renaming a required
+field, changing a constant, changing authority, or changing a fold effect requires a
+new schema version. New versions must not reuse `spacedock.gate-binding.v1`.
+
+The executable examples live in
+`internal/contract/testdata/ledger-boundary/`. They include the existing minimal
+binding, an extension-preservation case, invalid provider target cases, and a
+boundary fixture that links later Resolution, application, committed, and observed
+facts without putting those fields inside the binding. Additional fixtures prove
+same-key replay, changed-body conflict, response-lost application reads, epoch cursor
+invalidation, rewrite freeze, and typed provider-pin refusal.
+
+`internal/contract/testdata/ledger-boundary/helm-schemas/` vendors the exact Helm
+application and rewrite schemas used by those executable examples. Its manifest pins
+the source repository, source path, Git revision and blob identity, and raw SHA-256
+for each of the eight schemas. Contract tests validate the complete request fact,
+receipt, observation, application view, source-superseded evidence, generic provider
+binding, and rewrite evidence through those schemas without a live upstream read.
+They recursively walk every Helm `$ref` and reject an incomplete vendored schema
+closure, including a reference reachable only through an optional property.
+
+The manifest uses `provenance_status: complete` and pins Helm source revision
+`3d39fcdc67cc6aac22d51f4abcc2dfdadf56c838`. Every schema entry records its exact
+source path, Git blob ID, and raw SHA-256 so consumers can independently reproduce
+the vendored bytes from the immutable source commit.
+
+## Consumer checklist
+
+A consumer of `spacedock.gate-binding.v1` must:
+
+- verify required `ns` and `entity_ref`, plus any supplied optional target fields,
+  before using the provider pin;
+- read `gate_id`, `resolution_id`, and `application_id` from their Ledger-owned facts,
+  never by requiring them inside the binding;
+- validate target state and required capabilities before mutation;
+- persist `application_id` in durable mutation evidence;
+- treat committed acceptance as the only apply fold and observation as audit only;
+- recover a lost response by application read or same-key, same-body replay;
+- preserve unknown additive fields;
+- stop on projection invalidation or rewrite quarantine.
+
+## Contribution checklist
+
+A contract change must update the spec, schema, relevant valid and invalid fixtures,
+and `internal/contract/gate_binding_test.go` in the same pull request. Contributors
+must state whether the change is additive within v1 or requires a new version. A Helm
+wire-shape change also updates the vendored schema bytes, manifest digest, and all
+conforming Spacedock fixtures in the same pull request. Review-ready provenance
+requires `provenance_status: complete`, the exact 40-character Helm source commit,
+and the 40-character Git blob ID plus raw SHA-256 for every vendored schema.
+
+Review must confirm that Helm-owned attestation fields were not copied into the
+Spacedock schema, the orphan writer did not become public, unknown fields still round
+trip, unsupported provider pins fail closed, and no document claims the Draft runtime
+exists.

--- a/docs/specs/ledger-gate-binding.md
+++ b/docs/specs/ledger-gate-binding.md
@@ -3,13 +3,14 @@
 > **Draft for CL and Jared ratification.** This document and
 > [`gate-binding.v1.schema.json`](../schema/gate-binding.v1.schema.json) propose the
 > Spacedock-owned boundary. They do not claim a shipped writer, projector, watcher,
-> command, or endpoint.
+> ledger-bound adapter, provider attempt-state schema, command, or endpoint.
 
 Spacedock needs one stable way to bind a portable Ledger gate to workflow state
 without taking ownership of the gate or Ledger facts. `spacedock.gate-binding.v1`
-does that. It identifies the Spacedock target before a Resolution or application
-exists. Later Ledger facts link through the containing gate; they do not expand the
-binding payload.
+does that for a ledger-bound gate attempt. It identifies the Spacedock target before
+a Resolution or application exists. Later Ledger facts link through the containing
+gate; they do not expand the binding payload. A standalone Spacedock gate attempt is
+outside this binding contract and remains valid without Helm Ledger.
 
 ## Ownership
 
@@ -25,6 +26,62 @@ binding payload.
 
 There is no synchronous transaction across Git and Ledger. The boundary makes each
 uncertain window observable and assigns one recovery owner.
+
+## Authority selection
+
+A standalone-only Spacedock deployment remains outside this binding contract. A
+future implementation that supports ledger-bound attempts or both modes must select
+exactly one decision authority when an attempt opens:
+
+- A standalone attempt explicitly persists standalone authority in the
+  provider-owned attempt record before presenting the Briefing or accepting a
+  Resolution. It has no Helm Ledger gate or Spacedock binding. Spacedock may persist
+  the authoritative R&G Resolution and its local application state. Those are
+  Spacedock-local facts, not Helm facts.
+- A ledger-bound attempt explicitly persists ledger-bound authority before opening
+  a Helm Ledger gate with `spacedock.gate-binding.v1`. Helm owns `gate_id`,
+  `resolution_id`, `application_id`, the authoritative Resolution, and the
+  application fold. Spacedock persists their references plus workflow-owned state.
+
+The selection is immutable for that attempt and is never inferred from the absence
+of a readable Ledger gate or binding. Missing selection, an incomplete ledger-bound
+opening, Ledger unavailability, or projection lag all refuse closed. They never
+downgrade an attempt to standalone authority. Spacedock must also refuse before
+mutation if a ledger-bound attempt presents a Spacedock-local authoritative
+Resolution or locally minted Ledger identity. Converting a standalone attempt into
+a ledger-bound attempt requires a new attempt or a separately ratified import
+contract; it is not an in-place fallback.
+
+A ledger-bound workflow may omit the Resolution body entirely. If it caches a body
+for display, the cache must be explicitly non-authoritative, bound to the Ledger
+Resolution by digest, and immutable for that `resolution_id`. A digest mismatch
+discards or quarantines that cache record; a refetch creates a new cache record
+rather than replacing its contents in place. Ledger remains the source of truth.
+Provider-owned probe and room history neither selects the authority mode nor becomes
+a Ledger fact.
+
+## Ledger-bound adapter preconditions
+
+These requirements constrain a future ledger-bound adapter. They do not define or
+ship a provider attempt-state wire format in v1. A dual-mode implementation considers
+a standalone attempt ready only after its explicit authority selection is durable. A
+ledger-bound attempt uses this opening sequence:
+
+1. Spacedock durably selects ledger-bound authority and records the producer-owned
+   `openGate` idempotency key plus the exact command body bytes and their stable
+   digest.
+2. The opener creates the Helm Ledger gate with `spacedock.gate-binding.v1` using
+   that key and body.
+3. Spacedock durably records the returned gate and binding reference. A response-lost
+   retry reuses the same key and byte-identical body, so Ledger returns the same
+   `gate_id`.
+4. Only then may the attempt present the Briefing or accept a Resolution or
+   application action.
+
+If gate creation or the durable reference write has an unknown outcome, the attempt
+stays blocked in opening. The opener reconciles through the durable idempotency key
+before continuing or explicitly abandons the attempt. A retry cannot change the body
+or create a standalone authority path for the same attempt.
 
 ## Binding identity
 
@@ -74,7 +131,9 @@ vector uses OID `e69de29bb2d1d6434b8b29ae775ad8c2e48c5391` and payload digest
 
 ## Apply lifecycle
 
-1. Ledger opens the gate with the Spacedock binding, then records an authorized
+This lifecycle applies only to a ledger-bound attempt:
+
+1. After the gate-opening sequence completes, Ledger records an authorized
    Resolution and exposes a stable `application_id` for required apply.
 2. The Spacedock coordinator verifies the provider pin, target state, and required
    Ledger capabilities before mutation.
@@ -98,6 +157,7 @@ authority, or makes Ledger availability part of Git commit success.
 
 | Window | Reported state | Recovery owner and action |
 |---|---|---|
+| Gate creation or binding persistence has an unknown outcome | Attempt remains in opening; no Resolution is accepted | The opener replays the durable `openGate` idempotency key and byte-identical body to recover the same `gate_id`, then reconciles the provider attempt or abandons it. It never falls back to standalone authority. |
 | Binding validation fails before mutation | `binding_refused` | Spacedock refuses closed and returns the typed Ledger or provider validation error. |
 | Provider version or digest differs from the pinned contract | `helm.provider_binding.unsupported_version.v1` | Spacedock refuses before mutation and waits for an explicitly supported pin. |
 | Spacedock exits before commit | Ledger remains `pending_apply` | Spacedock cleans or reconciles its own worktree, then retries by `application_id`. |
@@ -176,6 +236,19 @@ When Spacedock is absent, this binding is absent. Helm keeps the existing Ledger
 This keeps Spacedock optional without creating a second decision or application
 model.
 
+## Operation without Helm Ledger
+
+When Helm Ledger is absent, the Spacedock binding is absent. Spacedock may run the
+standalone authority mode described above only after explicitly persisting that
+selection. Ledger unavailability or an unreadable binding is not standalone
+selection. A standalone attempt may include an authoritative R&G Resolution and
+local application state in its workflow record. It must not mint `gat_`,
+`resolution_id`, or `application_id` values that appear to be Helm Ledger facts.
+
+Adding Helm later does not retroactively convert the attempt. A new ledger-bound
+attempt may reference the same provider target and Briefing lineage, but it receives
+new Ledger-owned identities and authority.
+
 ## Compatibility rules
 
 The schema follows JSON Schema 2020-12 and accepts the existing minimal Helm binding
@@ -191,6 +264,14 @@ remains valid for optional fields.
 An additive optional field is compatible within v1. Removing or renaming a required
 field, changing a constant, changing authority, or changing a fold effect requires a
 new schema version. New versions must not reuse `spacedock.gate-binding.v1`.
+
+The standalone versus ledger-bound clarification changes neither the v1 schema
+document nor binding payload bytes. It defines preconditions for a future
+ledger-bound adapter; the versioned provider attempt-state representation remains a
+separate ratification surface. In a dual-mode implementation, the explicit
+provider-owned attempt selection chooses the mode. A valid binding on the containing
+Ledger gate confirms the ledger-bound path, but binding absence alone never selects
+standalone authority. A hybrid record is invalid rather than a third mode.
 
 The executable examples live in
 `internal/contract/testdata/ledger-boundary/`. They include the existing minimal
@@ -218,6 +299,16 @@ the vendored bytes from the immutable source commit.
 
 A consumer of `spacedock.gate-binding.v1` must:
 
+- determine whether the gate attempt is standalone or ledger-bound before mutation
+  by reading its explicit durable selection, never by treating an unavailable or
+  absent Ledger binding as standalone;
+- keep that authority selection fixed for the attempt and block while a ledger-bound
+  opening outcome is unknown;
+- persist the producer-owned `openGate` idempotency key, exact body bytes, and stable
+  body digest before calling Ledger, then reuse the same key and byte-identical body
+  for response-lost recovery;
+- refuse a ledger-bound record that also claims a Spacedock-local authoritative
+  Resolution or locally minted Ledger identity;
 - verify required `ns` and `entity_ref`, plus any supplied optional target fields,
   before using the provider pin;
 - read `gate_id`, `resolution_id`, and `application_id` from their Ledger-owned facts,
@@ -234,11 +325,13 @@ A consumer of `spacedock.gate-binding.v1` must:
 
 ## Contribution checklist
 
-A contract change must update the spec, schema, relevant valid and invalid fixtures,
-and `internal/contract/gate_binding_test.go` in the same pull request. Contributors
-must state whether the change is additive within v1 or requires a new version. A Helm
-wire-shape change also updates the vendored schema bytes, manifest digest, and all
-conforming Spacedock fixtures in the same pull request. Review-ready provenance
+A wire contract change must update the spec, schema, relevant valid and invalid
+fixtures, and `internal/contract/gate_binding_test.go` in the same pull request.
+Contributors must state whether the change is additive within v1 or requires a new
+version. A prose-only scope or consumer clarification leaves the schema document
+unchanged unless all raw-digest consumers update their pins in the same change. A
+Helm wire-shape change also updates the vendored schema bytes, manifest digest, and
+all conforming Spacedock fixtures in the same pull request. Review-ready provenance
 requires `provenance_status: complete`, the exact 40-character Helm source commit,
 and the 40-character Git blob ID plus raw SHA-256 for every vendored schema.
 

--- a/internal/contract/gate_binding_test.go
+++ b/internal/contract/gate_binding_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const gateBindingSchemaPath = "../../docs/schema/gate-binding.v1.schema.json"
-const helmSchemaSourceRevision = "3d39fcdc67cc6aac22d51f4abcc2dfdadf56c838"
+const helmSchemaSourceRevision = "e852f31e0ae6c5f06c44b51b5c7a82d0edc7da7a"
 
 func TestGateBindingSchemaPinsProviderTargetIdentity(t *testing.T) {
 	schema := readJSONObject(t, gateBindingSchemaPath)
@@ -92,7 +92,14 @@ func TestGateBindingDigestContractPinsRFC8785(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read binding spec: %v", err)
 	}
-	for _, required := range []string{"RFC 8785", "JSON Canonicalization Scheme (JCS)"} {
+	for _, required := range []string{
+		"RFC 8785",
+		"JSON Canonicalization Scheme (JCS)",
+		"raw Git object payload bytes",
+		"excludes the loose-object header",
+		"(application_id, idempotency_key)",
+		"An applied application never enters rewrite_quarantined",
+	} {
 		if !strings.Contains(string(rawSpec), required) {
 			t.Errorf("binding digest contract does not name %q", required)
 		}
@@ -160,6 +167,11 @@ func TestGateBindingApplicationReplayAndResponseLostRecovery(t *testing.T) {
 	fixture := readJSONObject(t, filepath.Join("testdata", "ledger-boundary", "application-recovery.json"))
 	request := objectValue(t, fixture, "committed_request")
 	assertDigestMatchesBinding(t, request, "fact", "body_digest")
+	fact := objectValue(t, request, "fact")
+	assertStringValue(t, fact, "tree_or_blob_kind", "blob")
+	assertStringValue(t, fact, "tree_or_blob_oid", "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")
+	emptyPayloadDigest := fmt.Sprintf("sha256:%x", sha256.Sum256(nil))
+	assertStringValue(t, fact, "tree_or_blob_digest", emptyPayloadDigest)
 	receipt := objectValue(t, fixture, "accepted_receipt")
 	replay := objectValue(t, fixture, "same_key_same_body_replay")
 	if !reflect.DeepEqual(receipt, replay) {

--- a/internal/contract/gate_binding_test.go
+++ b/internal/contract/gate_binding_test.go
@@ -1,0 +1,914 @@
+// ABOUTME: Contract tests for the Spacedock-owned gate-binding boundary.
+// ABOUTME: They validate the schema, dogfood fixtures, and additive-field preservation without runtime code.
+package contract
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+const gateBindingSchemaPath = "../../docs/schema/gate-binding.v1.schema.json"
+const helmSchemaSourceRevision = "3d39fcdc67cc6aac22d51f4abcc2dfdadf56c838"
+
+func TestGateBindingSchemaPinsProviderTargetIdentity(t *testing.T) {
+	schema := readJSONObject(t, gateBindingSchemaPath)
+
+	assertStringValue(t, schema, "$schema", "https://json-schema.org/draft/2020-12/schema")
+	assertStringValue(t, schema, "$id", "https://schemas.spacedock.dev/gate-binding.v1.schema.json")
+	assertStringValue(t, schema, "type", "object")
+	if got := schema["additionalProperties"]; got != true {
+		t.Fatalf("root additionalProperties = %#v, want true for additive compatibility", got)
+	}
+
+	required := stringSet(t, schema["required"])
+	for _, name := range []string{
+		"ns",
+		"entity_ref",
+	} {
+		if !required[name] {
+			t.Errorf("schema required does not contain %q", name)
+		}
+	}
+	for _, temporal := range []string{"gate_id", "resolution_id", "application_id", "application"} {
+		if required[temporal] {
+			t.Errorf("binding requires later lifecycle field %q", temporal)
+		}
+	}
+
+	properties := objectValue(t, schema, "properties")
+	assertStringValue(t, objectValue(t, properties, "ns"), "const", "spacedock.gate-binding.v1")
+	for _, routed := range []string{"entity_ref", "stage", "target_stage", "workflow_ref", "provider_instance_id", "expected_revision"} {
+		property := objectValue(t, properties, routed)
+		if _, ok := property["pattern"].(string); !ok {
+			t.Errorf("routing field %q lacks non-whitespace pattern", routed)
+		}
+	}
+	for _, optional := range []string{"stage", "target_stage"} {
+		if required[optional] {
+			t.Errorf("existing two-field binding compatibility requires %q to stay optional", optional)
+		}
+	}
+	for _, temporal := range []string{"gate_id", "resolution_id", "application_id", "application"} {
+		if _, defined := properties[temporal]; defined {
+			t.Errorf("binding schema defines later lifecycle field %q", temporal)
+		}
+	}
+}
+
+func TestGateBindingRejectsWhitespaceRoutingFields(t *testing.T) {
+	schema := readJSONObject(t, gateBindingSchemaPath)
+	for _, fixture := range []string{
+		"invalid-whitespace-entity-ref.json",
+		"invalid-whitespace-stage.json",
+		"invalid-whitespace-target-stage.json",
+		"invalid-whitespace-workflow-ref.json",
+		"invalid-whitespace-provider-instance-id.json",
+		"invalid-whitespace-expected-revision.json",
+	} {
+		t.Run(strings.TrimSuffix(fixture, ".json"), func(t *testing.T) {
+			binding := readJSONObject(t, filepath.Join("testdata", "ledger-boundary", fixture))
+			if err := validateGateBinding(schema, binding); err == nil {
+				t.Fatal("whitespace-only routing field unexpectedly validates")
+			}
+		})
+	}
+}
+
+func TestGateBindingDigestContractPinsRFC8785(t *testing.T) {
+	rawSpec, err := os.ReadFile("../../docs/specs/ledger-gate-binding.md")
+	if err != nil {
+		t.Fatalf("read binding spec: %v", err)
+	}
+	for _, required := range []string{"RFC 8785", "JSON Canonicalization Scheme (JCS)"} {
+		if !strings.Contains(string(rawSpec), required) {
+			t.Errorf("binding digest contract does not name %q", required)
+		}
+	}
+
+	unicodeVector := map[string]any{
+		"€":      "Euro Sign",
+		"\r":     "Carriage Return",
+		"דּ":      "Hebrew Letter Dalet With Dagesh",
+		"1":      "One",
+		"😀":      "Emoji: Grinning Face",
+		"\u0080": "Control",
+		"ö":      "Latin Small Letter O With Diaeresis",
+	}
+	wantUnicode := "{\"\\r\":\"Carriage Return\",\"1\":\"One\",\"\u0080\":\"Control\",\"ö\":\"Latin Small Letter O With Diaeresis\",\"€\":\"Euro Sign\",\"😀\":\"Emoji: Grinning Face\",\"דּ\":\"Hebrew Letter Dalet With Dagesh\"}"
+	assertJCSVector(t, "unicode-key-order-and-escaping", unicodeVector, wantUnicode)
+
+	numberVector := map[string]any{
+		"integer":      1.0,
+		"large":        1e20,
+		"negativeZero": math.Copysign(0, -1),
+		"scientific":   1e21,
+		"small":        1e-7,
+		"threshold":    1e-6,
+		"escape":       "\b\t\n\f\r\"\\",
+	}
+	wantNumber := "{\"escape\":\"\\b\\t\\n\\f\\r\\\"\\\\\",\"integer\":1,\"large\":100000000000000000000,\"negativeZero\":0,\"scientific\":1e+21,\"small\":1e-7,\"threshold\":0.000001}"
+	assertJCSVector(t, "number-and-string-representation", numberVector, wantNumber)
+}
+
+func TestGateBindingHelmWireFixturesConformToPinnedSchemas(t *testing.T) {
+	registry := loadPinnedHelmSchemas(t)
+	root := filepath.Join("testdata", "ledger-boundary")
+
+	recovery := readJSONObject(t, filepath.Join(root, "application-recovery.json"))
+	validatePinnedHelmObject(t, registry, "https://helm.spacedock.dev/schemas/ledger/application-record-committed-request.v1.json", objectValue(t, recovery, "committed_request"))
+	validatePinnedHelmObject(t, registry, "https://helm.spacedock.dev/schemas/ledger/application-committed-receipt.v1.json", objectValue(t, recovery, "accepted_receipt"))
+	validatePinnedHelmObject(t, registry, "https://helm.spacedock.dev/schemas/ledger/application-committed-receipt.v1.json", objectValue(t, recovery, "same_key_same_body_replay"))
+	conflict := objectValue(t, recovery, "changed_body_conflict")
+	validatePinnedHelmObject(t, registry, "https://helm.spacedock.dev/schemas/ledger/application-record-committed-request.v1.json", objectValue(t, conflict, "request"))
+	recoveryView := objectValue(t, objectValue(t, recovery, "response_lost_recovery"), "application_view")
+	validatePinnedHelmObject(t, registry, "https://helm.spacedock.dev/schemas/ledger/application-view.v1.json", recoveryView)
+
+	linkage := readJSONObject(t, filepath.Join(root, "valid-application-linkage.json"))
+	validatePinnedHelmObject(t, registry, "https://helm.spacedock.dev/schemas/ledger/application-committed.v1.json", objectValue(t, linkage, "committed"))
+	validatePinnedHelmObject(t, registry, "https://helm.spacedock.dev/schemas/ledger/application-observed.v1.json", objectValue(t, linkage, "observed"))
+	validatePinnedHelmObject(t, registry, "https://helm.spacedock.dev/schemas/ledger/application-source-superseded.v1.json", objectValue(t, linkage, "source_superseded"))
+
+	projection := readJSONObject(t, filepath.Join(root, "projection-recovery.json"))
+	validatePinnedHelmObject(t, registry, "https://helm.spacedock.dev/schemas/ledger/projection-rewrite-quarantined.v1.json", objectValue(t, projection, "rewrite_quarantined"))
+}
+
+func TestGateBindingAcceptsExistingMinimalOpaqueSlot(t *testing.T) {
+	schema := readJSONObject(t, gateBindingSchemaPath)
+	binding := map[string]any{
+		"ns":         "spacedock.gate-binding.v1",
+		"entity_ref": "docs/ship-flow/m4.13",
+	}
+	if err := validateGateBinding(schema, binding); err != nil {
+		t.Fatalf("existing Helm opaque binding slot rejected: %v", err)
+	}
+}
+
+func TestGateBindingApplicationReplayAndResponseLostRecovery(t *testing.T) {
+	fixture := readJSONObject(t, filepath.Join("testdata", "ledger-boundary", "application-recovery.json"))
+	request := objectValue(t, fixture, "committed_request")
+	assertDigestMatchesBinding(t, request, "fact", "body_digest")
+	receipt := objectValue(t, fixture, "accepted_receipt")
+	replay := objectValue(t, fixture, "same_key_same_body_replay")
+	if !reflect.DeepEqual(receipt, replay) {
+		t.Fatalf("same-key/same-body replay is not byte-semantic receipt replay\nreceipt: %#v\nreplay: %#v", receipt, replay)
+	}
+	assertEqualStringFields(t, request, receipt, "idempotency_key")
+	assertEqualStringFields(t, request, receipt, "body_digest")
+
+	conflict := objectValue(t, fixture, "changed_body_conflict")
+	conflictingRequest := objectValue(t, conflict, "request")
+	assertDigestMatchesBinding(t, conflictingRequest, "fact", "body_digest")
+	assertEqualStringFields(t, request, conflictingRequest, "idempotency_key")
+	if request["body_digest"] == conflictingRequest["body_digest"] {
+		t.Fatal("changed-body conflict fixture must change body_digest")
+	}
+	conflictError := objectValue(t, conflict, "error")
+	assertNumberValue(t, conflictError, "status", 409)
+	assertStringValue(t, conflictError, "code", "helm.application.idempotency_conflict.v1")
+	assertStringValue(t, conflict, "effect", "refuse_without_new_fact")
+
+	recovery := objectValue(t, fixture, "response_lost_recovery")
+	assertStringValue(t, recovery, "coordinator_state", "commit_succeeded_attestation_outcome_unknown")
+	read := objectValue(t, recovery, "read_application")
+	view := objectValue(t, recovery, "application_view")
+	assertEqualStringFields(t, read, view, "application_id")
+	assertStringValue(t, view, "schema", "helm.application.view.v1")
+	assertStringValue(t, view, "status", "applied")
+	viewReceipt := objectValue(t, view, "committed_receipt")
+	if !reflect.DeepEqual(receipt, viewReceipt) {
+		t.Fatal("response-lost recovery view must return the accepted committed receipt")
+	}
+}
+
+func TestGateBindingProjectionEpochInvalidationAndRewriteFreeze(t *testing.T) {
+	fixture := readJSONObject(t, filepath.Join("testdata", "ledger-boundary", "projection-recovery.json"))
+	page := objectValue(t, fixture, "initial_page")
+	invalidation := objectValue(t, fixture, "cursor_invalidation")
+	request := objectValue(t, invalidation, "request")
+	assertEqualStringFields(t, page, request, "projection_epoch")
+	pageCursor, pageCursorOK := page["next_cursor"].(string)
+	requestAfter, requestAfterOK := request["after"].(string)
+	if !pageCursorOK || !requestAfterOK || pageCursor != requestAfter {
+		t.Fatalf("event poll must replay opaque next_cursor as after: next_cursor=%#v after=%#v", page["next_cursor"], request["after"])
+	}
+	errorObject := objectValue(t, invalidation, "error")
+	assertNumberValue(t, errorObject, "status", 409)
+	assertStringValue(t, errorObject, "code", "helm.projection.cursor_invalidated.v1")
+	details := objectValue(t, errorObject, "details")
+	if details["current_projection_epoch"] == page["projection_epoch"] {
+		t.Fatal("cursor invalidation must return a new current projection epoch")
+	}
+
+	exposed := objectValue(t, fixture, "exposed_binding")
+	candidate := objectValue(t, fixture, "candidate_binding")
+	quarantine := objectValue(t, fixture, "rewrite_quarantined")
+	assertStringValue(t, quarantine, "schema", "helm.projection.rewrite_quarantined.v1")
+	assertStringValue(t, quarantine, "old_projection_epoch", page["projection_epoch"].(string))
+	assertStringValue(t, quarantine, "new_projection_epoch", details["current_projection_epoch"].(string))
+	assertStringValue(t, quarantine, "invalidated_cursor", pageCursor)
+	assertDigestMatchesBinding(t, quarantine, "exposed_binding", "exposed_binding_digest")
+	assertDigestMatchesBinding(t, quarantine, "candidate_binding", "candidate_binding_digest")
+	if !reflect.DeepEqual(exposed, objectValue(t, quarantine, "exposed_binding")) {
+		t.Fatal("rewrite quarantine must freeze the previously exposed binding")
+	}
+	if reflect.DeepEqual(exposed, candidate) {
+		t.Fatal("rewrite fixture must select a different candidate binding")
+	}
+	if !reflect.DeepEqual(candidate, objectValue(t, quarantine, "candidate_binding")) {
+		t.Fatal("rewrite quarantine must retain the candidate for explicit reconciliation")
+	}
+	expected := objectValue(t, fixture, "expected")
+	assertBoolValue(t, expected, "exposed_binding_frozen", true)
+	assertBoolValue(t, expected, "new_application_minted", false)
+}
+
+func TestGateBindingProviderPinFailsClosedWithTypedError(t *testing.T) {
+	schema := readJSONObject(t, gateBindingSchemaPath)
+	fixture := readJSONObject(t, filepath.Join("testdata", "ledger-boundary", "provider-pin-refusals.json"))
+	expectedPin := objectValue(t, fixture, "expected_pin")
+	for index, rawCase := range arrayValue(t, fixture, "cases") {
+		caseObject, ok := rawCase.(map[string]any)
+		if !ok {
+			t.Fatalf("case %d is not an object", index)
+		}
+		name, _ := caseObject["name"].(string)
+		t.Run(name, func(t *testing.T) {
+			observedPin := objectValue(t, caseObject, "observed_pin")
+			binding := objectValue(t, caseObject, "binding")
+			switch name {
+			case "unsupported-version":
+				if expectedPin["ns"] == observedPin["ns"] {
+					t.Fatal("unsupported-version case does not change ns")
+				}
+				if err := validateGateBinding(schema, binding); err == nil {
+					t.Fatal("unsupported binding namespace unexpectedly validates")
+				}
+			case "digest-mismatch":
+				if expectedPin["digest"] == observedPin["digest"] {
+					t.Fatal("digest-mismatch case does not change digest")
+				}
+				if err := validateGateBinding(schema, binding); err != nil {
+					t.Fatalf("digest mismatch must not reinterpret otherwise valid binding fields: %v", err)
+				}
+			default:
+				t.Fatalf("unknown provider pin refusal case %q", name)
+			}
+			errorObject := objectValue(t, caseObject, "error")
+			assertNumberValue(t, errorObject, "status", 409)
+			assertStringValue(t, errorObject, "code", "helm.provider_binding.unsupported_version.v1")
+			assertStringValue(t, caseObject, "effect", "refuse_before_mutation")
+			assertBoolValue(t, caseObject, "fallback_guess_allowed", false)
+		})
+	}
+}
+
+func TestGateBindingFixtures(t *testing.T) {
+	schema := readJSONObject(t, gateBindingSchemaPath)
+	cases := []struct {
+		name    string
+		fixture string
+		valid   bool
+	}{
+		{name: "minimal", fixture: "valid-minimal-binding.json", valid: true},
+		{name: "forward-compatible", fixture: "valid-binding-with-extensions.json", valid: true},
+		{name: "wrong-provider", fixture: "invalid-provider-namespace.json", valid: false},
+		{name: "missing-entity", fixture: "invalid-missing-entity-ref.json", valid: false},
+		{name: "empty-entity", fixture: "invalid-empty-entity-ref.json", valid: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := readJSONObject(t, filepath.Join("testdata", "ledger-boundary", tc.fixture))
+			err := validateGateBinding(schema, fixture)
+			if tc.valid && err != nil {
+				t.Fatalf("valid fixture rejected: %v", err)
+			}
+			if !tc.valid && err == nil {
+				t.Fatal("invalid fixture accepted")
+			}
+		})
+	}
+}
+
+func TestGateBindingUnknownFieldsSurviveRoundTrip(t *testing.T) {
+	original := readJSONObject(t, filepath.Join("testdata", "ledger-boundary", "valid-binding-with-extensions.json"))
+	raw, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	var roundTripped map[string]any
+	if err := json.Unmarshal(raw, &roundTripped); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	if !reflect.DeepEqual(original, roundTripped) {
+		t.Fatalf("unknown additive fields changed during round trip\noriginal: %#v\nround trip: %#v", original, roundTripped)
+	}
+
+	future := objectValue(t, roundTripped, "spacedock:future_binding_hint")
+	if future["mode"] == nil || roundTripped["spacedock:provider_instance_id"] == nil {
+		t.Fatal("forward-compatible fixture must exercise unknown scalar and object fields")
+	}
+}
+
+func TestGateBindingBoundaryFixtureKeepsLaterApplicationFactsOutsideBinding(t *testing.T) {
+	schema := readJSONObject(t, gateBindingSchemaPath)
+	boundary := readJSONObject(t, filepath.Join("testdata", "ledger-boundary", "valid-application-linkage.json"))
+	gate := objectValue(t, boundary, "gate")
+	binding := objectValue(t, gate, "binding")
+	if err := validateGateBinding(schema, binding); err != nil {
+		t.Fatalf("boundary binding rejected: %v", err)
+	}
+	for _, temporal := range []string{"gate_id", "resolution_id", "application_id", "application"} {
+		if _, exists := binding[temporal]; exists {
+			t.Errorf("binding contains later lifecycle field %q", temporal)
+		}
+	}
+
+	resolution := objectValue(t, boundary, "resolution")
+	application := objectValue(t, boundary, "application")
+	committed := objectValue(t, boundary, "committed")
+	observed := objectValue(t, boundary, "observed")
+	assertEqualStringFields(t, gate, resolution, "gate_id")
+	assertEqualStringFields(t, gate, application, "gate_id")
+	assertEqualStringFields(t, resolution, application, "resolution_id")
+	assertEqualStringFields(t, application, committed, "application_id")
+	assertEqualStringFields(t, application, observed, "application_id")
+	assertStringValue(t, committed, "schema", "helm.application.committed.v1")
+	assertStringValue(t, observed, "schema", "helm.application.observed.v1")
+	expected := objectValue(t, boundary, "expected")
+	assertStringValue(t, expected, "committed_effect", "pending_apply_to_applied")
+	assertStringValue(t, expected, "observed_effect", "audit_only")
+}
+
+func validateGateBinding(schema, binding map[string]any) error {
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("schema properties are missing")
+	}
+	for name := range stringSetValue(schema["required"]) {
+		if _, exists := binding[name]; !exists {
+			return fmt.Errorf("required property %q is missing", name)
+		}
+	}
+	for name, rawPropertySchema := range properties {
+		value, exists := binding[name]
+		if !exists {
+			continue
+		}
+		propertySchema, ok := rawPropertySchema.(map[string]any)
+		if !ok {
+			return fmt.Errorf("property schema %q is not an object", name)
+		}
+		if err := validateSchemaValue(name, propertySchema, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSchemaValue(path string, schema map[string]any, value any) error {
+	return validateSchemaValueWithRegistry(path, schema, value, nil)
+}
+
+func validateSchemaValueWithRegistry(path string, schema map[string]any, value any, registry map[string]map[string]any) error {
+	if ref, ok := schema["$ref"].(string); ok {
+		resolved, exists := registry[ref]
+		if !exists {
+			return fmt.Errorf("%s references unpinned schema %q", path, ref)
+		}
+		return validateSchemaValueWithRegistry(path, resolved, value, registry)
+	}
+	if constant, ok := schema["const"]; ok && !reflect.DeepEqual(value, constant) {
+		return fmt.Errorf("%s = %#v, want constant %#v", path, value, constant)
+	}
+	if enum, ok := schema["enum"].([]any); ok {
+		found := false
+		for _, candidate := range enum {
+			found = found || reflect.DeepEqual(value, candidate)
+		}
+		if !found {
+			return fmt.Errorf("%s = %#v, not in enum %#v", path, value, enum)
+		}
+	}
+
+	switch schema["type"] {
+	case "string":
+		text, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("%s must be a string", path)
+		}
+		if minLength, ok := schema["minLength"].(float64); ok && len(text) < int(minLength) {
+			return fmt.Errorf("%s is shorter than %d", path, int(minLength))
+		}
+		if pattern, ok := schema["pattern"].(string); ok {
+			matched, err := regexp.MatchString(pattern, text)
+			if err != nil {
+				return fmt.Errorf("%s has invalid schema pattern: %w", path, err)
+			}
+			if !matched {
+				return fmt.Errorf("%s = %q does not match %q", path, text, pattern)
+			}
+		}
+		if format, ok := schema["format"].(string); ok && format == "date-time" {
+			if _, err := time.Parse(time.RFC3339, text); err != nil {
+				return fmt.Errorf("%s = %q is not RFC3339 date-time", path, text)
+			}
+		}
+	case "object":
+		object, ok := value.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s must be an object", path)
+		}
+		_ = object
+	case "array":
+		items, ok := value.([]any)
+		if !ok {
+			return fmt.Errorf("%s must be an array", path)
+		}
+		if itemSchema, ok := schema["items"].(map[string]any); ok {
+			for index, item := range items {
+				if err := validateSchemaValueWithRegistry(fmt.Sprintf("%s[%d]", path, index), itemSchema, item, registry); err != nil {
+					return err
+				}
+			}
+		}
+	case "integer":
+		number, ok := value.(float64)
+		if !ok || math.Trunc(number) != number {
+			return fmt.Errorf("%s must be an integer", path)
+		}
+		if minimum, ok := schema["minimum"].(float64); ok && number < minimum {
+			return fmt.Errorf("%s = %v, want >= %v", path, number, minimum)
+		}
+	}
+
+	if object, ok := value.(map[string]any); ok {
+		for name := range stringSetValue(schema["required"]) {
+			if _, exists := object[name]; !exists {
+				return fmt.Errorf("%s.%s is required", path, name)
+			}
+		}
+		properties, _ := schema["properties"].(map[string]any)
+		for name, rawPropertySchema := range properties {
+			child, exists := object[name]
+			if !exists {
+				continue
+			}
+			propertySchema, ok := rawPropertySchema.(map[string]any)
+			if !ok {
+				return fmt.Errorf("%s.%s schema is not an object", path, name)
+			}
+			if err := validateSchemaValueWithRegistry(path+"."+name, propertySchema, child, registry); err != nil {
+				return err
+			}
+		}
+	}
+
+	if branches, ok := schema["allOf"].([]any); ok {
+		for index, rawBranch := range branches {
+			branch, ok := rawBranch.(map[string]any)
+			if !ok {
+				return fmt.Errorf("%s.allOf[%d] is not an object", path, index)
+			}
+			if err := validateSchemaValueWithRegistry(path, branch, value, registry); err != nil {
+				return err
+			}
+		}
+	}
+	if condition, ok := schema["if"].(map[string]any); ok {
+		if validateSchemaValueWithRegistry(path, condition, value, registry) == nil {
+			if thenSchema, ok := schema["then"].(map[string]any); ok {
+				if err := validateSchemaValueWithRegistry(path, thenSchema, value, registry); err != nil {
+					return err
+				}
+			}
+		} else if elseSchema, ok := schema["else"].(map[string]any); ok {
+			if err := validateSchemaValueWithRegistry(path, elseSchema, value, registry); err != nil {
+				return err
+			}
+		}
+	}
+	if notSchema, ok := schema["not"].(map[string]any); ok {
+		if validateSchemaValueWithRegistry(path, notSchema, value, registry) == nil {
+			return fmt.Errorf("%s matches forbidden schema", path)
+		}
+	}
+	if choices, ok := schema["anyOf"].([]any); ok {
+		matched := false
+		for _, rawChoice := range choices {
+			choice, ok := rawChoice.(map[string]any)
+			if ok && validateSchemaValueWithRegistry(path, choice, value, registry) == nil {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf("%s does not match any allowed schema", path)
+		}
+	}
+	return nil
+}
+
+func loadPinnedHelmSchemas(t *testing.T) map[string]map[string]any {
+	t.Helper()
+	root := filepath.Join("testdata", "ledger-boundary", "helm-schemas")
+	manifest := readJSONObject(t, filepath.Join(root, "manifest.json"))
+	provenanceStatus, _ := manifest["provenance_status"].(string)
+	if provenanceStatus != "complete" {
+		t.Fatalf("Helm schema provenance_status = %q, want complete", provenanceStatus)
+	}
+	assertStringValue(t, manifest, "source_repository", "https://github.com/spacedock-dev/helm")
+	assertStringValue(t, manifest, "source_revision", helmSchemaSourceRevision)
+	assertGitObjectID(t, manifest, "source_revision")
+	pins := objectValue(t, manifest, "schemas")
+	if len(pins) != 8 {
+		t.Fatalf("pinned Helm schema closure contains %d schemas, want 8", len(pins))
+	}
+	registry := make(map[string]map[string]any, len(pins))
+	for filename, rawPin := range pins {
+		pin, ok := rawPin.(map[string]any)
+		if !ok {
+			t.Fatalf("schema pin for %s is not an object", filename)
+		}
+		assertStringValue(t, pin, "source_path", filepath.ToSlash(filepath.Join("src", "ledger", "contracts", "schemas", filename)))
+		assertGitObjectID(t, pin, "git_blob")
+		digest, ok := pin["raw_sha256"].(string)
+		if !ok {
+			t.Fatalf("raw_sha256 for %s is not a string", filename)
+		}
+		raw, err := os.ReadFile(filepath.Join(root, filename))
+		if err != nil {
+			t.Fatalf("read pinned Helm schema %s: %v", filename, err)
+		}
+		got := fmt.Sprintf("sha256:%x", sha256.Sum256(raw))
+		if got != digest {
+			t.Fatalf("pinned Helm schema %s digest = %s, want %s", filename, got, digest)
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(raw, &schema); err != nil {
+			t.Fatalf("parse pinned Helm schema %s: %v", filename, err)
+		}
+		id, ok := schema["$id"].(string)
+		if !ok {
+			t.Fatalf("pinned Helm schema %s lacks $id", filename)
+		}
+		registry[id] = schema
+	}
+	for sourceID, schema := range registry {
+		refs := make(map[string]bool)
+		collectSchemaRefs(schema, refs)
+		for ref := range refs {
+			if strings.HasPrefix(ref, "https://helm.spacedock.dev/schemas/") {
+				if _, exists := registry[ref]; !exists {
+					t.Fatalf("pinned Helm schema closure is incomplete: %s references absent %s", sourceID, ref)
+				}
+			}
+		}
+	}
+	return registry
+}
+
+func assertGitObjectID(t *testing.T, object map[string]any, name string) {
+	t.Helper()
+	value, ok := object[name].(string)
+	matched, err := regexp.MatchString("^[0-9a-f]{40}$", value)
+	if !ok || err != nil || !matched {
+		t.Fatalf("%s = %#v, want 40 lowercase hex Git object ID", name, object[name])
+	}
+}
+
+func validatePinnedHelmObject(t *testing.T, registry map[string]map[string]any, schemaID string, object map[string]any) {
+	t.Helper()
+	schema, ok := registry[schemaID]
+	if !ok {
+		t.Fatalf("Helm schema %s is not pinned", schemaID)
+	}
+	if err := validateSchemaValueWithRegistry(schemaID, schema, object, registry); err != nil {
+		t.Fatalf("fixture does not conform to %s: %v", schemaID, err)
+	}
+}
+
+func assertDigestMatchesBinding(t *testing.T, object map[string]any, bindingField, digestField string) {
+	t.Helper()
+	binding := objectValue(t, object, bindingField)
+	raw, err := canonicalizeJCS(binding)
+	if err != nil {
+		t.Fatalf("RFC 8785 canonicalize %s: %v", bindingField, err)
+	}
+	want := fmt.Sprintf("sha256:%x", sha256.Sum256(raw))
+	assertStringValue(t, object, digestField, want)
+}
+
+func collectSchemaRefs(value any, refs map[string]bool) {
+	switch value := value.(type) {
+	case map[string]any:
+		for key, child := range value {
+			if key == "$ref" {
+				if ref, ok := child.(string); ok {
+					refs[ref] = true
+				}
+			}
+			collectSchemaRefs(child, refs)
+		}
+	case []any:
+		for _, child := range value {
+			collectSchemaRefs(child, refs)
+		}
+	}
+}
+
+func assertJCSVector(t *testing.T, name string, value any, want string) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		got, err := canonicalizeJCS(value)
+		if err != nil {
+			t.Fatalf("canonicalize: %v", err)
+		}
+		if string(got) != want {
+			t.Fatalf("JCS bytes differ\n got: %s\nwant: %s", got, want)
+		}
+	})
+}
+
+func canonicalizeJCS(value any) ([]byte, error) {
+	var out strings.Builder
+	if err := appendJCS(&out, value); err != nil {
+		return nil, err
+	}
+	return []byte(out.String()), nil
+}
+
+func appendJCS(out *strings.Builder, value any) error {
+	switch value := value.(type) {
+	case nil:
+		out.WriteString("null")
+	case bool:
+		if value {
+			out.WriteString("true")
+		} else {
+			out.WriteString("false")
+		}
+	case string:
+		return appendJCSString(out, value)
+	case json.Number:
+		number, err := strconv.ParseFloat(string(value), 64)
+		if err != nil {
+			return fmt.Errorf("unsupported JSON number %q: %w", value, err)
+		}
+		return appendJCSNumber(out, number)
+	case float64:
+		return appendJCSNumber(out, value)
+	case float32:
+		return appendJCSNumber(out, float64(value))
+	case int:
+		return appendJCSSafeInteger(out, int64(value))
+	case int64:
+		return appendJCSSafeInteger(out, value)
+	case int32:
+		return appendJCSSafeInteger(out, int64(value))
+	case uint:
+		return appendJCSSafeUnsigned(out, uint64(value))
+	case uint64:
+		return appendJCSSafeUnsigned(out, value)
+	case uint32:
+		return appendJCSSafeUnsigned(out, uint64(value))
+	case []any:
+		out.WriteByte('[')
+		for index, item := range value {
+			if index > 0 {
+				out.WriteByte(',')
+			}
+			if err := appendJCS(out, item); err != nil {
+				return err
+			}
+		}
+		out.WriteByte(']')
+	case map[string]any:
+		keys := make([]string, 0, len(value))
+		for key := range value {
+			if !utf8.ValidString(key) {
+				return fmt.Errorf("object key is not valid UTF-8")
+			}
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(i, j int) bool { return utf16Less(keys[i], keys[j]) })
+		out.WriteByte('{')
+		for index, key := range keys {
+			if index > 0 {
+				out.WriteByte(',')
+			}
+			if err := appendJCSString(out, key); err != nil {
+				return err
+			}
+			out.WriteByte(':')
+			if err := appendJCS(out, value[key]); err != nil {
+				return fmt.Errorf("key %q: %w", key, err)
+			}
+		}
+		out.WriteByte('}')
+	default:
+		return fmt.Errorf("unsupported JCS value type %T", value)
+	}
+	return nil
+}
+
+func appendJCSString(out *strings.Builder, value string) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("string is not valid UTF-8")
+	}
+	out.WriteByte('"')
+	for _, char := range value {
+		switch char {
+		case '\b':
+			out.WriteString("\\b")
+		case '\t':
+			out.WriteString("\\t")
+		case '\n':
+			out.WriteString("\\n")
+		case '\f':
+			out.WriteString("\\f")
+		case '\r':
+			out.WriteString("\\r")
+		case '"':
+			out.WriteString("\\\"")
+		case '\\':
+			out.WriteString("\\\\")
+		default:
+			if char >= 0 && char <= 0x1f {
+				fmt.Fprintf(out, "\\u%04x", char)
+			} else {
+				out.WriteRune(char)
+			}
+		}
+	}
+	out.WriteByte('"')
+	return nil
+}
+
+func appendJCSNumber(out *strings.Builder, value float64) error {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return fmt.Errorf("non-finite number is not valid JCS")
+	}
+	if value == 0 {
+		out.WriteByte('0')
+		return nil
+	}
+	abs := math.Abs(value)
+	if abs >= 1e-6 && abs < 1e21 {
+		out.WriteString(strconv.FormatFloat(value, 'f', -1, 64))
+		return nil
+	}
+	scientific := strconv.FormatFloat(value, 'e', -1, 64)
+	parts := strings.SplitN(scientific, "e", 2)
+	exponent, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return fmt.Errorf("normalize exponent %q: %w", scientific, err)
+	}
+	out.WriteString(parts[0])
+	out.WriteByte('e')
+	if exponent >= 0 {
+		out.WriteByte('+')
+	}
+	out.WriteString(strconv.Itoa(exponent))
+	return nil
+}
+
+func appendJCSSafeInteger(out *strings.Builder, value int64) error {
+	const maxSafeInteger = int64(1<<53 - 1)
+	if value < -maxSafeInteger || value > maxSafeInteger {
+		return fmt.Errorf("integer %d exceeds the interoperable IEEE-754 range", value)
+	}
+	out.WriteString(strconv.FormatInt(value, 10))
+	return nil
+}
+
+func appendJCSSafeUnsigned(out *strings.Builder, value uint64) error {
+	const maxSafeInteger = uint64(1<<53 - 1)
+	if value > maxSafeInteger {
+		return fmt.Errorf("integer %d exceeds the interoperable IEEE-754 range", value)
+	}
+	out.WriteString(strconv.FormatUint(value, 10))
+	return nil
+}
+
+func utf16Less(left, right string) bool {
+	leftUnits := utf16.Encode([]rune(left))
+	rightUnits := utf16.Encode([]rune(right))
+	for index := 0; index < len(leftUnits) && index < len(rightUnits); index++ {
+		if leftUnits[index] != rightUnits[index] {
+			return leftUnits[index] < rightUnits[index]
+		}
+	}
+	return len(leftUnits) < len(rightUnits)
+}
+
+func readJSONObject(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return object
+}
+
+func objectValue(t *testing.T, object map[string]any, name string) map[string]any {
+	t.Helper()
+	value, ok := object[name].(map[string]any)
+	if !ok {
+		t.Fatalf("%s is %#v, want object", name, object[name])
+	}
+	return value
+}
+
+func assertStringValue(t *testing.T, object map[string]any, name, want string) {
+	t.Helper()
+	got, ok := object[name].(string)
+	if !ok {
+		t.Fatalf("%s is %#v, want string", name, object[name])
+	}
+	if want != "" && got != want {
+		t.Errorf("%s = %q, want %q", name, got, want)
+	}
+}
+
+func assertEqualStringFields(t *testing.T, left, right map[string]any, name string) {
+	t.Helper()
+	leftValue, leftOK := left[name].(string)
+	rightValue, rightOK := right[name].(string)
+	if !leftOK || !rightOK || leftValue != rightValue {
+		t.Errorf("%s linkage differs: left=%#v right=%#v", name, left[name], right[name])
+	}
+}
+
+func assertNumberValue(t *testing.T, object map[string]any, name string, want float64) {
+	t.Helper()
+	got, ok := object[name].(float64)
+	if !ok || got != want {
+		t.Errorf("%s = %#v, want %v", name, object[name], want)
+	}
+}
+
+func assertBoolValue(t *testing.T, object map[string]any, name string, want bool) {
+	t.Helper()
+	got, ok := object[name].(bool)
+	if !ok || got != want {
+		t.Errorf("%s = %#v, want %v", name, object[name], want)
+	}
+}
+
+func arrayValue(t *testing.T, object map[string]any, name string) []any {
+	t.Helper()
+	got, ok := object[name].([]any)
+	if !ok {
+		t.Fatalf("%s is %#v, want array", name, object[name])
+	}
+	return got
+}
+
+func stringSet(t *testing.T, value any) map[string]bool {
+	t.Helper()
+	set, ok := stringSetValueChecked(value)
+	if !ok {
+		t.Fatalf("value is %#v, want string array", value)
+	}
+	return set
+}
+
+func stringSetValue(value any) map[string]bool {
+	set, _ := stringSetValueChecked(value)
+	return set
+}
+
+func stringSetValueChecked(value any) (map[string]bool, bool) {
+	items, ok := value.([]any)
+	if !ok {
+		return nil, false
+	}
+	set := make(map[string]bool, len(items))
+	for _, item := range items {
+		text, ok := item.(string)
+		if !ok || strings.TrimSpace(text) == "" {
+			return nil, false
+		}
+		set[text] = true
+	}
+	return set, true
+}

--- a/internal/contract/testdata/ledger-boundary/application-recovery.json
+++ b/internal/contract/testdata/ledger-boundary/application-recovery.json
@@ -2,7 +2,7 @@
   "committed_request": {
     "schema": "helm.application.record_committed_request.v1",
     "idempotency_key": "sd-apply:app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
-    "body_digest": "sha256:79c673da04916bc1ff370626f0d5aaa02c4fbfc708a7991bbfae308148ae4740",
+    "body_digest": "sha256:e37710ab552ed4ee0e46276b773378f788d8d71cbb24fdb998f14b9a7e915e43",
     "fact": {
       "schema": "helm.application.committed.v1",
       "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
@@ -18,7 +18,9 @@
       "parent_oids": [
         "0000000000000000000000000000000000000000"
       ],
-      "tree_or_blob_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "tree_or_blob_kind": "blob",
+      "tree_or_blob_oid": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "tree_or_blob_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "committed_at": "2026-07-14T08:00:00Z",
       "spacedock:stage_run_id": "sr1:demo"
     }
@@ -31,7 +33,7 @@
     "applied_at": "2026-07-14T08:00:01Z",
     "gate_status": "applied",
     "idempotency_key": "sd-apply:app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
-    "body_digest": "sha256:79c673da04916bc1ff370626f0d5aaa02c4fbfc708a7991bbfae308148ae4740"
+    "body_digest": "sha256:e37710ab552ed4ee0e46276b773378f788d8d71cbb24fdb998f14b9a7e915e43"
   },
   "same_key_same_body_replay": {
     "schema": "helm.application.committed_receipt.v1",
@@ -41,13 +43,13 @@
     "applied_at": "2026-07-14T08:00:01Z",
     "gate_status": "applied",
     "idempotency_key": "sd-apply:app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
-    "body_digest": "sha256:79c673da04916bc1ff370626f0d5aaa02c4fbfc708a7991bbfae308148ae4740"
+    "body_digest": "sha256:e37710ab552ed4ee0e46276b773378f788d8d71cbb24fdb998f14b9a7e915e43"
   },
   "changed_body_conflict": {
     "request": {
       "schema": "helm.application.record_committed_request.v1",
       "idempotency_key": "sd-apply:app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
-      "body_digest": "sha256:7f158adb41a904179cafe659c58a4db95064c4b189b17bb268f450837ce5dafa",
+      "body_digest": "sha256:48156d28f80d31e6155c3f8e20f9bd99799a897be5da97a7e7c15669a3f2997e",
       "fact": {
         "schema": "helm.application.committed.v1",
         "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
@@ -63,7 +65,9 @@
         "parent_oids": [
           "1111111111111111111111111111111111111111"
         ],
-        "tree_or_blob_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "tree_or_blob_kind": "blob",
+        "tree_or_blob_oid": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+        "tree_or_blob_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         "committed_at": "2026-07-14T08:00:02Z"
       }
     },
@@ -98,7 +102,7 @@
         "applied_at": "2026-07-14T08:00:01Z",
         "gate_status": "applied",
         "idempotency_key": "sd-apply:app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
-        "body_digest": "sha256:79c673da04916bc1ff370626f0d5aaa02c4fbfc708a7991bbfae308148ae4740"
+        "body_digest": "sha256:e37710ab552ed4ee0e46276b773378f788d8d71cbb24fdb998f14b9a7e915e43"
       },
       "observations": []
     }

--- a/internal/contract/testdata/ledger-boundary/application-recovery.json
+++ b/internal/contract/testdata/ledger-boundary/application-recovery.json
@@ -1,0 +1,106 @@
+{
+  "committed_request": {
+    "schema": "helm.application.record_committed_request.v1",
+    "idempotency_key": "sd-apply:app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+    "body_digest": "sha256:79c673da04916bc1ff370626f0d5aaa02c4fbfc708a7991bbfae308148ae4740",
+    "fact": {
+      "schema": "helm.application.committed.v1",
+      "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+      "gate_id": "gat_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e70",
+      "resolution_id": "resolution:approve-1",
+      "applier": "spacedock:apply-coordinator",
+      "target_owner": "spacedock:workflow",
+      "target_ref": "workflow:wf1-demo/entity:task-42",
+      "target_kind": "git",
+      "before": "plan",
+      "after": "execute",
+      "commit_oid": "1111111111111111111111111111111111111111",
+      "parent_oids": [
+        "0000000000000000000000000000000000000000"
+      ],
+      "tree_or_blob_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "committed_at": "2026-07-14T08:00:00Z",
+      "spacedock:stage_run_id": "sr1:demo"
+    }
+  },
+  "accepted_receipt": {
+    "schema": "helm.application.committed_receipt.v1",
+    "receipt_id": "rcpt_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e71",
+    "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+    "accepted_event_id": 43,
+    "applied_at": "2026-07-14T08:00:01Z",
+    "gate_status": "applied",
+    "idempotency_key": "sd-apply:app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+    "body_digest": "sha256:79c673da04916bc1ff370626f0d5aaa02c4fbfc708a7991bbfae308148ae4740"
+  },
+  "same_key_same_body_replay": {
+    "schema": "helm.application.committed_receipt.v1",
+    "receipt_id": "rcpt_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e71",
+    "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+    "accepted_event_id": 43,
+    "applied_at": "2026-07-14T08:00:01Z",
+    "gate_status": "applied",
+    "idempotency_key": "sd-apply:app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+    "body_digest": "sha256:79c673da04916bc1ff370626f0d5aaa02c4fbfc708a7991bbfae308148ae4740"
+  },
+  "changed_body_conflict": {
+    "request": {
+      "schema": "helm.application.record_committed_request.v1",
+      "idempotency_key": "sd-apply:app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+      "body_digest": "sha256:7f158adb41a904179cafe659c58a4db95064c4b189b17bb268f450837ce5dafa",
+      "fact": {
+        "schema": "helm.application.committed.v1",
+        "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+        "gate_id": "gat_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e70",
+        "resolution_id": "resolution:approve-1",
+        "applier": "spacedock:apply-coordinator",
+        "target_owner": "spacedock:workflow",
+        "target_ref": "workflow:wf1-demo/entity:task-42",
+        "target_kind": "git",
+        "before": "plan",
+        "after": "review",
+        "commit_oid": "2222222222222222222222222222222222222222",
+        "parent_oids": [
+          "1111111111111111111111111111111111111111"
+        ],
+        "tree_or_blob_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "committed_at": "2026-07-14T08:00:02Z"
+      }
+    },
+    "error": {
+      "schema": "helm.http.error.v1",
+      "status": 409,
+      "code": "helm.application.idempotency_conflict.v1"
+    },
+    "effect": "refuse_without_new_fact"
+  },
+  "response_lost_recovery": {
+    "coordinator_state": "commit_succeeded_attestation_outcome_unknown",
+    "read_application": {
+      "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f"
+    },
+    "application_view": {
+      "schema": "helm.application.view.v1",
+      "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+      "gate_id": "gat_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e70",
+      "resolution_id": "resolution:approve-1",
+      "apply_requirement": "required",
+      "status": "applied",
+      "provider_binding": {
+        "ns": "spacedock.gate-binding.v1",
+        "entity_ref": "task-42"
+      },
+      "committed_receipt": {
+        "schema": "helm.application.committed_receipt.v1",
+        "receipt_id": "rcpt_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e71",
+        "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+        "accepted_event_id": 43,
+        "applied_at": "2026-07-14T08:00:01Z",
+        "gate_status": "applied",
+        "idempotency_key": "sd-apply:app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+        "body_digest": "sha256:79c673da04916bc1ff370626f0d5aaa02c4fbfc708a7991bbfae308148ae4740"
+      },
+      "observations": []
+    }
+  }
+}

--- a/internal/contract/testdata/ledger-boundary/helm-schemas/application-committed-receipt.v1.json
+++ b/internal/contract/testdata/ledger-boundary/helm-schemas/application-committed-receipt.v1.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://helm.spacedock.dev/schemas/ledger/application-committed-receipt.v1.json",
+  "title": "helm.application.committed_receipt.v1",
+  "type": "object",
+  "required": ["schema", "receipt_id", "application_id", "accepted_event_id", "applied_at", "gate_status", "idempotency_key", "body_digest"],
+  "properties": {
+    "schema": { "const": "helm.application.committed_receipt.v1" },
+    "receipt_id": { "type": "string", "pattern": "^rcpt_" },
+    "application_id": { "type": "string", "pattern": "^app_" },
+    "accepted_event_id": { "type": "integer", "minimum": 1 },
+    "applied_at": { "type": "string", "format": "date-time" },
+    "gate_status": { "const": "applied" },
+    "idempotency_key": { "type": "string", "minLength": 1 },
+    "body_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$", "description": "Echoes the accepted request's verified RFC 8785 JCS fact digest." }
+  },
+  "additionalProperties": true
+}

--- a/internal/contract/testdata/ledger-boundary/helm-schemas/application-committed.v1.json
+++ b/internal/contract/testdata/ledger-boundary/helm-schemas/application-committed.v1.json
@@ -19,14 +19,16 @@
     "after": { "type": "string" },
     "commit_oid": { "type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$" },
     "parent_oids": { "type": "array", "items": { "type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$" } },
-    "tree_or_blob_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "tree_or_blob_kind": { "enum": ["tree", "blob"], "description": "Git object type whose raw payload is independently pinned." },
+    "tree_or_blob_oid": { "type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$", "description": "Full Git object id for the tree or blob whose payload is digested." },
+    "tree_or_blob_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$", "description": "sha256 over the exact raw Git object payload bytes named by tree_or_blob_kind and tree_or_blob_oid, excluding the loose-object '<kind> <size>\\0' header. Pretty-printed or text-normalized output is invalid." },
     "committed_at": { "type": "string", "format": "date-time" }
   },
   "allOf": [
     {
       "if": { "properties": { "target_kind": { "const": "git" } }, "required": ["target_kind"] },
       "then": {
-        "required": ["commit_oid", "parent_oids", "tree_or_blob_digest"]
+        "required": ["commit_oid", "parent_oids", "tree_or_blob_kind", "tree_or_blob_oid", "tree_or_blob_digest"]
       }
     },
     {
@@ -36,6 +38,8 @@
           "anyOf": [
             { "required": ["commit_oid"] },
             { "required": ["parent_oids"] },
+            { "required": ["tree_or_blob_kind"] },
+            { "required": ["tree_or_blob_oid"] },
             { "required": ["tree_or_blob_digest"] }
           ]
         }

--- a/internal/contract/testdata/ledger-boundary/helm-schemas/application-committed.v1.json
+++ b/internal/contract/testdata/ledger-boundary/helm-schemas/application-committed.v1.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://helm.spacedock.dev/schemas/ledger/application-committed.v1.json",
+  "title": "helm.application.committed.v1",
+  "description": "Append-only evidence that the accountable applier committed its canonical state. Git OIDs are full 40-hex SHA-1 or 64-hex SHA-256 values. Ledger acceptance is the sole pending_apply to applied fold input.",
+  "type": "object",
+  "required": ["schema", "application_id", "gate_id", "resolution_id", "applier", "target_owner", "target_ref", "target_kind", "before", "after", "committed_at"],
+  "properties": {
+    "schema": { "const": "helm.application.committed.v1" },
+    "application_id": { "type": "string", "pattern": "^app_" },
+    "supersedes_application_id": { "type": "string", "pattern": "^app_" },
+    "gate_id": { "type": "string", "pattern": "^gat_" },
+    "resolution_id": { "type": "string", "minLength": 1 },
+    "applier": { "type": "string", "minLength": 1 },
+    "target_owner": { "type": "string", "minLength": 1 },
+    "target_ref": { "type": "string", "minLength": 1 },
+    "target_kind": { "enum": ["git", "agent"] },
+    "before": { "type": "string" },
+    "after": { "type": "string" },
+    "commit_oid": { "type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$" },
+    "parent_oids": { "type": "array", "items": { "type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$" } },
+    "tree_or_blob_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "committed_at": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "target_kind": { "const": "git" } }, "required": ["target_kind"] },
+      "then": {
+        "required": ["commit_oid", "parent_oids", "tree_or_blob_digest"]
+      }
+    },
+    {
+      "if": { "properties": { "target_kind": { "const": "agent" } }, "required": ["target_kind"] },
+      "then": {
+        "not": {
+          "anyOf": [
+            { "required": ["commit_oid"] },
+            { "required": ["parent_oids"] },
+            { "required": ["tree_or_blob_digest"] }
+          ]
+        }
+      }
+    },
+    {
+      "not": {
+        "anyOf": [
+          { "required": ["idempotency_key"] },
+          { "required": ["body_digest"] }
+        ]
+      }
+    }
+  ],
+  "additionalProperties": true
+}

--- a/internal/contract/testdata/ledger-boundary/helm-schemas/application-observed.v1.json
+++ b/internal/contract/testdata/ledger-boundary/helm-schemas/application-observed.v1.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://helm.spacedock.dev/schemas/ledger/application-observed.v1.json",
+  "title": "helm.application.observed.v1",
+  "description": "Linked audit/publication evidence. observed_commit is a full 40-hex SHA-1 or 64-hex SHA-256 Git OID. Observation never folds a gate to applied.",
+  "type": "object",
+  "required": ["schema", "application_id", "source_event_key", "observed_commit", "ref", "provider", "observed_at", "provenance"],
+  "properties": {
+    "schema": { "const": "helm.application.observed.v1" },
+    "application_id": { "type": "string", "pattern": "^app_" },
+    "source_event_key": { "type": "string", "minLength": 1 },
+    "observed_commit": { "type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$" },
+    "ref": { "type": "string", "minLength": 1 },
+    "remote": { "type": "string" },
+    "provider": { "type": "string", "minLength": 1 },
+    "observed_at": { "type": "string", "format": "date-time" },
+    "provenance": { "enum": ["publisher", "watcher", "backfill", "manual"] }
+  },
+  "additionalProperties": true
+}

--- a/internal/contract/testdata/ledger-boundary/helm-schemas/application-record-committed-request.v1.json
+++ b/internal/contract/testdata/ledger-boundary/helm-schemas/application-record-committed-request.v1.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://helm.spacedock.dev/schemas/ledger/application-record-committed-request.v1.json",
+  "title": "helm.application.record_committed_request.v1",
+  "description": "Committed-attestation request. body_digest is sha256: plus lowercase SHA-256 over the fact's RFC 8785 JCS UTF-8 bytes and must be verified before acceptance.",
+  "type": "object",
+  "required": ["schema", "idempotency_key", "body_digest", "fact"],
+  "properties": {
+    "schema": { "const": "helm.application.record_committed_request.v1" },
+    "idempotency_key": { "type": "string", "minLength": 1 },
+    "body_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$", "description": "Exact RFC 8785 JCS digest of fact; a mismatch is helm.application.attestation_invalid.v1." },
+    "fact": { "$ref": "https://helm.spacedock.dev/schemas/ledger/application-committed.v1.json" }
+  },
+  "additionalProperties": true
+}

--- a/internal/contract/testdata/ledger-boundary/helm-schemas/application-source-superseded.v1.json
+++ b/internal/contract/testdata/ledger-boundary/helm-schemas/application-source-superseded.v1.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://helm.spacedock.dev/schemas/ledger/application-source-superseded.v1.json",
+  "title": "helm.application.source_superseded.v1",
+  "description": "Append-only evidence that a source pin changed; original application facts remain immutable.",
+  "type": "object",
+  "required": ["schema", "application_id", "old_source_pin", "new_source_pin", "reason", "observed_at"],
+  "properties": {
+    "schema": { "const": "helm.application.source_superseded.v1" },
+    "application_id": { "type": "string", "pattern": "^app_" },
+    "old_source_pin": {
+      "type": "string",
+      "minLength": 1,
+      "anyOf": [
+        { "pattern": "^git:(?:[0-9a-f]{40}|[0-9a-f]{64})$" },
+        { "not": { "pattern": "^git:" } }
+      ]
+    },
+    "new_source_pin": {
+      "type": "string",
+      "minLength": 1,
+      "anyOf": [
+        { "pattern": "^git:(?:[0-9a-f]{40}|[0-9a-f]{64})$" },
+        { "not": { "pattern": "^git:" } }
+      ]
+    },
+    "reason": { "type": "string", "minLength": 1 },
+    "observed_at": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": true
+}

--- a/internal/contract/testdata/ledger-boundary/helm-schemas/application-view.v1.json
+++ b/internal/contract/testdata/ledger-boundary/helm-schemas/application-view.v1.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://helm.spacedock.dev/schemas/ledger/application-view.v1.json",
+  "title": "helm.application.view.v1",
+  "description": "Stable recovery view keyed by application_id; raw events remain internal.",
+  "type": "object",
+  "required": ["schema", "application_id", "gate_id", "resolution_id", "apply_requirement", "status", "observations"],
+  "properties": {
+    "schema": { "const": "helm.application.view.v1" },
+    "application_id": { "type": "string", "pattern": "^app_" },
+    "gate_id": { "type": "string", "pattern": "^gat_" },
+    "resolution_id": { "type": "string", "minLength": 1 },
+    "apply_requirement": { "const": "required" },
+    "status": { "enum": ["pending_apply", "applied", "superseded", "rewrite_quarantined"] },
+    "provider_binding": { "$ref": "https://helm.spacedock.dev/schemas/ledger/provider-binding.v1.json" },
+    "committed_receipt": { "$ref": "https://helm.spacedock.dev/schemas/ledger/application-committed-receipt.v1.json" },
+    "observations": {
+      "type": "array",
+      "items": { "$ref": "https://helm.spacedock.dev/schemas/ledger/application-observed.v1.json" }
+    },
+    "supersessions": {
+      "type": "array",
+      "items": { "$ref": "https://helm.spacedock.dev/schemas/ledger/application-source-superseded.v1.json" }
+    },
+    "quarantine": { "$ref": "https://helm.spacedock.dev/schemas/ledger/projection-rewrite-quarantined.v1.json" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "pending_apply" } }, "required": ["status"] },
+      "then": {
+        "not": {
+          "anyOf": [
+            { "required": ["committed_receipt"] },
+            { "required": ["quarantine"] }
+          ]
+        }
+      }
+    },
+    {
+      "if": { "properties": { "status": { "const": "applied" } }, "required": ["status"] },
+      "then": {
+        "required": ["committed_receipt"],
+        "not": { "required": ["quarantine"] }
+      }
+    },
+    {
+      "if": { "properties": { "status": { "const": "rewrite_quarantined" } }, "required": ["status"] },
+      "then": {
+        "required": ["provider_binding", "quarantine"],
+        "not": { "required": ["committed_receipt"] }
+      }
+    },
+    {
+      "if": { "properties": { "status": { "const": "superseded" } }, "required": ["status"] },
+      "then": { "not": { "required": ["quarantine"] } }
+    }
+  ],
+  "additionalProperties": true
+}

--- a/internal/contract/testdata/ledger-boundary/helm-schemas/manifest.json
+++ b/internal/contract/testdata/ledger-boundary/helm-schemas/manifest.json
@@ -1,0 +1,47 @@
+{
+  "provenance_status": "complete",
+  "source_repository": "https://github.com/spacedock-dev/helm",
+  "source_revision": "3d39fcdc67cc6aac22d51f4abcc2dfdadf56c838",
+  "schemas": {
+    "application-record-committed-request.v1.json": {
+      "source_path": "src/ledger/contracts/schemas/application-record-committed-request.v1.json",
+      "git_blob": "c8e8565cf45c0b58c434d566d590256db2489f93",
+      "raw_sha256": "sha256:a4b9863f2105dc7a9a9dd91baf0a19477b6edb3a3825c948556018e6091696d0"
+    },
+    "application-committed.v1.json": {
+      "source_path": "src/ledger/contracts/schemas/application-committed.v1.json",
+      "git_blob": "c0d1bc132b8f7f979cbd1135108eb4a3cf8ae2b1",
+      "raw_sha256": "sha256:8b6083e2b474a2771e59422ea6bd8f67562cbc66b828246f3aa8645a8f1b90d2"
+    },
+    "application-committed-receipt.v1.json": {
+      "source_path": "src/ledger/contracts/schemas/application-committed-receipt.v1.json",
+      "git_blob": "284edb237773cb7d29f059972602f3aa504a2227",
+      "raw_sha256": "sha256:d9ec2b35f991176668f17a472d1e88210892f6bb5c8049cfdfb29af151d36682"
+    },
+    "application-observed.v1.json": {
+      "source_path": "src/ledger/contracts/schemas/application-observed.v1.json",
+      "git_blob": "5340539217020d22bcf0ed4626f19610d8e01520",
+      "raw_sha256": "sha256:f269282d4763877766069593883a4a0b0da662d886f9b09a5f30d8cb8d812b10"
+    },
+    "application-source-superseded.v1.json": {
+      "source_path": "src/ledger/contracts/schemas/application-source-superseded.v1.json",
+      "git_blob": "05d4e3ff060fb36d92bcc07c47666ad097decfa8",
+      "raw_sha256": "sha256:d38df905ca61f7facd93d26b5156d90ddca629f94cfc1c9fb1dbd4fddf7a9ba9"
+    },
+    "application-view.v1.json": {
+      "source_path": "src/ledger/contracts/schemas/application-view.v1.json",
+      "git_blob": "c0dda55e7b6ccda691116bc8929caf89521c4f85",
+      "raw_sha256": "sha256:7132cafbef0e065f92b5af65dc73f61327264a9fa55f657c2053079295d78a69"
+    },
+    "projection-rewrite-quarantined.v1.json": {
+      "source_path": "src/ledger/contracts/schemas/projection-rewrite-quarantined.v1.json",
+      "git_blob": "aaf216d4d82b0d5b9a2c84d925d920bb5d2aa986",
+      "raw_sha256": "sha256:f1c11a37d61285879953dd8c9b7e49b2ba1a142a04810404b4831e9cb22e67c5"
+    },
+    "provider-binding.v1.json": {
+      "source_path": "src/ledger/contracts/schemas/provider-binding.v1.json",
+      "git_blob": "862d4d1a7bda7a573c8a9582dd280665ad7f31b8",
+      "raw_sha256": "sha256:b4cef68b735cb8875b1acdbb8e04e43e7d8546ebe4e9f1bfbce92136f1eff04c"
+    }
+  }
+}

--- a/internal/contract/testdata/ledger-boundary/helm-schemas/manifest.json
+++ b/internal/contract/testdata/ledger-boundary/helm-schemas/manifest.json
@@ -1,7 +1,7 @@
 {
   "provenance_status": "complete",
   "source_repository": "https://github.com/spacedock-dev/helm",
-  "source_revision": "3d39fcdc67cc6aac22d51f4abcc2dfdadf56c838",
+  "source_revision": "e852f31e0ae6c5f06c44b51b5c7a82d0edc7da7a",
   "schemas": {
     "application-record-committed-request.v1.json": {
       "source_path": "src/ledger/contracts/schemas/application-record-committed-request.v1.json",
@@ -10,8 +10,8 @@
     },
     "application-committed.v1.json": {
       "source_path": "src/ledger/contracts/schemas/application-committed.v1.json",
-      "git_blob": "c0d1bc132b8f7f979cbd1135108eb4a3cf8ae2b1",
-      "raw_sha256": "sha256:8b6083e2b474a2771e59422ea6bd8f67562cbc66b828246f3aa8645a8f1b90d2"
+      "git_blob": "aa523f7d2324ecbae516e68b5005f4fd20ad7ff4",
+      "raw_sha256": "sha256:9ab83d7f781dbb6993518d5d7febbff2b33e1e5ba38be3dedec317cae1d18811"
     },
     "application-committed-receipt.v1.json": {
       "source_path": "src/ledger/contracts/schemas/application-committed-receipt.v1.json",

--- a/internal/contract/testdata/ledger-boundary/helm-schemas/projection-rewrite-quarantined.v1.json
+++ b/internal/contract/testdata/ledger-boundary/helm-schemas/projection-rewrite-quarantined.v1.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://helm.spacedock.dev/schemas/ledger/projection-rewrite-quarantined.v1.json",
+  "title": "helm.projection.rewrite_quarantined.v1",
+  "description": "Typed rewrite evidence that invalidates an old cursor and freezes the exposed binding until reconciliation.",
+  "type": "object",
+  "required": ["schema", "old_projection_epoch", "new_projection_epoch", "invalidated_cursor", "exposed_binding", "exposed_binding_digest", "candidate_binding", "candidate_binding_digest", "source_evidence", "quarantined_at"],
+  "properties": {
+    "schema": { "const": "helm.projection.rewrite_quarantined.v1" },
+    "old_projection_epoch": { "type": "string", "minLength": 1 },
+    "new_projection_epoch": { "type": "string", "minLength": 1 },
+    "invalidated_cursor": { "type": "string", "minLength": 1 },
+    "exposed_binding": { "$ref": "https://helm.spacedock.dev/schemas/ledger/provider-binding.v1.json" },
+    "exposed_binding_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "candidate_binding": { "$ref": "https://helm.spacedock.dev/schemas/ledger/provider-binding.v1.json" },
+    "candidate_binding_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "source_evidence": { "type": "object", "additionalProperties": true },
+    "quarantined_at": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": true
+}

--- a/internal/contract/testdata/ledger-boundary/helm-schemas/provider-binding.v1.json
+++ b/internal/contract/testdata/ledger-boundary/helm-schemas/provider-binding.v1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://helm.spacedock.dev/schemas/ledger/provider-binding.v1.json",
+  "title": "helm.provider.binding.v1",
+  "description": "Generic provider-owned opaque binding. Helm requires only a nonblank namespace and preserves additive provider fields without interpreting them.",
+  "type": "object",
+  "required": ["ns"],
+  "properties": {
+    "ns": { "type": "string", "minLength": 1, "pattern": "\\S" }
+  },
+  "additionalProperties": true
+}

--- a/internal/contract/testdata/ledger-boundary/invalid-empty-entity-ref.json
+++ b/internal/contract/testdata/ledger-boundary/invalid-empty-entity-ref.json
@@ -1,0 +1,4 @@
+{
+  "ns": "spacedock.gate-binding.v1",
+  "entity_ref": ""
+}

--- a/internal/contract/testdata/ledger-boundary/invalid-missing-entity-ref.json
+++ b/internal/contract/testdata/ledger-boundary/invalid-missing-entity-ref.json
@@ -1,0 +1,5 @@
+{
+  "ns": "spacedock.gate-binding.v1",
+  "stage": "shape",
+  "target_stage": "plan"
+}

--- a/internal/contract/testdata/ledger-boundary/invalid-provider-namespace.json
+++ b/internal/contract/testdata/ledger-boundary/invalid-provider-namespace.json
@@ -1,0 +1,6 @@
+{
+  "ns": "other-provider.gate-binding.v1",
+  "entity_ref": "docs/ship-flow/m4.13",
+  "stage": "shape",
+  "target_stage": "plan"
+}

--- a/internal/contract/testdata/ledger-boundary/invalid-whitespace-entity-ref.json
+++ b/internal/contract/testdata/ledger-boundary/invalid-whitespace-entity-ref.json
@@ -1,0 +1,4 @@
+{
+  "ns": "spacedock.gate-binding.v1",
+  "entity_ref": " \t\n"
+}

--- a/internal/contract/testdata/ledger-boundary/invalid-whitespace-expected-revision.json
+++ b/internal/contract/testdata/ledger-boundary/invalid-whitespace-expected-revision.json
@@ -1,0 +1,5 @@
+{
+  "ns": "spacedock.gate-binding.v1",
+  "entity_ref": "task-42",
+  "expected_revision": "  "
+}

--- a/internal/contract/testdata/ledger-boundary/invalid-whitespace-provider-instance-id.json
+++ b/internal/contract/testdata/ledger-boundary/invalid-whitespace-provider-instance-id.json
@@ -1,0 +1,5 @@
+{
+  "ns": "spacedock.gate-binding.v1",
+  "entity_ref": "task-42",
+  "provider_instance_id": "  \t"
+}

--- a/internal/contract/testdata/ledger-boundary/invalid-whitespace-stage.json
+++ b/internal/contract/testdata/ledger-boundary/invalid-whitespace-stage.json
@@ -1,0 +1,5 @@
+{
+  "ns": "spacedock.gate-binding.v1",
+  "entity_ref": "task-42",
+  "stage": "   "
+}

--- a/internal/contract/testdata/ledger-boundary/invalid-whitespace-target-stage.json
+++ b/internal/contract/testdata/ledger-boundary/invalid-whitespace-target-stage.json
@@ -1,0 +1,5 @@
+{
+  "ns": "spacedock.gate-binding.v1",
+  "entity_ref": "task-42",
+  "target_stage": "\t"
+}

--- a/internal/contract/testdata/ledger-boundary/invalid-whitespace-workflow-ref.json
+++ b/internal/contract/testdata/ledger-boundary/invalid-whitespace-workflow-ref.json
@@ -1,0 +1,5 @@
+{
+  "ns": "spacedock.gate-binding.v1",
+  "entity_ref": "task-42",
+  "workflow_ref": "\n"
+}

--- a/internal/contract/testdata/ledger-boundary/projection-recovery.json
+++ b/internal/contract/testdata/ledger-boundary/projection-recovery.json
@@ -1,0 +1,54 @@
+{
+  "initial_page": {
+    "projection_epoch": "epoch_01",
+    "next_cursor": "opaque:epoch_01:44"
+  },
+  "cursor_invalidation": {
+    "request": {
+      "projection_epoch": "epoch_01",
+      "after": "opaque:epoch_01:44"
+    },
+    "error": {
+      "schema": "helm.http.error.v1",
+      "status": 409,
+      "code": "helm.projection.cursor_invalidated.v1",
+      "details": {
+        "current_projection_epoch": "epoch_02",
+        "restart": "request a fresh cursor"
+      }
+    }
+  },
+  "exposed_binding": {
+    "ns": "spacedock.gate-binding.v1",
+    "entity_ref": "task-42"
+  },
+  "candidate_binding": {
+    "ns": "spacedock.gate-binding.v1",
+    "entity_ref": "task-99"
+  },
+  "rewrite_quarantined": {
+    "schema": "helm.projection.rewrite_quarantined.v1",
+    "old_projection_epoch": "epoch_01",
+    "new_projection_epoch": "epoch_02",
+    "invalidated_cursor": "opaque:epoch_01:44",
+    "exposed_binding": {
+      "ns": "spacedock.gate-binding.v1",
+      "entity_ref": "task-42"
+    },
+    "exposed_binding_digest": "sha256:b170621f50bbcedbf4950e4026191f63098b8ed3b73de338fca9186180e3422f",
+    "candidate_binding": {
+      "ns": "spacedock.gate-binding.v1",
+      "entity_ref": "task-99"
+    },
+    "candidate_binding_digest": "sha256:b1c07d3c26830652602baf4035bd47583831bc1cdcdfa4300d455d35d16e18e0",
+    "source_evidence": {
+      "old_commit": "1111111111111111111111111111111111111111",
+      "new_commit": "3333333333333333333333333333333333333333"
+    },
+    "quarantined_at": "2026-07-14T09:00:01Z"
+  },
+  "expected": {
+    "exposed_binding_frozen": true,
+    "new_application_minted": false
+  }
+}

--- a/internal/contract/testdata/ledger-boundary/provider-pin-refusals.json
+++ b/internal/contract/testdata/ledger-boundary/provider-pin-refusals.json
@@ -1,0 +1,44 @@
+{
+  "expected_pin": {
+    "ns": "spacedock.gate-binding.v1",
+    "digest": "sha256:cec57389af09a520888645d3c0b0b6e7f0cffebc266265befd07f53a746c330b"
+  },
+  "cases": [
+    {
+      "name": "unsupported-version",
+      "observed_pin": {
+        "ns": "spacedock.gate-binding.v2",
+        "digest": "sha256:cec57389af09a520888645d3c0b0b6e7f0cffebc266265befd07f53a746c330b"
+      },
+      "binding": {
+        "ns": "spacedock.gate-binding.v2",
+        "entity_ref": "task-42"
+      },
+      "error": {
+        "schema": "helm.http.error.v1",
+        "status": 409,
+        "code": "helm.provider_binding.unsupported_version.v1"
+      },
+      "effect": "refuse_before_mutation",
+      "fallback_guess_allowed": false
+    },
+    {
+      "name": "digest-mismatch",
+      "observed_pin": {
+        "ns": "spacedock.gate-binding.v1",
+        "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "binding": {
+        "ns": "spacedock.gate-binding.v1",
+        "entity_ref": "task-42"
+      },
+      "error": {
+        "schema": "helm.http.error.v1",
+        "status": 409,
+        "code": "helm.provider_binding.unsupported_version.v1"
+      },
+      "effect": "refuse_before_mutation",
+      "fallback_guess_allowed": false
+    }
+  ]
+}

--- a/internal/contract/testdata/ledger-boundary/valid-application-linkage.json
+++ b/internal/contract/testdata/ledger-boundary/valid-application-linkage.json
@@ -1,0 +1,59 @@
+{
+  "gate": {
+    "gate_id": "gat_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e70",
+    "binding": {
+      "ns": "spacedock.gate-binding.v1",
+      "entity_ref": "docs/ship-flow/m4.13"
+    }
+  },
+  "resolution": {
+    "gate_id": "gat_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e70",
+    "resolution_id": "resolution:approve-1"
+  },
+  "application": {
+    "gate_id": "gat_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e70",
+    "resolution_id": "resolution:approve-1",
+    "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f"
+  },
+  "committed": {
+    "schema": "helm.application.committed.v1",
+    "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+    "gate_id": "gat_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e70",
+    "resolution_id": "resolution:approve-1",
+    "applier": "spacedock:apply-coordinator",
+    "target_owner": "spacedock:workflow",
+    "target_ref": "workflow:wf1-demo/entity:task-42",
+    "target_kind": "git",
+    "before": "plan",
+    "after": "execute",
+    "commit_oid": "1111111111111111111111111111111111111111",
+    "parent_oids": [
+      "0000000000000000000000000000000000000000"
+    ],
+    "tree_or_blob_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "committed_at": "2026-07-14T08:00:00Z"
+  },
+  "observed": {
+    "schema": "helm.application.observed.v1",
+    "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+    "source_event_key": "github:spacedock:refs/heads/main:1111111",
+    "observed_commit": "1111111111111111111111111111111111111111",
+    "ref": "refs/heads/main",
+    "remote": "origin",
+    "provider": "github",
+    "observed_at": "2026-07-14T08:05:00Z",
+    "provenance": "watcher"
+  },
+  "source_superseded": {
+    "schema": "helm.application.source_superseded.v1",
+    "application_id": "app_0190c3f2-6a1b-7c3d-8e2f-1a2b3c4d5e6f",
+    "old_source_pin": "git:1111111111111111111111111111111111111111",
+    "new_source_pin": "git:3333333333333333333333333333333333333333",
+    "reason": "canonical ref was rebased",
+    "observed_at": "2026-07-14T09:00:00Z"
+  },
+  "expected": {
+    "committed_effect": "pending_apply_to_applied",
+    "observed_effect": "audit_only"
+  }
+}

--- a/internal/contract/testdata/ledger-boundary/valid-application-linkage.json
+++ b/internal/contract/testdata/ledger-boundary/valid-application-linkage.json
@@ -30,7 +30,9 @@
     "parent_oids": [
       "0000000000000000000000000000000000000000"
     ],
-    "tree_or_blob_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "tree_or_blob_kind": "blob",
+    "tree_or_blob_oid": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+    "tree_or_blob_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "committed_at": "2026-07-14T08:00:00Z"
   },
   "observed": {

--- a/internal/contract/testdata/ledger-boundary/valid-binding-with-extensions.json
+++ b/internal/contract/testdata/ledger-boundary/valid-binding-with-extensions.json
@@ -1,0 +1,13 @@
+{
+  "ns": "spacedock.gate-binding.v1",
+  "entity_ref": "docs/ship-flow/m4.13",
+  "stage": "shape",
+  "target_stage": "plan",
+  "workflow_ref": "docs/ship-flow/README.md",
+  "provider_instance_id": "sd_local_paris",
+  "expected_revision": "9d6f7e1",
+  "spacedock:provider_instance_id": "sd_future_paris",
+  "spacedock:future_binding_hint": {
+    "mode": "content-addressed"
+  }
+}

--- a/internal/contract/testdata/ledger-boundary/valid-minimal-binding.json
+++ b/internal/contract/testdata/ledger-boundary/valid-minimal-binding.json
@@ -1,0 +1,4 @@
+{
+  "ns": "spacedock.gate-binding.v1",
+  "entity_ref": "docs/ship-flow/m4.13"
+}


### PR DESCRIPTION
## Summary

- publish a Draft `spacedock.gate-binding.v1` ecosystem boundary for CL/Jared ratification
- define canonical binding, committed application, observed audit, epoch invalidation, and source-supersession schemas
- distinguish standalone Spacedock authority from the Helm Ledger-bound path without changing the v1 schema bytes
- define fail-closed preconditions for a future ledger-bound adapter, including durable authority selection and response-lost `openGate` recovery
- include valid/invalid fixtures and contract tests, with exact cross-pins to the Helm consumer schemas

## Draft boundary

This PR is intentionally contract-only. It does not implement a writer, projector, watcher, ledger-bound adapter, provider attempt-state schema, CLI, HTTP surface, or runtime coordinator.

- A standalone-only Spacedock deployment remains valid without Helm Ledger and owns its local R&G Resolution and application state.
- A future ledger-bound or dual-mode adapter must persist an explicit authority selection. Missing or unreadable Ledger state never implies standalone authority.
- Ledger-bound opening persists the producer-owned `openGate` idempotency key, exact request bytes, and digest before calling Ledger. Response-loss recovery replays the same key and byte-identical body.
- Helm owns `gate_id`, `resolution_id`, `application_id`, the authoritative Resolution, and the application fold for ledger-bound attempts.
- Spacedock owns workflow state and coordination, then emits a typed committed attestation.
- Provider-owned probe and room history stays outside Ledger facts.
- A cached Ledger Resolution body is non-authoritative, digest-bound, immutable, and discarded or quarantined on mismatch.
- Without Spacedock, the existing Ledger path is unchanged.
- Observed evidence remains audit-only and cannot move `pending_apply` to `applied`.

The versioned provider attempt-state representation remains a separate ratification surface. This clarification leaves `gate-binding.v1.schema.json` unchanged so existing raw-digest pins remain valid.

Helm is dogfooding this exact source revision/blob/raw digest as an offline pinned provider schema. The paired Helm PR is stacked on Helm #61.

## Verification

- focused GateBinding contract and race tests passed
- all eight vendored Helm schemas were reproduced against the pinned Helm commit, Git blobs, and raw SHA-256 values
- schema validation, fixtures, `jq`, docs checks, and diff checks passed
- three independent contract/test/schema review lanes returned clean on the final diff
- repository-wide `go test ./...` and race runs retain one unrelated, reproducible existing failure in `skills/integration/TestSurveyCodexPresenceThroughSync` (`blank_cwd=0`); every other package passed

## Review focus

Please ratify or revise the ecosystem boundary before runtime implementation: authority selection, schema ownership, canonical identity, response-lost opening recovery, application attestation semantics, and epoch/supersession behavior.