### PR TITLE
Retire the keep-moving permission narration oracle

### DIFF
--- a/internal/ensigncycle/shared_keep_moving_negative_test.go
+++ b/internal/ensigncycle/shared_keep_moving_negative_test.go
@@ -9,9 +9,9 @@ import (
 // replay fixtures. It proves the grader holds the invariant triple for a captain correction
 // (corrected entity does not drive FORWARD until folded; everything else keeps moving; the
 // folded re-shape SURFACES or its rework is honestly named in-flight) from the REAL fixture
-// tokens: the correct trace PASSES, and every incident reds in isolation — a post-approval
-// permission question, a serialized independent dispatch, a dropped re-shape, a FORWARD
-// drive of the corrected entity, and a silent wait/park that never surfaces the re-shape.
+// tokens: the correct trace PASSES, and every incident reds in isolation — a serialized
+// independent dispatch, a dropped re-shape, a FORWARD drive of the corrected entity, and a
+// silent wait/park that never surfaces the re-shape.
 // The re-shape MECHANISM is free: a routed rework dispatch of the corrected entity is NOT a
 // violation (only a forward status is). The replay fixtures distil the three recorded
 // cycle-1 drives (run 28843487385): codex green (surfaced a gate review), sonnet green
@@ -26,10 +26,6 @@ func kmCorrectFinal() string {
 		"Dispatched " + kmReadyOne + " and " + kmReadyTwo + " in parallel in one turn. " +
 		"Re-shaped " + kmQuestioned + " to fold the captain's symlink correction and presented it for gate review, " +
 		"holding it from advancing until the correction is folded."
-}
-
-func kmPermissionFinal() string {
-	return "I reviewed the captain's approval of " + kmApprovedGate + ". Want me to advance it to " + kmNextStage + " and dispatch the stage?"
 }
 
 // kmSilentWaitFinal is the opus cycle-1 specimen verbatim: everything dispatched, then a
@@ -71,13 +67,6 @@ func TestGradeKeepMoving(t *testing.T) {
 	// Positive: the correct trace passes.
 	if err := gradeKeepMoving(kmCorrectTrace(), independent); err != nil {
 		t.Fatalf("the correct keep-moving trace must pass: %v", err)
-	}
-
-	// Negative (S1 pause): the FO asked permission to advance/dispatch after the approval.
-	asked := kmCorrectTrace()
-	asked.askedPermission = true
-	if err := gradeKeepMoving(asked, independent); err == nil {
-		t.Fatal("expected a post-approval permission question to fail")
 	}
 
 	// Negative (S1): the approved entity was never advanced.
@@ -138,11 +127,6 @@ func TestAssertClaudeKeepMoving(t *testing.T) {
 	// Positive: the correct stream + a surfacing final message passes.
 	if err := assertClaudeKeepMoving(kmClaudeCorrectStream(), kmCorrectFinal(), independent); err != nil {
 		t.Fatalf("the correct Claude keep-moving trace must pass: %v", err)
-	}
-
-	// Negative (S1 pause): correct actions, a permission-question final message.
-	if err := assertClaudeKeepMoving(kmClaudeCorrectStream(), kmPermissionFinal(), independent); err == nil {
-		t.Fatal("expected a permission-question final message to fail the Claude assertion")
 	}
 
 	// Negative (S4 silent park): correct actions, a silent-wait final that never names the
@@ -276,11 +260,6 @@ func TestAssertCodexKeepMoving(t *testing.T) {
 		t.Fatalf("the codex merge-guard terminalization dialect must pass (PR #480 false-negative regression): %v", err)
 	}
 
-	// Negative (S1 pause): correct actions, a permission-question final message.
-	if err := assertCodexKeepMoving(kmCodexCorrectStream(), kmPermissionFinal(), independent); err == nil {
-		t.Fatal("expected a permission-question final message to fail the Codex assertion")
-	}
-
 	// Negative (S4 silent park): correct actions, a silent-wait final that never names the
 	// corrected entity.
 	if err := assertCodexKeepMoving(kmCodexCorrectStream(), kmSilentWaitFinal(), independent); err == nil {
@@ -363,5 +342,69 @@ func TestKeepMovingReplayFromRecordedDrives(t *testing.T) {
 		"Gate review: " + kmQuestioned + " - review. Recommend approve. Decision: approve to enter " + kmNextStage + ", or reject."
 	if err := assertCodexKeepMoving(codexReplay, codexFinal, independent); err != nil {
 		t.Fatalf("codex replay: a surfaced gate review must pass: %v", err)
+	}
+}
+
+// kmNegatedQuotationFinals are the two Opus final-message shapes that falsely failed the run
+// this scenario targets (PR #512 Runtime Live E2E run 29382760645, jobs 87249808752 and
+// 87252929149): each honestly reports the completed advance + parallel dispatch and surfaces
+// the corrected entity's re-shape while NEGATING a quoted permission phrase ("want me to
+// advance?", "should I proceed?"). The structured advance/dispatch evidence, not the summary
+// wording, is the no-false-stop proof, so a correct motion carrying either summary must pass.
+func kmNegatedQuotationFinals() []string {
+	return []string{
+		"Advanced " + kmApprovedGate + " to " + kmNextStage + " and dispatched its next stage — " +
+			`the approval is the trigger, so there was no "want me to advance?" pause. ` +
+			"Dispatched " + kmReadyOne + " and " + kmReadyTwo + " in parallel in one turn. " +
+			"Re-shaped " + kmQuestioned + " to fold the captain's correction and presented it for gate review, " +
+			"holding it from advancing until the correction folds.",
+		"Advanced " + kmApprovedGate + " to " + kmNextStage + " and dispatched it. " +
+			"Dispatched " + kmReadyOne + " and " + kmReadyTwo + " together in parallel. " +
+			`I did not stop to ask "should I proceed?" — approval already permits the reversible step. ` +
+			"Re-shaped " + kmQuestioned + " and surfaced its re-shape as a gate-review recommendation, " +
+			"kept off the forward path until folded.",
+	}
+}
+
+func TestKeepMovingNegatedQuotationReplay(t *testing.T) {
+	independent := kmIndependent()
+	finals := kmNegatedQuotationFinals()
+
+	// AC-1: both negated-quotation summaries over the correct completed motion PASS on the
+	// structured advance/dispatch evidence — the quoted permission phrase does not veto.
+	for i, final := range finals {
+		if err := assertClaudeKeepMoving(kmClaudeReplayStream(), final, independent); err != nil {
+			t.Fatalf("negated-quotation final #%d: a correct completed motion must pass on structured evidence: %v", i, err)
+		}
+	}
+
+	// AC-2: the same summary neither rescues nor condemns — a real false stop stays RED and names
+	// the missing action, independently for a missing advance and a missing dispatch.
+	final := finals[0]
+
+	// Missing the approved advance: dispatched and re-shaped, but approved-gate never advanced.
+	noAdvance := strings.Join([]string{
+		claudeToolUse("Agent", `{"description":"Approved Gate: `+kmNextStage+`","prompt":"Dispatch `+kmApprovedGate+`."}`),
+		claudeToolUse("Agent", `{"description":"Ready One: `+kmNextStage+`","prompt":"Dispatch `+kmReadyOne+`."}`),
+		claudeToolUse("Agent", `{"description":"Ready Two: `+kmNextStage+`","prompt":"Dispatch `+kmReadyTwo+`."}`),
+		claudeToolUse("Agent", `{"description":"Questioned: `+kmReopenStage+` re-shape","prompt":"Rework `+kmQuestioned+`."}`),
+	}, "\n")
+	if err := assertClaudeKeepMoving(noAdvance, final, independent); err == nil {
+		t.Fatal("missing approved advance must stay red under a negated-quotation final")
+	} else if !strings.Contains(err.Error(), "advance") {
+		t.Fatalf("the missing-advance error must name the missing advance: %v", err)
+	}
+
+	// Missing the approved dispatch: approved-gate advanced, but its next stage never dispatched.
+	noDispatch := strings.Join([]string{
+		claudeToolUse("Bash", `{"command":"spacedock status --workflow-dir . --set `+kmApprovedGate+` status=`+kmNextStage+`"}`),
+		claudeToolUse("Agent", `{"description":"Ready One: `+kmNextStage+`","prompt":"Dispatch `+kmReadyOne+`."}`),
+		claudeToolUse("Agent", `{"description":"Ready Two: `+kmNextStage+`","prompt":"Dispatch `+kmReadyTwo+`."}`),
+		claudeToolUse("Agent", `{"description":"Questioned: `+kmReopenStage+` re-shape","prompt":"Rework `+kmQuestioned+`."}`),
+	}, "\n")
+	if err := assertClaudeKeepMoving(noDispatch, final, independent); err == nil {
+		t.Fatal("missing approved dispatch must stay red under a negated-quotation final")
+	} else if !strings.Contains(err.Error(), "dispatch") {
+		t.Fatalf("the missing-dispatch error must name the missing dispatch: %v", err)
 	}
 }

--- a/internal/ensigncycle/shared_keep_moving_test.go
+++ b/internal/ensigncycle/shared_keep_moving_test.go
@@ -13,11 +13,13 @@ import (
 // pause, sequential-instead-of-parallel dispatch, turn-end on an async launch with work
 // remaining, and a captain correction halting the session. The durable end-state cannot
 // tell keep-moving from a false stop, so the ACTIONS (advance, dispatch, re-shape) are read
-// from the transcript and the turn-ending POSTURES (a permission question; whether the
-// corrected entity's re-shape was surfaced or silently parked) are read from the FINAL
-// MESSAGE. Reading the postures from the final message, not from all narration, avoids the
-// contract-read false-positive: the FO's mid-stream reasoning quotes the shared-core
-// keep-moving blockquote, which a stream-wide phrase scan would misread.
+// from the transcript. The post-approval pause is proven by those actions: an approved entity
+// that was advanced AND dispatched did not pause for permission, so the structured
+// advance/dispatch evidence is the no-false-stop proof — the free-form summary wording is not
+// scanned for question phrasing. The one posture the actions cannot show — whether the
+// corrected entity's re-shape was surfaced or silently parked — is read from the FINAL
+// MESSAGE, not from all narration, so the FO's mid-stream reasoning quoting the shared-core
+// keep-moving blockquote is not misread by a stream-wide phrase scan.
 //
 // A captain correction on one entity means an invariant TRIPLE (the shipped S4 clause and
 // this grader key on the same thing): (1) the corrected entity does NOT drive FORWARD
@@ -47,13 +49,6 @@ const (
 )
 
 func kmIndependent() []string { return []string{kmReadyOne, kmReadyTwo} }
-
-// kmPermissionRe matches the post-approval permission question (pattern 1): the FO asking
-// the captain's leave to take the reversible advance+dispatch step the approval already
-// triggered. Drive-cue: the 2026-07-06/07 Commander session's self-imposed gate stall under
-// a standing conn grant. Keyed on an ask verb near a proceed verb so a plain status report
-// ("I advanced and dispatched") does not match.
-var kmPermissionRe = regexp.MustCompile(`(?i)(want me to|shall i|should i|do you want me to|would you like me to|let me know (if|whether)|awaiting your (go|ok|approval|sign-?off))\b[^.?!]{0,48}?\b(advance|dispatch|proceed|continue|kick off|go ahead|engage|move forward|move on)`)
 
 // kmCorrectedDispositionRe matches, in the final message, a substantive disposition of the
 // corrected entity's re-shape — SURFACED (a gate review / decision / re-presentation for the
@@ -126,7 +121,6 @@ type keepMovingTrace struct {
 	correctedReshaped     bool            // the corrected entity's design was re-shaped (in-house edit, routed rework, or re-open to ideation)
 	correctedDriven       bool            // the corrected entity was driven FORWARD (to implementation/done/merge) before the re-shape folded
 	correctedAddressed    bool            // at stop, the re-shape was surfaced or its rework honestly named as in-flight
-	askedPermission       bool            // the final message asks the captain's leave to advance/dispatch (pattern 1)
 }
 
 func newKeepMovingTrace() keepMovingTrace {
@@ -134,15 +128,13 @@ func newKeepMovingTrace() keepMovingTrace {
 }
 
 // gradeKeepMoving is host-neutral: it holds the FO's motion trace to the keep-moving
-// patterns. Approval triggers the advance AND the dispatch with no permission question (S1);
-// every independent ready entity is dispatched, not serialized behind a pause (S2); the
-// corrected entity is re-shaped, held from driving forward, and its re-shape surfaced or
-// honestly named as in-flight while the independent ones keep moving (S4). The re-shape
-// mechanism is free — only a FORWARD drive of the corrected entity or a silent park fails.
+// patterns. Approval triggers the advance AND the dispatch — performing both is the proof the
+// FO did not pause for permission (S1); every independent ready entity is dispatched, not
+// serialized behind a pause (S2); the corrected entity is re-shaped, held from driving
+// forward, and its re-shape surfaced or honestly named as in-flight while the independent
+// ones keep moving (S4). The re-shape mechanism is free — only a FORWARD drive of the
+// corrected entity or a silent park fails.
 func gradeKeepMoving(tr keepMovingTrace, independent []string) error {
-	if tr.askedPermission {
-		return fmt.Errorf("the FO asked the captain's permission to advance/dispatch after the gate approval — approval triggers the next action, it is not a turn boundary (advance+dispatch is reversible work the contract already permits)")
-	}
 	if !tr.approvedAdvanced {
 		return fmt.Errorf("the FO did not advance the approved entity %q past its gate to the next stage after the captain's approval", kmApprovedGate)
 	}
@@ -233,7 +225,6 @@ func claudeKeepMovingTrace(stream, finalMessage string, independent []string) ke
 			}
 		}
 	}
-	tr.askedPermission = kmPermissionRe.MatchString(finalMessage)
 	tr.correctedAddressed = kmCorrectedAddressed(finalMessage, kmQuestioned)
 	return tr
 }
@@ -315,7 +306,6 @@ func codexKeepMovingTrace(jsonl, finalMessage string, independent []string) keep
 	if dispatchEvidence.stageReport[kmQuestioned] {
 		tr.correctedReshaped = true
 	}
-	tr.askedPermission = kmPermissionRe.MatchString(finalMessage)
 	tr.correctedAddressed = kmCorrectedAddressed(finalMessage, kmQuestioned)
 	return tr
 }


### PR DESCRIPTION
Retires a narration-regex permission oracle that false-failed correct live runs, leaving structured advance/dispatch evidence as the keep-moving proof.

## What changed
- Delete `kmPermissionRe`, the `askedPermission` field, and its grade check.
- Remove both host-extractor `askedPermission` assignments and `kmPermissionFinal`.
- Drop the narration-only permission-question negatives.
- Add `TestKeepMovingNegatedQuotationReplay` from the two failing Opus finals.

## Evidence
- `go test ./...` and `go test ./... -race`: green (exit 0).
- Replay fixture confirms both Opus finals genuinely tripped the retired regex yet pass on structured advance/dispatch; missing-advance/dispatch stays red.

## Review guidance
- Deferred (intentional): a permission-question final accompanying completed advance+dispatch is no longer graded; structured evidence + the live E2E lane remain the proof. No new narration parser by design.

---
[bj](/spacedock-dev/spacedock/blob/6cc3536a4200f319c9b59052f24caa68db5f084a/retire-keep-moving-permission-narration-oracle/index.md)
