### PR TITLE
Replace reviewer-reuse inference with structured evidence

### DIFF
--- a/internal/ensigncycle/codex_live_runner_test.go
+++ b/internal/ensigncycle/codex_live_runner_test.go
@@ -3,6 +3,7 @@
 package ensigncycle
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -205,8 +206,18 @@ func runCodexRejectionFlowScenario(t *testing.T, runner codexLiveRunner, scenari
 	if err := assertRejectionFlow(entityAfter, result.finalMessage+"\n"+result.jsonl); err != nil {
 		t.Fatalf("%v\nFinal message:\n%s\nArtifacts: %s", err, result.finalMessage, result.artifactDir)
 	}
-	if err := assertCodexReviewerReuseWithDurableState(result.jsonl, entityAfter); err != nil {
-		t.Fatalf("%v\nFinal message:\n%s\nArtifacts: %s", err, result.finalMessage, result.artifactDir)
+	// assertRejectionFlow (above) proves the two-cycle re-review OCCURRED from the
+	// durable entity body. assertCodexReviewerReuse grades WHO performed it from
+	// structured handles: a re-review routed to a non-validation thread fails; reuse
+	// and structurally-distinct fresh both pass; an absent identity handle is
+	// identity-not-provable — log it, do not fail, since the durable two-cycle proof
+	// already stands.
+	if err := assertCodexReviewerReuse(result.jsonl); err != nil {
+		if errors.Is(err, errReviewerIdentityUnsupported) {
+			t.Logf("rejection-flow reviewer identity abstained (re-review OCCURRED per durable state, but WHO is not structurally provable): %s", err)
+		} else {
+			t.Fatalf("%v\nFinal message:\n%s\nArtifacts: %s", err, result.finalMessage, result.artifactDir)
+		}
 	}
 	emitCodexScenarioMetrics(t, scenario, result)
 }

--- a/internal/ensigncycle/codex_single_run_test.go
+++ b/internal/ensigncycle/codex_single_run_test.go
@@ -274,21 +274,3 @@ func helperArgs(argv []string) []string {
 	}
 	return nil
 }
-
-func passingRejectionEntity() string {
-	return "---\nstatus: validation\n---\n" +
-		rejectionFixMarker + "\n\n" +
-		"## Stage Report: implementation\n\n- DONE: Initial implementation\n\n" +
-		"## Stage Report: implementation\n\n- DONE: Applied rejection fix\n\n" +
-		"### Feedback Cycles\n\n- Cycle 1: REJECTED\n- Cycle 2: PASSED\n"
-}
-
-func passingRejectionEntityWithValidationReports() string {
-	return "---\nstatus: validation\n---\n" +
-		rejectionFixMarker + "\n\n" +
-		"## Stage Report: implementation\n\n- DONE: Initial implementation\n\n" +
-		"## Stage Report: validation\n\nRecommendation: REJECTED.\n\n" +
-		"## Stage Report: implementation\n\n- DONE: Applied rejection fix\n\n" +
-		"## Stage Report: validation\n\nRecommendation: PASSED.\n\n" +
-		"### Feedback Cycles\n\n- Cycle 1: REJECTED\n- Cycle 2: PASSED\n"
-}

--- a/internal/ensigncycle/shared_assertions_impl_test.go
+++ b/internal/ensigncycle/shared_assertions_impl_test.go
@@ -47,12 +47,6 @@ var feedbackCycleEntry = regexp.MustCompile(`(?im)^- Cycle \d+:`)
 // report rather than any prose that merely names the stage.
 var implementationReport = regexp.MustCompile(`(?m)^## Stage Report: implementation`)
 
-// validationReport anchors validation worker output in the durable entity body.
-// Codex exec may omit spawn/thread/assignment metadata, so the Codex live
-// reviewer oracle can fall back to this durable stage report only after the
-// host-neutral two-cycle rejection state has passed.
-var validationReport = regexp.MustCompile(`(?m)^## Stage Report: validation`)
-
 // feedbackCyclesSection returns the body of the entity's `### Feedback Cycles`
 // section — from its heading to the next heading (any `##`/`###`/etc.) or EOF.
 // Scoping the cycle-entry and escalation-marker matches to this section keeps the

--- a/internal/ensigncycle/shared_reviewer_reuse_table_test.go
+++ b/internal/ensigncycle/shared_reviewer_reuse_table_test.go
@@ -1,16 +1,20 @@
 package ensigncycle
 
 import (
-	"os"
+	"errors"
 	"strings"
 	"testing"
 )
 
 // Offline table tests for the host-specific reviewer-reuse assertions. They prove
-// each assertion requires a REAL reuse tool call targeting the validation reviewer
-// — not loose narration, not an unrelated tool, not a call to a different
-// recipient. Without these the assertions are exercised only by the model-spending
-// live runners; here they cost milliseconds and pin the discriminating behavior.
+// each assertion reads reviewer identity ONLY from structured native handles — the
+// Claude validation spawn's agentId/input.name correlated to a SendMessage.to, the
+// Codex validation spawn_agent's receiver_thread_ids correlated to a followup_task/
+// send_input — and reports an explicit errReviewerIdentityUnsupported when no such
+// handle exists. Command strings, wait counts, durable reports, and free-form
+// narration never manufacture a reuse claim. Without these the assertions are
+// exercised only by the model-spending live runners; here they cost milliseconds and
+// pin the discriminating behavior.
 
 func TestAssertClaudeReviewerReuse(t *testing.T) {
 	// The agentId-addressed reuse shape — one shape the FO emits in a Claude team
@@ -18,68 +22,68 @@ func TestAssertClaudeReviewerReuse(t *testing.T) {
 	// spawn returned). A validation-stage Agent spawn (exactly one) returns an
 	// agentId on completion; the FO resumes THAT reviewer by agentId for the cycle-2
 	// re-review. Both events must be present and correlated for this to pass.
-	validationSpawn := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_V","input":{"description":"Rejection Task: validation","subagent_type":"spacedock:ensign"}}]}}`
+	validationSpawn := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_V","input":{"description":"Rejection Task: validation","subagent_type":"spacedock:ensign","name":"spacedock-ensign-rejection-task-validation"}}]}}`
 	validationResult := `{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_V","content":[{"type":"text","text":"Verdict: REJECTED."},{"type":"text","text":"agentId: a94abe89c85f9f4cc (use SendMessage with to: 'a94abe89c85f9f4cc' to continue this agent)"}]}]}}`
 	reuseByAgentID := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SendMessage","input":{"to":"a94abe89c85f9f4cc","message":"re-review: the fix marker is now present"}}]}}`
 	agentIDReuse := validationSpawn + "\n" + validationResult + "\n" + reuseByAgentID
 
 	// An agentId from an IMPLEMENTATION spawn, not the validation reviewer: a
-	// SendMessage to it is NOT reviewer reuse and must NOT pass. This pins the
-	// correlation — the assertion must tie the reused handle back to the validation
-	// spawn, not accept any agentId.
-	implSpawn := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_I","input":{"description":"Rejection Task: implementation","subagent_type":"spacedock:ensign"}}]}}`
+	// SendMessage to it is NOT reviewer reuse and must NOT pass. There is no
+	// validation spawn to correlate, so the identity surface is unsupported.
+	implSpawn := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_I","input":{"description":"Rejection Task: implementation","subagent_type":"spacedock:ensign","name":"spacedock-ensign-rejection-task-implementation"}}]}}`
 	implResult := `{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_I","content":[{"type":"text","text":"agentId: a000impl0000 (use SendMessage with to: 'a000impl0000' to continue this agent)"}]}]}}`
 	reuseImplAgentID := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SendMessage","input":{"to":"a000impl0000","message":"apply the fix"}}]}}`
 	wrongAgentIDReuse := implSpawn + "\n" + implResult + "\n" + reuseImplAgentID
 
 	// A SendMessage to a validation-reviewer agentId that was NEVER spawned/returned
-	// in this transcript: an opaque handle with no correlating validation spawn must
-	// NOT pass.
+	// in this transcript: an opaque handle with no correlating validation spawn — the
+	// identity surface is unsupported, not a reuse pass.
 	uncorrelatedAgentID := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SendMessage","input":{"to":"adeadbeef0000000","message":"re-review"}}]}}`
 
 	// Genuine NAME-addressed reuse: the FO spawns the cycle-1 validation reviewer
-	// ONCE, then re-engages it for cycle 2 by its spawn NAME (the production shape —
-	// testdata/*.jsonl address members by name, not agentId). Exactly one validation
-	// spawn + a name-message to it = genuine reuse → PASS.
-	nameSpawnValidation := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_NV","input":{"description":"Rejection Task: validation","subagent_type":"spacedock:ensign"}}]}}`
+	// ONCE declaring its teammate handle in input.name, then re-engages it for cycle 2
+	// by that exact handle (the production shape — every recorded spawn carries
+	// input.name and SendMessage.to matches it). Exactly one validation spawn + a
+	// name-correlated message to it = genuine reuse → PASS.
+	nameSpawnValidation := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_NV","input":{"description":"Rejection Task: validation","subagent_type":"spacedock:ensign","name":"spacedock-ensign-rejection-task-validation"}}]}}`
 	reuseByName := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SendMessage","input":{"to":"spacedock-ensign-rejection-task-validation","message":"re-review: the fix marker is now present"}}]}}`
 	nameReuse := nameSpawnValidation + "\n" + reuseByName
 
-	// FRESH-DISPATCH false-pass (the #302/cycle-8 hole): the FO drives cycle-1
-	// validation (spawn #1), then FRESH-dispatches the cycle-2 validator (a SECOND
-	// validation Agent spawn — the FORBIDDEN behavior the #141 keepalive contract
-	// prohibits) and kicks it off by its validation NAME. The old assertion greened
-	// this on the bare name substring; the strengthened one must RED it — two
-	// validation spawns means the FO did NOT reuse the kept-alive cycle-1 reviewer.
-	freshCycle2Spawn := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_FV","input":{"description":"Rejection Task: validation (cycle 2)","subagent_type":"spacedock:ensign"}}]}}`
+	// FRESH-DISPATCH (two validation spawns): the FO drives cycle-1 validation
+	// (spawn #1), then FRESH-dispatches the cycle-2 validator (a SECOND validation
+	// Agent spawn) and kicks it off by its validation NAME. Two validation spawns is
+	// structurally FRESH, not reuse — the team-mode #141 keepalive assertion RED-flags
+	// it (the reviewer was not kept alive and reused).
+	freshCycle2Spawn := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_FV","input":{"description":"Rejection Task: validation (cycle 2)","subagent_type":"spacedock:ensign","name":"spacedock-ensign-rejection-task-validation-cycle2"}}]}}`
 	freshDispatchNameMessage := nameSpawnValidation + "\n" + freshCycle2Spawn + "\n" + reuseByName
 
 	cases := []struct {
-		name    string
-		stream  string
-		wantErr bool
+		name            string
+		stream          string
+		wantErr         bool
+		wantUnsupported bool
 	}{
-		{"genuine name-addressed reuse (one validation spawn)", nameReuse, false},
-		{"reuse by correlated validation agentId", agentIDReuse, false},
-		{"fresh cycle-2 dispatch + name message must RED", freshDispatchNameMessage, true},
+		{"genuine name-addressed reuse (one validation spawn)", nameReuse, false, false},
+		{"reuse by correlated validation agentId", agentIDReuse, false, false},
+		{"fresh cycle-2 dispatch (two validation spawns) must RED as fresh", freshDispatchNameMessage, true, false},
 		{
 			"loose narration only",
 			`{"type":"assistant","message":{"content":[{"type":"text","text":"I will reuse the validation reviewer via SendMessage."}]}}`,
-			true,
+			true, true,
 		},
 		{
-			"unrelated tool targeting validation",
+			"validation spawn exposing no agentId or input.name handle",
 			`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","input":{"to":"spacedock-ensign-validation","description":"fresh validation dispatch"}}]}}`,
-			true,
+			true, true,
 		},
 		{
-			"SendMessage to a non-validation recipient by name",
+			"SendMessage to a non-validation recipient with no validation spawn",
 			`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SendMessage","input":{"to":"spacedock-ensign-implementation","message":"apply the fix"}}]}}`,
-			true,
+			true, true,
 		},
-		{"reuse of an implementation agentId, not the reviewer", wrongAgentIDReuse, true},
-		{"SendMessage to an uncorrelated agentId", uncorrelatedAgentID, true},
-		{"empty stream", "", true},
+		{"reuse of an implementation agentId, no validation spawn", wrongAgentIDReuse, true, true},
+		{"SendMessage to an uncorrelated agentId, no validation spawn", uncorrelatedAgentID, true, true},
+		{"empty stream", "", true, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -90,33 +94,27 @@ func TestAssertClaudeReviewerReuse(t *testing.T) {
 			if !tc.wantErr && err != nil {
 				t.Fatalf("expected pass for %q, got: %v", tc.name, err)
 			}
+			if got := errors.Is(err, errReviewerIdentityUnsupported); got != tc.wantUnsupported {
+				t.Fatalf("errReviewerIdentityUnsupported = %v for %q, want %v (err: %v)", got, tc.name, tc.wantUnsupported, err)
+			}
 		})
 	}
 }
 
-// TestClaudeSingleEntityRejectionFlow is the CONTRACT-correct single-entity (`-p`)
-// reviewer producer-signal table (the option-(b) correction of the AC-3 finding,
-// backlog seed e3z). It pins the deterministic bare-mode end-state — two distinct
-// fresh validation spawns, fix-agent and reviewer separate — over committed,
-// model-free transcripts, including the TWO observed non-deterministic live shapes
-// (2-fresh-spawns and impl-reused-through-validation), so the validator's live
-// re-run has an offline oracle.
+// TestClaudeSingleEntityRejectionFlow is the single-entity (`-p`) reviewer
+// producer-signal table. It pins the two contract-valid end-states — bare-mode two
+// distinct fresh validation spawns, and team-mode one spawn reused via SendMessage —
+// over committed, model-free transcripts, so the validator's live re-run has an
+// offline oracle.
 //
 // Root cause (verified in the contract, not assumed):
 //   - The Claude runner launches `spacedock claude -- -p {prompt}` and the prompt
 //     names one entity, so the run is single-entity → bare (first-officer-shared-
 //     core.md `## Single-Entity Mode`; claude-fo-dispatch.md "In single-entity mode,
-//     skip team creation. Use bare-mode dispatch for all agent spawning"). That
-//     clause predates P2 (since the original vendoring `83c73494`), so the single-
-//     entity reviewer is bare both before and after lazy-TeamCreate — the contradiction
-//     is pre-existing; the old assertClaudeReviewerReuse encoded a team-mode
-//     assumption the `-p` run can never satisfy.
-//   - In bare mode the contract makes the flow DETERMINISTIC and SEQUENTIAL
-//     (claude-fo-dispatch.md `## Feedback Rejection Flow (bare mode)`: "dispatch fix
-//     agent (wait for completion), then dispatch reviewer (wait for completion)").
-//     So the contract-correct end-state is two distinct fresh validation spawns with
-//     the fix agent and reviewer as SEPARATE dispatches — which is exactly what
-//     assertClaudeSingleEntityRejectionFlow asserts.
+//     skip team creation. Use bare-mode dispatch for all agent spawning"), which
+//     fresh-dispatches a distinct reviewer per cycle — two validation spawns. When
+//     the `-p` FO opts into team mode it keeps the cycle-1 reviewer alive and reuses
+//     it. Both reach a validation worker; neither collapses onto the fix worker.
 //
 // NOTE the Codex contrast: Codex has no team registry, so its reviewer reuse via
 // `send_input` to a persistent thread is contract-valid even in single-entity
@@ -126,33 +124,33 @@ func TestAssertClaudeReviewerReuse(t *testing.T) {
 func TestClaudeSingleEntityRejectionFlow(t *testing.T) {
 	// CONTRACT-CORRECT (bare mode): two distinct fresh validation spawns (cycle-1 +
 	// cycle-2), the bare-mode-sequential end-state — PASS.
-	bareCycle1Validation := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_BV1","input":{"description":"Rejection Task: validation","subagent_type":"spacedock:ensign"}}]}}`
-	bareCycle2Validation := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_BV2","input":{"description":"Rejection Task: validation (cycle 2 fresh)","subagent_type":"spacedock:ensign"}}]}}`
+	bareCycle1Validation := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_BV1","input":{"description":"Rejection Task: validation","subagent_type":"spacedock:ensign","name":"spacedock-ensign-rejection-task-validation"}}]}}`
+	bareCycle2Validation := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_BV2","input":{"description":"Rejection Task: validation (cycle 2 fresh)","subagent_type":"spacedock:ensign","name":"spacedock-ensign-rejection-task-validation-cycle2"}}]}}`
 	twoFreshSpawns := bareCycle1Validation + "\n" + bareCycle2Validation
 
 	// VIOLATION: the cycle-2 re-review collapsed onto the implementation worker via a
 	// SendMessage instructing it to validate its own rework — the impl-as-validator
 	// shape. Must FAIL.
-	implRework := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_BI","input":{"description":"Rejection Task: implementation rework","subagent_type":"spacedock:ensign"}}]}}`
+	implRework := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_BI","input":{"description":"Rejection Task: implementation rework","subagent_type":"spacedock:ensign","name":"spacedock-ensign-rejection-task-implementation"}}]}}`
 	implAsValidator := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SendMessage","input":{"to":"spacedock-ensign-rejection-task-implementation","message":"now validate your own rework"}}]}}`
 	implReusedThroughValidation := bareCycle1Validation + "\n" + implRework + "\n" + implAsValidator
 
 	// VIOLATION: only one validation spawn, no second re-review at all. Must FAIL on
-	// the spawn-count check.
+	// the no-reuse check.
 	onlyCycle1 := bareCycle1Validation
 
 	// CONTRACT-CORRECT (team mode supersede-teardown): two fresh validation spawns
 	// PLUS a shutdown_request to the superseded cycle-1 implementation worker. The
 	// shutdown is the contract-mandated supersede teardown, not a re-review routing —
-	// it must NOT trip the impl-as-validator check. This is the original opus CI
-	// false-positive shape (run 27861449587 att1). Must PASS.
+	// it must NOT trip the no-reuse check. This is the original opus CI false-positive
+	// shape (run 27861449587 att1). Must PASS.
 	implShutdownObject := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SendMessage","input":{"to":"spacedock-ensign-rejection-task-implementation","message":{"type":"shutdown_request","reason":"superseded by fresh implementation-rework dispatch"}}}]}}`
 	teamSupersedeTeardown := bareCycle1Validation + "\n" + implRework + "\n" + implShutdownObject + "\n" + bareCycle2Validation
 
 	// CONTRACT-CORRECT (team mode reviewer reuse): one validation spawn, then the
-	// cycle-2 re-review reuses the kept-alive `…-validation` reviewer via SendMessage,
-	// with a shutdown_request reaping the superseded cycle-1 impl worker. This is the
-	// local opus team-mode reuse shape. Must PASS.
+	// cycle-2 re-review reuses the kept-alive `…-validation` reviewer via SendMessage
+	// to its correlated handle, with a shutdown_request reaping the superseded cycle-1
+	// impl worker. This is the local opus team-mode reuse shape. Must PASS.
 	reviewerReuseMessage := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SendMessage","input":{"to":"spacedock-ensign-rejection-task-validation","message":"Advancing to next stage: validation (cycle 2 re-review). Re-review the updated entity state."}}]}}`
 	teamReviewerReuse := bareCycle1Validation + "\n" + implRework + "\n" + implShutdownObject + "\n" + reviewerReuseMessage
 
@@ -185,9 +183,10 @@ func TestAssertCodexReviewerReuse(t *testing.T) {
 	// The Codex collab_tool_call shape. A spawn_agent dispatching the validation
 	// stage binds the reviewer's thread id (vThread); a later followup_task
 	// (or legacy send_input fixture) to vThread is the cycle-2 reviewer reuse.
-	// Both events, correlated, are the only passing shape.
+	// Both events, correlated, are the only reuse-passing shape.
 	const vThread = "019e9695-1a3a-7481-be31-a1e81d53ec6d"
 	const iThread = "019e9693-ad11-7701-b615-90d6a86b2dc8"
+	const uThread = "019e9698-3c5c-96a3-d053-c3fa3f75fe8f"
 	spawnValidation := `{"type":"item.completed","item":{"type":"collab_tool_call","tool":"spawn_agent","receiver_thread_ids":["` + vThread + `"],"prompt":"Read /tmp/spacedock-dispatch/spacedock-ensign-rejection-task-validation.md and treat its content as your assignment."}}`
 	spawnImpl := `{"type":"item.completed","item":{"type":"collab_tool_call","tool":"spawn_agent","receiver_thread_ids":["` + iThread + `"],"prompt":"Read /tmp/spacedock-dispatch/spacedock-ensign-rejection-task-implementation.md and treat its content as your assignment."}}`
 	reuseValidation := `{"type":"item.started","item":{"type":"collab_tool_call","tool":"send_input","receiver_thread_ids":["` + vThread + `"],"prompt":"Re-run validation for rejection-task as cycle 2 using your existing validation reviewer context."}}`
@@ -197,111 +196,61 @@ func TestAssertCodexReviewerReuse(t *testing.T) {
 	realReuse := spawnValidation + "\n" + spawnImpl + "\n" + feedbackToImpl + "\n" + reuseValidation
 	realReuseV2 := spawnValidation + "\n" + spawnImpl + "\n" + feedbackToImpl + "\n" + reuseValidationV2
 
-	// FRESH-DISPATCH false-pass (the cycle-8 M2 hole): the FO drives cycle-1
-	// validation (spawn #1 → vThread), then FRESH-spawns a SECOND cycle-2 validation
-	// reviewer (vThread2 — its prompt also names validation) and routes to THAT
-	// new thread. The old assertion bound ANY validation-prompt spawn as "the
-	// validation thread", so a message to the fresh cycle-2 thread passed as
-	// "reuse". The strengthened assertion must RED it: two validation spawn_agents
-	// means the FO fresh-dispatched, it did not reuse the kept-alive cycle-1 reviewer.
+	// Two distinct validation spawn_agents with NO narration line: the FO
+	// fresh-dispatched a cycle-2 reviewer distinct from cycle-1. This is structurally
+	// FRESH — the contract-correct choice when the host exposes no addressable-worker
+	// reuse route — and passes without any narration proving it (narration is no
+	// longer load-bearing).
 	const vThread2 = "019e9696-2b4b-8592-cf42-b2f92e64fd7e"
 	freshCycle2Spawn := `{"type":"item.completed","item":{"type":"collab_tool_call","tool":"spawn_agent","receiver_thread_ids":["` + vThread2 + `"],"prompt":"Read /tmp/spacedock-dispatch/spacedock-ensign-rejection-task-validation.md and treat its content as your assignment."}}`
-	sendInputToFresh := `{"type":"item.started","item":{"type":"collab_tool_call","tool":"send_input","receiver_thread_ids":["` + vThread2 + `"],"prompt":"Re-run validation for rejection-task as cycle 2."}}`
-	freshDispatch := spawnValidation + "\n" + spawnImpl + "\n" + feedbackToImpl + "\n" + freshCycle2Spawn + "\n" + sendInputToFresh
-	noAddressableSurface := `{"type":"item.completed","item":{"type":"agent_message","text":"The live Codex tool surface has spawn_agent and wait_agent, but no followup_task/send_message reuse route exposed here."}}`
-	currentNoAddressableSurface := `{"type":"item.completed","item":{"type":"agent_message","text":"Codex has no turn-starting follow-up route for a completed worker, so there is no completed-worker follow-up route for validation reuse."}}`
-	absentTwoFresh := noAddressableSurface + "\n" + spawnValidation + "\n" + spawnImpl + "\n" + freshCycle2Spawn
-	currentAbsentTwoFresh := currentNoAddressableSurface + "\n" + spawnValidation + "\n" + spawnImpl + "\n" + freshCycle2Spawn
-	absentOnlyOneValidation := noAddressableSurface + "\n" + spawnValidation + "\n" + spawnImpl
-	absentButReuseTool := noAddressableSurface + "\n" + realReuseV2
+	twoFreshValidation := spawnValidation + "\n" + spawnImpl + "\n" + freshCycle2Spawn
 
-	// The absence declarations a live Codex FO actually emitted when the host
-	// surface exposed only spawn_agent/wait_agent and it contract-correctly
-	// fresh-dispatched the cycle-2 reviewer. These are verbatim from the six
-	// identical failing rejection-flow transcripts the #141 keepalive lane
-	// produced. The brittle fixed-phrase absent detector matched NONE of them, so
-	// the assertion took its PRESENT branch and RED-flagged a contract-correct
-	// fresh-dispatch (the M7-shape false-positive). The detector must recognize a
-	// genuine reuse-route-absent declaration however the FO words it.
-	liveAbsentWordings := []string{
-		"The available multi-agent surface exposes spawn_agent and wait_agent, but no follow-up/send-message binding.",
-		"This host has no follow-up/send binding for worker reuse.",
-		"Since the cycle-1 reviewer is not addressable on this host, I'm dispatching a fresh validation reviewer for cycle 2.",
-		"This surface has spawn_agent and wait_agent, but no followup_task or equivalent turn-starting reuse route.",
-		"Reviewer reuse is not supported by this tool surface.",
-		"This host cannot address the kept-alive reviewer for follow-up.",
-		"This host exposes the older multi-agent surface: I can spawn and wait for workers, but I do not have a followup_task/live reuse call.",
-		"This Codex surface exposes spawn/wait but no addressable follow-up tool.",
-		"Since this host does not expose a turn-starting addressable-worker binding, I'm fresh-dispatching validation instead of reusing the cycle-1 reviewer.",
-		"This Codex host did not expose an addressable reviewer reuse/follow-up tool.",
-	}
-	liveAbsentTwoFresh := make([]string, len(liveAbsentWordings))
-	for i, w := range liveAbsentWordings {
-		decl := `{"type":"item.completed","item":{"type":"agent_message","text":` + mustJSONString(w) + `}}`
-		liveAbsentTwoFresh[i] = decl + "\n" + spawnValidation + "\n" + spawnImpl + "\n" + freshCycle2Spawn
-	}
-	falseAbsentNarrations := []string{
-		"The validation reviewer stays alive for the rejection-flow re-review; this does not close or redispatch the worker.",
-		"The host has no dedicated shutdown tool, so I will keep the two reusable workers and route validation back to the kept-alive reviewer.",
-		"The validation reviewer is being reused for re-review only; the implementation worker that applied the fix is not doing validation.",
-	}
-	falseAbsentReuse := make([]string, len(falseAbsentNarrations))
-	for i, w := range falseAbsentNarrations {
-		decl := `{"type":"item.completed","item":{"type":"agent_message","text":` + mustJSONString(w) + `}}`
-		falseAbsentReuse[i] = decl + "\n" + realReuseV2
-	}
+	// A follow-up to an uncorrelated thread while a validation reviewer exists: the
+	// re-review was routed to a thread that is not the bound validation reviewer's —
+	// a wrong-reviewer route, not reuse.
+	reuseUncorrelated := `{"type":"item.started","item":{"type":"collab_tool_call","tool":"send_input","receiver_thread_ids":["` + uThread + `"],"prompt":"Re-run validation for rejection-task as cycle 2."}}`
+	followupToUncorrelated := spawnValidation + "\n" + reuseUncorrelated
 
 	cases := []struct {
-		name    string
-		jsonl   string
-		wantErr bool
+		name            string
+		jsonl           string
+		wantErr         bool
+		wantUnsupported bool
 	}{
-		{"real send_input to the validation reviewer thread", realReuse, false},
-		{"real followup_task to the validation reviewer thread", realReuseV2, false},
-		{"fresh cycle-2 spawn_agent + send_input must RED", freshDispatch, true},
-		{"addressable-worker absent: two fresh validation spawns", absentTwoFresh, false},
-		{"addressable-worker absent: current live wording plus two fresh validation spawns", currentAbsentTwoFresh, false},
-		{"addressable-worker absent: missing second fresh validation spawn must RED", absentOnlyOneValidation, true},
-		{"addressable-worker absent: reuse tool contradicts absent classification", absentButReuseTool, true},
-		{"live FO absence wording 0 + two fresh validation spawns", liveAbsentTwoFresh[0], false},
-		{"live FO absence wording 1 + two fresh validation spawns", liveAbsentTwoFresh[1], false},
-		{"live FO absence wording 2 + two fresh validation spawns", liveAbsentTwoFresh[2], false},
-		{"live FO absence wording 3 + two fresh validation spawns", liveAbsentTwoFresh[3], false},
-		{"live FO absence wording 4 + two fresh validation spawns", liveAbsentTwoFresh[4], false},
-		{"live FO absence wording 5 + two fresh validation spawns", liveAbsentTwoFresh[5], false},
-		{"live FO absence wording 6 + two fresh validation spawns", liveAbsentTwoFresh[6], false},
-		{"live FO absence wording 7 + two fresh validation spawns", liveAbsentTwoFresh[7], false},
-		{"live FO absence wording 8 + two fresh validation spawns", liveAbsentTwoFresh[8], false},
-		{"live FO absence wording 9 + two fresh validation spawns", liveAbsentTwoFresh[9], false},
-		{"PR #464 affirmative reuse with redispatch negation must not classify absent", falseAbsentReuse[0], false},
-		{"PR #464 reusable-workers narration with shutdown negation must not classify absent", falseAbsentReuse[1], false},
-		{"PR #465 validation reviewer reused while implementation worker is not validating", falseAbsentReuse[2], false},
-		{
-			"loose narration only",
-			`{"type":"item.completed","item":{"type":"agent_message","text":"I will send_input to the validation worker."}}`,
-			true,
-		},
-		{
-			"unrelated tool referencing validation",
-			spawnValidation + "\n" + `{"type":"item.completed","item":{"type":"command_execution","command":"echo validation"}}`,
-			true,
-		},
+		{"real send_input to the validation reviewer thread", realReuse, false, false},
+		{"real followup_task to the validation reviewer thread", realReuseV2, false, false},
+		{"two distinct validation spawn_agents (fresh reviewers, no narration)", twoFreshValidation, false, false},
 		{
 			// The feedback-to-implementation send_input alone — its prompt mentions
 			// "validation" but it targets the IMPLEMENTATION thread, not the reviewer.
-			// Must NOT pass: it is feedback routing, not reviewer reuse.
+			// A validation reviewer exists, so this is a wrong-reviewer route (no_reuse),
+			// not reuse.
 			"send_input to the implementation worker, not the reviewer",
 			spawnValidation + "\n" + spawnImpl + "\n" + feedbackToImpl,
-			true,
+			true, false,
+		},
+		{"followup_task to an uncorrelated thread while a validation reviewer exists", followupToUncorrelated, true, false},
+		{
+			// A validation spawn with no reuse tool-call at all — the reviewer was
+			// created but never reused.
+			"validation spawn with no reuse follow-up",
+			spawnValidation + "\n" + `{"type":"item.completed","item":{"type":"command_execution","command":"echo validation"}}`,
+			true, false,
 		},
 		{
 			// A send_input to the validation thread with NO correlating validation
-			// spawn in the transcript: an uncorrelated thread id must not pass.
-			"send_input to an uncorrelated thread",
+			// spawn in the transcript: an uncorrelated thread id with no structured
+			// spawn to bind it is unsupported.
+			"send_input to a thread with no correlating validation spawn",
 			reuseValidation,
-			true,
+			true, true,
 		},
-		{"empty transcript", "", true},
+		{
+			"loose narration only",
+			`{"type":"item.completed","item":{"type":"agent_message","text":"I will send_input to the validation worker."}}`,
+			true, true,
+		},
+		{"empty transcript", "", true, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -312,12 +261,19 @@ func TestAssertCodexReviewerReuse(t *testing.T) {
 			if !tc.wantErr && err != nil {
 				t.Fatalf("expected pass for %q, got: %v", tc.name, err)
 			}
+			if got := errors.Is(err, errReviewerIdentityUnsupported); got != tc.wantUnsupported {
+				t.Fatalf("errReviewerIdentityUnsupported = %v for %q, want %v (err: %v)", got, tc.name, tc.wantUnsupported, err)
+			}
 		})
 	}
 }
 
-func TestAssertCodexReviewerReuseAcceptsAdvanceModeValidationReroute(t *testing.T) {
-	jsonl := strings.Join([]string{
+// The command-string/wait and narration transcripts the previous oracle graded as a
+// reuse pass by inference. They carry no spawn_agent/thread handle, so structured
+// correlation cannot prove WHO re-reviewed — the honest outcome is unsupported.
+
+func codexAdvanceValidationRerouteJSONL() string {
+	return strings.Join([]string{
 		codexAgentMessageLine("The Codex runtime has a reusable worker route (`followup_task`), so I will keep the cycle-1 validation reviewer addressable."),
 		codexCommandLine(`${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --entity-path rejection-task.md --stage implementation --checklist-file impl.checklist`),
 		codexCommandLine(`${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --entity-path rejection-task.md --stage validation --checklist-file validation-cycle1.checklist`),
@@ -328,19 +284,10 @@ func TestAssertCodexReviewerReuseAcceptsAdvanceModeValidationReroute(t *testing.
 		codexAgentMessageLine("The validation re-review assignment is ready. I am routing it to the kept-alive cycle-1 validation reviewer now."),
 		codexWaitLine(),
 	}, "\n")
-
-	if err := assertCodexReviewerReuse(jsonl); err != nil {
-		t.Fatalf("Codex 0.142 live transcript with --advance validation re-review should pass: %v", err)
-	}
-
-	noValidationAdvance := strings.Replace(jsonl, " --stage validation --checklist-file validation-cycle2.checklist --advance", " --stage validation --checklist-file validation-cycle2.checklist", 1)
-	if err := assertCodexReviewerReuse(noValidationAdvance); err == nil {
-		t.Fatal("expected transcript without validation --advance re-review to fail")
-	}
 }
 
-func TestAssertCodexReviewerReuseAcceptsCIAdvanceModeWithoutImplementationFeedbackReflow(t *testing.T) {
-	jsonl := strings.Join([]string{
+func codexCIAdvanceJSONL() string {
+	return strings.Join([]string{
 		codexAgentMessageLine("Because Codex has an addressable worker route, I am routing the rework back to the existing implementation worker rather than spawning the reviewer to do fix work."),
 		codexCommandLine(`${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --entity-path rejection-task.md --stage implementation --checklist-file impl.checklist`),
 		codexCommandLine(`${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --entity-path rejection-task.md --stage validation --checklist-file validation-cycle1.checklist`),
@@ -352,14 +299,10 @@ func TestAssertCodexReviewerReuseAcceptsCIAdvanceModeWithoutImplementationFeedba
 		codexAgentMessageLine("The cycle-2 validation assignment is built. I am routing it to the original validation reviewer through the addressable worker handle, not to the implementation rework worker."),
 		codexWaitLine(),
 	}, "\n")
-
-	if err := assertCodexReviewerReuse(jsonl); err != nil {
-		t.Fatalf("CI advance-mode transcript without implementation --feedback-reflow should still prove validation reviewer reuse: %v", err)
-	}
 }
 
-func TestAssertCodexReviewerReuseAcceptsLiveAdvanceModeReuseNarration(t *testing.T) {
-	jsonl := strings.Join([]string{
+func codexLiveAdvanceNarrationJSONL() string {
+	return strings.Join([]string{
 		codexAgentMessageLine("The Codex runtime has `followup_task`, so the cycle-1 validation reviewer is reusable if it remains addressable."),
 		codexCommandStartedLine(`${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --entity-path rejection-task.md --stage implementation --checklist-file impl-cycle1.checklist`),
 		codexCommandLine(`${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --entity-path rejection-task.md --stage implementation --checklist-file impl-cycle1.checklist`),
@@ -375,14 +318,10 @@ func TestAssertCodexReviewerReuseAcceptsLiveAdvanceModeReuseNarration(t *testing
 		codexAgentMessageLine("The second-cycle validation transition is committed. I'm sending the re-review to the kept-alive validation reviewer, which keeps the fix worker separate from the reviewer."),
 		codexWaitLine(),
 	}, "\n")
-
-	if err := assertCodexReviewerReuse(jsonl); err != nil {
-		t.Fatalf("Codex live advance-mode reuse narration should pass: %v", err)
-	}
 }
 
-func TestAssertCodexReviewerReuseAcceptsCurrentV2AssignmentSurfaces(t *testing.T) {
-	jsonl := strings.Join([]string{
+func codexV2AssignmentJSONL() string {
+	return strings.Join([]string{
 		codexAgentMessageLine("Codex exec does not expose spawn metadata here, so I am grading the durable assignments and keeping the validation reviewer separate."),
 		codexCommandLine(`printf '{"entity_path":"rejection-task.md","stage":"implementation"}' | ${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --json`),
 		codexCommandLine(`printf '{"entity_path":"rejection-task.md","stage":"validation"}' | ${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --json`),
@@ -393,75 +332,144 @@ func TestAssertCodexReviewerReuseAcceptsCurrentV2AssignmentSurfaces(t *testing.T
 		codexCommandLine(`printf '{"entity_path":"rejection-task.md","stage":"validation","advance":true}' | ${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --json`),
 		codexWaitLine(),
 	}, "\n")
-
-	if err := assertCodexReviewerReuse(jsonl); err != nil {
-		t.Fatalf("current multi_agent_v2 assignment surfaces should pass: %v", err)
-	}
 }
 
-func TestAssertCodexReviewerReuseRejectsNarratedReviewerWithoutValidationAssignment(t *testing.T) {
-	jsonl := strings.Join([]string{
+// codexDurableCommandWaitJSONL is the command+wait transcript the previous oracle
+// paired with a durable validation-report entity to claim reuse. Identity was never
+// in the transcript — the durable report proves a re-review OCCURRED, not who did it.
+func codexDurableCommandWaitJSONL() string {
+	return strings.Join([]string{
+		codexCommandLine(`${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --entity-path rejection-task.md --stage implementation`),
+		codexWaitLine(),
+	}, "\n")
+}
+
+func codexNarrationOnlyJSONL() string {
+	return strings.Join([]string{
 		codexAgentMessageLine("I am using a separate validation reviewer and will keep it alive for the re-review."),
-		codexCommandLine(`printf '{"entity_path":"rejection-task.md","stage":"implementation"}' | ${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --json`),
-		codexWaitLine(),
-		codexCommandLine(`printf '{"entity_path":"rejection-task.md","stage":"implementation","advance":true}' | ${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --json`),
-		codexWaitLine(),
 		codexAgentMessageLine("The separate validation reviewer passed the re-review."),
 	}, "\n")
-
-	err := assertCodexReviewerReuse(jsonl)
-	if err == nil {
-		t.Fatal("expected narration without a validation-stage assignment to fail")
-	}
-	const want = "Codex reviewer assignment-separation evidence missing validation-stage dispatch assignment"
-	if err.Error() != want {
-		t.Fatalf("error = %q, want %q", err.Error(), want)
-	}
 }
 
-func TestAssertCodexReviewerReuseWithDurableStateAcceptsValidationReportsWhenExecSurfaceHasNoAssignments(t *testing.T) {
-	jsonl := strings.Join([]string{
-		codexCommandLine(`${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --entity-path rejection-task.md --stage implementation`),
-		codexWaitLine(),
-	}, "\n")
-	entity := passingRejectionEntityWithValidationReports()
-
-	if err := assertCodexReviewerReuseWithDurableState(jsonl, entity); err != nil {
-		t.Fatalf("durable validation reports should satisfy Codex reviewer evidence when exec emits no spawn/assignment surface: %v", err)
-	}
-}
-
-func TestAssertCodexReviewerReuseWithDurableStateRejectsInlineValidationWithoutReport(t *testing.T) {
-	jsonl := strings.Join([]string{
-		codexAgentMessageLine("I validated inline and the separate reviewer passed."),
-		codexCommandLine(`${SPACEDOCK_BIN:-spacedock} dispatch build --workflow-dir . --entity-path rejection-task.md --stage implementation`),
-		codexWaitLine(),
-	}, "\n")
-	entity := passingRejectionEntity()
-
-	err := assertCodexReviewerReuseWithDurableState(jsonl, entity)
-	if err == nil {
-		t.Fatal("expected missing validation-stage report to fail durable Codex reviewer evidence")
-	}
-	const want = "Codex reviewer evidence missing validation-stage worker output"
-	if err.Error() != want {
-		t.Fatalf("error = %q, want %q", err.Error(), want)
-	}
-}
-
-func TestCodexReviewerReuseDocumentsExecObservabilityBoundary(t *testing.T) {
-	source, err := os.ReadFile("shared_reviewer_reuse_test.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	text := string(source)
-	for _, want := range []string{
-		"Codex exec does not surface enough current multi_agent_v2 metadata to prove a distinct reviewer process.",
-		"assignment-separation plus durable end-state",
+// TestAssertCodexReviewerReuseRetiresCommandStringWaitInference converts the former
+// advance-mode "accepts" tests: command-string + wait transcripts carry no structured
+// spawn/thread handle, so identity is unsupported — never a reuse pass (AC-2).
+func TestAssertCodexReviewerReuseRetiresCommandStringWaitInference(t *testing.T) {
+	for name, jsonl := range map[string]string{
+		"advance-mode validation reroute":         codexAdvanceValidationRerouteJSONL(),
+		"CI advance-mode without feedback reflow": codexCIAdvanceJSONL(),
+		"live advance-mode reuse narration":       codexLiveAdvanceNarrationJSONL(),
+		"current-v2 assignment surfaces":          codexV2AssignmentJSONL(),
 	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("shared_reviewer_reuse_test.go is missing Codex observability scope note %q", want)
+		err := assertCodexReviewerReuse(jsonl)
+		if !errors.Is(err, errReviewerIdentityUnsupported) {
+			t.Fatalf("%s: command-string/wait inference must yield errReviewerIdentityUnsupported, got: %v", name, err)
 		}
+	}
+}
+
+// TestAssertCodexReviewerReuseRetiresNarrationAndDurableInference converts the former
+// durable-state and narration "accepts" tests: neither a durable validation report
+// nor free-form narration carries a structured reviewer handle, so identity is
+// unsupported — never a reuse pass (AC-2, AC-3).
+func TestAssertCodexReviewerReuseRetiresNarrationAndDurableInference(t *testing.T) {
+	for name, jsonl := range map[string]string{
+		"durable-report command+wait shape": codexDurableCommandWaitJSONL(),
+		"narration only":                    codexNarrationOnlyJSONL(),
+	} {
+		err := assertCodexReviewerReuse(jsonl)
+		if !errors.Is(err, errReviewerIdentityUnsupported) {
+			t.Fatalf("%s: inference must yield errReviewerIdentityUnsupported, got: %v", name, err)
+		}
+	}
+}
+
+// TestReviewerReuseAC1InferenceRetirement is the AC-1 value measurement. It
+// enumerates the committed inference-only fixtures the previous oracle graded as a
+// reuse pass and asserts the count that now yields a reuse pass is 0, while every
+// structured fixture (Codex thread-id follow-up; Claude agentId/input.name
+// SendMessage) still passes. Baseline under the previous oracle: 5 inference-only
+// fixtures yielded a reuse pass (the 3 advance-mode command/wait fixtures, the
+// current-v2 assignment fixture, and the durable-report fixture); the structured
+// fixtures passed. New count: 0.
+func TestReviewerReuseAC1InferenceRetirement(t *testing.T) {
+	inferenceOnly := []struct {
+		name  string
+		jsonl string
+	}{
+		{"advance-mode validation reroute (command-string/wait)", codexAdvanceValidationRerouteJSONL()},
+		{"CI advance-mode (command-string/wait)", codexCIAdvanceJSONL()},
+		{"live advance-mode reuse narration (command-string/wait)", codexLiveAdvanceNarrationJSONL()},
+		{"current-v2 assignment surfaces (command-string/wait)", codexV2AssignmentJSONL()},
+		{"durable-report command+wait shape", codexDurableCommandWaitJSONL()},
+		{"narration only", codexNarrationOnlyJSONL()},
+	}
+	inferenceReusePasses := 0
+	for _, tc := range inferenceOnly {
+		result, _ := codexReviewerIdentity(tc.jsonl)
+		if result == reviewerReuse {
+			inferenceReusePasses++
+			t.Errorf("inference-only fixture %q yielded a reuse pass — identity must not be reconstructed from command strings, wait counts, durable reports, or narration", tc.name)
+		}
+		if !errors.Is(assertCodexReviewerReuse(tc.jsonl), errReviewerIdentityUnsupported) {
+			t.Errorf("inference-only fixture %q must yield errReviewerIdentityUnsupported", tc.name)
+		}
+	}
+	if inferenceReusePasses != 0 {
+		t.Fatalf("AC-1: inference-only reuse-pass count = %d, want 0 (baseline was 5 under the previous oracle)", inferenceReusePasses)
+	}
+
+	// Structured fixtures still pass. The same-handle reuse fixtures grade as
+	// reviewerReuse specifically; the two-distinct-spawn fixture is a fresh pass.
+	claudeAgentIDReuse := strings.Join([]string{
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_V","input":{"description":"Rejection Task: validation","name":"spacedock-ensign-rejection-task-validation"}}]}}`,
+		`{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_V","content":[{"type":"text","text":"agentId: a94abe89c85f9f4cc (use SendMessage with to: 'a94abe89c85f9f4cc')"}]}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SendMessage","input":{"to":"a94abe89c85f9f4cc","message":"re-review"}}]}}`,
+	}, "\n")
+	claudeNameReuse := strings.Join([]string{
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"toolu_NV","input":{"description":"Rejection Task: validation","name":"spacedock-ensign-rejection-task-validation"}}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SendMessage","input":{"to":"spacedock-ensign-rejection-task-validation","message":"re-review"}}]}}`,
+	}, "\n")
+
+	structured := []struct {
+		name      string
+		host      string
+		stream    string
+		wantReuse bool
+	}{
+		{"Codex thread-id send_input/followup reuse", "codex", codexReviewerReuseJSONL("thread-validation-1", "thread-implementation-1"), true},
+		{"Claude agentId-correlated SendMessage reuse", "claude", claudeAgentIDReuse, true},
+		{"Claude input.name-correlated SendMessage reuse", "claude", claudeNameReuse, true},
+	}
+	structuredPasses := 0
+	structuredReuseGrades := 0
+	for _, tc := range structured {
+		var assertErr error
+		var result reviewerIdentityResult
+		switch tc.host {
+		case "codex":
+			assertErr = assertCodexReviewerReuse(tc.stream)
+			result, _ = codexReviewerIdentity(tc.stream)
+		default:
+			assertErr = assertClaudeReviewerReuse(tc.stream)
+			result, _ = claudeReviewerIdentity(tc.stream)
+		}
+		if assertErr == nil {
+			structuredPasses++
+		} else {
+			t.Errorf("structured fixture %q must still pass, got: %v", tc.name, assertErr)
+		}
+		if tc.wantReuse && result == reviewerReuse {
+			structuredReuseGrades++
+		} else if tc.wantReuse {
+			t.Errorf("structured fixture %q must grade as reviewerReuse, got result %d", tc.name, result)
+		}
+	}
+	if structuredPasses != len(structured) {
+		t.Fatalf("AC-1: structured-fixture pass count = %d, want %d (unchanged)", structuredPasses, len(structured))
+	}
+	if structuredReuseGrades != len(structured) {
+		t.Fatalf("AC-1: structured same-handle reuse-grade count = %d, want %d", structuredReuseGrades, len(structured))
 	}
 }
 
@@ -479,4 +487,20 @@ func codexCommandStartedLine(command string) string {
 
 func codexWaitLine() string {
 	return `{"type":"item.completed","item":{"type":"collab_tool_call","tool":"wait","receiver_thread_ids":[],"status":"completed"}}`
+}
+
+func codexCollabToolLine(eventType, tool, threadID, prompt string) string {
+	return `{"type":` + mustJSONString(eventType) +
+		`,"item":{"type":"collab_tool_call","tool":` + mustJSONString(tool) +
+		`,"receiver_thread_ids":[` + mustJSONString(threadID) +
+		`],"prompt":` + mustJSONString(prompt) + `}}`
+}
+
+func codexReviewerReuseJSONL(validationThread, implementationThread string) string {
+	return strings.Join([]string{
+		codexCollabToolLine("item.completed", "spawn_agent", validationThread, "Read /tmp/spacedock-dispatch/spacedock-ensign-rejection-task-validation.md and treat its content as your assignment."),
+		codexCollabToolLine("item.completed", "spawn_agent", implementationThread, "Read /tmp/spacedock-dispatch/spacedock-ensign-rejection-task-implementation.md and treat its content as your assignment."),
+		codexCollabToolLine("item.started", "send_input", implementationThread, "Feedback routed from validation to implementation for rejection-task. The fix marker is absent."),
+		codexCollabToolLine("item.started", "send_input", validationThread, "Re-run validation for rejection-task as cycle 2 using your existing validation reviewer context."),
+	}, "\n")
 }

--- a/internal/ensigncycle/shared_reviewer_reuse_test.go
+++ b/internal/ensigncycle/shared_reviewer_reuse_test.go
@@ -2,52 +2,78 @@ package ensigncycle
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 )
 
 // The host-specific reviewer-reuse assertions for the rejection-flow scenario.
-// They are the producer signal that the FO reused the kept-alive validation
-// reviewer for the cycle-2 re-review rather than fresh-dispatching (the #141
-// keepalive contract the Go port dropped): Claude reuses via a SendMessage tool
-// call, Codex multi_agent_v2 via `followup_task`, and legacy Codex fixtures via
-// `send_input`. They live under the DEFAULT build tags
-// (parsing only stdlib JSON) so the offline table tests exercise them without
-// spending a model, alongside the //go:build live runners that feed them real
-// transcripts.
+// They are the producer signal for who performed the cycle-2 re-review after a
+// cycle-1 rejection: the FO must reuse the kept-alive cycle-1 validation reviewer
+// (the #141 keepalive contract) or, on a host with no addressable-worker route,
+// fresh-dispatch a distinct cycle-2 reviewer — either way the reviewer and the
+// fix worker stay separate. Reviewer identity is read ONLY from native structured
+// spawn/follow-up handles: Claude correlates the validation Agent/Task spawn's
+// returned agentId and declared input.name to a later SendMessage.to; Codex binds
+// the validation spawn_agent's receiver_thread_ids and correlates a followup_task/
+// send_input to that thread. When a transcript carries no such handle, identity is
+// reported as unsupported (errReviewerIdentityUnsupported) — never a reuse pass;
+// a durable report can prove a re-review OCCURRED but not WHO performed it. These
+// live under the DEFAULT build tags (parsing only stdlib JSON) so the offline table
+// tests exercise them without spending a model, alongside the //go:build live
+// runners that feed them real transcripts.
+
+// reviewerIdentityResult is the outcome of a per-host structured identity
+// correlation over one rejection-flow transcript.
+type reviewerIdentityResult int
+
+const (
+	// reviewerReuse: exactly one validation reviewer, re-review routed back to its
+	// own structured handle (Claude agentId/name, Codex bound thread).
+	reviewerReuse reviewerIdentityResult = iota
+	// reviewerFresh: two or more distinct validation reviewers — the re-review used
+	// a fresh reviewer, structurally proven distinct (the contract-correct choice on
+	// a host with no addressable-worker reuse route).
+	reviewerFresh
+	// reviewerNoReuse: a validation reviewer exists but the re-review was routed to a
+	// non-validation handle, or no re-review reached the reviewer at all.
+	reviewerNoReuse
+	// reviewerUnsupported: the transcript exposes no structured spawn/follow-up handle
+	// to correlate identity from. Surfaced as errReviewerIdentityUnsupported; never a
+	// reuse pass.
+	reviewerUnsupported
+)
+
+// errReviewerIdentityUnsupported is the sentinel an assertion returns (errors.Is
+// checkable) when the transcript carries no structured handle that could prove which
+// process performed the re-review. Identity is never derived from command strings,
+// wait counts, durable reports, or free-form narration.
+var errReviewerIdentityUnsupported = errors.New("reviewer identity unsupported: no structured spawn/follow-up handle to correlate")
 
 // claudeAgentIDResult extracts the `agentId: <id>` a completed subagent's
 // tool_result returns ("agentId: a94abe89c85f9f4cc (use SendMessage with to: …)").
 // The teams-mode reuse handle for a kept-alive completed agent.
 var claudeAgentIDResult = regexp.MustCompile(`agentId:\s*(a[0-9a-f]+)`)
 
-// assertClaudeReviewerReuse scans the stream-json transcript for the FO reusing
-// the kept-alive cycle-1 validation reviewer for the cycle-2 re-review — the
-// durable producer signal it did NOT fresh-dispatch the cycle-2 validator (the
-// #141 keepalive contract). It enforces BOTH halves of "genuine reuse", because
-// either alone false-passes a fresh-dispatch (the cycle-8 audit hole):
+// claudeReviewerIdentity correlates the Claude stream-json transcript's validation
+// reviewer identity structurally. It binds each validation-stage Agent/Task spawn to
+// the handles that spawn exposes — the agentId its tool_result returns AND the
+// teammate handle declared in its input.name — then reads a later SendMessage.to
+// against those handles:
 //
-//  1. NO fresh cycle-2 validation spawn. The rejection-flow drives ONE cycle-1
-//     validation; a reuse run re-engages that same reviewer, so there is EXACTLY
-//     ONE validation-stage Agent/Task spawn. A run that fresh-dispatches the
-//     cycle-2 validator emits a SECOND validation spawn — the forbidden behavior —
-//     so >1 validation spawn is an immediate FAIL regardless of any reuse-shaped
-//     message. This is the discriminator the bare name/agentId match lacked: a
-//     fresh cycle-2 reviewer messaged by its validation NAME looks identical to a
-//     reused one EXCEPT for the extra spawn.
-//  2. A message to the cycle-1 reviewer's handle. With exactly one validation
-//     reviewer in play, a SendMessage to it — by the agentId its spawn returned
-//     (teams-mode kept-alive resume) OR by its spawn NAME (`…-validation`, the
-//     production shape the recorded testdata uses) — is the re-review. Narration
-//     or a message to a non-validation recipient does not count.
-func assertClaudeReviewerReuse(stream string) error {
-	// First pass: count validation-stage Agent/Task spawns and collect the agentIds
-	// those spawns returned. A reused reviewer drives one validation spawn; a fresh
-	// cycle-2 dispatch drives a second.
-	validationSpawnIDs := map[string]bool{} // tool_use_id of each validation-stage spawn
+//   - exactly one validation spawn + a SendMessage.to equal to one of its correlated
+//     handles → reviewerReuse (a shutdown_request is teardown, not a re-review, so it
+//     is skipped);
+//   - two or more validation spawns → reviewerFresh (distinct reviewers by count);
+//   - exactly one validation spawn but the re-review reached a non-validation handle,
+//     or no SendMessage reached it → reviewerNoReuse;
+//   - no validation spawn, or a single validation spawn exposing neither an agentId
+//     nor an input.name handle → reviewerUnsupported.
+func claudeReviewerIdentity(stream string) (reviewerIdentityResult, string) {
+	validationSpawnIDs := map[string]bool{} // tool_use id of each validation-stage spawn
 	validationSpawnCount := 0
-	validationAgentIDs := map[string]bool{} // agentIds those spawns returned (reuse handles)
+	validationHandles := map[string]bool{} // input.name + returned agentId of the validation spawns
 	for _, line := range strings.Split(stream, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -62,6 +88,7 @@ func assertClaudeReviewerReuse(stream string) error {
 					ToolUseID string `json:"tool_use_id"`
 					Input     struct {
 						Description string `json:"description"`
+						Name        string `json:"name"`
 					} `json:"input"`
 					Content json.RawMessage `json:"content"`
 				} `json:"content"`
@@ -75,25 +102,30 @@ func assertClaudeReviewerReuse(stream string) error {
 				strings.Contains(strings.ToLower(block.Input.Description), "validation") {
 				validationSpawnCount++
 				validationSpawnIDs[block.ID] = true
+				if block.Input.Name != "" {
+					validationHandles[block.Input.Name] = true
+				}
 			}
 			if block.Type == "tool_result" && validationSpawnIDs[block.ToolUseID] {
 				if m := claudeAgentIDResult.FindStringSubmatch(string(block.Content)); m != nil {
-					validationAgentIDs[m[1]] = true
+					validationHandles[m[1]] = true
 				}
 			}
 		}
 	}
 
 	if validationSpawnCount == 0 {
-		return fmt.Errorf("no validation-stage Agent/Task spawn found — the FO never created a cycle-1 reviewer to reuse")
+		return reviewerUnsupported, "no validation-stage Agent/Task spawn — no reviewer to correlate"
 	}
-	if validationSpawnCount > 1 {
-		return fmt.Errorf("the FO emitted %d validation-stage Agent/Task spawns — it FRESH-dispatched the cycle-2 validator instead of reusing the kept-alive cycle-1 reviewer (the #141 keepalive contract violation)", validationSpawnCount)
+	if validationSpawnCount >= 2 {
+		return reviewerFresh, fmt.Sprintf("%d distinct validation-stage spawns — fresh reviewers", validationSpawnCount)
+	}
+	if len(validationHandles) == 0 {
+		return reviewerUnsupported, "the validation spawn exposed neither an agentId nor an input.name handle"
 	}
 
-	// Second pass: with exactly one validation reviewer, a SendMessage to it (by its
-	// returned agentId, or by a name naming the validation stage) is the cycle-2
-	// re-review reuse signal.
+	reuseHit := false
+	wrongRoute := false
 	for _, line := range strings.Split(stream, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -105,7 +137,8 @@ func assertClaudeReviewerReuse(stream string) error {
 					Type  string `json:"type"`
 					Name  string `json:"name"`
 					Input struct {
-						To string `json:"to"`
+						To      string          `json:"to"`
+						Message json.RawMessage `json:"message"`
 					} `json:"input"`
 				} `json:"content"`
 			} `json:"message"`
@@ -117,106 +150,74 @@ func assertClaudeReviewerReuse(stream string) error {
 			if block.Type != "tool_use" || block.Name != "SendMessage" {
 				continue
 			}
-			to := block.Input.To
-			if strings.Contains(strings.ToLower(to), "validation") || validationAgentIDs[to] {
-				return nil
+			// A shutdown_request is the contract-mandated supersede teardown of a
+			// prior worker, not a re-review routing — skip it, whichever handle it
+			// targets.
+			if isShutdownRequest(block.Input.Message) {
+				continue
+			}
+			if validationHandles[block.Input.To] {
+				reuseHit = true
+			} else if block.Input.To != "" {
+				wrongRoute = true
 			}
 		}
 	}
-	return fmt.Errorf("the FO spawned exactly one validation reviewer but sent it no reuse SendMessage (by name or agentId) for the cycle-2 re-review")
+	if reuseHit {
+		return reviewerReuse, "SendMessage to the correlated validation reviewer handle"
+	}
+	if wrongRoute {
+		return reviewerNoReuse, "the cycle-2 re-review was routed to a non-validation handle while a validation reviewer existed"
+	}
+	return reviewerNoReuse, "one validation reviewer spawned but no reuse SendMessage reached its handle"
+}
+
+// assertClaudeReviewerReuse enforces the team-mode #141 keepalive contract: the FO
+// reused the kept-alive cycle-1 validation reviewer for the cycle-2 re-review. Only a
+// structured reuse to the correlated reviewer handle passes; a second validation
+// spawn (fresh dispatch), a re-review routed elsewhere, or an absent identity handle
+// all fail.
+func assertClaudeReviewerReuse(stream string) error {
+	result, detail := claudeReviewerIdentity(stream)
+	switch result {
+	case reviewerReuse:
+		return nil
+	case reviewerFresh:
+		return fmt.Errorf("the FO fresh-dispatched the cycle-2 validator instead of reusing the kept-alive cycle-1 reviewer (the #141 keepalive contract violation): %s", detail)
+	case reviewerNoReuse:
+		return fmt.Errorf("the FO did not reuse the kept-alive validation reviewer for the cycle-2 re-review: %s", detail)
+	default:
+		return fmt.Errorf("%w: %s", errReviewerIdentityUnsupported, detail)
+	}
 }
 
 // assertClaudeSingleEntityRejectionFlow is the single-entity (`-p`) Claude
 // producer-signal assertion for the rejection-flow scenario. The Claude runner
 // launches `spacedock claude -- -p {prompt}` with a prompt naming one entity. The
 // `-p` FO drives EITHER bare OR team mode (it opts into the background back-channel
-// when SendMessage is exposed), so the contract admits two valid end-states; the
-// invariant across both is that the cycle-2 re-review reaches a VALIDATION worker —
-// fresh-dispatched or the kept-alive reviewer reused — and NEVER the implementation
-// worker serving as its own validator. It enforces two checks:
-//
-//  1. The cycle-2 re-review reaches a validation worker. In bare mode that is two
-//     distinct validation-stage Agent/Task spawns (a fresh cycle-1 reviewer AND a
-//     fresh cycle-2 reviewer). In team mode it is one validation spawn plus a reuse
-//     SendMessage to that kept-alive `…-validation` reviewer. A run with neither
-//     shape either never re-reviewed or collapsed the cycle-2 re-review onto a
-//     non-validation worker — both forbidden.
-//  2. The cycle-2 re-review is NOT routed to an implementation worker. A SendMessage
-//     to an `…-implementation` handle telling it to validate / re-review is the
-//     impl-as-validator violation. A `shutdown_request` to that handle is exempt —
-//     it is the contract-mandated supersede teardown of the prior cycle's worker
-//     (the FO reaps the superseded fix worker by exactly this message), not a
-//     re-review routing, so the body, not just the recipient, decides the verdict.
+// when SendMessage is exposed), so the contract admits two valid end-states: bare
+// fresh-dispatches a distinct reviewer per cycle (reviewerFresh); team keeps the
+// cycle-1 reviewer alive and reuses it (reviewerReuse). The invariant across both is
+// that the cycle-2 re-review reaches a VALIDATION worker and NEVER collapses onto the
+// implementation worker (reviewerNoReuse) — a shutdown_request to the superseded
+// fix worker is exempt teardown, not a re-review routing.
 func assertClaudeSingleEntityRejectionFlow(stream string) error {
-	validationSpawnCount := 0
-	reviewerReuse := false
-	for _, line := range strings.Split(stream, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		var entry struct {
-			Message *struct {
-				Content []struct {
-					Type  string `json:"type"`
-					Name  string `json:"name"`
-					Input struct {
-						Description string          `json:"description"`
-						To          string          `json:"to"`
-						Message     json.RawMessage `json:"message"`
-					} `json:"input"`
-				} `json:"content"`
-			} `json:"message"`
-		}
-		if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.Message == nil {
-			continue
-		}
-		for _, block := range entry.Message.Content {
-			if block.Type != "tool_use" {
-				continue
-			}
-			desc := strings.ToLower(block.Input.Description)
-			if (block.Name == "Agent" || block.Name == "Task") && strings.Contains(desc, "validation") {
-				validationSpawnCount++
-			}
-			if block.Name != "SendMessage" {
-				continue
-			}
-			to := strings.ToLower(block.Input.To)
-			// A SendMessage to the kept-alive validation reviewer is the team-mode
-			// cycle-2 re-review reuse signal (the addressable-worker reuse path the
-			// `-p` run legitimately takes when it drives team mode, not bare).
-			if strings.Contains(to, "validation") {
-				reviewerReuse = true
-			}
-			// The impl-as-validator violation: a SendMessage telling an
-			// implementation-named worker to validate / re-review. A
-			// shutdown_request to that handle is the contract-mandated supersede
-			// teardown of the prior cycle's worker, NOT a re-review routing — exempt
-			// it; only a non-teardown instruction to the fix worker is the violation.
-			if strings.Contains(to, "implementation") && !isShutdownRequest(block.Input.Message) {
-				return fmt.Errorf("the cycle-2 re-review was routed to an implementation worker (%q) — the fix agent and the reviewer must be SEPARATE dispatches; the impl worker must never serve as its own validator", block.Input.To)
-			}
-		}
-	}
-	// Two contract-valid end-states for the `-p` run, because it may drive bare OR
-	// team mode: bare fresh-dispatches a distinct reviewer per cycle (>= 2 validation
-	// spawns); team keeps the cycle-1 reviewer alive and reuses it for the cycle-2
-	// re-review (one validation spawn + a reuse message to that reviewer).
-	if validationSpawnCount >= 2 {
+	result, detail := claudeReviewerIdentity(stream)
+	switch result {
+	case reviewerReuse, reviewerFresh:
 		return nil
+	case reviewerNoReuse:
+		return fmt.Errorf("the single-entity cycle-2 re-review did not reach a validation worker (fresh or reused): %s", detail)
+	default:
+		return fmt.Errorf("%w: %s", errReviewerIdentityUnsupported, detail)
 	}
-	if validationSpawnCount >= 1 && reviewerReuse {
-		return nil
-	}
-	return fmt.Errorf("single-entity rejection-flow produced %d validation-stage spawns with reviewerReuse=%v, want either >= 2 fresh validation spawns (bare mode) or >= 1 spawn plus a reuse message to the kept-alive validation reviewer (team mode) — the cycle-2 re-review must reach a validation worker, fresh or reused", validationSpawnCount, reviewerReuse)
 }
 
 // isShutdownRequest reports whether a SendMessage `message` payload is a
 // cooperative teardown (`{"type":"shutdown_request",...}`), sent either as a JSON
 // object or as a JSON string carrying that type. The supersede-shutdown contract
 // requires the FO to reap a superseded worker by this message, so a shutdown_request
-// to an implementation handle is mandatory teardown, not a re-review routing.
+// to a worker handle is mandatory teardown, not a re-review routing.
 func isShutdownRequest(raw json.RawMessage) bool {
 	if len(raw) == 0 {
 		return false
@@ -256,48 +257,22 @@ type codexCollabItem struct {
 	} `json:"item"`
 }
 
-const codexReviewerAssignmentMissing = "Codex reviewer assignment-separation evidence missing validation-stage dispatch assignment"
-const codexReviewerDurableOutputMissing = "Codex reviewer evidence missing validation-stage worker output"
-
-// assertCodexReviewerReuse scans the `codex exec --json` transcript for the FO's
-// rejection-flow reviewer routing. When the transcript proves a turn-starting
-// `«addressable-worker»` route exists, the FO must reuse the kept-alive cycle-1
-// validation reviewer for the cycle-2 re-review — the durable producer signal it
-// did NOT fresh-dispatch the cycle-2 validator (the #141 keepalive contract).
-// Current public Codex live surfaces may expose only spawn/wait; when the FO
-// explicitly observes that no turn-starting reuse route is exposed, the contract is
-// characterized as addressable-worker ABSENT and the cycle-2 reviewer is fresh.
-// Codex exec does not surface enough current multi_agent_v2 metadata to prove a distinct reviewer process.
-// When spawn/thread evidence is absent, the Codex lane
-// grades assignment-separation plus durable end-state: this assertion accepts
-// distinct implementation and validation dispatch-build surfaces; the live-runner
-// wrapper can also accept durable validation-stage worker output after
-// assertRejectionFlow grades the two-cycle entity body. The Claude runner remains
-// the process-level separation oracle because its stream exposes Agent/SendMessage
-// evidence.
-// Codex multi_agent_v2 reuses via a `followup_task` collab_tool_call to the
-// reviewer's thread; legacy pre-v2 fixtures use `send_input`. The thread is bound
-// by the `spawn_agent` whose prompt dispatched the validation stage. In the PRESENT
-// branch it enforces BOTH halves of "genuine reuse", because binding ANY
-// validation-prompt spawn alone false-passes a fresh-dispatch (the cycle-8 M2 hole):
+// codexReviewerIdentity correlates the `codex exec --json` transcript's validation
+// reviewer identity structurally. It binds each validation spawn_agent
+// (`item.completed`, prompt dispatches validation) to its receiver_thread_ids, then
+// reads the follow-up routing:
 //
-//  1. NO fresh cycle-2 validation spawn. The rejection-flow drives ONE cycle-1
-//     validation spawn_agent; a reuse run re-engages that same thread. A run that
-//     fresh-spawns the cycle-2 validator emits a SECOND validation spawn_agent — the
-//     forbidden behavior — so >1 validation spawn_agent is an immediate FAIL, even
-//     though a follow-up to the fresh thread otherwise looks like reuse.
-//  2. A turn-triggering reuse call to the cycle-1 reviewer's bound thread. With
-//     exactly one validation spawn, a follow-up to its thread is the re-review —
-//     not feedback-to-implementation routing (which targets the impl thread), not
-//     loose narration.
-func assertCodexReviewerReuse(jsonl string) error {
-	if codexAddressableWorkerAbsent(jsonl) {
-		return assertCodexFreshValidationWhenAddressableAbsent(jsonl)
-	}
-
-	// First pass: count validation spawn_agents and bind their thread id(s). A
-	// reused reviewer drives one validation spawn; a fresh cycle-2 dispatch drives a
-	// second.
+//   - exactly one validation spawn + a followup_task/send_input to its bound thread
+//     → reviewerReuse (a feedback send_input to the implementation thread is normal
+//     routing and does not itself count as reuse);
+//   - two or more distinct validation spawn_agents → reviewerFresh (distinct
+//     reviewers by count — the contract-correct behavior when the host exposes no
+//     addressable-worker reuse route);
+//   - exactly one validation spawn but the follow-up reached a non-validation thread,
+//     or no follow-up reached the reviewer → reviewerNoReuse;
+//   - no validation spawn_agent, or a validation spawn exposing no thread id → no
+//     structured handle to correlate → reviewerUnsupported.
+func codexReviewerIdentity(jsonl string) (reviewerIdentityResult, string) {
 	validationThreads := map[string]bool{}
 	validationSpawnCount := 0
 	for _, line := range strings.Split(jsonl, "\n") {
@@ -325,17 +300,17 @@ func assertCodexReviewerReuse(jsonl string) error {
 	}
 
 	if validationSpawnCount == 0 {
-		if codexReviewerReuseViaAssignmentSurfaces(jsonl) {
-			return nil
-		}
-		return fmt.Errorf(codexReviewerAssignmentMissing)
+		return reviewerUnsupported, "no validation spawn_agent — no structured thread handle to correlate"
 	}
-	if validationSpawnCount > 1 {
-		return fmt.Errorf("the FO emitted %d validation spawn_agents — it FRESH-dispatched the cycle-2 validator instead of reusing the kept-alive cycle-1 reviewer (the #141 keepalive contract violation)", validationSpawnCount)
+	if validationSpawnCount >= 2 {
+		return reviewerFresh, fmt.Sprintf("%d distinct validation spawn_agents — fresh reviewers", validationSpawnCount)
+	}
+	if len(validationThreads) == 0 {
+		return reviewerUnsupported, "the validation spawn_agent exposed no receiver_thread_ids handle"
 	}
 
-	// Second pass: with exactly one validation reviewer, a turn-triggering reuse
-	// call to its bound thread is the cycle-2 re-review reuse signal.
+	reuseHit := false
+	wrongRoute := false
 	for _, line := range strings.Split(jsonl, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -349,272 +324,47 @@ func assertCodexReviewerReuse(jsonl string) error {
 		if it.Type != "collab_tool_call" || !codexReviewerReuseTool(it.Tool) {
 			continue
 		}
+		hitValidation := false
 		for _, tid := range it.ReceiverThreadIDs {
 			if validationThreads[tid] {
-				return nil
+				hitValidation = true
 			}
 		}
+		if hitValidation {
+			reuseHit = true
+		} else if len(it.ReceiverThreadIDs) > 0 {
+			wrongRoute = true
+		}
 	}
-	return fmt.Errorf("the FO spawned exactly one validation reviewer but sent it no followup_task/send_input for the cycle-2 re-review")
+	if reuseHit {
+		return reviewerReuse, "followup_task/send_input to the bound validation reviewer thread"
+	}
+	if wrongRoute {
+		return reviewerNoReuse, "the cycle-2 re-review was routed to a non-validation thread while a validation reviewer existed"
+	}
+	return reviewerNoReuse, "one validation reviewer bound but no followup_task/send_input reused its thread"
 }
 
-func assertCodexReviewerReuseWithDurableState(jsonl, entity string) error {
-	err := assertCodexReviewerReuse(jsonl)
-	if err == nil {
+// assertCodexReviewerReuse enforces the rejection-flow reviewer routing over the
+// `codex exec --json` transcript. Structured reuse (followup_task/send_input to the
+// bound validation thread) and structurally-distinct fresh reviewers both pass — the
+// latter is the contract-correct choice when the host exposes no addressable-worker
+// route. A re-review routed to a non-validation thread fails; an absent structured
+// handle yields errReviewerIdentityUnsupported (never a reuse pass).
+func assertCodexReviewerReuse(jsonl string) error {
+	result, detail := codexReviewerIdentity(jsonl)
+	switch result {
+	case reviewerReuse, reviewerFresh:
 		return nil
+	case reviewerNoReuse:
+		return fmt.Errorf("the FO did not route the cycle-2 re-review to a validation reviewer: %s", detail)
+	default:
+		return fmt.Errorf("%w: %s", errReviewerIdentityUnsupported, detail)
 	}
-	if err.Error() != codexReviewerAssignmentMissing {
-		return err
-	}
-	if codexReviewerDurableValidationOutput(entity) {
-		return nil
-	}
-	return fmt.Errorf(codexReviewerDurableOutputMissing)
-}
-
-func codexReviewerDurableValidationOutput(entity string) bool {
-	if !validationReport.MatchString(entity) {
-		return false
-	}
-	lower := strings.ToLower(entity)
-	return strings.Contains(lower, "cycle 1: rejected") &&
-		strings.Contains(lower, "cycle 2: passed")
-}
-
-func codexReviewerReuseViaAssignmentSurfaces(jsonl string) bool {
-	initialValidationBuilds := 0
-	validationAdvanceBuilds := 0
-	implementationAdvances := 0
-	waitCalls := 0
-	for _, line := range strings.Split(jsonl, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		var ev struct {
-			Type string `json:"type"`
-			Item struct {
-				Type    string `json:"type"`
-				Tool    string `json:"tool"`
-				Command string `json:"command"`
-			} `json:"item"`
-		}
-		if err := json.Unmarshal([]byte(line), &ev); err != nil {
-			continue
-		}
-		switch ev.Item.Type {
-		case "collab_tool_call":
-			if ev.Item.Tool == "wait" || ev.Item.Tool == "wait_agent" || ev.Item.Tool == "collab:wait" {
-				waitCalls++
-			}
-		case "command_execution":
-			if ev.Type != "item.completed" {
-				continue
-			}
-			build, ok := codexDispatchBuildFromCommand(ev.Item.Command)
-			if !ok {
-				continue
-			}
-			switch build.stage {
-			case "validation":
-				if build.advance {
-					validationAdvanceBuilds++
-				} else {
-					initialValidationBuilds++
-				}
-			}
-			if build.stage == "implementation" {
-				if build.advance {
-					implementationAdvances++
-				}
-			}
-		}
-	}
-	return initialValidationBuilds >= 1 &&
-		validationAdvanceBuilds >= 1 &&
-		implementationAdvances >= 1 &&
-		waitCalls >= 2
-}
-
-type codexDispatchBuild struct {
-	stage   string
-	advance bool
-}
-
-func codexDispatchBuildFromCommand(command string) (codexDispatchBuild, bool) {
-	lower := strings.ToLower(command)
-	if !strings.Contains(lower, "dispatch build") {
-		return codexDispatchBuild{}, false
-	}
-	build := codexDispatchBuild{
-		stage:   codexDispatchStageFromFlags(lower),
-		advance: strings.Contains(lower, "--advance"),
-	}
-	for _, obj := range jsonObjectsIn(command) {
-		var payload struct {
-			Stage   string `json:"stage"`
-			Advance bool   `json:"advance"`
-		}
-		if err := json.Unmarshal([]byte(obj), &payload); err != nil {
-			continue
-		}
-		if payload.Stage != "" {
-			build.stage = strings.ToLower(payload.Stage)
-		}
-		if payload.Advance {
-			build.advance = true
-		}
-	}
-	if build.stage == "" {
-		return codexDispatchBuild{}, false
-	}
-	return build, true
-}
-
-func codexDispatchStageFromFlags(command string) string {
-	fields := strings.Fields(command)
-	for i, field := range fields {
-		if field == "--stage" && i+1 < len(fields) {
-			return strings.Trim(fields[i+1], `'"`)
-		}
-		if strings.HasPrefix(field, "--stage=") {
-			return strings.Trim(strings.TrimPrefix(field, "--stage="), `'"`)
-		}
-	}
-	return ""
-}
-
-func jsonObjectsIn(s string) []string {
-	var objects []string
-	for start := 0; start < len(s); start++ {
-		if s[start] != '{' {
-			continue
-		}
-		depth := 0
-		inString := false
-		escaped := false
-		for end := start; end < len(s); end++ {
-			ch := s[end]
-			if inString {
-				if escaped {
-					escaped = false
-					continue
-				}
-				if ch == '\\' {
-					escaped = true
-					continue
-				}
-				if ch == '"' {
-					inString = false
-				}
-				continue
-			}
-			switch ch {
-			case '"':
-				inString = true
-			case '{':
-				depth++
-			case '}':
-				depth--
-				if depth == 0 {
-					objects = append(objects, s[start:end+1])
-					start = end
-					end = len(s)
-				}
-			}
-		}
-	}
-	return objects
 }
 
 func codexReviewerReuseTool(tool string) bool {
 	return tool == "followup_task" || tool == "send_input"
-}
-
-// codexAddressableWorkerAbsent reports whether the FO observed that the live
-// Codex surface exposes no turn-starting reuse route for a completed worker, so a
-// fresh cycle-2 reviewer is the contract-correct choice. The live FO words this
-// observation freely ("no follow-up/send binding for worker reuse", "the cycle-1
-// reviewer is not addressable on this host", "no followup_task or equivalent
-// turn-starting reuse route"), so a fixed phrase list false-RED-flags a
-// contract-correct fresh-dispatch. The detector instead reads the FO's narration
-// (agent_message text only — never command output, which can echo the runtime
-// doc) and treats a message that negates a reuse-route concept as the absence
-// observation. A reuse tool actually appearing in the transcript still overrides
-// this via assertCodexFreshValidationWhenAddressableAbsent.
-func codexAddressableWorkerAbsent(jsonl string) bool {
-	for _, line := range strings.Split(jsonl, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		var ev struct {
-			Item struct {
-				Type string `json:"type"`
-				Text string `json:"text"`
-			} `json:"item"`
-		}
-		if err := json.Unmarshal([]byte(line), &ev); err != nil || ev.Item.Type != "agent_message" {
-			continue
-		}
-		if codexNarrationNegatesReuseRoute(ev.Item.Text) {
-			return true
-		}
-	}
-	return false
-}
-
-// codexNarrationNegatesReuseRoute reports whether a single FO narration message
-// states that the reuse/follow-up route is absent. The negation must bind to the
-// route, binding, tool, support, or addressability claim; affirmative reuse
-// narration can contain unrelated negation ("not doing validation") without
-// choosing the addressable-worker-ABSENT branch.
-func codexNarrationNegatesReuseRoute(text string) bool {
-	lower := strings.ToLower(text)
-	for _, pattern := range codexReuseRouteAbsencePatterns {
-		if pattern.MatchString(lower) {
-			return true
-		}
-	}
-	return false
-}
-
-var codexReuseRouteAbsencePatterns = []*regexp.Regexp{
-	regexp.MustCompile(`\bno\s+(?:turn-starting\s+|completed-worker\s+|addressable[- ]worker\s+|addressable\s+)?(?:follow[- ]?up(?:_task)?|followup_task|send[-_ ]?(?:message|input)|reuse|addressable)(?:[/_a-z0-9 -]{0,80})?\b(?:binding|route|tool|call)(?:\s+exposed)?\b`),
-	regexp.MustCompile(`\b(?:do|does|did)\s+not\s+have\s+(?:a\s+|an\s+)?(?:follow[- ]?up(?:_task)?|followup_task|addressable|reuse)(?:[/_a-z0-9 -]{0,80})?\b(?:binding|route|tool|call)\b`),
-	regexp.MustCompile(`\b(?:do|does|did)\s+not\s+expose\s+(?:a\s+|an\s+)?(?:turn-starting\s+)?(?:addressable[- ]worker|addressable\s+reviewer|follow[- ]?up(?:_task)?|followup_task|reuse)(?:[/_a-z0-9 -]{0,80})?\b(?:binding|route|tool|call)\b`),
-	regexp.MustCompile(`\breviewer\s+reuse\s+is\s+not\s+supported\b`),
-	regexp.MustCompile(`\breuse\s+is\s+not\s+supported\b`),
-	regexp.MustCompile(`\b(?:reviewer|cycle-1 reviewer|worker)\s+is\s+not\s+addressable\b`),
-	regexp.MustCompile(`\bcannot\s+address\s+(?:the\s+)?(?:kept-alive\s+)?reviewer\b`),
-}
-
-func assertCodexFreshValidationWhenAddressableAbsent(jsonl string) error {
-	validationSpawnCount := 0
-	for _, line := range strings.Split(jsonl, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		var ev codexCollabItem
-		if err := json.Unmarshal([]byte(line), &ev); err != nil {
-			continue
-		}
-		it := ev.Item
-		if it.Type != "collab_tool_call" {
-			continue
-		}
-		if codexReviewerReuseTool(it.Tool) {
-			return fmt.Errorf("Codex addressable-worker was characterized ABSENT, but transcript contains turn-starting reuse tool %q", it.Tool)
-		}
-		if it.Tool == "spawn_agent" && ev.Type == "item.completed" && codexDispatchesValidation(it.Prompt) {
-			validationSpawnCount++
-		}
-	}
-	if validationSpawnCount < 2 {
-		return fmt.Errorf("Codex addressable-worker ABSENT rejection-flow produced %d validation spawn_agents, want >= 2 fresh validation reviewers for cycle 1 and cycle 2", validationSpawnCount)
-	}
-	return nil
 }
 
 // codexDispatchesValidation reports whether a spawn_agent prompt dispatched the


### PR DESCRIPTION
Retire inference-based reviewer-reuse grading for structured native-handle correlation, so a reuse claim proves same-vs-distinct reviewer identity instead of guessing from narration.

## What changed
- Consolidate reviewer identity into one structured correlator per host (Codex `receiver_thread_ids`, Claude `agentId`/`input.name`).
- Surface `errReviewerIdentityUnsupported` where no handle exists — never a reuse pass.
- Delete the narration regex bank, command-string/wait-count inference, and durable-report identity matcher.
- Remove the self-source test; rework fixtures to structured same-handle correlation.

## Evidence
- `go test ./...` and `go test ./... -race`: green (exit 0); gofmt/vet clean.
- AC-1 value: inference-only reuse-pass count 5 → 0 (baseline reproduced out-of-tree at `main`); structured fixtures still pass; net −240 test-infra lines.

## Review guidance
- Deferred (intentional; roborev job 1647, 3× Medium): (1) `unsupported`→pass relies on `assertRejectionFlow`, which does not require a second validation report/verdict; (2) `fresh` derives from raw spawn count (no dedup / cycle-2 route check); (3) `reuse` correlation is order/purpose-blind (handle-anywhere). Net improvement over the retired inference oracle; adversarial edges to tighten in a follow-up. Revisit condition: a false-green surfaces in a live rejection-flow run.

---
[6v](/spacedock-dev/spacedock/blob/77c85dfbf792ff0c58baf6df4dad441e8e3e6443/replace-reviewer-reuse-oracle-with-structured-evidence/index.md)
