### PR TITLE
fix(release): guard cask xattr postflight for linux

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,7 @@
 # Release build for the spacedock launcher: darwin + linux arm64 + amd64
 # tarballs, a checksums file, a GitHub Release, and a Homebrew formula bump on
-# the own-tap (cask is darwin-only; linux installs via install.sh).
+# the own-tap (the cask carries both darwin and linux URLs; linux may also
+# install via install.sh).
 version: 2
 
 project_name: spacedock
@@ -150,10 +151,18 @@ homebrew_casks:
       # download carries com.apple.quarantine and Gatekeeper kills the first
       # launch. Strip the attribute from the staged binary so the user needs no
       # manual step. Interim until a Developer ID notarized build lands.
+      #
+      # The cask ships linux URLs too (goreleaser emits them from the linux
+      # archives), so this postflight also runs on a `brew install` on linux —
+      # where `/usr/bin/xattr` does not exist and the hook aborts the install
+      # with exit 127. Guard on OS.mac? so the quarantine strip is a no-op off
+      # macOS (there is no quarantine attribute to strip there anyway).
       post:
         install: |
-          system_command "/usr/bin/xattr",
-                         args: ["-dr", "com.apple.quarantine", "#{staged_path}/spacedock"]
+          if OS.mac?
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/spacedock"]
+          end
   # The EDGE cask: `brew install spacedock-dev/tap/spacedock@next` ships the
   # devBranch=next binary that installs the `next` plugin. Its on-demand re-pull
   # cadence rides the unchanged next-publish.yml; goreleaser only emits the cask.
@@ -193,10 +202,14 @@ homebrew_casks:
         safehouse  — sandboxes agent runs (https://agent-safehouse.dev)
         brew install eugene1g/safehouse/agent-safehouse
     hooks:
+      # Same quarantine strip as the stable cask, guarded on OS.mac? so the
+      # linux `brew install` path does not abort on the missing /usr/bin/xattr.
       post:
         install: |
-          system_command "/usr/bin/xattr",
-                         args: ["-dr", "com.apple.quarantine", "#{staged_path}/spacedock"]
+          if OS.mac?
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/spacedock"]
+          end
 
 snapshot:
   # Used by `goreleaser release --snapshot --clean` (the dry-run oracle). The

--- a/internal/release/goreleaser_guard_test.go
+++ b/internal/release/goreleaser_guard_test.go
@@ -91,6 +91,74 @@ func TestGoreleaserBuildGuardRejectsDroppedLinux(t *testing.T) {
 	}
 }
 
+// parseCaskXattrHooks returns every homebrew_casks post-install hook body that
+// invokes /usr/bin/xattr — the macOS-only quarantine strip that must never run
+// unguarded, since the generated cask carries linux URLs and the hook otherwise
+// aborts a linux `brew install` on the missing binary. A config that does not
+// parse yields nil (the guard's per-hook assertion then finds nothing to check
+// and the caller fails loudly).
+func parseCaskXattrHooks(config string) []string {
+	var doc struct {
+		HomebrewCasks []struct {
+			Hooks struct {
+				Post struct {
+					Install string `yaml:"install"`
+				} `yaml:"post"`
+			} `yaml:"hooks"`
+		} `yaml:"homebrew_casks"`
+	}
+	if err := yaml.Unmarshal([]byte(config), &doc); err != nil {
+		return nil
+	}
+	var hooks []string
+	for _, c := range doc.HomebrewCasks {
+		if strings.Contains(c.Hooks.Post.Install, "xattr") {
+			hooks = append(hooks, c.Hooks.Post.Install)
+		}
+	}
+	return hooks
+}
+
+// TestCaskXattrHookGuardedForLinux locks the fix for the linux `brew install`
+// failure: every cask post-install hook that runs the macOS-only /usr/bin/xattr
+// must guard it with OS.mac?, so the quarantine strip is a no-op on linux rather
+// than aborting the install with exit 127 on the missing binary. Each cask
+// (stable + edge) ships such a hook, so the parsed set must be non-empty and
+// every member guarded.
+func TestCaskXattrHookGuardedForLinux(t *testing.T) {
+	hooks := parseCaskXattrHooks(readGoreleaserConfig(t))
+	if len(hooks) == 0 {
+		t.Fatal("parsed no xattr post-install hooks from .goreleaser.yaml; the guard check has nothing to bind")
+	}
+	for i, hook := range hooks {
+		if !strings.Contains(hook, "OS.mac?") {
+			t.Errorf("homebrew_casks xattr hook #%d runs /usr/bin/xattr without an OS.mac? guard; it will abort a linux `brew install`:\n%s", i, hook)
+		}
+	}
+}
+
+// TestCaskXattrGuardRejectsUnguardedHook proves the guard is load-bearing: an
+// xattr hook with its OS.mac? guard stripped (the pre-fix shape that broke linux)
+// must fail the check.
+func TestCaskXattrGuardRejectsUnguardedHook(t *testing.T) {
+	config := readGoreleaserConfig(t)
+	adversarial := strings.ReplaceAll(config, "OS.mac?", "true")
+	if adversarial == config {
+		t.Fatal("no OS.mac? token in .goreleaser.yaml to strip; the load-bearing check cannot bind")
+	}
+	for i, hook := range parseCaskXattrHooks(adversarial) {
+		if strings.Contains(hook, "OS.mac?") {
+			t.Fatalf("stripping OS.mac? left the guard in xattr hook #%d; the check is not load-bearing", i)
+		}
+	}
+	// With the guards gone the lock test must have something to catch; assert the
+	// adversarial config indeed carries an unguarded xattr hook.
+	hooks := parseCaskXattrHooks(adversarial)
+	if len(hooks) == 0 {
+		t.Fatal("adversarial config parsed no xattr hooks; cannot prove the guard trips")
+	}
+}
+
 func targetSetString(targets map[buildTarget]bool) string {
 	var names []string
 	for target := range targets {

--- a/internal/release/goreleaser_guard_test.go
+++ b/internal/release/goreleaser_guard_test.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -119,6 +120,19 @@ func parseCaskXattrHooks(config string) []string {
 	return hooks
 }
 
+func validateCaskXattrHooks(config string) error {
+	hooks := parseCaskXattrHooks(config)
+	if len(hooks) == 0 {
+		return fmt.Errorf("parsed no xattr post-install hooks from .goreleaser.yaml; the guard check has nothing to bind")
+	}
+	for i, hook := range hooks {
+		if !strings.Contains(hook, "OS.mac?") {
+			return fmt.Errorf("homebrew_casks xattr hook #%d runs /usr/bin/xattr without an OS.mac? guard; it will abort a linux `brew install`:\n%s", i, hook)
+		}
+	}
+	return nil
+}
+
 // TestCaskXattrHookGuardedForLinux locks the fix for the linux `brew install`
 // failure: every cask post-install hook that runs the macOS-only /usr/bin/xattr
 // must guard it with OS.mac?, so the quarantine strip is a no-op on linux rather
@@ -126,14 +140,8 @@ func parseCaskXattrHooks(config string) []string {
 // (stable + edge) ships such a hook, so the parsed set must be non-empty and
 // every member guarded.
 func TestCaskXattrHookGuardedForLinux(t *testing.T) {
-	hooks := parseCaskXattrHooks(readGoreleaserConfig(t))
-	if len(hooks) == 0 {
-		t.Fatal("parsed no xattr post-install hooks from .goreleaser.yaml; the guard check has nothing to bind")
-	}
-	for i, hook := range hooks {
-		if !strings.Contains(hook, "OS.mac?") {
-			t.Errorf("homebrew_casks xattr hook #%d runs /usr/bin/xattr without an OS.mac? guard; it will abort a linux `brew install`:\n%s", i, hook)
-		}
+	if err := validateCaskXattrHooks(readGoreleaserConfig(t)); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -146,16 +154,12 @@ func TestCaskXattrGuardRejectsUnguardedHook(t *testing.T) {
 	if adversarial == config {
 		t.Fatal("no OS.mac? token in .goreleaser.yaml to strip; the load-bearing check cannot bind")
 	}
-	for i, hook := range parseCaskXattrHooks(adversarial) {
-		if strings.Contains(hook, "OS.mac?") {
-			t.Fatalf("stripping OS.mac? left the guard in xattr hook #%d; the check is not load-bearing", i)
-		}
+	err := validateCaskXattrHooks(adversarial)
+	if err == nil {
+		t.Fatal("xattr hook validation accepted a config with its OS.mac? guards stripped")
 	}
-	// With the guards gone the lock test must have something to catch; assert the
-	// adversarial config indeed carries an unguarded xattr hook.
-	hooks := parseCaskXattrHooks(adversarial)
-	if len(hooks) == 0 {
-		t.Fatal("adversarial config parsed no xattr hooks; cannot prove the guard trips")
+	if !strings.Contains(err.Error(), "without an OS.mac? guard") {
+		t.Fatalf("xattr hook validation rejected the adversarial config for the wrong reason: %v", err)
 	}
 }
 

--- a/internal/release/goreleaser_guard_test.go
+++ b/internal/release/goreleaser_guard_test.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -120,6 +121,8 @@ func parseCaskXattrHooks(config string) []string {
 	return hooks
 }
 
+var errUnguardedCaskXattrHook = errors.New("homebrew cask xattr hook is unguarded")
+
 func validateCaskXattrHooks(config string) error {
 	hooks := parseCaskXattrHooks(config)
 	if len(hooks) == 0 {
@@ -127,7 +130,7 @@ func validateCaskXattrHooks(config string) error {
 	}
 	for i, hook := range hooks {
 		if !strings.Contains(hook, "OS.mac?") {
-			return fmt.Errorf("homebrew_casks xattr hook #%d runs /usr/bin/xattr without an OS.mac? guard; it will abort a linux `brew install`:\n%s", i, hook)
+			return fmt.Errorf("%w: hook #%d runs /usr/bin/xattr without an OS.mac? guard; it will abort a linux `brew install`:\n%s", errUnguardedCaskXattrHook, i, hook)
 		}
 	}
 	return nil
@@ -154,12 +157,8 @@ func TestCaskXattrGuardRejectsUnguardedHook(t *testing.T) {
 	if adversarial == config {
 		t.Fatal("no OS.mac? token in .goreleaser.yaml to strip; the load-bearing check cannot bind")
 	}
-	err := validateCaskXattrHooks(adversarial)
-	if err == nil {
-		t.Fatal("xattr hook validation accepted a config with its OS.mac? guards stripped")
-	}
-	if !strings.Contains(err.Error(), "without an OS.mac? guard") {
-		t.Fatalf("xattr hook validation rejected the adversarial config for the wrong reason: %v", err)
+	if err := validateCaskXattrHooks(adversarial); !errors.Is(err, errUnguardedCaskXattrHook) {
+		t.Fatalf("xattr hook validation did not reject the stripped config as unguarded: %v", err)
 	}
 }
 

--- a/internal/release/goreleaser_guard_test.go
+++ b/internal/release/goreleaser_guard_test.go
@@ -91,52 +91,6 @@ func TestGoreleaserBuildGuardRejectsDroppedLinux(t *testing.T) {
 	}
 }
 
-// parseCaskXattrHooks returns every homebrew_casks post-install hook body that
-// invokes /usr/bin/xattr — the macOS-only quarantine strip that must never run
-// unguarded, since the generated cask carries linux URLs and the hook otherwise
-// aborts a linux `brew install` on the missing binary. A config that does not
-// parse yields nil (the guard's per-hook assertion then finds nothing to check
-// and the caller fails loudly).
-func parseCaskXattrHooks(config string) []string {
-	var doc struct {
-		HomebrewCasks []struct {
-			Hooks struct {
-				Post struct {
-					Install string `yaml:"install"`
-				} `yaml:"post"`
-			} `yaml:"hooks"`
-		} `yaml:"homebrew_casks"`
-	}
-	if err := yaml.Unmarshal([]byte(config), &doc); err != nil {
-		return nil
-	}
-	var hooks []string
-	for _, c := range doc.HomebrewCasks {
-		if strings.Contains(c.Hooks.Post.Install, "xattr") {
-			hooks = append(hooks, c.Hooks.Post.Install)
-		}
-	}
-	return hooks
-}
-
-// TestCaskXattrHookGuardedForLinux locks the fix for the linux `brew install`
-// failure: every cask post-install hook that runs the macOS-only /usr/bin/xattr
-// must guard it with OS.mac?, so the quarantine strip is a no-op on linux rather
-// than aborting the install with exit 127 on the missing binary. Each cask
-// (stable + edge) ships such a hook, so the parsed set must be non-empty and
-// every member guarded.
-func TestCaskXattrHookGuardedForLinux(t *testing.T) {
-	hooks := parseCaskXattrHooks(readGoreleaserConfig(t))
-	if len(hooks) == 0 {
-		t.Fatal("parsed no xattr post-install hooks from .goreleaser.yaml; the guard check has nothing to bind")
-	}
-	for i, hook := range hooks {
-		if !strings.Contains(hook, "OS.mac?") {
-			t.Errorf("homebrew_casks xattr hook #%d runs /usr/bin/xattr without an OS.mac? guard; it will abort a linux `brew install`:\n%s", i, hook)
-		}
-	}
-}
-
 func targetSetString(targets map[buildTarget]bool) string {
 	var names []string
 	for target := range targets {

--- a/internal/release/goreleaser_guard_test.go
+++ b/internal/release/goreleaser_guard_test.go
@@ -1,8 +1,6 @@
 package release
 
 import (
-	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -121,21 +119,6 @@ func parseCaskXattrHooks(config string) []string {
 	return hooks
 }
 
-var errUnguardedCaskXattrHook = errors.New("homebrew cask xattr hook is unguarded")
-
-func validateCaskXattrHooks(config string) error {
-	hooks := parseCaskXattrHooks(config)
-	if len(hooks) == 0 {
-		return fmt.Errorf("parsed no xattr post-install hooks from .goreleaser.yaml; the guard check has nothing to bind")
-	}
-	for i, hook := range hooks {
-		if !strings.Contains(hook, "OS.mac?") {
-			return fmt.Errorf("%w: hook #%d runs /usr/bin/xattr without an OS.mac? guard; it will abort a linux `brew install`:\n%s", errUnguardedCaskXattrHook, i, hook)
-		}
-	}
-	return nil
-}
-
 // TestCaskXattrHookGuardedForLinux locks the fix for the linux `brew install`
 // failure: every cask post-install hook that runs the macOS-only /usr/bin/xattr
 // must guard it with OS.mac?, so the quarantine strip is a no-op on linux rather
@@ -143,22 +126,14 @@ func validateCaskXattrHooks(config string) error {
 // (stable + edge) ships such a hook, so the parsed set must be non-empty and
 // every member guarded.
 func TestCaskXattrHookGuardedForLinux(t *testing.T) {
-	if err := validateCaskXattrHooks(readGoreleaserConfig(t)); err != nil {
-		t.Fatal(err)
+	hooks := parseCaskXattrHooks(readGoreleaserConfig(t))
+	if len(hooks) == 0 {
+		t.Fatal("parsed no xattr post-install hooks from .goreleaser.yaml; the guard check has nothing to bind")
 	}
-}
-
-// TestCaskXattrGuardRejectsUnguardedHook proves the guard is load-bearing: an
-// xattr hook with its OS.mac? guard stripped (the pre-fix shape that broke linux)
-// must fail the check.
-func TestCaskXattrGuardRejectsUnguardedHook(t *testing.T) {
-	config := readGoreleaserConfig(t)
-	adversarial := strings.ReplaceAll(config, "OS.mac?", "true")
-	if adversarial == config {
-		t.Fatal("no OS.mac? token in .goreleaser.yaml to strip; the load-bearing check cannot bind")
-	}
-	if err := validateCaskXattrHooks(adversarial); !errors.Is(err, errUnguardedCaskXattrHook) {
-		t.Fatalf("xattr hook validation did not reject the stripped config as unguarded: %v", err)
+	for i, hook := range hooks {
+		if !strings.Contains(hook, "OS.mac?") {
+			t.Errorf("homebrew_casks xattr hook #%d runs /usr/bin/xattr without an OS.mac? guard; it will abort a linux `brew install`:\n%s", i, hook)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #519

## Problem

`brew install spacedock` fails on Linux. The generated Homebrew cask carries linux download URLs (goreleaser emits them from the linux archives), so the install resolves and downloads the linux binary — but the cask `postflight` hook unconditionally runs `/usr/bin/xattr -dr com.apple.quarantine`, a macOS-only command. On Linux there is no `/usr/bin/xattr`, so the hook exits 127 and Homebrew rolls the whole install back:

```
Error: Failure while executing; `/usr/bin/env /usr/bin/xattr -dr com.apple.quarantine .../spacedock` exited with 127.
env: '/usr/bin/xattr': No such file or directory
```

## Fix

- Guard the quarantine strip with `if OS.mac?` in **both** the stable and edge cask hooks in `.goreleaser.yaml`, so it is a no-op off macOS (there is no quarantine attribute to strip there anyway) and the linux cask install completes.
- Correct the stale `cask is darwin-only` header comment (the cask has always shipped linux URLs).

## Testing

- `go test ./internal/release/` — green.
- Verified end-to-end on SteamOS/Linuxbrew: patching the installed tap cask with the same `if OS.mac? ... end` wrapper makes `brew install --cask spacedock` succeed and link `spacedock` (`spacedock 0.25.0`), where it previously failed with exit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
