### PR TITLE
Document dispatch entity path base

### DIFF
--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -1047,7 +1047,8 @@ func emitBuildSchema(stdout io.Writer) int {
 				"const": schemaVersion,
 			},
 			"entity_path": map[string]any{
-				"type": "string",
+				"type":        "string",
+				"description": "Absolute path or path relative to the caller's current working directory; never relative to workflow_dir. Identifies the project-root/state-checkout entity, not a code-worktree copy (for example, docs/dev/.spacedock-state/example/index.md).",
 			},
 			"workflow_dir": map[string]any{
 				"type": "string",

--- a/internal/dispatch/build_json_ergonomics_test.go
+++ b/internal/dispatch/build_json_ergonomics_test.go
@@ -271,6 +271,31 @@ func TestBuildSchemaAndValidateOnly(t *testing.T) {
 	})
 }
 
+func TestBuildSchemaDocumentsEntityPathBase(t *testing.T) {
+	native := runNativePreservingHostEnv("", "build", "--print-schema")
+	if native.exit != 0 {
+		t.Fatalf("print-schema exit=%d stderr=%s", native.exit, native.stderr)
+	}
+
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(native.stdout), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v\n%s", err, native.stdout)
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema missing properties object:\n%s", native.stdout)
+	}
+	entityPath, ok := props["entity_path"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema missing entity_path property:\n%s", native.stdout)
+	}
+
+	const want = "Absolute path or path relative to the caller's current working directory; never relative to workflow_dir. Identifies the project-root/state-checkout entity, not a code-worktree copy (for example, docs/dev/.spacedock-state/example/index.md)."
+	if got := entityPath["description"]; got != want {
+		t.Fatalf("entity_path description = %q, want %q", got, want)
+	}
+}
+
 func buildHostFixture(t *testing.T) (string, string) {
 	t.Helper()
 	root := t.TempDir()

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -302,13 +302,14 @@ Flags:
 
 Stdin JSON fields:
   schema_version  Dispatch schema version. The current supported value is 2.
-  entity_path     Path to the entity file for this dispatch.
+  entity_path     May be absolute or relative to the caller's current working directory; never relative to workflow_dir.
+                  Identifies the project-root/state-checkout entity, not a code-worktree copy.
   workflow_dir    Workflow directory for the dispatch request.
   stage           Stage name to dispatch.
   checklist       Array of checklist strings for the dispatched worker.
 
-Example:
-  {"schema_version":2,"entity_path":"thing.md","workflow_dir":".","stage":"implementation","checklist":["DONE: run tests"]}
+Split-root example (called from the project root):
+  {"schema_version":2,"entity_path":"docs/dev/.spacedock-state/example/index.md","workflow_dir":"docs/dev","stage":"implementation","checklist":["DONE: run tests"]}
 `)
 }
 

--- a/internal/dispatch/help_test.go
+++ b/internal/dispatch/help_test.go
@@ -33,6 +33,24 @@ func TestDispatchBuildHelpBeforeRequiredFlags(t *testing.T) {
 	}
 }
 
+func TestDispatchBuildHelpDocumentsEntityPathBase(t *testing.T) {
+	res := runNative("", "build", "--help")
+	if res.exit != 0 {
+		t.Fatalf("dispatch build --help exit=%d, want 0\nstderr=%q", res.exit, res.stderr)
+	}
+	if res.stderr != "" {
+		t.Fatalf("dispatch build --help stderr=%q, want empty", res.stderr)
+	}
+
+	assertContainsAll(t, res.stdout,
+		"absolute or relative to the caller's current working directory",
+		"never relative to workflow_dir",
+		"project-root/state-checkout entity, not a code-worktree copy",
+		`"entity_path":"docs/dev/.spacedock-state/example/index.md"`,
+		`"workflow_dir":"docs/dev"`,
+	)
+}
+
 func TestDispatchShowStageDefHelpBeforeRequiredFlags(t *testing.T) {
 	for _, helpFlag := range []string{"--help", "-h"} {
 		t.Run(helpFlag, func(t *testing.T) {


### PR DESCRIPTION
Clarify dispatch entity path resolution so operators can use split-root workflows without guessing the correct path base.

## What changed

- Document caller-relative entity paths in built-in dispatch help.
- Mirror path semantics in the machine-readable dispatch schema.
- Add behavioral and schema tests for split-root resolution.

## Evidence

- Go package suites: 17/17 passed in standard and race modes.
- Live probes: 3/3 path-resolution variants matched expected behavior.

---

[93](/spacedock-dev/spacedock/blob/c836a277981a7c3401b6dc4f9e900ebc4d97a957/document-dispatch-entity-path-base/index.md)
