### PR TITLE
Auto-load the adjacent Spacedock plugin

### DIFF
--- a/docs/site/contributing/build-from-source.md
+++ b/docs/site/contributing/build-from-source.md
@@ -20,15 +20,18 @@ effect immediately. For a normal install, see [Install Spacedock](../get-started
 
     Prints `spacedock <version>` for your local build.
 
-3. **Launch with the local plugin.**
+3. **Launch with the adjacent local plugin.**
 
     ```bash
-    ./spacedock claude "your task" -- --plugin-dir "$PWD"
+    ./spacedock claude "your task"
     ```
 
-    `--plugin-dir` is a host flag, so it rides after `--`. It loads the
-    first-officer and ensign agents from your checkout instead of the installed
-    plugin. Edits to the repo are live.
+    The launcher resolves its own executable and validates the adjacent
+    `.claude-plugin/plugin.json` before selecting this checkout. Codex does the
+    same with `.codex-plugin/plugin.json` through its local marketplace adapter.
+    Use `--plugin-dir /another/checkout` before `--` only when you need an
+    explicit Spacedock override. On Claude, a plugin directory after `--` is an
+    additional host plugin and does not replace Spacedock.
 
 The `next` branch is the development channel. If you want the bleeding edge
 without building from source, install the **edge channel** (`spacedock-edge`)

--- a/docs/site/get-started/install.md
+++ b/docs/site/get-started/install.md
@@ -68,10 +68,20 @@ dogfooding a marketplace change before it reaches the production marketplace:
 SPACEDOCK_MARKETPLACE_SOURCE=/path/to/local/marketplace spacedock install --host codex
 ```
 
-Launching with `--plugin-dir` loads a local plugin checkout directly. On Claude
-and Pi this is an ephemeral, install-free override — it bypasses installed-plugin
-resolution for that one launch and does not wrap the launch in the safehouse
-sandbox; use it for plugin development, not as an install substitute.
+When the resolved `spacedock` executable sits at the root of a checkout whose
+host manifest names `spacedock` and points to an existing skills directory, the
+launcher selects that adjacent checkout automatically. A source build at
+`./spacedock` therefore needs no `--plugin-dir` for either Claude or Codex. A
+release binary in a `bin/` directory, or a checkout with a missing or invalid
+host manifest, keeps the normal installed-plugin resolution and compatibility
+gate.
+
+An explicit `--plugin-dir <checkout>` before `--` overrides adjacent discovery.
+On Claude and Pi this is an ephemeral, install-free override — it bypasses
+installed-plugin resolution for that one launch and does not wrap the launch in
+the safehouse sandbox; use it for plugin development, not as an install
+substitute. On Claude, a `--plugin-dir` after `--` remains a native additional
+session plugin: it does not replace Spacedock or suppress the compatibility gate.
 
 Codex has no such flag on its own CLI, so `spacedock codex --plugin-dir
 <checkout>` and `spacedock install --host codex --plugin-dir <checkout>` build a
@@ -84,7 +94,9 @@ channel replaces any existing stable or edge Spacedock Codex plugin so
 point-in-time snapshot: editing the checkout afterward has no effect until the
 command is re-run. The command prints an advisory that names the selected channel
 and notes that the reported version reflects the checkout's checked-in manifest,
-not necessarily its current HEAD.
+not necessarily its current HEAD. Codex does not accept a post-`--`
+`--plugin-dir`; install additional Codex plugins persistently with
+`codex plugin add`.
 
 ## Sandboxing
 

--- a/docs/site/reference/command-reference.md
+++ b/docs/site/reference/command-reference.md
@@ -24,7 +24,25 @@ The `Sandbox:` line is one of `enabled (safehouse)`, `available, not enabled (no
 spacedock claude [task] [spacedock-flags] [-- host-flags]
 ```
 
-The task comes first and becomes the launch prompt. Anything after `--` forwards verbatim to the host (`--model`, `resume`, and the like). For Codex, Spacedock keeps its normal launch banner, default approval posture, and bootstrap prompt unless the forwarded token slice contains an exact token equal to `resume`. It does not parse Codex option grammar: `spacedock codex -- --model gpt-5.6-sol` remains a fresh first-officer launch, while `spacedock codex -- --model gpt-5.6-sol resume <id>` stays prompt-free. Use bare `spacedock codex` to start the first officer. When no plugin is installed, the launcher auto-installs it and launches, so the single command yields a working session; a contract mismatch fails fast. The sandbox flags (`--safehouse` and its knobs) and the contract-gate flags are listed by `spacedock claude --help`.
+The task comes first and becomes the launch prompt. Supported host arguments
+after `--` forward verbatim (`--model`, `resume`, and the like). For Codex,
+Spacedock keeps its normal launch banner, default approval posture, and bootstrap
+prompt unless the forwarded token slice contains an exact token equal to
+`resume`. It does not parse Codex option grammar: `spacedock codex -- --model
+gpt-5.6-sol` remains a fresh first-officer launch, while `spacedock codex --
+--model gpt-5.6-sol resume <id>` stays prompt-free. Use bare `spacedock codex` to
+start the first officer. When no plugin is installed, the launcher auto-installs
+it and launches, so the single command yields a working session; a contract
+mismatch fails fast. The sandbox flags (`--safehouse` and its knobs) and the
+contract-gate flags are listed by `spacedock claude --help`.
+
+For Claude and Codex, a valid Spacedock plugin checkout beside the resolved
+launcher is selected automatically. `--plugin-dir <checkout>` before `--` is an
+explicit Spacedock override and takes precedence. Claude treats a post-`--`
+`--plugin-dir` as an additional native session plugin, so the installed or
+adjacent Spacedock provider is still gated normally. Codex has no native
+session-local flag: a post-`--` `--plugin-dir` is rejected, and additional Codex
+plugins must be installed persistently with `codex plugin add`.
 
 An unsandboxed bootstrap launch carries no safehouse isolation, so per-action permission prompting is friction without a matching safety gain: `spacedock claude` starts in `--permission-mode auto` and Codex starts in `--ask-for-approval on-request` unless you supply an approval mode. A sandboxed bootstrap launch instead skips/bypasses approvals (`--dangerously-skip-permissions` for claude, `--dangerously-bypass-approvals-and-sandbox` for codex) since the sandbox is the gate. Claude suppresses its defaults when you pass your own mode or a resume. Codex suppresses its banner and bootstrap prompt only when its forwarded argv contains the exact `resume` token; an explicit approval mode prevents only a duplicate automatic approval flag.
 

--- a/internal/cli/adjacent_plugin_test.go
+++ b/internal/cli/adjacent_plugin_test.go
@@ -1,0 +1,285 @@
+// ABOUTME: Adjacent Spacedock plugin discovery and front-door selection tests.
+// ABOUTME: Covers host-manifest qualification, precedence, gating, and Codex preflight safety.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type resolvingHost struct {
+	fakeHost
+	resolveCalls     int
+	resolvedManifest string
+}
+
+func (h *resolvingHost) ResolveManifest(host string) (string, error) {
+	h.resolveCalls++
+	manifest, err := h.fakeHost.ResolveManifest(host)
+	h.resolvedManifest = manifest
+	return manifest, err
+}
+
+func localPluginCheckout(t *testing.T, host string) (root, executable string) {
+	t.Helper()
+	root = t.TempDir()
+	executable = filepath.Join(root, "spacedock")
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeLocalPluginManifest(t, root, host, "spacedock", "./skills/")
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolvedRoot, executable
+}
+
+func writeLocalPluginManifest(t *testing.T, root, host, name, skills string) string {
+	t.Helper()
+	manifestDir := "." + host + "-plugin"
+	manifestPath := filepath.Join(root, manifestDir, "plugin.json")
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if skills != "" {
+		skillsPath := skills
+		if !filepath.IsAbs(skillsPath) {
+			skillsPath = filepath.Join(root, filepath.FromSlash(skillsPath))
+		}
+		if err := os.MkdirAll(skillsPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	body := fmt.Sprintf(`{"name":%q,"version":%q,"skills":%q}`+"\n", name, displayVersion(), skills)
+	if err := os.WriteFile(manifestPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return manifestPath
+}
+
+func TestAdjacentPluginAutomaticallySelectedForClaude(t *testing.T) {
+	root, executable := localPluginCheckout(t, "claude")
+	withExecutablePath(t, executable, nil)
+	host := &resolvingHost{fakeHost: fakeHost{resolveErr: fmt.Errorf("installed resolver must not run")}}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), nil, t.TempDir(), host, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if host.resolveCalls != 0 {
+		t.Fatalf("installed resolver called %d times, want 0 for adjacent checkout", host.resolveCalls)
+	}
+	want := []string{"claude", "--agent", "spacedock:first-officer", "--permission-mode", "auto", "--plugin-dir", root, wantBootstrapPrompt}
+	if !equalArgv(host.launchedArg, want) {
+		t.Fatalf("launch argv = %v, want %v", host.launchedArg, want)
+	}
+}
+
+func TestAdjacentPluginAutomaticallySelectedForCodex(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	root, executable := localPluginCheckout(t, "codex")
+	withExecutablePath(t, executable, nil)
+	host := &codexPluginDirHost{fakeHost: fakeHost{manifest: filepath.Join(root, ".codex-plugin", "plugin.json")}}
+	var stdout, stderr bytes.Buffer
+
+	code := runCodex(context.Background(), nil, t.TempDir(), host, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if host.inspectErr != nil {
+		t.Fatalf("marketplace inspection failed: %v", host.inspectErr)
+	}
+	if host.installedSymlinkDest != root {
+		t.Fatalf("installed checkout = %q, want adjacent root %q", host.installedSymlinkDest, root)
+	}
+	if host.launchedArg == nil {
+		t.Fatal("Codex launch seam was not reached")
+	}
+}
+
+func TestInvalidAdjacentPluginFallsBackToInstalledProvider(t *testing.T) {
+	for _, hostName := range []string{"claude", "codex"} {
+		for _, tc := range []struct {
+			name  string
+			setup func(t *testing.T, root string)
+		}{
+			{name: "missing manifest"},
+			{name: "wrong manifest name", setup: func(t *testing.T, root string) {
+				writeLocalPluginManifest(t, root, hostName, "not-spacedock", "./skills/")
+			}},
+			{name: "missing skills directory", setup: func(t *testing.T, root string) {
+				writeLocalPluginManifest(t, root, hostName, "spacedock", "./skills/")
+				if err := os.RemoveAll(filepath.Join(root, "skills")); err != nil {
+					t.Fatal(err)
+				}
+			}},
+			{name: "release-style bin directory", setup: func(t *testing.T, root string) {
+				writeLocalPluginManifest(t, filepath.Dir(root), hostName, "spacedock", "./skills/")
+			}},
+		} {
+			t.Run(hostName+"/"+tc.name, func(t *testing.T) {
+				t.Setenv("CODEX_HOME", t.TempDir())
+				root := t.TempDir()
+				if tc.name == "release-style bin directory" {
+					root = filepath.Join(root, "bin")
+					if err := os.MkdirAll(root, 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if tc.setup != nil {
+					tc.setup(t, root)
+				}
+				executable := filepath.Join(root, "spacedock")
+				if err := os.WriteFile(executable, []byte("#!/bin/sh\n"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				withExecutablePath(t, executable, nil)
+				h := &resolvingHost{fakeHost: fakeHost{manifest: compatibleManifest(t)}}
+				var stdout, stderr bytes.Buffer
+				var code int
+				if hostName == "claude" {
+					code = runClaude(context.Background(), nil, t.TempDir(), h, lookFound, &stdout, &stderr)
+					if strings.Contains(strings.Join(h.launchedArg, " "), "--plugin-dir") {
+						t.Fatalf("invalid adjacent checkout reached Claude argv: %v", h.launchedArg)
+					}
+				} else {
+					code = runCodex(context.Background(), nil, t.TempDir(), h, lookFound, &stdout, &stderr)
+					if len(h.installCmds) != 0 {
+						t.Fatalf("invalid adjacent checkout invoked Codex install: %v", h.installCmds)
+					}
+				}
+				if code != 0 || h.resolveCalls == 0 {
+					t.Fatalf("installed fallback: exit=%d resolveCalls=%d stderr=%q", code, h.resolveCalls, stderr.String())
+				}
+			})
+		}
+	}
+}
+
+func TestMissingAdjacentPluginPreservesAutoInstall(t *testing.T) {
+	for _, hostName := range []string{"claude", "codex"} {
+		t.Run(hostName, func(t *testing.T) {
+			t.Setenv("CODEX_HOME", t.TempDir())
+			executable := filepath.Join(t.TempDir(), "spacedock")
+			if err := os.WriteFile(executable, []byte("#!/bin/sh\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			withExecutablePath(t, executable, nil)
+			h := &resolvingHost{fakeHost: fakeHost{manifestAfterInstall: compatibleManifest(t)}}
+			var stdout, stderr bytes.Buffer
+			var code int
+			if hostName == "claude" {
+				code = runClaude(context.Background(), nil, t.TempDir(), h, lookFound, &stdout, &stderr)
+			} else {
+				code = runCodex(context.Background(), nil, t.TempDir(), h, lookFound, &stdout, &stderr)
+			}
+			if code != 0 {
+				t.Fatalf("exit = %d, want installed fallback to heal (stderr=%q)", code, stderr.String())
+			}
+			if len(h.installCmds) != 3 || h.installCmds[0] != hostName {
+				t.Fatalf("install seam = %v, want one %s auto-install", h.installCmds, hostName)
+			}
+			if h.resolveCalls != 2 || h.launchedArg == nil {
+				t.Fatalf("fallback did not re-gate then launch: resolveCalls=%d argv=%v", h.resolveCalls, h.launchedArg)
+			}
+		})
+	}
+}
+
+func TestExplicitPluginDirPrecedesAdjacentPlugin(t *testing.T) {
+	adjacent, executable := localPluginCheckout(t, "claude")
+	explicit, _ := localPluginCheckout(t, "claude")
+	withExecutablePath(t, executable, nil)
+	host := &resolveErrHost{}
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), []string{"--plugin-dir", explicit}, t.TempDir(), host, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	joined := strings.Join(host.launchedArg, " ")
+	if !strings.Contains(joined, "--plugin-dir "+explicit) || strings.Contains(joined, "--plugin-dir "+adjacent) {
+		t.Fatalf("explicit override did not win: %v", host.launchedArg)
+	}
+}
+
+func TestExplicitCodexPluginDirPrecedesAdjacentPlugin(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	adjacent, executable := localPluginCheckout(t, "codex")
+	explicit, _ := localPluginCheckout(t, "codex")
+	withExecutablePath(t, executable, nil)
+	host := &codexPluginDirHost{fakeHost: fakeHost{manifest: filepath.Join(explicit, ".codex-plugin", "plugin.json")}}
+	var stdout, stderr bytes.Buffer
+
+	code := runCodex(context.Background(), []string{"--plugin-dir", explicit}, t.TempDir(), host, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if host.installedSymlinkDest != explicit {
+		t.Fatalf("installed checkout = %q, want explicit %q (adjacent was %q)", host.installedSymlinkDest, explicit, adjacent)
+	}
+}
+
+func TestClaudePostFencePluginDirDoesNotBypassGate(t *testing.T) {
+	additional := t.TempDir()
+	writeLocalPluginManifest(t, additional, "claude", "additional-tools", "./skills/")
+	installedManifest := compatibleManifest(t)
+	host := &resolvingHost{fakeHost: fakeHost{manifest: installedManifest}}
+	withExecutablePath(t, filepath.Join(t.TempDir(), "missing-spacedock"), os.ErrNotExist)
+	var stdout, stderr bytes.Buffer
+
+	code := runClaude(context.Background(), []string{"--", "--plugin-dir", additional}, t.TempDir(), host, lookFound, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if host.resolveCalls == 0 {
+		t.Fatal("post-fence additional plugin bypassed the installed Spacedock gate")
+	}
+	if host.resolvedManifest != installedManifest {
+		t.Fatalf("selected Spacedock manifest = %q, want installed provider %q", host.resolvedManifest, installedManifest)
+	}
+	want := []string{"claude", "--agent", "spacedock:first-officer", "--permission-mode", "auto", "--plugin-dir", additional, wantBootstrapPrompt}
+	if !equalArgv(host.launchedArg, want) {
+		t.Fatalf("launch argv = %v, want %v", host.launchedArg, want)
+	}
+}
+
+func TestCodexInvalidExplicitPluginFailsBeforeMutation(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	checkout := t.TempDir()
+	writeLocalPluginManifest(t, checkout, "codex", "not-spacedock", "./skills/")
+	host := &fakeHost{manifest: compatibleManifest(t)}
+	var stdout, stderr bytes.Buffer
+
+	code := runCodex(context.Background(), []string{"--plugin-dir", checkout}, t.TempDir(), host, lookFound, &stdout, &stderr)
+
+	if code == 0 {
+		t.Fatalf("exit = 0, want invalid-checkout failure (stderr=%q)", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), ".codex-plugin/plugin.json") || !strings.Contains(stderr.String(), "name") {
+		t.Fatalf("diagnostic is not actionable: %q", stderr.String())
+	}
+	if len(host.installCmds) != 0 {
+		t.Fatalf("install seam called before validation: %v", host.installCmds)
+	}
+	entries, err := os.ReadDir(codexHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("Codex config mutated before validation: %v", entries)
+	}
+}

--- a/internal/cli/claude_provider_identity_test.go
+++ b/internal/cli/claude_provider_identity_test.go
@@ -1,0 +1,238 @@
+// ABOUTME: Real-Claude AC-3 provider identity proof for post-fence additional plugins.
+// ABOUTME: Reads Claude's agent-listing event and includes an impersonating-provider mutation.
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	installedProviderMarker = "INSTALLED_PROVIDER_IDENTITY"
+	mutantProviderMarker    = "MUTANT_ADDITIONAL_PROVIDER_IDENTITY"
+)
+
+// claudeProviderHost keeps the production resolver but captures the real host
+// launch. A Claude authentication failure remains a host exit code, not a launch
+// error, so the pre-API agent-listing event can be inspected deterministically.
+type claudeProviderHost struct {
+	execHost
+	resolveCalls     int
+	resolvedManifest string
+	launchedArg      []string
+	launchOutput     string
+}
+
+func (h *claudeProviderHost) ResolveManifest(host string) (string, error) {
+	h.resolveCalls++
+	manifest, err := h.execHost.ResolveManifest(host)
+	h.resolvedManifest = manifest
+	return manifest, err
+}
+
+func (h *claudeProviderHost) Launch(argv []string, env []string) (int, error) {
+	h.launchedArg = append([]string(nil), argv...)
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	h.launchOutput = string(out)
+	if err == nil {
+		return 0, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), nil
+	}
+	return 1, err
+}
+
+// TestClaudeAdditionalPluginKeepsInstalledSpacedockProvider drives the real
+// Claude 2.x loader in an isolated config. Claude records its resolved agents in
+// an agent_listing_delta before the deliberately invalid API key is rejected,
+// giving the test a host-owned provider-identity observation without an LLM
+// response oracle.
+//
+// The second observation is the adversarial mutation: changing only the
+// additional plugin's manifest name to `spacedock` makes it impersonate the
+// provider. The installed compatibility gate still runs and the post-fence argv
+// is byte-identical, but Claude's registered spacedock:first-officer description
+// flips to the mutant marker. If the positive assertion were accidentally wired
+// only to gate/argv again, this sensitivity check would fail.
+func TestClaudeAdditionalPluginKeepsInstalledSpacedockProvider(t *testing.T) {
+	claudeBin, err := exec.LookPath("claude")
+	if err != nil {
+		t.Skip("claude not on PATH; provider-identity behavior test requires the host CLI")
+	}
+	savedBranch := devBranch
+	devBranch = "main"
+	defer func() { devBranch = savedBranch }()
+
+	observed, positive := observeClaudeFirstOfficerProvider(t, claudeBin, "additional-tools")
+	if !strings.Contains(observed, installedProviderMarker) {
+		t.Fatalf("resolved provider = %q, want installed marker %q; launch=%v output=%s", observed, installedProviderMarker, positive.launchedArg, positive.launchOutput)
+	}
+	if positive.resolveCalls == 0 || positive.resolvedManifest == "" {
+		t.Fatalf("installed compatibility gate was not observed: resolves=%d manifest=%q", positive.resolveCalls, positive.resolvedManifest)
+	}
+	if !argvContainsPair(positive.launchedArg, "--plugin-dir", positive.additionalDir) {
+		t.Fatalf("additional plugin did not reach Claude unchanged: %v", positive.launchedArg)
+	}
+
+	mutated, mutant := observeClaudeFirstOfficerProvider(t, claudeBin, "spacedock")
+	if !strings.Contains(mutated, mutantProviderMarker) {
+		t.Fatalf("mutation did not make the additional directory win: provider=%q launch=%v output=%s", mutated, mutant.launchedArg, mutant.launchOutput)
+	}
+	if mutant.resolveCalls == 0 || mutant.resolvedManifest == "" || !argvContainsPair(mutant.launchedArg, "--plugin-dir", mutant.additionalDir) {
+		t.Fatalf("mutation changed the gate/argv preconditions instead of provider identity: resolves=%d argv=%v", mutant.resolveCalls, mutant.launchedArg)
+	}
+	if !equalArgv(normalizeClaudeProviderArgv(positive.launchedArg), normalizeClaudeProviderArgv(mutant.launchedArg)) {
+		t.Fatalf("mutation changed launch shape instead of only provider identity:\npositive=%v\nmutant=%v", positive.launchedArg, mutant.launchedArg)
+	}
+}
+
+type claudeProviderObservation struct {
+	*claudeProviderHost
+	additionalDir string
+}
+
+func observeClaudeFirstOfficerProvider(t *testing.T, claudeBin, additionalName string) (string, claudeProviderObservation) {
+	t.Helper()
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	cacheDir := filepath.Join(tmp, "cache")
+	homeDir := filepath.Join(tmp, "home")
+	mustMkdir(t, configDir)
+	mustMkdir(t, cacheDir)
+	mustMkdir(t, homeDir)
+
+	marketplace := buildClaudeProviderMarketplace(t, filepath.Join(tmp, "marketplace-root"))
+	additional := buildClaudeProviderPlugin(t, filepath.Join(tmp, "additional"), additionalName, mutantProviderMarker)
+	t.Setenv("HOME", homeDir)
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+	t.Setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", cacheDir)
+	t.Setenv("ANTHROPIC_API_KEY", "invalid-provider-identity-test-key")
+	t.Setenv("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
+	withExecutablePath(t, filepath.Join(tmp, "not-adjacent"), os.ErrNotExist)
+
+	env := os.Environ()
+	runHost(t, claudeBin, env, "plugin", "marketplace", "add", marketplace)
+	runHost(t, claudeBin, env, "plugin", "install", "spacedock@spacedock")
+
+	debugLog := filepath.Join(tmp, "claude-debug.log")
+	host := &claudeProviderHost{}
+	var stdout, stderr bytes.Buffer
+	code := runClaude(context.Background(), []string{
+		"--", "--plugin-dir", additional,
+		"--print", "--debug-file", debugLog, "--max-budget-usd", "0.01",
+	}, t.TempDir(), host, lookFound, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("Claude unexpectedly accepted the deliberately invalid API key; output=%s", host.launchOutput)
+	}
+
+	provider := readClaudeAgentListing(t, configDir, "spacedock:first-officer")
+	return provider, claudeProviderObservation{claudeProviderHost: host, additionalDir: additional}
+}
+
+func buildClaudeProviderMarketplace(t *testing.T, root string) string {
+	t.Helper()
+	marketplace := filepath.Join(root, "marketplace")
+	plugin := filepath.Join(marketplace, "spacedock")
+	mustMkdir(t, filepath.Join(marketplace, ".claude-plugin"))
+	buildClaudeProviderPlugin(t, plugin, "spacedock", installedProviderMarker)
+	mustWrite(t, filepath.Join(marketplace, ".claude-plugin", "marketplace.json"), `{
+  "name": "spacedock",
+  "owner": { "name": "test" },
+  "plugins": [
+    { "name": "spacedock", "source": "./spacedock", "description": "test", "category": "workflow" }
+  ]
+}
+`)
+	return marketplace
+}
+
+func buildClaudeProviderPlugin(t *testing.T, root, name, marker string) string {
+	t.Helper()
+	mustMkdir(t, filepath.Join(root, ".claude-plugin"))
+	mustMkdir(t, filepath.Join(root, "agents"))
+	mustMkdir(t, filepath.Join(root, "skills"))
+	mustWrite(t, filepath.Join(root, ".claude-plugin", "plugin.json"),
+		`{"name":"`+name+`","version":"`+displayVersion()+`","skills":"./skills/"}`+"\n")
+	mustWrite(t, filepath.Join(root, "agents", "first-officer.md"),
+		"---\nname: first-officer\ndescription: "+marker+"\n---\n\n"+marker+"\n")
+	return root
+}
+
+func readClaudeAgentListing(t *testing.T, configDir, agentName string) string {
+	t.Helper()
+	var found string
+	err := filepath.WalkDir(configDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".jsonl" {
+			return nil
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			var event struct {
+				Attachment struct {
+					Type       string   `json:"type"`
+					AddedLines []string `json:"addedLines"`
+				} `json:"attachment"`
+			}
+			if json.Unmarshal(scanner.Bytes(), &event) != nil || event.Attachment.Type != "agent_listing_delta" {
+				continue
+			}
+			prefix := "- " + agentName + ":"
+			for _, line := range event.Attachment.AddedLines {
+				if strings.HasPrefix(line, prefix) {
+					found = line
+				}
+			}
+		}
+		return scanner.Err()
+	})
+	if err != nil {
+		t.Fatalf("read Claude agent listing: %v", err)
+	}
+	if found == "" {
+		t.Fatalf("Claude session did not record provider %s under %s", agentName, configDir)
+	}
+	return found
+}
+
+func argvContainsPair(argv []string, flag, value string) bool {
+	for i := 0; i+1 < len(argv); i++ {
+		if argv[i] == flag && argv[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeClaudeProviderArgv(argv []string) []string {
+	out := append([]string(nil), argv...)
+	for i := 0; i+1 < len(out); i++ {
+		switch out[i] {
+		case "--plugin-dir":
+			out[i+1] = "<additional-plugin>"
+		case "--debug-file":
+			out[i+1] = "<debug-log>"
+		}
+	}
+	return out
+}

--- a/internal/cli/codex_marketplace.go
+++ b/internal/cli/codex_marketplace.go
@@ -122,6 +122,11 @@ func WriteCodexLocalMarketplace(marketplaceRoot, repoRoot, marketplaceName strin
 // `--plugin-dir` install reports the checkout's checked-in .codex-plugin/plugin.json
 // version, not necessarily its current HEAD (the full stamping fix is deferred).
 func installCodexLocalPluginDir(ops hostOps, checkout string, stderr io.Writer) error {
+	// Preflight the checkout before creating the persistent marketplace directory,
+	// replacing its symlink, or asking Codex to remove/install any channel.
+	if err := validateLocalSpacedockPlugin(checkout, "codex"); err != nil {
+		return err
+	}
 	marketplaceRoot := filepath.Join(codexHome(), "spacedock-plugin-dir", channelMarketplace(devBranch))
 	if err := os.MkdirAll(marketplaceRoot, 0o755); err != nil {
 		return fmt.Errorf("create local marketplace dir: %w", err)

--- a/internal/cli/codex_plugin_dir_test.go
+++ b/internal/cli/codex_plugin_dir_test.go
@@ -41,7 +41,7 @@ func (h *codexPluginDirHost) Install(host, source, branch string) (string, error
 // re-introduction of the passthrough bug flips this assertion.
 func TestRunCodexPluginDirInstallsThenLaunchesWithoutTheFlag(t *testing.T) {
 	t.Setenv("CODEX_HOME", t.TempDir()) // isolate the persistent local marketplace
-	checkout := t.TempDir()
+	checkout, _ := localPluginCheckout(t, "codex")
 	host := &codexPluginDirHost{fakeHost: fakeHost{manifest: compatibleManifest(t)}}
 	var stdout, stderr bytes.Buffer
 
@@ -77,7 +77,7 @@ func TestRunCodexPluginDirInstallsThenLaunchesWithoutTheFlag(t *testing.T) {
 // the checkout flag nor its value reaches the real Codex argv.
 func TestRunCodexPluginDirPostFenceResumeStaysPromptFree(t *testing.T) {
 	t.Setenv("CODEX_HOME", t.TempDir()) // isolate the persistent local marketplace
-	checkout := t.TempDir()
+	checkout, _ := localPluginCheckout(t, "codex")
 	host := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
@@ -100,7 +100,7 @@ func TestRunCodexPluginDirPostFenceResumeStaysPromptFree(t *testing.T) {
 // never the Spacedock-owned checkout tokens.
 func TestRunCodexPluginDirModelOnlyRetainsBootstrapPosture(t *testing.T) {
 	t.Setenv("CODEX_HOME", t.TempDir()) // isolate the persistent local marketplace
-	checkout := t.TempDir()
+	checkout, _ := localPluginCheckout(t, "codex")
 	host := &fakeHost{manifest: compatibleManifest(t)}
 	var stdout, stderr bytes.Buffer
 
@@ -119,7 +119,7 @@ func TestRunCodexPluginDirModelOnlyRetainsBootstrapPosture(t *testing.T) {
 	}
 }
 
-func TestRunCodexPostFencePluginDirRemainsForwardedAndBootstraps(t *testing.T) {
+func TestRunCodexPostFencePluginDirIsRejectedTruthfully(t *testing.T) {
 	t.Setenv("CODEX_HOME", t.TempDir())
 	postFenceCheckout := t.TempDir()
 	host := &fakeHost{manifest: compatibleManifest(t)}
@@ -128,18 +128,17 @@ func TestRunCodexPostFencePluginDirRemainsForwardedAndBootstraps(t *testing.T) {
 	args := []string{"--", "--plugin-dir", postFenceCheckout}
 	code := runCodex(context.Background(), args, t.TempDir(), host, lookFound, &stdout, &stderr)
 
-	if code != 0 {
-		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
-	}
-	want := []string{"codex", "--ask-for-approval", "on-request", "--plugin-dir", postFenceCheckout, wantCodexBootstrapPrompt}
-	if !equalArgv(host.launchedArg, want) {
-		t.Fatalf("launch argv = %v, want %v", host.launchedArg, want)
+	if code == 0 {
+		t.Fatalf("exit = 0, want unsupported forwarded flag failure (stderr=%q)", stderr.String())
 	}
 	if len(host.installCmds) != 0 {
 		t.Fatalf("post-fence --plugin-dir invoked the local-install seam: %v", host.installCmds)
 	}
-	if !strings.Contains(stderr.String(), "· launching codex") {
-		t.Fatalf("post-fence --plugin-dir launch omitted the Codex banner: %q", stderr.String())
+	if host.launchedArg != nil {
+		t.Fatalf("post-fence --plugin-dir reached Codex argv: %v", host.launchedArg)
+	}
+	if !strings.Contains(stderr.String(), "does not accept forwarded --plugin-dir") || !strings.Contains(stderr.String(), "codex plugin add") {
+		t.Fatalf("post-fence diagnostic is not actionable: %q", stderr.String())
 	}
 }
 
@@ -154,7 +153,7 @@ func TestCodexPluginDirAdvisoryPresenceAndAbsence(t *testing.T) {
 
 	t.Run("present on --plugin-dir", func(t *testing.T) {
 		t.Setenv("CODEX_HOME", t.TempDir()) // isolate the persistent local marketplace
-		checkout := t.TempDir()
+		checkout, _ := localPluginCheckout(t, "codex")
 		fake := &fakeHost{manifest: compatibleManifest(t)}
 		var stdout, stderr bytes.Buffer
 		code := runCodex(context.Background(), []string{"--plugin-dir", checkout}, t.TempDir(), fake, lookFound, &stdout, &stderr)
@@ -197,7 +196,7 @@ func TestCodexPluginDirAdvisoryPresenceAndAbsence(t *testing.T) {
 // than the pre-change rejection.
 func TestInstallCodexPluginDirInstallsViaSharedHelper(t *testing.T) {
 	t.Setenv("CODEX_HOME", t.TempDir()) // isolate the persistent local marketplace
-	checkout := t.TempDir()
+	checkout, _ := localPluginCheckout(t, "codex")
 	host := &codexPluginDirHost{fakeHost: fakeHost{manifest: compatibleManifest(t)}}
 	var stdout, stderr bytes.Buffer
 

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -354,8 +354,10 @@ func printHealableRemedy(host string, res contract.Result, stderr io.Writer) {
 // `--safehouse-*` knobs translate into the safehouse `extra` slot. The bootstrap
 // prompt is appended last (base, or base + " " + task when a task is fenced after
 // `--`) unless a resume is forwarded. The gate is bypassed by an explicit
-// `--skip-compat-check` or by any `--plugin-dir` (the local checkout supersedes
-// the installed plugin). `lookPath` resolves the safehouse binary (default
+// `--skip-compat-check`, by a declared pre-fence `--plugin-dir`, or by a valid
+// host-specific plugin checkout adjacent to the resolved launcher. Post-fence
+// plugin directories remain native Claude additions and do not affect provider
+// selection or gating. `lookPath` resolves the safehouse binary (default
 // exec.LookPath; injected so tests pin not-found).
 func runClaude(ctx context.Context, args []string, dir string, ops hostOps, lookPath func(string) (string, error), stdout, stderr io.Writer) int {
 	fd, err := parseFrontDoorArgs(args)
@@ -368,10 +370,19 @@ func runClaude(ctx context.Context, args []string, dir string, ops hostOps, look
 		fmt.Fprintf(stderr, "spacedock claude: %v\n", err)
 		return 1
 	}
-	// A `--plugin-dir` launch loads the LOCAL plugin checkout, so the installed
-	// plugin's version verdict is irrelevant — it relaxes the gate exactly like
-	// an explicit `--skip-compat-check`.
-	if !fd.skipCheck && !hasPluginDir(fd.passthrough) {
+	// A declared pre-fence plugin directory is the compatibility-preserving local
+	// Spacedock override. Without one, a valid checkout beside the resolved
+	// launcher supplies the same session-local provider automatically. Native
+	// post-fence Claude plugin directories are additions only: they neither select
+	// Spacedock nor suppress the installed compatibility gate.
+	localSpacedock := fd.pluginDirPairs > 0
+	if !localSpacedock {
+		if adjacent, ok := adjacentSpacedockPluginRoot("claude"); ok {
+			fd.passthrough = append([]string{"--plugin-dir", adjacent}, fd.passthrough...)
+			localSpacedock = true
+		}
+	}
+	if !fd.skipCheck && !localSpacedock {
 		if !resolveHealableGate(ops, "claude", fd.noInstall, stderr) {
 			return 1
 		}
@@ -539,10 +550,12 @@ const codexBootstrapPrompt = "You totally got this. Take your time. I love you. 
 // sandbox). After Spacedock consumes its own pre-fence flags, an exact `resume`
 // token in Codex's forwarded argv suppresses the banner, default approval mode,
 // and bootstrap prompt; every other forwarded argv retains the normal fresh-launch
-// posture. A declared pre-fence `--plugin-dir` installs its local checkout before
-// the normal gate; `--skip-compat-check` alone bypasses that gate. `lookPath`
-// resolves the safehouse binary (default exec.LookPath; injected so tests pin
-// not-found).
+// posture. A declared pre-fence `--plugin-dir`, or a valid host-specific plugin
+// checkout adjacent to the resolved launcher when no explicit override exists,
+// installs the local checkout before the normal gate. Forwarded post-fence
+// `--plugin-dir` is rejected because Codex has no such native session flag.
+// `--skip-compat-check` alone bypasses the gate. `lookPath` resolves the safehouse
+// binary (default exec.LookPath; injected so tests pin not-found).
 func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookPath func(string) (string, error), stdout, stderr io.Writer) int {
 	fd, err := parseFrontDoorArgs(args)
 	if err != nil {
@@ -554,20 +567,25 @@ func runCodex(ctx context.Context, args []string, dir string, ops hostOps, lookP
 		fmt.Fprintf(stderr, "spacedock codex: %v\n", err)
 		return 1
 	}
-	// `spacedock codex --plugin-dir <checkout>` has no codex-native flag to forward
-	// — codex's CLI hard-rejects `--plugin-dir` — so consume it here: strip it from
-	// the passthrough so the real codex never sees it, build a local marketplace
-	// from the checkout, and install it under the binary's own channel. The normal
-	// gate then runs against the just-installed plugin. Unlike Claude's ephemeral
-	// --plugin-dir bypass, a Codex --plugin-dir is a real on-disk install. It is
-	// gate-checked rather than treated as redundant.
-	if dir, rest, found := takeCodexPluginDir(fd.passthrough, fd.pluginDirPairs); found {
-		fd.passthrough = rest
-		if dir == "" {
-			fmt.Fprintln(stderr, "spacedock codex: --plugin-dir requires a checkout path")
-			return 1
-		}
-		if err := installCodexLocalPluginDir(ops, dir, stderr); err != nil {
+	// Codex has no native session-local plugin flag. Consume only Spacedock's
+	// declared pre-fence override; reject a post-fence occurrence truthfully before
+	// any persistent work. When there is no explicit override, use a qualified
+	// checkout beside the resolved launcher. Explicit selection always wins.
+	pluginDir, rest, explicitPluginDir := takeCodexPluginDir(fd.passthrough, fd.pluginDirPairs)
+	fd.passthrough = rest
+	if hasPluginDir(fd.passthrough) {
+		fmt.Fprintln(stderr, "spacedock codex: Codex does not accept forwarded --plugin-dir; place the Spacedock checkout flag before `--`, or install additional Codex plugins with `codex plugin add`")
+		return 1
+	}
+	if explicitPluginDir && pluginDir == "" {
+		fmt.Fprintln(stderr, "spacedock codex: --plugin-dir requires a checkout path")
+		return 1
+	}
+	if !explicitPluginDir {
+		pluginDir, _ = adjacentSpacedockPluginRoot("codex")
+	}
+	if pluginDir != "" {
+		if err := installCodexLocalPluginDir(ops, pluginDir, stderr); err != nil {
 			fmt.Fprintf(stderr, "spacedock codex: %v\n", err)
 			return 1
 		}
@@ -767,7 +785,7 @@ func bindFrontDoorFlags(fs *pflag.FlagSet) frontDoorFlags {
 		addDirsRO: fs.StringArray("safehouse-add-dirs-ro", nil,
 			"Grant safehouse read-only access to a directory; repeatable"),
 		pluginDir: fs.StringArray("plugin-dir", nil,
-			"Load a local plugin checkout (relaxes the version gate); repeatable"),
+			"Select a local Spacedock checkout before -- (relaxes the version gate); repeatable"),
 	}
 }
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -48,17 +48,30 @@ func printHelp(w io.Writer) {
 func setFrontDoorHelp(cmd *cobra.Command, host string, w io.Writer) {
 	declareFrontDoorHelpFlags(cmd)
 	cmd.SetHelpFunc(func(c *cobra.Command, _ []string) {
+		pluginBehavior := `A valid Spacedock checkout beside the resolved launcher is selected automatically.
+Use --plugin-dir before -- to override that selection with another local checkout.
+For Claude, --plugin-dir after -- is a native additional session plugin; it does
+not replace Spacedock or bypass the installed-plugin compatibility gate.`
+		forwardingExamples := `Claude model/session flags and additional --plugin-dir entries.`
+		lastExample := `spacedock claude --safehouse-add-dirs ~/scratch -- --plugin-dir ./additional-plugin`
+		if host == "codex" {
+			pluginBehavior = `A valid Spacedock checkout beside the resolved launcher is selected automatically.
+Use --plugin-dir before -- to override that selection with another local checkout.
+Codex installs the selected checkout through its persistent local marketplace.
+Codex has no forwarded --plugin-dir flag; install additional plugins with
+"codex plugin add" instead.`
+			forwardingExamples = `Codex model/session flags. A forwarded --plugin-dir is rejected.`
+			lastExample = `spacedock codex -- --model gpt-5.6-sol`
+		}
 		fmt.Fprint(w, tagline+`
 
 Usage:
   spacedock `+host+` [task] [spacedock-flags] [-- `+host+`-flags]
 
 Start `+hostTitle(host)+` as your Spacedock first officer. The optional task is the
-launch prompt; everything after -- forwards verbatim to `+host+`.
+launch prompt; supported host arguments after -- forward verbatim to `+host+`.
 
-A --plugin-dir launch loads a local plugin checkout and relaxes the version gate,
-so it does not require a prior "spacedock install". --plugin-dir is accepted both
-before -- (as a spacedock-parsed flag, repeatable) and after -- (forwarded verbatim).
+`+pluginBehavior+`
 
 Flags:
 `)
@@ -66,13 +79,13 @@ Flags:
 		fmt.Fprint(w, `
 Forwarding:
   Tokens before -- are spacedock's (the task + the flags above). Tokens after --
-  forward verbatim to `+host+`, e.g. `+host+` model/session flags and --plugin-dir.
+  forward verbatim where supported to `+host+`: `+forwardingExamples+`
 
 Examples:
   spacedock `+host+`
   spacedock `+host+` "review the open PRs"
   spacedock `+host+` --plugin-dir ./checkout
-  spacedock `+host+` --safehouse-add-dirs ~/scratch -- --plugin-dir ./checkout
+  `+lastExample+`
 `)
 	})
 }

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -38,6 +38,15 @@ func TestFrontDoorHelpCarriesDetail(t *testing.T) {
 					t.Errorf("%s --help missing %q:\n%s", host, want, out)
 				}
 			}
+			hostTruth := []string{"additional session plugin", "not replace Spacedock"}
+			if host == "codex" {
+				hostTruth = []string{"persistent local marketplace", "forwarded --plugin-dir is rejected", "codex plugin add"}
+			}
+			for _, want := range hostTruth {
+				if !strings.Contains(out, want) {
+					t.Errorf("%s --help missing host-specific behavior %q:\n%s", host, want, out)
+				}
+			}
 		})
 	}
 }

--- a/internal/cli/launch_parity_test.go
+++ b/internal/cli/launch_parity_test.go
@@ -358,22 +358,21 @@ func TestCodexPostFenceWithoutResumeBootstrapsFirstOfficer(t *testing.T) {
 	}
 }
 
-// LP-AC-3: for claude, --plugin-dir passes through (multiplicity, order) AND
-// relaxes the gate (launches even on a failing manifest); without it the gate
-// still fails. Codex is the exception: its CLI has no --plugin-dir flag, so the
+// LP-AC-3: for claude, only a declared pre-fence --plugin-dir passes through AND
+// relaxes the gate; a post-fence directory is a native addition and the gate
+// still runs. Codex is the exception: its CLI has no --plugin-dir flag, so the
 // flag is consumed into a real local-marketplace install and the gate then runs
 // against that install rather than being relaxed (the codex sub-case below).
 func TestPluginDirRelaxesGate(t *testing.T) {
-	t.Run("claude-relaxes-on-failing-manifest", func(t *testing.T) {
+	t.Run("claude-post-fence-does-not-relax-failing-manifest", func(t *testing.T) {
 		fake := &fakeHost{manifest: tooOldBinaryManifest(t)} // gate would FAIL
 		var stdout, stderr bytes.Buffer
 		code := runClaude(context.Background(), []string{"--", "--plugin-dir", "/a", "--plugin-dir", "/b"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
-		if code != 0 {
-			t.Fatalf("exit = %d, want 0 (--plugin-dir relaxes the gate); stderr=%q", code, stderr.String())
+		if code == 0 {
+			t.Fatalf("exit = 0, want installed-gate failure for post-fence additions; stderr=%q", stderr.String())
 		}
-		want := []string{"claude", "--agent", "spacedock:first-officer", "--permission-mode", "auto", "--plugin-dir", "/a", "--plugin-dir", "/b", wantBootstrapPrompt}
-		if !equalArgv(fake.launchedArg, want) {
-			t.Fatalf("launch argv = %v, want %v", fake.launchedArg, want)
+		if fake.launchedArg != nil {
+			t.Fatalf("post-fence additions bypassed gate and launched: %v", fake.launchedArg)
 		}
 	})
 	t.Run("codex-plugin-dir-installs-then-gates-not-relaxed", func(t *testing.T) {
@@ -383,9 +382,10 @@ func TestPluginDirRelaxesGate(t *testing.T) {
 		// manifest, the gate FAILS — proving codex --plugin-dir installs then gates
 		// rather than relaxing.
 		t.Setenv("CODEX_HOME", t.TempDir()) // isolate the persistent local marketplace
+		checkout, _ := localPluginCheckout(t, "codex")
 		fake := &fakeHost{manifest: tooOldBinaryManifest(t)}
 		var stdout, stderr bytes.Buffer
-		code := runCodex(context.Background(), []string{"--plugin-dir", "/a"}, t.TempDir(), fake, lookFound, &stdout, &stderr)
+		code := runCodex(context.Background(), []string{"--plugin-dir", checkout}, t.TempDir(), fake, lookFound, &stdout, &stderr)
 		if code == 0 {
 			t.Fatalf("exit = 0, want non-zero (codex --plugin-dir gate-checks the install, not relaxes); stderr=%q", stderr.String())
 		}

--- a/internal/cli/local_plugin.go
+++ b/internal/cli/local_plugin.go
@@ -1,0 +1,80 @@
+// ABOUTME: Host-specific validation and adjacent discovery for local Spacedock plugins.
+// ABOUTME: A launcher selects its own checkout only when the host manifest and skills directory agree.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type localPluginManifest struct {
+	Name   string `json:"name"`
+	Skills string `json:"skills"`
+}
+
+func localPluginManifestPath(root, host string) (string, error) {
+	switch host {
+	case "claude":
+		return filepath.Join(root, ".claude-plugin", "plugin.json"), nil
+	case "codex":
+		return filepath.Join(root, ".codex-plugin", "plugin.json"), nil
+	default:
+		return "", fmt.Errorf("unsupported plugin host %q", host)
+	}
+}
+
+// validateLocalSpacedockPlugin qualifies root as a plugin for the named host.
+// The host manifest must parse, identify Spacedock, configure a skills path, and
+// point that path at an existing directory. Callers use the same validator for
+// automatic discovery and explicit Codex installs so validation always precedes
+// persistent marketplace mutation.
+func validateLocalSpacedockPlugin(root, host string) error {
+	manifestPath, err := localPluginManifestPath(root, host)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("invalid local Spacedock plugin %s: read manifest: %w", manifestPath, err)
+	}
+	var manifest localPluginManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("invalid local Spacedock plugin %s: parse manifest: %w", manifestPath, err)
+	}
+	if manifest.Name != "spacedock" {
+		return fmt.Errorf("invalid local Spacedock plugin %s: name is %q, want %q", manifestPath, manifest.Name, "spacedock")
+	}
+	if manifest.Skills == "" {
+		return fmt.Errorf("invalid local Spacedock plugin %s: skills path is empty", manifestPath)
+	}
+	skillsPath := filepath.FromSlash(manifest.Skills)
+	if !filepath.IsAbs(skillsPath) {
+		skillsPath = filepath.Join(root, skillsPath)
+	}
+	info, err := os.Stat(skillsPath)
+	if err != nil {
+		return fmt.Errorf("invalid local Spacedock plugin %s: skills directory %s: %w", manifestPath, skillsPath, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("invalid local Spacedock plugin %s: skills path %s is not a directory", manifestPath, skillsPath)
+	}
+	return nil
+}
+
+// adjacentSpacedockPluginRoot returns the directory containing the resolved
+// launcher only when it is a valid host-specific Spacedock plugin checkout.
+// Invalid or release-style layouts are simply not adjacent providers; callers
+// retain the installed resolver/gate behavior.
+func adjacentSpacedockPluginRoot(host string) (string, bool) {
+	bin, ok := resolvedLauncherBin()
+	if !ok {
+		return "", false
+	}
+	root := filepath.Dir(bin)
+	if err := validateLocalSpacedockPlugin(root, host); err != nil {
+		return "", false
+	}
+	return root, true
+}

--- a/internal/cli/plugin_dir_frontdoor_test.go
+++ b/internal/cli/plugin_dir_frontdoor_test.go
@@ -38,14 +38,14 @@ func (h *resolveErrHost) ResolveManifest(string) (string, error) {
 }
 
 // TestDevLanePluginDirReachesLaunchSeam locks AC-2(a) under the Option-2 grammar:
-// `spacedock claude "task" -- --plugin-dir <vendored-repo>` reaches the launch
+// `spacedock claude "task" --plugin-dir <vendored-repo>` reaches the launch
 // seam with the inner argv beginning `claude --agent spacedock:first-officer`, the
 // task-bearing prompt appended LAST, and NO contract-gate rejection — proving the
 // manifest this entity vendors flows through the dev lane. The host's
 // ResolveManifest is wired to fail; a launch on exit 0 with the FO seam present
 // proves the gate was relaxed (ResolveManifest never consulted). The prompt is
-// always the last spacedock-built token and --plugin-dir rides in the post-`--`
-// passthrough with its value bound, so the host never binds the prompt here
+// always the last spacedock-built token and --plugin-dir is re-injected into the
+// host passthrough with its value bound, so the host never binds the prompt here
 // (AC-3). The narrow limit — a dangling value-taking flag as the FINAL passthrough
 // token — is covered by TestDanglingValueTakingHostFlagStillSwallows.
 func TestDevLanePluginDirReachesLaunchSeam(t *testing.T) {
@@ -53,7 +53,7 @@ func TestDevLanePluginDirReachesLaunchSeam(t *testing.T) {
 	host := &resolveErrHost{}
 	var stdout, stderr bytes.Buffer
 
-	code := runClaude(context.Background(), []string{"do the thing", "--", "--plugin-dir", repo}, t.TempDir(), host, lookFound, &stdout, &stderr)
+	code := runClaude(context.Background(), []string{"do the thing", "--plugin-dir", repo}, t.TempDir(), host, lookFound, &stdout, &stderr)
 
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (--plugin-dir <repo> must relax the gate); stderr=%q", code, stderr.String())


### PR DESCRIPTION
Make source-built Spacedock launchers use their adjacent plugin checkout so local development survives release-version skew without explicit overrides.

## What changed

- Discover adjacent Spacedock manifests beside source-built launcher binaries.
- Prefer adjacent Claude and Codex providers unless explicitly overridden.
- Preserve post-fence Claude plugin directories as independent additions.
- Reject invalid Codex checkouts before mutating installation state.
- Document truthful host-specific development behavior.

## Evidence

- Go suites: 17/17 packages passed in standard and race modes; strict docs passed.
- Live probes: Claude and Codex selected adjacent providers; provider impersonation turned the AC-3 oracle red.

## Review guidance

Focus on pre/post-fence Claude provider selection and live-host test isolation.

---

[zbx](/spacedock-dev/spacedock/blob/38a6de7a63f1d82b6f108bdc759d3617433863e8/auto-load-adjacent-spacedock-plugin/index.md)
