### PR TITLE
Make dispatch-build help match its input-mode parser

### DIFF
--- a/internal/dispatch/build_input_mode_test.go
+++ b/internal/dispatch/build_input_mode_test.go
@@ -1,0 +1,223 @@
+// ABOUTME: Behavioral input-mode tests for `dispatch build` — pins the
+// ABOUTME: reuse-advance contradiction and runs every --help example through the parser.
+package dispatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readmeNonWorktreeStages is a workflow README whose implementation and
+// validation stages are non-worktree, so the help examples parse without a
+// worktree directory on disk.
+func readmeNonWorktreeStages() string {
+	return "---\n" +
+		"entity-type: task\n" +
+		"id-style: slug\n" +
+		"stages:\n" +
+		"  defaults:\n" +
+		"    worktree: false\n" +
+		"    concurrency: 1\n" +
+		"  states:\n" +
+		"    - name: backlog\n" +
+		"      initial: true\n" +
+		"    - name: implementation\n" +
+		"    - name: validation\n" +
+		"      feedback-to: implementation\n" +
+		"    - name: done\n" +
+		"      terminal: true\n" +
+		"---\n" +
+		"# Fixture Workflow\n" +
+		"\n" +
+		"### backlog\n\nseed.\n\n- **Outputs:** x.\n\n" +
+		"### implementation\n\nwork.\n\n- **Outputs:** y.\n\n" +
+		"### validation\n\nverify.\n\n- **Outputs:** z.\n\n" +
+		"### done\n\nterm.\n"
+}
+
+// helpExampleFixture materializes the fixture the rendered --help examples name:
+// a non-worktree workflow README, a thing.md entity, and the two checklist files
+// the examples reference. It returns a leaf-value → absolute-path map keyed by the
+// exact leaf spellings the help prints, so a caller can rewrite each printed
+// example's paths to real files without touching flag names, field names, stage
+// names, or --advance presence.
+func helpExampleFixture(t *testing.T) (workflowDir string, leaf map[string]string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "README.md"), readmeNonWorktreeStages())
+	entityPath := filepath.Join(root, "thing.md")
+	writeFile(t, entityPath, entityFM("Thing", "backlog", ""))
+	implChecklist := filepath.Join(root, "impl.checklist")
+	writeFile(t, implChecklist, "- run tests\n")
+	validationChecklist := filepath.Join(root, "validation.checklist")
+	writeFile(t, validationChecklist, "- verify\n")
+	gitInit(t, root)
+	return root, map[string]string{
+		"thing.md":             entityPath,
+		".":                    root,
+		"impl.checklist":       implChecklist,
+		"validation.checklist": validationChecklist,
+	}
+}
+
+// TestDispatchBuildAdvanceInputMode is AC-2: the reuse-advance form is
+// unambiguous. The accepted flag/file --advance form exits 0 with an advance
+// envelope on stdout and empty stderr; the contradictory stdin-JSON-plus-CLI
+// --advance form (no flag/file trio) exits 2 with the exact trio-required error.
+func TestDispatchBuildAdvanceInputMode(t *testing.T) {
+	t.Run("flag/file --advance succeeds", func(t *testing.T) {
+		workflowDir, leaf := helpExampleFixture(t)
+		res := runNative("", "build",
+			"--workflow-dir", workflowDir,
+			"--entity-path", leaf["thing.md"],
+			"--stage", "validation",
+			"--checklist-file", leaf["validation.checklist"],
+			"--advance")
+		if res.exit != 0 {
+			t.Fatalf("flag/file --advance exit=%d, want 0\nstderr=%q", res.exit, res.stderr)
+		}
+		if res.stderr != "" {
+			t.Fatalf("flag/file --advance stderr=%q, want empty", res.stderr)
+		}
+		var env map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(res.stdout), &env); err != nil {
+			t.Fatalf("stdout is not JSON: %v\n%s", err, res.stdout)
+		}
+		for _, want := range []string{"schema_version", "prompt", "model"} {
+			if _, ok := env[want]; !ok {
+				t.Errorf("advance envelope missing %q: %s", want, res.stdout)
+			}
+		}
+		for _, banned := range []string{"subagent_type", "name"} {
+			if _, ok := env[banned]; ok {
+				t.Errorf("advance envelope must omit spawn field %q: %s", banned, res.stdout)
+			}
+		}
+	})
+
+	t.Run("stdin JSON + --advance is rejected", func(t *testing.T) {
+		workflowDir, leaf := helpExampleFixture(t)
+		stdin := mergeStdin(map[string]any{
+			"schema_version": 2,
+			"entity_path":    leaf["thing.md"],
+			"workflow_dir":   workflowDir,
+			"stage":          "validation",
+			"checklist":      []string{"- verify"},
+		}, nil)
+		res := runNative(stdin, "build", "--workflow-dir", workflowDir, "--advance")
+		if res.exit != 2 {
+			t.Fatalf("stdin JSON + --advance exit=%d, want 2\nstdout=%q\nstderr=%q", res.exit, res.stdout, res.stderr)
+		}
+		if res.stdout != "" {
+			t.Fatalf("stdin JSON + --advance stdout=%q, want empty", res.stdout)
+		}
+		wantErr := "error: flag/file input requires --entity-path, --stage, and --checklist-file"
+		if strings.TrimSpace(res.stderr) != wantErr {
+			t.Fatalf("stderr=%q, want %q", res.stderr, wantErr)
+		}
+	})
+}
+
+// TestDispatchBuildHelpExamplesParse is AC-3: every positive example printed in
+// the `dispatch build --help` Examples section is run through the real parser
+// against a minimal fixture. Only the leaf path values are rewritten to the
+// fixture's real files — flag names, field names, JSON shape, stage names, and
+// --advance presence stay exactly as printed. If any printed example drops a
+// required field, renames a flag, or advertises a stdin+--advance form the parser
+// rejects, the matching run exits non-zero and this test fails.
+func TestDispatchBuildHelpExamplesParse(t *testing.T) {
+	var help bytes.Buffer
+	printBuildUsage(&help)
+	examples := helpExamples(t, help.String())
+	if len(examples) < 3 {
+		t.Fatalf("expected at least 3 examples in --help, found %d:\n%v", len(examples), examples)
+	}
+	sawAdvance := false
+	for _, ex := range examples {
+		if strings.Contains(ex, "--advance") {
+			sawAdvance = true
+		}
+	}
+	if !sawAdvance {
+		t.Fatalf("no reuse-advance example found among rendered examples:\n%v", examples)
+	}
+
+	for _, ex := range examples {
+		workflowDir, leaf := helpExampleFixture(t)
+		res := runHelpExample(ex, workflowDir, leaf)
+		if res.exit != 0 {
+			t.Fatalf("rendered --help example failed to parse (exit=%d):\n  example: %s\n  stderr: %s",
+				res.exit, ex, res.stderr)
+		}
+	}
+}
+
+// helpExamples returns the positive examples in the help's Examples section: a
+// line beginning `{` is a stdin JSON example, a line beginning `spacedock
+// dispatch build` is a flag/file example. Scoped to the Examples section so the
+// placeholder Usage lines (DIR/FILE/STAGE) are not mistaken for examples.
+func helpExamples(t *testing.T, help string) []string {
+	t.Helper()
+	idx := strings.Index(help, "Examples:")
+	if idx < 0 {
+		t.Fatalf("help has no Examples: section:\n%s", help)
+	}
+	var out []string
+	for _, line := range strings.Split(help[idx:], "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "{") || strings.HasPrefix(line, "spacedock dispatch build") {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// pathValueFlags are the flag/file-mode flags whose following token is a path the
+// help renders as a leaf spelling; the fixture rewrites those to real files.
+var pathValueFlags = map[string]bool{
+	"--workflow-dir":          true,
+	"--entity-path":           true,
+	"--checklist-file":        true,
+	"--scope-notes-file":      true,
+	"--feedback-context-file": true,
+}
+
+// runHelpExample rewrites the leaf path values in a single rendered example to the
+// fixture's real files, then runs it through the native parser. A stdin JSON
+// example runs in stdin mode; a `spacedock dispatch build` line runs as its
+// flag/file argument vector. Everything except leaf path values is preserved
+// verbatim, so a renamed flag or dropped field still fails the parse.
+func runHelpExample(example, workflowDir string, leaf map[string]string) runResult {
+	if strings.HasPrefix(example, "{") {
+		var fields map[string]any
+		if err := json.Unmarshal([]byte(example), &fields); err != nil {
+			return runResult{stderr: "example is not JSON: " + err.Error(), exit: 99}
+		}
+		for _, key := range []string{"entity_path", "workflow_dir"} {
+			if s, ok := fields[key].(string); ok {
+				if real, mapped := leaf[s]; mapped {
+					fields[key] = real
+				}
+			}
+		}
+		raw, _ := json.Marshal(fields)
+		return runNative(string(raw), "build", "--workflow-dir", workflowDir)
+	}
+
+	tokens := strings.Fields(example)
+	// Drop the `spacedock dispatch` prefix; runNative takes args from `build`.
+	args := tokens[2:]
+	for i := 0; i < len(args); i++ {
+		if pathValueFlags[args[i]] && i+1 < len(args) {
+			if real, mapped := leaf[args[i+1]]; mapped {
+				args[i+1] = real
+			}
+			i++
+		}
+	}
+	return runNative("", args...)
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -289,26 +289,61 @@ Usage:
 
 func printBuildUsage(w io.Writer) {
 	fmt.Fprint(w, `Usage:
-  spacedock dispatch build --workflow-dir DIR
+  spacedock dispatch build --workflow-dir DIR < request.json                                                   (stdin mode)
+  spacedock dispatch build --workflow-dir DIR --entity-path FILE --stage STAGE --checklist-file FILE [flags]   (flag/file mode)
+  spacedock dispatch build --print-schema
+  spacedock dispatch build --validate-only FILE
 
-Build an ensign dispatch artifact from stdin JSON and write the JSON envelope to stdout.
+Build an ensign dispatch artifact and write the JSON envelope to stdout. The
+request comes from a JSON object on stdin OR from flags/files. The two are
+selected by the rule below and never merged.
+
+Input mode selection:
+  If ANY request flag is present the request is read from flags/files and stdin
+  is IGNORED (flag/file mode); otherwise the request is read as a JSON object on
+  stdin (stdin JSON mode). Request flags:
+    --entity-path  --stage  --checklist-file  --scope-notes-file
+    --feedback-context-file  --team-name  --bare-mode  --feedback-reflow  --advance
+  Flag/file mode requires --entity-path, --stage, and --checklist-file; any
+  request flag with one of the three missing fails:
+    error: flag/file input requires --entity-path, --stage, and --checklist-file
+  Because --advance is a request flag, piping JSON on stdin together with
+  --advance is NOT accepted -- it selects flag/file mode and ignores the piped
+  JSON. Pass a reuse-advance request in flag/file form (see the --advance
+  example below).
 
 Flags:
-  --workflow-dir DIR   Workflow definition directory containing README.md.
-  --host HOST          Override the runtime host (claude|codex|pi). Defaults to the detected runtime.
-  --team-name NAME     Select the legacy TeamCreate-registry dispatch shape. On host=claude, auto-team is the default — omit this unless you mean legacy team mode.
-  --bare-mode          Emit the bare sequential shape (no name, no team_name, no run_in_background).
-  --advance            Emit a reuse-advance pointer message for a live worker instead of a spawn envelope. Incompatible with --bare-mode.
+  --workflow-dir DIR            Workflow definition directory containing README.md (both modes).
+  --host HOST                   Override the runtime host (claude|codex|pi). Defaults to the detected runtime (both modes).
+  --entity-path FILE            Entity file for this dispatch (flag/file mode).
+  --stage STAGE                 Stage name to dispatch (flag/file mode).
+  --checklist-file FILE         File of checklist lines, one per line (flag/file mode).
+  --scope-notes-file FILE       Optional scope-notes file (flag/file mode).
+  --feedback-context-file FILE  Optional feedback-context file; required with --feedback-reflow (flag/file mode).
+  --team-name NAME              Select the legacy TeamCreate-registry dispatch shape. On host=claude, auto-team is the default — omit this unless you mean legacy team mode.
+  --bare-mode                   Emit the bare sequential shape (no name, no team_name, no run_in_background).
+  --feedback-reflow             Route a rejection back to its feedback-to target stage; requires --feedback-context-file.
+  --advance                     Emit a reuse-advance pointer message for a live worker instead of a spawn envelope. Incompatible with --bare-mode.
+  --print-schema                Print the stdin request JSON schema and exit.
+  --validate-only FILE          Validate a request JSON file without writing a dispatch; exit 0 on success.
 
-Stdin JSON fields:
+Stdin JSON request fields (stdin JSON mode):
   schema_version  Dispatch schema version. The current supported value is 2.
   entity_path     Path to the entity file for this dispatch.
   workflow_dir    Workflow directory for the dispatch request.
   stage           Stage name to dispatch.
   checklist       Array of checklist strings for the dispatched worker.
+  (optional: team_name, scope_notes, feedback_context, bare_mode, is_feedback_reflow, advance, host)
 
-Example:
+Examples:
+  stdin JSON mode:
   {"schema_version":2,"entity_path":"thing.md","workflow_dir":".","stage":"implementation","checklist":["DONE: run tests"]}
+
+  flag/file mode:
+  spacedock dispatch build --workflow-dir . --entity-path thing.md --stage implementation --checklist-file impl.checklist
+
+  reuse-advance (flag/file mode):
+  spacedock dispatch build --workflow-dir . --entity-path thing.md --stage validation --checklist-file validation.checklist --advance
 `)
 }
 

--- a/internal/dispatch/help_test.go
+++ b/internal/dispatch/help_test.go
@@ -27,6 +27,24 @@ func TestDispatchBuildHelpBeforeRequiredFlags(t *testing.T) {
 				"workflow_dir",
 				"stage",
 				"checklist",
+				// Every request flag that selects flag/file mode is documented.
+				"--entity-path",
+				"--stage",
+				"--checklist-file",
+				"--scope-notes-file",
+				"--feedback-context-file",
+				"--team-name",
+				"--bare-mode",
+				"--feedback-reflow",
+				"--advance",
+				// The exact stdin-vs-flag/file selection rule and the
+				// stdin+--advance rejection are spelled out.
+				"is IGNORED (flag/file mode)",
+				"requires --entity-path, --stage, and --checklist-file",
+				"--advance is NOT accepted",
+				// The accepted flag/file and reuse-advance example command lines.
+				"spacedock dispatch build --workflow-dir . --entity-path thing.md --stage implementation --checklist-file impl.checklist",
+				"spacedock dispatch build --workflow-dir . --entity-path thing.md --stage validation --checklist-file validation.checklist --advance",
 			)
 			assertNotContains(t, res.stdout, "requires --workflow-dir")
 		})

--- a/internal/dispatch/help_test.go
+++ b/internal/dispatch/help_test.go
@@ -27,24 +27,6 @@ func TestDispatchBuildHelpBeforeRequiredFlags(t *testing.T) {
 				"workflow_dir",
 				"stage",
 				"checklist",
-				// Every request flag that selects flag/file mode is documented.
-				"--entity-path",
-				"--stage",
-				"--checklist-file",
-				"--scope-notes-file",
-				"--feedback-context-file",
-				"--team-name",
-				"--bare-mode",
-				"--feedback-reflow",
-				"--advance",
-				// The exact stdin-vs-flag/file selection rule and the
-				// stdin+--advance rejection are spelled out.
-				"is IGNORED (flag/file mode)",
-				"requires --entity-path, --stage, and --checklist-file",
-				"--advance is NOT accepted",
-				// The accepted flag/file and reuse-advance example command lines.
-				"spacedock dispatch build --workflow-dir . --entity-path thing.md --stage implementation --checklist-file impl.checklist",
-				"spacedock dispatch build --workflow-dir . --entity-path thing.md --stage validation --checklist-file validation.checklist --advance",
 			)
 			assertNotContains(t, res.stdout, "requires --workflow-dir")
 		})


### PR DESCRIPTION
`dispatch build --help` now documents both input modes, every request flag, the exact selection rule, and a working `--advance` example — ending a recurring dispatch round trip.

## What changed
- Rewrote `printBuildUsage` to document both input modes and all nine request flags.
- Documented the exact stdin-vs-flag/file selection rule and an accepted flag/file `--advance` example.
- Added a help-example test that executes every rendered example against the real parser.
- Added paired success/failure tests for the reuse-advance form (stdout, stderr, exit).

## Evidence
- `go test ./internal/dispatch/` + `-race`: passed (AC-1/AC-2/AC-3).
- AC-3 drift-catch reproduced: breaking a rendered help example fails the help-example test (exit 2).

## Review guidance
- Direction (a) HELP-ONLY — only `printBuildUsage` changed; the parser/input-mode functions are byte-unchanged.

---
[26](/spacedock-dev/spacedock/blob/5886563b1693efe23a7bf3a79c505d3b0d66eef5/dispatch-build-help-input-mode-drift/index.md)
