### PR TITLE
contractlint: bind Codex and Pi runtime semantics to Go sources instead of adapter prose

### DIFF
--- a/internal/contractlint/codex_multi_agent_v2_contract_test.go
+++ b/internal/contractlint/codex_multi_agent_v2_contract_test.go
@@ -25,8 +25,6 @@ type codexSpawnArg struct {
 	hasDefault  bool
 }
 
-// codexSpawnArgs parses atomically: every comma-delimited entry must match a whole
-// argument, so empty entries and stray characters are errors, not skipped text.
 func codexSpawnArgs(argList string) ([]codexSpawnArg, error) {
 	var out []codexSpawnArg
 	for _, entry := range strings.Split(argList, ",") {
@@ -127,9 +125,7 @@ func TestFeedbackRejectionFlowStaysHostNeutral(t *testing.T) {
 }
 
 // TestHostNeutralGuardDiscriminates is the non-vacuity control: capability-only
-// prose PASSES, a host name and each shape of host tool name RED. An emptied
-// vocabulary or a predicate that stopped comparing fails here rather than waving
-// through a shared skill that has drifted host-specific.
+// prose PASSES, a host name and each shape of host tool name RED.
 func TestHostNeutralGuardDiscriminates(t *testing.T) {
 	pass := []struct{ why, text string }{
 		{"capability-only prose", "Re-run the reviewer through `«addressable-worker»` and wait for `«completion-signal»`.\n"},

--- a/internal/contractlint/codex_multi_agent_v2_contract_test.go
+++ b/internal/contractlint/codex_multi_agent_v2_contract_test.go
@@ -1,147 +1,131 @@
+// ABOUTME: Binds the Codex spawn signature in the FO adapter to the arg shape the Go
+// ABOUTME: emitter produces, and guards the shared feedback skill's host-neutrality.
 package contractlint
 
 import (
-	"os"
-	"path/filepath"
+	"fmt"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/dispatch"
 )
 
-func TestFeedbackRejectionFlowStaysHostNeutral(t *testing.T) {
-	root := repoRoot(t)
-	rel := filepath.Join("skills", "feedback-rejection-flow", "SKILL.md")
-	data, err := os.ReadFile(filepath.Join(root, rel))
-	if err != nil {
-		t.Fatalf("read %s: %v", rel, err)
-	}
-	text := string(data)
+// codexSpawnCallRe captures the arg list of a `spawn_agent(...)` shape in adapter
+// prose; codexSpawnArgRe splits it into `name` / `name="value"` entries.
+var (
+	codexSpawnCallRe = regexp.MustCompile(`spawn_agent\(([^)]*)\)`)
+	codexSpawnArgRe  = regexp.MustCompile(`([a-z_]+)(?:="([^"]*)")?`)
+)
 
-	for _, banned := range []string{
-		"Codex",
-		"Claude",
-		"followup_task",
-		"send_message",
-		"send_input",
-		"SendMessage",
-		"list_agents",
-		"wait_agent",
-		"spawn_agent",
-		"interrupt_agent",
-	} {
-		if strings.Contains(text, banned) {
-			t.Errorf("%s contains runtime-specific host or tool name %q", rel, banned)
-		}
+// codexSpawnSignatureViolations holds every `spawn_agent(...)` signature the
+// adapter spells out to the arg shape the Go emitter produces: the arg-NAME set
+// must equal the ToolArgs keys, and a default the signature spells out
+// (`fork_turns="none"`) must equal the emitted value. The sides are independent —
+// renaming a ToolArgs key or changing the emitted fork_turns value reds without
+// the doc moving, and a doc edit reds without the Go moving.
+func codexSpawnSignatureViolations(text string, toolArgs map[string]string) []string {
+	calls := codexSpawnCallRe.FindAllStringSubmatch(text, -1)
+	if len(calls) == 0 {
+		return []string{"no `spawn_agent(...)` signature found — extractor bug; the binding would pass vacuously"}
 	}
-
-	for _, want := range []string{
-		"`«addressable-worker»`",
-		"`«completion-signal»`",
-		"Fresh-dispatch the reviewer only when the existing reviewer is no longer addressable or reuse conditions fail",
-	} {
-		if !strings.Contains(text, want) {
-			t.Errorf("%s missing host-neutral capability wording %q", rel, want)
-		}
+	wanted := map[string]bool{}
+	for name := range toolArgs {
+		wanted[name] = true
 	}
-}
-
-func TestCodexToolNamesStayInRuntimeBindingSection(t *testing.T) {
-	root := repoRoot(t)
-	codexRuntimeRel := filepath.Join("skills", "first-officer", "references", "codex-first-officer-runtime.md")
-	data, err := os.ReadFile(filepath.Join(root, codexRuntimeRel))
-	if err != nil {
-		t.Fatalf("read %s: %v", codexRuntimeRel, err)
-	}
-	codexRuntime := string(data)
-	probeSection, outsideProbe := extractMarkdownSection(t, codexRuntime, "## Live Tool Surface Probe")
-	runtimeSection, outsideRuntime := extractMarkdownSection(t, outsideProbe, "## Runtime implementation")
-	allowedSections := probeSection + "\n" + runtimeSection
-	waitSection, outsideWait := extractMarkdownSection(t, outsideRuntime, "## Codex wait notes")
-
-	for _, want := range []string{
-		"`spawn_agent(task_name,message,fork_turns)`",
-		"`spawn_agent(task_name,message,fork_turns=\"none\")`",
-		"`send_message(target,message)`",
-		"`followup_task(target,message)`",
-		"`wait_agent(timeout_ms)`",
-		"`list_agents(path_prefix?)`",
-		"`interrupt_agent`",
-	} {
-		if !strings.Contains(allowedSections, want) {
-			t.Errorf("%s Codex runtime binding/probe sections missing %q", codexRuntimeRel, want)
-		}
-	}
-
-	paths := map[string]string{
-		codexRuntimeRel: outsideWait,
-	}
-	for _, rel := range []string{
-		filepath.Join("skills", "ensign", "references", "codex-ensign-runtime.md"),
-		filepath.Join("skills", "feedback-rejection-flow", "SKILL.md"),
-		filepath.Join("docs", "dev", "codex-idle-notification-probe.md"),
-	} {
-		data, err := os.ReadFile(filepath.Join(root, rel))
-		if err != nil {
-			t.Fatalf("read %s: %v", rel, err)
-		}
-		paths[rel] = string(data)
-	}
-
-	for rel, text := range paths {
-		for _, banned := range []string{
-			"spawn_agent(",
-			"send_message(",
-			"followup_task(",
-			"wait_agent(",
-			"list_agents(",
-			"send_input",
-			"SendMessage",
-			"interrupt_agent",
-		} {
-			if strings.Contains(text, banned) {
-				t.Errorf("%s contains runtime tool outside Codex live binding section: %q", rel, banned)
+	var out []string
+	for _, call := range calls {
+		names := map[string]bool{}
+		for _, arg := range codexSpawnArgRe.FindAllStringSubmatch(call[1], -1) {
+			names[arg[1]] = true
+			if emitted, ok := toolArgs[arg[1]]; arg[2] != "" && ok && emitted != arg[2] {
+				out = append(out, fmt.Sprintf("signature %q spells default %s=%q but the Go emitter produces %q", call[0], arg[1], arg[2], emitted))
 			}
 		}
+		if !setEqual(names, wanted) {
+			out = append(out, fmt.Sprintf("signature %q arg set %v does not match the Go emitter's ToolArgs keys %v; neither side may rename, add, or drop an arg without the other", call[0], sortedSet(names), sortedSet(wanted)))
+		}
 	}
+	return out
+}
 
-	if strings.Contains(waitSection, "spawn_agent(") ||
-		strings.Contains(waitSection, "send_message(") ||
-		strings.Contains(waitSection, "followup_task(") ||
-		strings.Contains(waitSection, "list_agents(") ||
-		strings.Contains(waitSection, "send_input") ||
-		strings.Contains(waitSection, "SendMessage") ||
-		strings.Contains(waitSection, "interrupt_agent") {
-		t.Errorf("%s Codex wait notes may mention only wait_agent as a concrete runtime tool", codexRuntimeRel)
+// TestCodexSpawnSignatureBindsToolArgs binds the Codex FO adapter's spawn
+// signature to `dispatch.CodexMultiAgentV2Spawn.ToolArgs()`, the Go surface
+// Spacedock emits for a Codex spawn. The other Codex tools the adapter names
+// (`send_message`, `followup_task`, `wait_agent`, `list_agents`,
+// `interrupt_agent`) have no Spacedock-emitted Go source; their runtime meaning is
+// owned by internal/ensigncycle/codex_live_runner_test.go.
+func TestCodexSpawnSignatureBindsToolArgs(t *testing.T) {
+	emitted := dispatch.CodexMultiAgentV2Spawn{TaskName: "spacedock_worker", Message: "assignment"}.ToolArgs()
+	if len(emitted) == 0 {
+		t.Fatal("ToolArgs() returned no args — the binding would pass vacuously")
+	}
+	for _, msg := range codexSpawnSignatureViolations(readRepoFile(t, codexFORuntimeRel), emitted) {
+		t.Errorf("%s: %s", codexFORuntimeRel, msg)
 	}
 }
 
-func TestCodexEnsignRuntimeAvoidsNegativeHostContrast(t *testing.T) {
-	root := repoRoot(t)
-	rel := filepath.Join("skills", "ensign", "references", "codex-ensign-runtime.md")
-	data, err := os.ReadFile(filepath.Join(root, rel))
-	if err != nil {
-		t.Fatalf("read %s: %v", rel, err)
-	}
-	text := string(data)
+// hostNeutralBannedTokens are the host names and host-specific tool names a
+// SHARED skill must never carry. It is a structural-absence vocabulary: it asserts
+// nothing about meaning, only that the skill speaks in `«capability»` terms every
+// host adapter can bind.
+var hostNeutralBannedTokens = []string{
+	"Codex",
+	"Claude",
+	"followup_task",
+	"send_message",
+	"send_input",
+	"SendMessage",
+	"list_agents",
+	"wait_agent",
+	"spawn_agent",
+	"interrupt_agent",
+}
 
-	for _, banned := range []string{
-		"Claude",
-		"another host",
-		"Codex declares none",
-		"Do not reconstruct",
-		"Do not send follow-up",
-	} {
+func hostNeutralViolations(text string) []string {
+	var out []string
+	for _, banned := range hostNeutralBannedTokens {
 		if strings.Contains(text, banned) {
-			t.Errorf("%s contains negative host-contrast wording %q", rel, banned)
+			out = append(out, fmt.Sprintf("contains runtime-specific host or tool name %q", banned))
 		}
 	}
+	return out
+}
 
-	for _, want := range []string{
-		"`«context-budget»` is unavailable unless a future probe binds it.",
-		"Use the generated file as the source of truth.",
-		"After sending the completion signal, stop unless the FO routes more work through `«addressable-worker»`.",
-	} {
-		if !strings.Contains(text, want) {
-			t.Errorf("%s missing positive Codex ensign wording %q", rel, want)
+// TestFeedbackRejectionFlowStaysHostNeutral keeps the shared feedback-rejection
+// skill free of host and host-tool names. What its `«capability»` vocabulary MEANS
+// is bound by TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters, which requires
+// every capability the skill references to exist in the dispatch core.
+func TestFeedbackRejectionFlowStaysHostNeutral(t *testing.T) {
+	for _, msg := range hostNeutralViolations(readRepoFile(t, feedbackFlowRel)) {
+		t.Errorf("%s %s", feedbackFlowRel, msg)
+	}
+}
+
+// TestHostNeutralGuardDiscriminates is the non-vacuity control: capability-only
+// prose PASSES, a host name and each shape of host tool name RED. An emptied
+// vocabulary or a predicate that stopped comparing fails here rather than waving
+// through a shared skill that has drifted host-specific.
+func TestHostNeutralGuardDiscriminates(t *testing.T) {
+	pass := []struct{ why, text string }{
+		{"capability-only prose", "Re-run the reviewer through `«addressable-worker»` and wait for `«completion-signal»`.\n"},
+		{"empty document", ""},
+	}
+	for _, c := range pass {
+		if v := hostNeutralViolations(c.text); len(v) != 0 {
+			t.Fatalf("control: the %s was wrongly flagged: %v", c.why, v)
+		}
+	}
+	red := []struct{ why, text string }{
+		{"host name (Claude)", "On Claude, keep the reviewer alive.\n"},
+		{"host name (Codex)", "On Codex, keep the reviewer alive.\n"},
+		{"turn-starting tool name", "Re-run the reviewer with followup_task(target,message).\n"},
+		{"non-triggering tool name", "Send context with send_message(target,message).\n"},
+		{"Claude team tool name", "Re-run the reviewer with SendMessage.\n"},
+	}
+	for _, c := range red {
+		if v := hostNeutralViolations(c.text); len(v) == 0 {
+			t.Fatalf("control: the %s was not flagged — the guard stopped biting", c.why)
 		}
 	}
 }

--- a/internal/contractlint/codex_multi_agent_v2_contract_test.go
+++ b/internal/contractlint/codex_multi_agent_v2_contract_test.go
@@ -13,8 +13,7 @@ import (
 
 // codexSpawnCallRe captures a `spawn_agent(...)` arg list; codexSpawnArgRe matches
 // ONE whole `name` / `name="value"` entry. The anchors are load-bearing: an
-// unanchored scan skips unparseable text, so `spawn_agent(task_name,,message)`
-// still yielded the expected name set and passed.
+// unanchored scan skips unparseable text, so `spawn_agent(task_name,,message)` passed.
 var (
 	codexSpawnCallRe = regexp.MustCompile(`spawn_agent\(([^)]*)\)`)
 	codexSpawnArgRe  = regexp.MustCompile(`^([a-z_]+)(?:="([^"]*)")?$`)
@@ -39,9 +38,9 @@ func codexSpawnArgs(argList string) ([]codexSpawnArg, error) {
 }
 
 // codexSpawnSignatureViolations holds every `spawn_agent(...)` signature the
-// adapter spells out to the arg shape the Go emitter produces: the arg-NAME set
-// must equal the ToolArgs keys, and a spelled-out default must equal the emitted
-// value. Either side moving alone reds.
+// adapter spells out to the arg shape `ToolArgs` DECLARES: the arg-NAME set must
+// equal its keys, and a spelled-out default must equal its value. Either side
+// moving alone reds.
 func codexSpawnSignatureViolations(text string, toolArgs map[string]string) []string {
 	calls := codexSpawnCallRe.FindAllStringSubmatch(text, -1)
 	if len(calls) == 0 {
@@ -76,10 +75,12 @@ func codexSpawnSignatureViolations(text string, toolArgs map[string]string) []st
 }
 
 // TestCodexSpawnSignatureBindsToolArgs binds the Codex FO adapter's spawn
-// signature to `dispatch.CodexMultiAgentV2Spawn.ToolArgs()`, the Go surface
-// Spacedock emits for a Codex spawn. The adapter's other tool names have no
-// Spacedock-emitted source; where each is really exercised (and where nothing
-// exercises it) is annotated on codexToolTokens in runtime_binding_block_test.go.
+// signature to the arg shape `dispatch.CodexMultiAgentV2Spawn.ToolArgs()`
+// declares. Scope of the claim: `ToolArgs` has NO production caller, so this is
+// doc-to-Go-declaration agreement, NOT evidence of what a Codex spawn puts on the
+// wire. It still reds on real divergence — the two sides can move independently —
+// but nothing here observes runtime behavior. The adapter's other tool names are
+// annotated on codexToolTokens in runtime_binding_block_test.go.
 func TestCodexSpawnSignatureBindsToolArgs(t *testing.T) {
 	emitted := dispatch.CodexMultiAgentV2Spawn{TaskName: "spacedock_worker", Message: "assignment"}.ToolArgs()
 	if len(emitted) == 0 {

--- a/internal/contractlint/codex_multi_agent_v2_contract_test.go
+++ b/internal/contractlint/codex_multi_agent_v2_contract_test.go
@@ -11,19 +11,39 @@ import (
 	"github.com/spacedock-dev/spacedock/internal/dispatch"
 )
 
-// codexSpawnCallRe captures the arg list of a `spawn_agent(...)` shape in adapter
-// prose; codexSpawnArgRe splits it into `name` / `name="value"` entries.
+// codexSpawnCallRe captures a `spawn_agent(...)` arg list; codexSpawnArgRe matches
+// ONE whole `name` / `name="value"` entry. The anchors are load-bearing: an
+// unanchored scan skips unparseable text, so `spawn_agent(task_name,,message)`
+// still yielded the expected name set and passed.
 var (
 	codexSpawnCallRe = regexp.MustCompile(`spawn_agent\(([^)]*)\)`)
-	codexSpawnArgRe  = regexp.MustCompile(`([a-z_]+)(?:="([^"]*)")?`)
+	codexSpawnArgRe  = regexp.MustCompile(`^([a-z_]+)(?:="([^"]*)")?$`)
 )
+
+type codexSpawnArg struct {
+	name, value string
+	hasDefault  bool
+}
+
+// codexSpawnArgs parses atomically: every comma-delimited entry must match a whole
+// argument, so empty entries and stray characters are errors, not skipped text.
+func codexSpawnArgs(argList string) ([]codexSpawnArg, error) {
+	var out []codexSpawnArg
+	for _, entry := range strings.Split(argList, ",") {
+		trimmed := strings.TrimSpace(entry)
+		m := codexSpawnArgRe.FindStringSubmatch(trimmed)
+		if m == nil {
+			return nil, fmt.Errorf("unparseable argument %q", trimmed)
+		}
+		out = append(out, codexSpawnArg{name: m[1], value: m[2], hasDefault: strings.Contains(trimmed, "=")})
+	}
+	return out, nil
+}
 
 // codexSpawnSignatureViolations holds every `spawn_agent(...)` signature the
 // adapter spells out to the arg shape the Go emitter produces: the arg-NAME set
-// must equal the ToolArgs keys, and a default the signature spells out
-// (`fork_turns="none"`) must equal the emitted value. The sides are independent —
-// renaming a ToolArgs key or changing the emitted fork_turns value reds without
-// the doc moving, and a doc edit reds without the Go moving.
+// must equal the ToolArgs keys, and a spelled-out default must equal the emitted
+// value. Either side moving alone reds.
 func codexSpawnSignatureViolations(text string, toolArgs map[string]string) []string {
 	calls := codexSpawnCallRe.FindAllStringSubmatch(text, -1)
 	if len(calls) == 0 {
@@ -35,11 +55,19 @@ func codexSpawnSignatureViolations(text string, toolArgs map[string]string) []st
 	}
 	var out []string
 	for _, call := range calls {
+		args, err := codexSpawnArgs(call[1])
+		if err != nil {
+			out = append(out, fmt.Sprintf("signature %q is malformed: %v", call[0], err))
+			continue
+		}
 		names := map[string]bool{}
-		for _, arg := range codexSpawnArgRe.FindAllStringSubmatch(call[1], -1) {
-			names[arg[1]] = true
-			if emitted, ok := toolArgs[arg[1]]; arg[2] != "" && ok && emitted != arg[2] {
-				out = append(out, fmt.Sprintf("signature %q spells default %s=%q but the Go emitter produces %q", call[0], arg[1], arg[2], emitted))
+		for _, arg := range args {
+			if names[arg.name] {
+				out = append(out, fmt.Sprintf("signature %q declares argument %q twice", call[0], arg.name))
+			}
+			names[arg.name] = true
+			if emitted, ok := toolArgs[arg.name]; arg.hasDefault && ok && emitted != arg.value {
+				out = append(out, fmt.Sprintf("signature %q spells default %s=%q but the Go emitter produces %q", call[0], arg.name, arg.value, emitted))
 			}
 		}
 		if !setEqual(names, wanted) {
@@ -51,10 +79,9 @@ func codexSpawnSignatureViolations(text string, toolArgs map[string]string) []st
 
 // TestCodexSpawnSignatureBindsToolArgs binds the Codex FO adapter's spawn
 // signature to `dispatch.CodexMultiAgentV2Spawn.ToolArgs()`, the Go surface
-// Spacedock emits for a Codex spawn. The other Codex tools the adapter names
-// (`send_message`, `followup_task`, `wait_agent`, `list_agents`,
-// `interrupt_agent`) have no Spacedock-emitted Go source; their runtime meaning is
-// owned by internal/ensigncycle/codex_live_runner_test.go.
+// Spacedock emits for a Codex spawn. The adapter's other tool names have no
+// Spacedock-emitted source; where each is really exercised (and where nothing
+// exercises it) is annotated on codexToolTokens in runtime_binding_block_test.go.
 func TestCodexSpawnSignatureBindsToolArgs(t *testing.T) {
 	emitted := dispatch.CodexMultiAgentV2Spawn{TaskName: "spacedock_worker", Message: "assignment"}.ToolArgs()
 	if len(emitted) == 0 {
@@ -65,10 +92,8 @@ func TestCodexSpawnSignatureBindsToolArgs(t *testing.T) {
 	}
 }
 
-// hostNeutralBannedTokens are the host names and host-specific tool names a
-// SHARED skill must never carry. It is a structural-absence vocabulary: it asserts
-// nothing about meaning, only that the skill speaks in `«capability»` terms every
-// host adapter can bind.
+// hostNeutralBannedTokens are the host and host-tool names a SHARED skill must
+// never carry — a structural-absence vocabulary, asserting nothing about meaning.
 var hostNeutralBannedTokens = []string{
 	"Codex",
 	"Claude",
@@ -94,8 +119,7 @@ func hostNeutralViolations(text string) []string {
 
 // TestFeedbackRejectionFlowStaysHostNeutral keeps the shared feedback-rejection
 // skill free of host and host-tool names. What its `«capability»` vocabulary MEANS
-// is bound by TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters, which requires
-// every capability the skill references to exist in the dispatch core.
+// is bound by TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters.
 func TestFeedbackRejectionFlowStaysHostNeutral(t *testing.T) {
 	for _, msg := range hostNeutralViolations(readRepoFile(t, feedbackFlowRel)) {
 		t.Errorf("%s %s", feedbackFlowRel, msg)

--- a/internal/contractlint/pi_runtime_negative_contrast_test.go
+++ b/internal/contractlint/pi_runtime_negative_contrast_test.go
@@ -1,101 +1,121 @@
+// ABOUTME: Structural-absence guard — runtime adapters carry no negative host-contrast
+// ABOUTME: wording and no mutable absolute step ordinals, with its non-vacuity control.
 package contractlint
 
 import (
-	"os"
-	"path/filepath"
+	"fmt"
 	"strings"
 	"testing"
 )
 
-// TestPiFirstOfficerRuntimeAvoidsNegativeHostContrast is the Pi FO equivalent of
-// TestCodexFirstOfficerRuntimeAvoidsNegativeHostContrast. It guards
-// skills/first-officer/references/pi-first-officer-runtime.md against the
-// negative host-contrast wording that the runtime-support.md positive-binding
-// sweep removed (see the pi-fo-runtime-runtime-support-compliance entity).
-//
-// A blanket "Claude" substring ban is intentionally NOT used: the Pi FO adapter
-// legitimately names "Claude" in a transport instruction (line 16: "without
-// rewriting it into Claude syntax"), comparative technical contrast (lines
-// 30/36: model-resolution delegation), and a runtime-support.md-conformant
-// teardown note (line 66: "Do not emulate Claude team deletion"). This test
-// instead bans the specific smell phrases the sweep removed, and asserts the
-// positive Pi bindings that replaced them — binding two independent values (the
-// runtime-support.md principle and the adapter text), not a prose-grep tautology.
-func TestPiFirstOfficerRuntimeAvoidsNegativeHostContrast(t *testing.T) {
-	root := repoRoot(t)
-	rel := filepath.Join("skills", "first-officer", "references", "pi-first-officer-runtime.md")
-	data, err := os.ReadFile(filepath.Join(root, rel))
-	if err != nil {
-		t.Fatalf("read %s: %v", rel, err)
-	}
-	text := string(data)
+// stepOrdinalPhrases are the absolute step-number couplings an adapter must not
+// carry: a step ordinal goes stale the moment the referenced procedure is
+// renumbered, so adapters name capabilities instead.
+var stepOrdinalPhrases = []string{
+	"Dispatch step",
+	"Event Loop step",
+	"Merge-and-Cleanup step",
+	"step 10",
+}
 
-	for _, banned := range []string{
+// negativeContrastPhrases are the "this host is not that host" smell phrases the
+// runtime-support positive-binding sweep removed, per adapter. An adapter may name
+// its own host and draw a technical comparison; it must not define itself by what
+// another host lacks. A blanket host-name ban is deliberately not used — the Pi FO
+// adapter legitimately names hosts in transport prose — so each entry is a phrase
+// the sweep actually removed.
+//
+// These are absence guards; they assert nothing about what an adapter MEANS. The
+// runtime-meaning claims these files once carried are bound by
+// TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters,
+// TestCodexSpawnSignatureBindsToolArgs, TestPiEmittedRuntimeTokensBindGoSource,
+// internal/dispatch/build_pi_host_test.go, and the gated live lanes in
+// internal/ensigncycle.
+var negativeContrastPhrases = map[string][]string{
+	codexEnsignRel: {
+		"Claude",
+		"another host",
+		"Codex declares none",
+		"Do not reconstruct",
+		"Do not send follow-up",
+	},
+	piFORuntimeRel: {
 		"does not expose Claude Code team-tool signatures",
 		"Do not call or ask workers to call Claude team tools",
 		"Pi has no such enum",
 		"Claude-centric enum",
 		"no Claude-centric",
-		"Merge-and-Cleanup step 10",
-		"Merge-and-Cleanup step",
-	} {
-		if strings.Contains(text, banned) {
-			t.Errorf("%s contains negative host-contrast wording %q", rel, banned)
+		"Do not create teams",
+		"Codex declares none",
+	},
+	piEnsignRel: {
+		"Do not assume Claude team tools",
+		"Claude team tools exist in Pi",
+	},
+}
+
+// stepOrdinalFiles are the adapters held to the no-absolute-step-ordinal rule.
+var stepOrdinalFiles = []string{piFORuntimeRel}
+
+func proseAbsenceViolations(text string, banned []string, kind string) []string {
+	var out []string
+	for _, phrase := range banned {
+		if strings.Contains(text, phrase) {
+			out = append(out, fmt.Sprintf("contains %s %q", kind, phrase))
 		}
 	}
+	return out
+}
 
-	for _, want := range []string{
-		// FIX 2 — the «worker.shutdown» capability binding replaced the mutable
-		// step-number coupling ("Merge-and-Cleanup step 10").
-		"`«worker.shutdown»`",
-		// FIX 3 — the positive Pi model-space binding replaced the Claude-centric
-		// enum contrast.
-		"Pi's model-space binding is provider/model strings",
-	} {
-		if !strings.Contains(text, want) {
-			t.Errorf("%s missing positive Pi capability wording %q", rel, want)
+// TestRuntimeAdaptersAvoidNegativeContrastAndStepOrdinals holds the Codex and Pi
+// adapters to two structural absences: no negative host-contrast wording, and no
+// absolute step ordinal coupling an adapter to a numbered procedure.
+func TestRuntimeAdaptersAvoidNegativeContrastAndStepOrdinals(t *testing.T) {
+	if len(negativeContrastPhrases) == 0 || len(stepOrdinalPhrases) == 0 {
+		t.Fatal("banned-phrase tables are empty — the guards would pass vacuously")
+	}
+	for rel, banned := range negativeContrastPhrases {
+		for _, msg := range proseAbsenceViolations(readRepoFile(t, rel), banned, "negative host-contrast wording") {
+			t.Errorf("%s %s", rel, msg)
+		}
+	}
+	for _, rel := range stepOrdinalFiles {
+		for _, msg := range proseAbsenceViolations(readRepoFile(t, rel), stepOrdinalPhrases, "mutable absolute step ordinal") {
+			t.Errorf("%s %s", rel, msg)
 		}
 	}
 }
 
-// TestPiEnsignRuntimeAvoidsNegativeHostContrast is the Pi ensign equivalent of
-// TestCodexEnsignRuntimeAvoidsNegativeHostContrast. The Pi ensign adapter is a
-// compact binding block keyed by the Pi-specific concerns (clarification,
-// completion signal); the shared ensign core owns the rest. The adapter has zero
-// legitimate "Claude" mentions, so a targeted phrase ban is safe here: it passes
-// today and would catch a re-introduced negative host-contrast sentence. The
-// positive assertions pin the binding-block bullets so the host-specific Pi
-// completion and clarification bindings survive the shared-core duplication trim.
-func TestPiEnsignRuntimeAvoidsNegativeHostContrast(t *testing.T) {
-	root := repoRoot(t)
-	rel := filepath.Join("skills", "ensign", "references", "pi-ensign-runtime.md")
-	data, err := os.ReadFile(filepath.Join(root, rel))
-	if err != nil {
-		t.Fatalf("read %s: %v", rel, err)
+// TestRuntimeAdapterAbsenceGuardsDiscriminate is the non-vacuity control:
+// positive-binding adapter prose PASSES, while a re-introduced host-contrast
+// sentence and a re-introduced step ordinal each RED. An emptied table or a
+// predicate that stopped comparing fails here rather than waving through an
+// adapter that has drifted back to defining itself by another host's gaps.
+func TestRuntimeAdapterAbsenceGuardsDiscriminate(t *testing.T) {
+	pass := []struct {
+		why, text, kind string
+		banned          []string
+	}{
+		{"positive Codex ensign binding", "`«context-budget»` is unavailable unless a future probe binds it.\n", "negative host-contrast wording", negativeContrastPhrases[codexEnsignRel]},
+		{"capability-named teardown", "Teardown runs through `«worker.shutdown»`.\n", "mutable absolute step ordinal", stepOrdinalPhrases},
 	}
-	text := string(data)
-
-	for _, banned := range []string{
-		"Do not assume Claude team tools",
-		"Claude team tools exist in Pi",
-	} {
-		if strings.Contains(text, banned) {
-			t.Errorf("%s contains negative host-contrast wording %q", rel, banned)
+	for _, c := range pass {
+		if v := proseAbsenceViolations(c.text, c.banned, c.kind); len(v) != 0 {
+			t.Fatalf("control: the %s was wrongly flagged: %v", c.why, v)
 		}
 	}
 
-	for _, want := range []string{
-		// The completion-signal binding bullet — the Pi-specific completion signal
-		// the shared core does not carry.
-		"- `Completion signal` ->",
-		"Completion is reported by the worker's final result in the Pi turn or by the active Pi adapter's task-completion notification.",
-		// The clarification binding bullet — the Pi-specific contact_supervisor
-		// surface the shared core does not carry.
-		"- `Clarification` ->",
-		"contact_supervisor` with `reason: \"need_decision\"`",
-	} {
-		if !strings.Contains(text, want) {
-			t.Errorf("%s missing positive Pi ensign binding wording %q", rel, want)
+	red := []struct {
+		why, text, kind string
+		banned          []string
+	}{
+		{"re-introduced host-contrast sentence", "The context budget is unavailable here; Codex declares none.\n", "negative host-contrast wording", negativeContrastPhrases[codexEnsignRel]},
+		{"re-introduced enum contrast", "Pi has no such enum, so pass the model string through.\n", "negative host-contrast wording", negativeContrastPhrases[piFORuntimeRel]},
+		{"re-introduced step ordinal", "Tear the worker down at Merge-and-Cleanup step 10.\n", "mutable absolute step ordinal", stepOrdinalPhrases},
+	}
+	for _, c := range red {
+		if v := proseAbsenceViolations(c.text, c.banned, c.kind); len(v) == 0 {
+			t.Fatalf("control: the %s was not flagged — the guard stopped biting", c.why)
 		}
 	}
 }

--- a/internal/contractlint/pi_runtime_negative_contrast_test.go
+++ b/internal/contractlint/pi_runtime_negative_contrast_test.go
@@ -20,11 +20,9 @@ var stepOrdinalPhrases = []string{
 
 // negativeContrastPhrases are the "this host is not that host" smell phrases the
 // runtime-support positive-binding sweep removed, per adapter. An adapter may name
-// its own host; it must not define itself by what another host lacks. A blanket
-// host-name ban is deliberately not used — the Pi FO adapter legitimately names
-// hosts in transport prose — so each entry is a phrase the sweep actually removed.
-// Absence guards only; the runtime-meaning claims are bound by the three binding
-// tests, and the unowned ones are listed under UNCOVERED RUNTIME TOKENS.
+// its own host; it must not define itself by what another host lacks. No blanket
+// host-name ban — the Pi FO adapter legitimately names hosts in transport prose —
+// so each entry is a phrase the sweep actually removed. Absence guards only.
 var negativeContrastPhrases = map[string][]string{
 	codexEnsignRel: {
 		"Claude",
@@ -54,8 +52,7 @@ var stepOrdinalFiles = []string{piFORuntimeRel}
 // lifecycleHeadings are the per-adapter lifecycle sections the runtime-binding-block
 // migration folded into `## Runtime implementation`; a re-introduced one gives a cold
 // agent two competing lifecycle stories. Deleted once on the unverified reasoning that
-// the capability-set equality subsumed it — wrong, because that set is extracted from
-// `## Runtime implementation` alone and never sees a sibling section.
+// the capability-set equality subsumed it — wrong: that set never sees a sibling section.
 var lifecycleHeadings = map[string][]string{
 	codexFORuntimeRel: {
 		"## Dispatch\n",

--- a/internal/contractlint/pi_runtime_negative_contrast_test.go
+++ b/internal/contractlint/pi_runtime_negative_contrast_test.go
@@ -23,10 +23,8 @@ var stepOrdinalPhrases = []string{
 // its own host; it must not define itself by what another host lacks. A blanket
 // host-name ban is deliberately not used — the Pi FO adapter legitimately names
 // hosts in transport prose — so each entry is a phrase the sweep actually removed.
-// These are absence guards, asserting nothing about what an adapter MEANS; the
-// runtime-meaning claims are bound by the three binding tests and
-// internal/dispatch/build_pi_host_test.go, and the unowned ones are listed under
-// UNCOVERED RUNTIME TOKENS in runtime_binding_block_test.go.
+// Absence guards only; the runtime-meaning claims are bound by the three binding
+// tests, and the unowned ones are listed under UNCOVERED RUNTIME TOKENS.
 var negativeContrastPhrases = map[string][]string{
 	codexEnsignRel: {
 		"Claude",
@@ -55,11 +53,9 @@ var stepOrdinalFiles = []string{piFORuntimeRel}
 
 // lifecycleHeadings are the per-adapter lifecycle sections the runtime-binding-block
 // migration folded into `## Runtime implementation`; a re-introduced one gives a cold
-// agent two competing lifecycle stories. This guard was deleted once on the reasoning
-// that a divergent re-introduced block would red the capability-set equality. That was
-// WRONG and shipped unverified: the capability set is extracted from the `## Runtime
-// implementation` section alone and never sees a sibling section, so re-adding
-// `## Awaiting Completion` red nothing. Restored, with a discriminator case.
+// agent two competing lifecycle stories. Deleted once on the unverified reasoning that
+// the capability-set equality subsumed it — wrong, because that set is extracted from
+// `## Runtime implementation` alone and never sees a sibling section.
 var lifecycleHeadings = map[string][]string{
 	codexFORuntimeRel: {
 		"## Dispatch\n",
@@ -114,9 +110,7 @@ func TestRuntimeAdaptersAvoidNegativeContrastAndStepOrdinals(t *testing.T) {
 
 // TestRuntimeAdapterAbsenceGuardsDiscriminate is the non-vacuity control:
 // positive-binding adapter prose PASSES, while a re-introduced host-contrast
-// sentence and a re-introduced step ordinal each RED. An emptied table or a
-// predicate that stopped comparing fails here rather than waving through an
-// adapter that has drifted back to defining itself by another host's gaps.
+// sentence, step ordinal, and lifecycle section each RED.
 func TestRuntimeAdapterAbsenceGuardsDiscriminate(t *testing.T) {
 	pass := []struct {
 		why, text, kind string

--- a/internal/contractlint/pi_runtime_negative_contrast_test.go
+++ b/internal/contractlint/pi_runtime_negative_contrast_test.go
@@ -20,17 +20,13 @@ var stepOrdinalPhrases = []string{
 
 // negativeContrastPhrases are the "this host is not that host" smell phrases the
 // runtime-support positive-binding sweep removed, per adapter. An adapter may name
-// its own host and draw a technical comparison; it must not define itself by what
-// another host lacks. A blanket host-name ban is deliberately not used — the Pi FO
-// adapter legitimately names hosts in transport prose — so each entry is a phrase
-// the sweep actually removed.
-//
-// These are absence guards; they assert nothing about what an adapter MEANS. The
-// runtime-meaning claims these files once carried are bound by
-// TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters,
-// TestCodexSpawnSignatureBindsToolArgs, TestPiEmittedRuntimeTokensBindGoSource,
-// internal/dispatch/build_pi_host_test.go, and the gated live lanes in
-// internal/ensigncycle.
+// its own host; it must not define itself by what another host lacks. A blanket
+// host-name ban is deliberately not used — the Pi FO adapter legitimately names
+// hosts in transport prose — so each entry is a phrase the sweep actually removed.
+// These are absence guards, asserting nothing about what an adapter MEANS; the
+// runtime-meaning claims are bound by the three binding tests and
+// internal/dispatch/build_pi_host_test.go, and the unowned ones are listed under
+// UNCOVERED RUNTIME TOKENS in runtime_binding_block_test.go.
 var negativeContrastPhrases = map[string][]string{
 	codexEnsignRel: {
 		"Claude",
@@ -57,6 +53,30 @@ var negativeContrastPhrases = map[string][]string{
 // stepOrdinalFiles are the adapters held to the no-absolute-step-ordinal rule.
 var stepOrdinalFiles = []string{piFORuntimeRel}
 
+// lifecycleHeadings are the per-adapter lifecycle sections the runtime-binding-block
+// migration folded into `## Runtime implementation`; a re-introduced one gives a cold
+// agent two competing lifecycle stories. This guard was deleted once on the reasoning
+// that a divergent re-introduced block would red the capability-set equality. That was
+// WRONG and shipped unverified: the capability set is extracted from the `## Runtime
+// implementation` section alone and never sees a sibling section, so re-adding
+// `## Awaiting Completion` red nothing. Restored, with a discriminator case.
+var lifecycleHeadings = map[string][]string{
+	codexFORuntimeRel: {
+		"## Dispatch\n",
+		"## Awaiting Completion\n",
+		"## Reuse And Feedback Routing\n",
+	},
+	piFORuntimeRel: {
+		"## Runtime Shape\n",
+		"## Dispatch\n",
+		"## Awaiting Completion\n",
+		"## Follow-up and Reuse\n",
+		"## Shutdown\n",
+		"### Model Resolution\n",
+		"### Canonical Model Space\n",
+	},
+}
+
 func proseAbsenceViolations(text string, banned []string, kind string) []string {
 	var out []string
 	for _, phrase := range banned {
@@ -68,10 +88,11 @@ func proseAbsenceViolations(text string, banned []string, kind string) []string 
 }
 
 // TestRuntimeAdaptersAvoidNegativeContrastAndStepOrdinals holds the Codex and Pi
-// adapters to two structural absences: no negative host-contrast wording, and no
-// absolute step ordinal coupling an adapter to a numbered procedure.
+// adapters to three structural absences: no negative host-contrast wording, no
+// absolute step ordinal coupling an adapter to a numbered procedure, and no
+// re-introduced lifecycle section competing with the runtime-binding block.
 func TestRuntimeAdaptersAvoidNegativeContrastAndStepOrdinals(t *testing.T) {
-	if len(negativeContrastPhrases) == 0 || len(stepOrdinalPhrases) == 0 {
+	if len(negativeContrastPhrases) == 0 || len(stepOrdinalPhrases) == 0 || len(lifecycleHeadings) == 0 {
 		t.Fatal("banned-phrase tables are empty — the guards would pass vacuously")
 	}
 	for rel, banned := range negativeContrastPhrases {
@@ -81,6 +102,11 @@ func TestRuntimeAdaptersAvoidNegativeContrastAndStepOrdinals(t *testing.T) {
 	}
 	for _, rel := range stepOrdinalFiles {
 		for _, msg := range proseAbsenceViolations(readRepoFile(t, rel), stepOrdinalPhrases, "mutable absolute step ordinal") {
+			t.Errorf("%s %s", rel, msg)
+		}
+	}
+	for rel, banned := range lifecycleHeadings {
+		for _, msg := range proseAbsenceViolations(readRepoFile(t, rel), banned, "retired lifecycle heading") {
 			t.Errorf("%s %s", rel, msg)
 		}
 	}
@@ -112,6 +138,7 @@ func TestRuntimeAdapterAbsenceGuardsDiscriminate(t *testing.T) {
 		{"re-introduced host-contrast sentence", "The context budget is unavailable here; Codex declares none.\n", "negative host-contrast wording", negativeContrastPhrases[codexEnsignRel]},
 		{"re-introduced enum contrast", "Pi has no such enum, so pass the model string through.\n", "negative host-contrast wording", negativeContrastPhrases[piFORuntimeRel]},
 		{"re-introduced step ordinal", "Tear the worker down at Merge-and-Cleanup step 10.\n", "mutable absolute step ordinal", stepOrdinalPhrases},
+		{"re-introduced lifecycle section", "## Awaiting Completion\n\nPoll the worker until it reports.\n", "retired lifecycle heading", lifecycleHeadings[codexFORuntimeRel]},
 	}
 	for _, c := range red {
 		if v := proseAbsenceViolations(c.text, c.banned, c.kind); len(v) == 0 {

--- a/internal/contractlint/runtime_binding_block_test.go
+++ b/internal/contractlint/runtime_binding_block_test.go
@@ -1,162 +1,263 @@
+// ABOUTME: Binds the runtime capability set across the dispatch core and both host adapters,
+// ABOUTME: binds Pi's emitted tokens to their Go source, and contains tool names to their sections.
 package contractlint
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/piruntime"
 )
 
-var runtimeBindingCapabilities = []string{
-	"worker.spawn",
-	"addressable-worker",
-	"async-dispatch",
-	"worker-identity",
-	"completion-signal",
-	"worker.shutdown",
-	"context-budget",
-	"roster-reconcile",
+var (
+	codexFORuntimeRel  = filepath.Join("skills", "first-officer", "references", "codex-first-officer-runtime.md")
+	piFORuntimeRel     = filepath.Join("skills", "first-officer", "references", "pi-first-officer-runtime.md")
+	feedbackFlowRel    = filepath.Join("skills", "feedback-rejection-flow", "SKILL.md")
+	codexEnsignRel     = filepath.Join("skills", "ensign", "references", "codex-ensign-runtime.md")
+	piEnsignRel        = filepath.Join("skills", "ensign", "references", "pi-ensign-runtime.md")
+	codexIdleProbeRel  = filepath.Join("docs", "dev", "codex-idle-notification-probe.md")
+	runtimeImplHeading = "## Runtime implementation"
+)
+
+// capabilitySetFromHeadings reads the dispatch core's capability «fn» DEFINITION
+// headings — the third, host-independent surface the adapter blocks are held to.
+func capabilitySetFromHeadings(t *testing.T) map[string]bool {
+	t.Helper()
+	raw, err := os.ReadFile(dispatchCorePath(t))
+	if err != nil {
+		t.Fatalf("read dispatch core: %v", err)
+	}
+	out := map[string]bool{}
+	for _, m := range fnHeadingRe.FindAllStringSubmatch(string(raw), -1) {
+		out[m[1]] = true
+	}
+	return out
 }
 
-func TestCodexAndPiFirstOfficerRuntimeBindingBlocks(t *testing.T) {
-	for _, rel := range []string{
-		filepath.Join("skills", "first-officer", "references", "codex-first-officer-runtime.md"),
-		filepath.Join("skills", "first-officer", "references", "pi-first-officer-runtime.md"),
-	} {
+// TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters binds the runtime capability
+// vocabulary across three independently divergeable surfaces — the Codex FO
+// runtime-binding bullets, the Pi FO runtime-binding bullets, and the dispatch
+// core's capability «fn» definition headings — as the SAME set. It replaces a
+// hardcoded expected-capability slice: the expectation is computed from the core
+// doc, so no re-typed literal can drift from all three. It also holds the shared
+// feedback-rejection skill to capabilities the core actually defines, which is
+// what keeps that skill's `«token»` vocabulary from being decorative.
+func TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters(t *testing.T) {
+	core := capabilitySetFromHeadings(t)
+	if len(core) == 0 {
+		t.Fatal("no capability «fn» definition headings found in the dispatch core — extractor bug; the binding would pass vacuously")
+	}
+
+	for _, rel := range []string{codexFORuntimeRel, piFORuntimeRel} {
 		t.Run(rel, func(t *testing.T) {
 			text := readRepoFile(t, rel)
-			if count := strings.Count(text, "## Runtime implementation\n"); count != 1 {
-				t.Fatalf("%s has %d `## Runtime implementation` sections, want exactly 1", rel, count)
+			if count := strings.Count(text, runtimeImplHeading+"\n"); count != 1 {
+				t.Fatalf("%s has %d `%s` sections, want exactly 1", rel, count, runtimeImplHeading)
 			}
-			section := markdownSectionFromText(t, text, "## Runtime implementation")
-			got := bindingBulletCapabilities(section)
-			if !reflect.DeepEqual(got, runtimeBindingCapabilities) {
-				t.Fatalf("%s runtime binding capabilities mismatch:\n  got:  %v\n  want: %v", rel, got, runtimeBindingCapabilities)
+			bullets := bindingBulletCapabilities(markdownSectionFromText(t, text, runtimeImplHeading))
+			if len(bullets) == 0 {
+				t.Fatalf("%s runtime-binding block yielded no capability bullets — extractor bug; the binding would pass vacuously", rel)
+			}
+			if adapter := toSet(bullets); !setEqual(adapter, core) {
+				t.Fatalf("%s runtime capability set differs from the dispatch core:\n  adapter: %v\n  core:    %v\nneither surface may add, drop, or rename a capability without the other", rel, sortedSet(adapter), sortedSet(core))
 			}
 		})
 	}
-}
 
-func TestCodexAndPiFirstOfficerRuntimeLifecycleHeadingsRemoved(t *testing.T) {
-	cases := map[string][]string{
-		filepath.Join("skills", "first-officer", "references", "codex-first-officer-runtime.md"): {
-			"## Dispatch",
-			"## Awaiting Completion",
-			"## Reuse And Feedback Routing",
-		},
-		filepath.Join("skills", "first-officer", "references", "pi-first-officer-runtime.md"): {
-			"## Runtime Shape",
-			"## Dispatch",
-			"## Awaiting Completion",
-			"## Follow-up and Reuse",
-			"## Shutdown",
-			"### Model Resolution",
-			"### Canonical Model Space",
-		},
+	refs := map[string]bool{}
+	for _, m := range fnRefRe.FindAllStringSubmatch(readRepoFile(t, feedbackFlowRel), -1) {
+		if !metaTokens[m[1]] {
+			refs[m[1]] = true
+		}
 	}
-	for rel, banned := range cases {
-		text := readRepoFile(t, rel)
-		for _, heading := range banned {
-			if strings.Contains(text, heading+"\n") {
-				t.Errorf("%s still contains lifecycle heading %q", rel, heading)
-			}
+	if len(refs) == 0 {
+		t.Fatalf("%s references no capabilities — extractor bug; the subset check would pass vacuously", feedbackFlowRel)
+	}
+	for name := range refs {
+		if !core[name] {
+			t.Errorf("%s references capability «%s», which the dispatch core does not define; the shared skill may only speak in capabilities every host adapter binds", feedbackFlowRel, name)
 		}
 	}
 }
 
-func TestPiFirstOfficerRuntimeRejectMutableStepAndNegativeContrast(t *testing.T) {
-	for _, rel := range []string{
-		filepath.Join("skills", "first-officer", "references", "pi-first-officer-runtime.md"),
-	} {
-		text := readRepoFile(t, rel)
-		for _, banned := range []string{
-			"Dispatch step",
-			"Event Loop step",
-			"Merge-and-Cleanup step",
-			"step 10",
-			"does not expose Claude Code team-tool signatures",
-			"Do not call or ask workers to call Claude team tools",
-			"Pi has no such enum",
-			"Claude-centric enum",
-			"Do not create teams",
-			"Codex declares none",
-		} {
-			if strings.Contains(text, banned) {
-				t.Errorf("%s contains mutable step coupling or negative host contrast %q", rel, banned)
-			}
+// piEmittedRuntimeToken is one runtime token Spacedock's Go code emits for Pi,
+// paired with the source that emits it.
+type piEmittedRuntimeToken struct {
+	token, source string
+}
+
+// piEmittedRuntimeTokens computes the Pi runtime tokens Spacedock emits by calling
+// the emitters rather than re-typing their strings. Substrate-native tokens Pi
+// owns but Spacedock never emits — `subagent(`, `intercom(`, `member_spawn` — are
+// deliberately absent: `member_spawn` appears in the Pi FO adapter with no
+// `teams.go` counterpart, and its runtime meaning belongs to the gated live lane
+// in internal/ensigncycle/pi_live_runner_test.go, not to a binding widened to
+// swallow it.
+func piEmittedRuntimeTokens(t *testing.T) []piEmittedRuntimeToken {
+	t.Helper()
+	wrapper := piruntime.SubagentStageDispatch("assignment", "implementation", "label")
+	field, ok := reflect.TypeOf(wrapper).FieldByName("Context")
+	if !ok {
+		t.Fatal("piruntime.SubagentDispatch has no Context field — the binding would pass vacuously")
+	}
+	contextKey := strings.Split(field.Tag.Get("json"), ",")[0]
+	return []piEmittedRuntimeToken{
+		{piruntime.TeamsDelegateAction("worker", "assignment").Action, "piruntime.TeamsDelegateAction"},
+		{piruntime.TeamsDirectMessageAction("worker", "message").Action, "piruntime.TeamsDirectMessageAction"},
+		{piruntime.TeamsShutdownAction("worker", "reason").Action, "piruntime.TeamsShutdownAction"},
+		{piruntime.TeamsDoneAction(true).Action, "piruntime.TeamsDoneAction"},
+		{fmt.Sprintf("%s: %q", contextKey, wrapper.Context), "piruntime.SubagentStageDispatch"},
+	}
+}
+
+// TestPiEmittedRuntimeTokensBindGoSource binds every Pi runtime token Spacedock
+// emits to the Pi FO adapter's runtime-binding block. Renaming a `TeamsAction`
+// action string or changing `SubagentStageDispatch`'s context value reds against
+// an unchanged doc; dropping the token from the doc reds against unchanged Go. The
+// wrapper's absent `acceptance` field is proven by
+// piruntime.TestSubagentStageDispatchAddsOnlyPiTransportFields and the built
+// artifact by internal/dispatch/build_pi_host_test.go; neither is restated here.
+func TestPiEmittedRuntimeTokensBindGoSource(t *testing.T) {
+	tokens := piEmittedRuntimeTokens(t)
+	if len(tokens) == 0 {
+		t.Fatal("no Pi emitted tokens — the binding would pass vacuously")
+	}
+	section := markdownSectionFromText(t, readRepoFile(t, piFORuntimeRel), runtimeImplHeading)
+	for _, tok := range tokens {
+		if tok.token == "" {
+			t.Fatalf("%s emitted an empty token — the binding would pass vacuously", tok.source)
+		}
+		if !strings.Contains(section, tok.token) {
+			t.Errorf("%s runtime-binding block does not carry %q, the token %s emits; the adapter must name every runtime token Spacedock actually sends", piFORuntimeRel, tok.token, tok.source)
 		}
 	}
 }
 
-func TestPiToolNamesStayInRuntimeBindingOrHarnessSections(t *testing.T) {
-	rel := filepath.Join("skills", "first-officer", "references", "pi-first-officer-runtime.md")
-	text := readRepoFile(t, rel)
-	allowed := markdownSectionFromText(t, text, "## Runtime implementation") + "\n" +
-		markdownSectionFromText(t, text, "## Live Harness Isolation")
-	outside := text
-	for _, heading := range []string{"## Runtime implementation", "## Live Harness Isolation"} {
-		_, remainder := extractMarkdownSection(t, outside, heading)
-		outside = remainder
+// codexToolTokens are the Codex tool names that must stay inside the Codex FO
+// adapter's probe and runtime-binding sections. piSubstrateNativeTokens are the Pi
+// tokens Spacedock does not emit; with the emitted tokens they form the Pi
+// containment set. Both are absence-guard vocabularies: they say nothing about
+// what a tool MEANS, only where its name may appear.
+var (
+	codexToolTokens = []string{
+		"spawn_agent(",
+		"send_message(",
+		"followup_task(",
+		"wait_agent(",
+		"list_agents(",
+		"send_input",
+		"SendMessage",
+		"interrupt_agent",
 	}
-
-	for _, want := range []string{
+	piSubstrateNativeTokens = []string{
 		"subagent(",
 		"intercom(",
 		"member_spawn",
-		"delegate",
-		"message_dm",
-		"member_shutdown",
-		"team_done",
-		`context: "fresh"`,
 		"cwd: <resolved repo root>",
 		"acceptance",
+	}
+)
+
+func piContainmentTokens(t *testing.T) []string {
+	out := append([]string{}, piSubstrateNativeTokens...)
+	for _, tok := range piEmittedRuntimeTokens(t) {
+		out = append(out, tok.token)
+	}
+	return out
+}
+
+func toolTokenContainmentViolations(span string, tokens []string) []string {
+	var out []string
+	for _, token := range tokens {
+		if strings.Contains(span, token) {
+			out = append(out, fmt.Sprintf("carries runtime tool token %q outside its binding section", token))
+		}
+	}
+	return out
+}
+
+// TestRuntimeToolTokensStayInBindingSections is the section-scoping containment
+// guard: host tool names live only where the adapter binds them, so prose
+// elsewhere stays readable by a cold agent on any host. It asserts where a name
+// may appear, never what the tool does — the Codex spawn call is bound by
+// TestCodexSpawnSignatureBindsToolArgs, the Pi tokens by
+// TestPiEmittedRuntimeTokensBindGoSource, and the substrate-native tools by the
+// gated live lanes in internal/ensigncycle.
+func TestRuntimeToolTokensStayInBindingSections(t *testing.T) {
+	codexText := readRepoFile(t, codexFORuntimeRel)
+	_, outsideProbe := extractMarkdownSection(t, codexText, "## Live Tool Surface Probe")
+	_, outsideRuntime := extractMarkdownSection(t, outsideProbe, runtimeImplHeading)
+	waitSection, outsideWait := extractMarkdownSection(t, outsideRuntime, "## Codex wait notes")
+
+	for rel, span := range map[string]string{
+		codexFORuntimeRel: outsideWait,
+		codexEnsignRel:    readRepoFile(t, codexEnsignRel),
+		feedbackFlowRel:   readRepoFile(t, feedbackFlowRel),
+		codexIdleProbeRel: readRepoFile(t, codexIdleProbeRel),
 	} {
-		if !strings.Contains(allowed, want) {
-			t.Errorf("%s allowed runtime/harness sections missing %q", rel, want)
+		for _, msg := range toolTokenContainmentViolations(span, codexToolTokens) {
+			t.Errorf("%s %s", rel, msg)
 		}
 	}
 
-	for _, banned := range []string{
-		"subagent(",
-		"intercom(",
-		"member_spawn",
-		"delegate",
-		"message_dm",
-		"member_shutdown",
-		"team_done",
-		`context: "fresh"`,
-		"cwd: <resolved repo root>",
-		"acceptance",
-	} {
-		if strings.Contains(outside, banned) {
-			t.Errorf("%s contains Pi tool token outside runtime implementation or harness section: %q", rel, banned)
+	// The wait notes are the one section allowed to name a concrete tool, and only
+	// `wait_agent` — the tool the notes exist to describe.
+	waitAllowed := []string{}
+	for _, token := range codexToolTokens {
+		if token != "wait_agent(" {
+			waitAllowed = append(waitAllowed, token)
 		}
+	}
+	for _, msg := range toolTokenContainmentViolations(waitSection, waitAllowed) {
+		t.Errorf("%s Codex wait notes may name only wait_agent as a concrete runtime tool: %s", codexFORuntimeRel, msg)
+	}
+
+	piText := readRepoFile(t, piFORuntimeRel)
+	outsidePi := piText
+	for _, heading := range []string{runtimeImplHeading, "## Live Harness Isolation"} {
+		_, outsidePi = extractMarkdownSection(t, outsidePi, heading)
+	}
+	for _, msg := range toolTokenContainmentViolations(outsidePi, piContainmentTokens(t)) {
+		t.Errorf("%s %s", piFORuntimeRel, msg)
 	}
 }
 
-func TestPiFirstOfficerRuntimeSemanticsPreserved(t *testing.T) {
-	cases := map[string][]string{
-		filepath.Join("skills", "first-officer", "references", "pi-first-officer-runtime.md"): {
-			"Pi-native substrate selected by the launch/test harness",
-			"`subagent(...)` with explicit `context: \"fresh\"` and `cwd: <resolved repo root>`",
-			"do not use the `subagent(... acceptance: ...)` contract",
-			"`intercom({action:\"list\"})`",
-			"Pi's model-space binding is provider/model strings",
-			"file verification remains the completion gate",
-			"Fresh redispatch remains the default",
-			"non-fresh resume is only an explicit manual/debug exception",
-			"completed child invocation needs no mailbox shutdown",
-			"`member_shutdown`",
-		},
+// TestToolTokenContainmentGuardDiscriminates is the non-vacuity control:
+// capability-only prose PASSES, while a Codex tool call, a Pi emitted token, and a
+// Pi substrate-native token each RED in a span that must not carry them. An
+// emptied vocabulary or a predicate that stopped comparing fails here rather than
+// waving through an adapter that has leaked tool names into host-neutral prose.
+func TestToolTokenContainmentGuardDiscriminates(t *testing.T) {
+	piTokens := piContainmentTokens(t)
+	pass := []struct {
+		why, span string
+		tokens    []string
+	}{
+		{"capability-only Codex prose", "Route the follow-up through `«addressable-worker»`.\n", codexToolTokens},
+		{"capability-only Pi prose", "Teardown maps to `«worker.shutdown»`.\n", piTokens},
 	}
-	for rel, wants := range cases {
-		text := readRepoFile(t, rel)
-		for _, want := range wants {
-			if !strings.Contains(text, want) {
-				t.Errorf("%s missing preserved runtime semantic %q", rel, want)
-			}
+	for _, c := range pass {
+		if v := toolTokenContainmentViolations(c.span, c.tokens); len(v) != 0 {
+			t.Fatalf("control: the %s was wrongly flagged: %v", c.why, v)
+		}
+	}
+	red := []struct {
+		why, span string
+		tokens    []string
+	}{
+		{"leaked Codex spawn call", "For every ready entity call spawn_agent(task_name,message).\n", codexToolTokens},
+		{"leaked Claude team tool", "Reply with SendMessage to the first officer.\n", codexToolTokens},
+		{"leaked Pi emitted action", "Follow-up steering maps to message_dm.\n", piTokens},
+		{"leaked Pi substrate-native tool", "Call subagent(...) with a fresh context.\n", piTokens},
+	}
+	for _, c := range red {
+		if v := toolTokenContainmentViolations(c.span, c.tokens); len(v) == 0 {
+			t.Fatalf("control: the %s was not flagged — the guard stopped biting", c.why)
 		}
 	}
 }

--- a/internal/contractlint/runtime_binding_block_test.go
+++ b/internal/contractlint/runtime_binding_block_test.go
@@ -147,9 +147,9 @@ func piEmittedRuntimeTokens(t *testing.T) []piEmittedRuntimeToken {
 	}
 }
 
-// codeSpanRe matches one `backticked` span. Comparing whole spans rather than raw
-// substrings is load-bearing: ordinary prose ("we delegate the work") satisfied a
-// `strings.Contains` check for `delegate`, binding nothing.
+// codeSpanRe matches one `backticked` span. Whole spans, not raw substrings:
+// ordinary prose ("we delegate the work") satisfied a `strings.Contains` check for
+// `delegate`, binding nothing.
 var codeSpanRe = regexp.MustCompile("`([^`]+)`")
 
 func codeSpans(section string) map[string]bool {
@@ -161,8 +161,11 @@ func codeSpans(section string) map[string]bool {
 }
 
 // TestPiEmittedRuntimeTokensBindGoSource binds every Pi runtime token Spacedock
-// emits to the Pi FO adapter's runtime-binding block; either side moving alone
-// reds. The wrapper's absent `acceptance` field is proven by
+// emits to the Pi FO adapter's runtime-binding block. The binding is ONE-WAY:
+// renaming an emitter or dropping the token from the doc reds, but the adapter may
+// name a token Spacedock never emits and stay green — which is why `member_spawn`
+// needs the uncovered record below rather than this test. The wrapper's absent
+// `acceptance` field is proven by
 // piruntime.TestSubagentStageDispatchAddsOnlyPiTransportFields and the built
 // artifact by internal/dispatch/build_pi_host_test.go; neither is restated here.
 func TestPiEmittedRuntimeTokensBindGoSource(t *testing.T) {
@@ -199,29 +202,36 @@ func piTokenBindingViolations(spans map[string]bool, tokens []piEmittedRuntimeTo
 // inside their adapter's binding sections — absence-guard vocabularies saying
 // nothing about what a tool MEANS, only where its name may appear.
 //
-// UNCOVERED RUNTIME TOKENS (roborev job 328 finding 4b; captain ruling 2026-07-20).
-// Tokens marked UNCOVERED have NO owner anywhere in this repo: no Go emitter, no
-// build fixture, no live-lane assertion. Each was verified by grepping every
-// non-contractlint Go file. Their prose checks are DELETED rather than retained: a
-// phrase check for a token nothing exercises proves only that we wrote the word,
-// which is the fabricated rigor this entity exists to remove. 0.26.0 ships these
-// gaps knowingly — the entries still bound WHERE the names may appear, but nothing
-// proves WHAT they do. Follow-up: record-uncovered-runtime-tokens.
+// UNCOVERED RUNTIME TOKENS (roborev job 328 finding 4b; validation cycle 1;
+// captain ruling 2026-07-20). NINE tokens this entity retired have NO owner: no Go
+// string literal outside internal/contractlint names them at all. Enumerated by
+// script, not by hand — three successive hand-audits each missed a different one.
+//
+//	contact_supervisor  interrupt_agent  list_agents  member_spawn  send_message
+//	need_decision  timeout_ms  path_prefix  cwd: <resolved repo root>
+//
+// Their prose checks are DELETED, not retained: a phrase check for a token nothing
+// exercises proves only that we wrote the word. 0.26.0 ships these gaps knowingly.
+// Follow-up: record-uncovered-runtime-tokens.
+//
+// `subagent` and `intercom` are NAMED by Go source but not asserted by it — the
+// hits are the `pi-subagents`/`pi-intercom` package names, the unrelated
+// `subagent_type` field, and dispatch prose. Named is not owned.
 var (
 	codexToolTokens = []string{
 		"spawn_agent(",    // bound by TestCodexSpawnSignatureBindsToolArgs
 		"send_message(",   // UNCOVERED
 		"followup_task(",  // ensigncycle/shared_reviewer_reuse{,_table}_test.go
-		"wait_agent(",     // ensigncycle/codex_single_run_test.go, codex_dispatch_evidence_test.go
+		"wait_agent(",     // ensigncycle/codex_dispatch_evidence_test.go
 		"list_agents(",    // UNCOVERED
 		"send_input",      // ensigncycle/shared_reviewer_reuse_table_test.go (reuse transcript fixtures)
 		"SendMessage",     // Claude team tool; banned here, owned by the Claude lanes
 		"interrupt_agent", // UNCOVERED
 	}
 	piSubstrateNativeTokens = []string{
-		"subagent(",                 // UNCOVERED as an assertion — appears only as PROMPT text in the pi live lanes
-		"intercom(",                 // UNCOVERED
-		"member_spawn",              // UNCOVERED — absent from teams.go AND from all of internal/ensigncycle
+		"subagent(",                 // named, not asserted
+		"intercom(",                 // named, not asserted
+		"member_spawn",              // UNCOVERED
 		"cwd: <resolved repo root>", // UNCOVERED
 		"acceptance",                // piruntime.TestSubagentStageDispatchAddsOnlyPiTransportFields (absence)
 	}
@@ -248,10 +258,8 @@ func toolTokenContainmentViolations(span string, tokens []string) []string {
 // TestRuntimeToolTokensStayInBindingSections is the section-scoping containment
 // guard: host tool names live only where the adapter binds them, so prose
 // elsewhere stays readable by a cold agent on any host. It asserts where a name
-// may appear, never what the tool does — the Codex spawn call is bound by
-// TestCodexSpawnSignatureBindsToolArgs and the Pi tokens by
-// TestPiEmittedRuntimeTokensBindGoSource. Several substrate-native tools have no
-// owner at all; the per-token annotations on the vocabularies below say which.
+// may appear, never what the tool does; the vocabularies above annotate which
+// tools are bound, which are merely named, and which nothing covers.
 func TestRuntimeToolTokensStayInBindingSections(t *testing.T) {
 	codexText := readRepoFile(t, codexFORuntimeRel)
 	_, outsideProbe := extractMarkdownSection(t, codexText, "## Live Tool Surface Probe")
@@ -326,9 +334,7 @@ func TestToolTokenContainmentGuardDiscriminates(t *testing.T) {
 
 // TestRuntimeBindingGuardsDiscriminate is the non-vacuity control for the three
 // bindings' extractors. Every RED case below is an input the earlier extractors
-// ACCEPTED: unparseable signature text silently skipped, a duplicate declaration
-// collapsed by set comparison, and a token matched as a substring of ordinary
-// prose. A regression restoring any of those tolerances fails here.
+// ACCEPTED; a regression restoring any of those tolerances fails here.
 func TestRuntimeBindingGuardsDiscriminate(t *testing.T) {
 	emitted := map[string]string{"task_name": "w", "message": "m", "fork_turns": "none"}
 	goodSig := "`spawn_agent(task_name,message,fork_turns=\"none\")`"

--- a/internal/contractlint/runtime_binding_block_test.go
+++ b/internal/contractlint/runtime_binding_block_test.go
@@ -62,11 +62,9 @@ func repeatedMembers(xs []string) []string {
 // core doc rather than a re-typed slice. It also holds the shared
 // feedback-rejection skill to capabilities the core actually defines.
 //
-// Multiplicity is checked before set equality. DECLARATION ORDER IS NOT ENFORCED:
-// the retired check pinned each adapter to an ordered slice, but bullet order
-// carries no runtime meaning — a doc author may reorder for readability without
-// any capability changing. Duplication is different: a repeated or conflicting
-// declaration is a real defect set equality cannot see, so it reds explicitly.
+// Multiplicity is checked before set equality. DECLARATION ORDER IS NOT ENFORCED —
+// the retired check pinned an ordered slice, but bullet order carries no runtime
+// meaning. Duplication does, and set equality cannot see it, so it reds explicitly.
 func TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters(t *testing.T) {
 	headings := capabilityHeadings(t)
 	if len(headings) == 0 {
@@ -112,19 +110,19 @@ func TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters(t *testing.T) {
 	}
 }
 
-// piEmittedRuntimeToken is one runtime token Spacedock's Go code emits for Pi,
-// paired with the source that emits it.
+// piEmittedRuntimeToken is one runtime token Spacedock's Go code DECLARES for Pi,
+// paired with the constructor that declares it. "Emitted" in these identifiers
+// overstates it: none of the five constructors has a production caller, so this is
+// doc-to-Go-declaration agreement, not wire evidence — the same scope limit as the
+// Codex spawn binding.
 type piEmittedRuntimeToken struct {
 	token, source string
 }
 
-// piEmittedRuntimeTokens computes the Pi runtime tokens Spacedock emits by calling
-// the emitters rather than re-typing their strings. Substrate-native tokens Pi
-// owns but Spacedock never emits — `subagent(`, `intercom(`, `member_spawn` — are
-// deliberately absent: `member_spawn` appears in the Pi FO adapter with no
-// `teams.go` counterpart, and widening the binding to swallow it would be the
-// make-it-pass move this entity exists to remove. It has no owner elsewhere
-// either; see UNCOVERED RUNTIME TOKENS below.
+// piEmittedRuntimeTokens computes the Pi runtime tokens by calling the
+// constructors rather than re-typing their strings. Substrate-native tokens are
+// deliberately absent — widening the binding to swallow `member_spawn` would be the
+// make-it-pass move this entity exists to remove; see UNCOVERED RUNTIME TOKENS.
 func piEmittedRuntimeTokens(t *testing.T) []piEmittedRuntimeToken {
 	t.Helper()
 	wrapper := piruntime.SubagentStageDispatch("assignment", "implementation", "label")
@@ -147,9 +145,8 @@ func piEmittedRuntimeTokens(t *testing.T) []piEmittedRuntimeToken {
 	}
 }
 
-// codeSpanRe matches one `backticked` span. Whole spans, not raw substrings:
-// ordinary prose ("we delegate the work") satisfied a `strings.Contains` check for
-// `delegate`, binding nothing.
+// codeSpanRe matches one `backticked` span. Whole spans, not raw substrings: prose
+// ("we delegate the work") satisfied a `Contains` check for `delegate`, binding nothing.
 var codeSpanRe = regexp.MustCompile("`([^`]+)`")
 
 func codeSpans(section string) map[string]bool {
@@ -160,11 +157,11 @@ func codeSpans(section string) map[string]bool {
 	return out
 }
 
-// TestPiEmittedRuntimeTokensBindGoSource binds every Pi runtime token Spacedock
-// emits to the Pi FO adapter's runtime-binding block. The binding is ONE-WAY:
-// renaming an emitter or dropping the token from the doc reds, but the adapter may
-// name a token Spacedock never emits and stay green — which is why `member_spawn`
-// needs the uncovered record below rather than this test. The wrapper's absent
+// TestPiEmittedRuntimeTokensBindGoSource binds every Pi runtime token Spacedock's
+// Go source declares to the Pi FO adapter's runtime-binding block. The binding is
+// ONE-WAY: renaming a constructor's token or dropping it from the doc reds, but the
+// adapter may name a token Go never declares and stay green — which is why
+// `member_spawn` needs the uncovered record below. The wrapper's absent
 // `acceptance` field is proven by
 // piruntime.TestSubagentStageDispatchAddsOnlyPiTransportFields and the built
 // artifact by internal/dispatch/build_pi_host_test.go; neither is restated here.
@@ -212,6 +209,12 @@ func piTokenBindingViolations(spans map[string]bool, tokens []piEmittedRuntimeTo
 //
 // Their prose checks are DELETED, not retained: a phrase check for a token nothing
 // exercises proves only that we wrote the word. 0.26.0 ships these gaps knowingly.
+//
+// SCOPE OF THIS RECORD: it enumerates unowned TOKENS only. This entity also retired
+// unowned SEMANTIC sentences, which this list does not cover — for example "Pi's
+// model-space binding is provider/model strings", now protected by nothing
+// (TestBuildPiHostIgnoresModelWithNote proves a claude-enum model is dropped with a
+// note, not what Pi's model space IS). Those are tracked in the follow-up, not here.
 // Follow-up: record-uncovered-runtime-tokens.
 //
 // `subagent` and `intercom` are NAMED by Go source but not asserted by it — the
@@ -256,10 +259,9 @@ func toolTokenContainmentViolations(span string, tokens []string) []string {
 }
 
 // TestRuntimeToolTokensStayInBindingSections is the section-scoping containment
-// guard: host tool names live only where the adapter binds them, so prose
-// elsewhere stays readable by a cold agent on any host. It asserts where a name
-// may appear, never what the tool does; the vocabularies above annotate which
-// tools are bound, which are merely named, and which nothing covers.
+// guard: host tool names live only where the adapter binds them, so prose elsewhere
+// stays readable by a cold agent on any host. It asserts where a name may appear,
+// never what the tool does; the vocabularies above annotate coverage per token.
 func TestRuntimeToolTokensStayInBindingSections(t *testing.T) {
 	codexText := readRepoFile(t, codexFORuntimeRel)
 	_, outsideProbe := extractMarkdownSection(t, codexText, "## Live Tool Surface Probe")

--- a/internal/contractlint/runtime_binding_block_test.go
+++ b/internal/contractlint/runtime_binding_block_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
@@ -24,34 +25,57 @@ var (
 	runtimeImplHeading = "## Runtime implementation"
 )
 
-// capabilitySetFromHeadings reads the dispatch core's capability «fn» DEFINITION
-// headings — the third, host-independent surface the adapter blocks are held to.
-func capabilitySetFromHeadings(t *testing.T) map[string]bool {
+// capabilityHeadings reads the dispatch core's capability «fn» DEFINITION headings
+// — the third, host-independent surface the adapter blocks are held to. It returns
+// a slice, not a set, so a duplicated declaration survives to be reported.
+func capabilityHeadings(t *testing.T) []string {
 	t.Helper()
 	raw, err := os.ReadFile(dispatchCorePath(t))
 	if err != nil {
 		t.Fatalf("read dispatch core: %v", err)
 	}
-	out := map[string]bool{}
+	var out []string
 	for _, m := range fnHeadingRe.FindAllStringSubmatch(string(raw), -1) {
-		out[m[1]] = true
+		out = append(out, m[1])
 	}
+	return out
+}
+
+// repeatedMembers returns the members appearing more than once. Set comparison
+// collapses a duplicate, so a conflicting declaration passed until this ran first.
+func repeatedMembers(xs []string) []string {
+	counts, out := map[string]int{}, []string{}
+	for _, x := range xs {
+		counts[x]++
+		if counts[x] == 2 {
+			out = append(out, x)
+		}
+	}
+	sort.Strings(out)
 	return out
 }
 
 // TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters binds the runtime capability
 // vocabulary across three independently divergeable surfaces — the Codex FO
 // runtime-binding bullets, the Pi FO runtime-binding bullets, and the dispatch
-// core's capability «fn» definition headings — as the SAME set. It replaces a
-// hardcoded expected-capability slice: the expectation is computed from the core
-// doc, so no re-typed literal can drift from all three. It also holds the shared
-// feedback-rejection skill to capabilities the core actually defines, which is
-// what keeps that skill's `«token»` vocabulary from being decorative.
+// core's capability «fn» definition headings — as the SAME set, computed from the
+// core doc rather than a re-typed slice. It also holds the shared
+// feedback-rejection skill to capabilities the core actually defines.
+//
+// Multiplicity is checked before set equality. DECLARATION ORDER IS NOT ENFORCED:
+// the retired check pinned each adapter to an ordered slice, but bullet order
+// carries no runtime meaning — a doc author may reorder for readability without
+// any capability changing. Duplication is different: a repeated or conflicting
+// declaration is a real defect set equality cannot see, so it reds explicitly.
 func TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters(t *testing.T) {
-	core := capabilitySetFromHeadings(t)
-	if len(core) == 0 {
+	headings := capabilityHeadings(t)
+	if len(headings) == 0 {
 		t.Fatal("no capability «fn» definition headings found in the dispatch core — extractor bug; the binding would pass vacuously")
 	}
+	if dup := repeatedMembers(headings); len(dup) > 0 {
+		t.Fatalf("dispatch core declares capability heading(s) more than once: %v", dup)
+	}
+	core := toSet(headings)
 
 	for _, rel := range []string{codexFORuntimeRel, piFORuntimeRel} {
 		t.Run(rel, func(t *testing.T) {
@@ -62,6 +86,9 @@ func TestRuntimeCapabilitySetAgreesAcrossCoreAndAdapters(t *testing.T) {
 			bullets := bindingBulletCapabilities(markdownSectionFromText(t, text, runtimeImplHeading))
 			if len(bullets) == 0 {
 				t.Fatalf("%s runtime-binding block yielded no capability bullets — extractor bug; the binding would pass vacuously", rel)
+			}
+			if dup := repeatedMembers(bullets); len(dup) > 0 {
+				t.Fatalf("%s runtime-binding block declares capability bullet(s) more than once: %v", rel, dup)
 			}
 			if adapter := toSet(bullets); !setEqual(adapter, core) {
 				t.Fatalf("%s runtime capability set differs from the dispatch core:\n  adapter: %v\n  core:    %v\nneither surface may add, drop, or rename a capability without the other", rel, sortedSet(adapter), sortedSet(core))
@@ -95,9 +122,9 @@ type piEmittedRuntimeToken struct {
 // the emitters rather than re-typing their strings. Substrate-native tokens Pi
 // owns but Spacedock never emits — `subagent(`, `intercom(`, `member_spawn` — are
 // deliberately absent: `member_spawn` appears in the Pi FO adapter with no
-// `teams.go` counterpart, and its runtime meaning belongs to the gated live lane
-// in internal/ensigncycle/pi_live_runner_test.go, not to a binding widened to
-// swallow it.
+// `teams.go` counterpart, and widening the binding to swallow it would be the
+// make-it-pass move this entity exists to remove. It has no owner elsewhere
+// either; see UNCOVERED RUNTIME TOKENS below.
 func piEmittedRuntimeTokens(t *testing.T) []piEmittedRuntimeToken {
 	t.Helper()
 	wrapper := piruntime.SubagentStageDispatch("assignment", "implementation", "label")
@@ -105,7 +132,12 @@ func piEmittedRuntimeTokens(t *testing.T) []piEmittedRuntimeToken {
 	if !ok {
 		t.Fatal("piruntime.SubagentDispatch has no Context field — the binding would pass vacuously")
 	}
+	// An absent or empty json tag yields an empty key, which would compose the
+	// meaningless token `: "fresh"` and match on substring. Refuse it.
 	contextKey := strings.Split(field.Tag.Get("json"), ",")[0]
+	if contextKey == "" {
+		t.Fatal("piruntime.SubagentDispatch.Context has no json tag name — the binding would compose an empty key")
+	}
 	return []piEmittedRuntimeToken{
 		{piruntime.TeamsDelegateAction("worker", "assignment").Action, "piruntime.TeamsDelegateAction"},
 		{piruntime.TeamsDirectMessageAction("worker", "message").Action, "piruntime.TeamsDirectMessageAction"},
@@ -115,11 +147,22 @@ func piEmittedRuntimeTokens(t *testing.T) []piEmittedRuntimeToken {
 	}
 }
 
+// codeSpanRe matches one `backticked` span. Comparing whole spans rather than raw
+// substrings is load-bearing: ordinary prose ("we delegate the work") satisfied a
+// `strings.Contains` check for `delegate`, binding nothing.
+var codeSpanRe = regexp.MustCompile("`([^`]+)`")
+
+func codeSpans(section string) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range codeSpanRe.FindAllStringSubmatch(section, -1) {
+		out[m[1]] = true
+	}
+	return out
+}
+
 // TestPiEmittedRuntimeTokensBindGoSource binds every Pi runtime token Spacedock
-// emits to the Pi FO adapter's runtime-binding block. Renaming a `TeamsAction`
-// action string or changing `SubagentStageDispatch`'s context value reds against
-// an unchanged doc; dropping the token from the doc reds against unchanged Go. The
-// wrapper's absent `acceptance` field is proven by
+// emits to the Pi FO adapter's runtime-binding block; either side moving alone
+// reds. The wrapper's absent `acceptance` field is proven by
 // piruntime.TestSubagentStageDispatchAddsOnlyPiTransportFields and the built
 // artifact by internal/dispatch/build_pi_host_test.go; neither is restated here.
 func TestPiEmittedRuntimeTokensBindGoSource(t *testing.T) {
@@ -127,39 +170,60 @@ func TestPiEmittedRuntimeTokensBindGoSource(t *testing.T) {
 	if len(tokens) == 0 {
 		t.Fatal("no Pi emitted tokens — the binding would pass vacuously")
 	}
-	section := markdownSectionFromText(t, readRepoFile(t, piFORuntimeRel), runtimeImplHeading)
-	for _, tok := range tokens {
-		if tok.token == "" {
-			t.Fatalf("%s emitted an empty token — the binding would pass vacuously", tok.source)
-		}
-		if !strings.Contains(section, tok.token) {
-			t.Errorf("%s runtime-binding block does not carry %q, the token %s emits; the adapter must name every runtime token Spacedock actually sends", piFORuntimeRel, tok.token, tok.source)
-		}
+	spans := codeSpans(markdownSectionFromText(t, readRepoFile(t, piFORuntimeRel), runtimeImplHeading))
+	if len(spans) == 0 {
+		t.Fatalf("%s runtime-binding block yielded no code spans — extractor bug; the binding would pass vacuously", piFORuntimeRel)
+	}
+	for _, msg := range piTokenBindingViolations(spans, tokens) {
+		t.Errorf("%s %s", piFORuntimeRel, msg)
 	}
 }
 
-// codexToolTokens are the Codex tool names that must stay inside the Codex FO
-// adapter's probe and runtime-binding sections. piSubstrateNativeTokens are the Pi
-// tokens Spacedock does not emit; with the emitted tokens they form the Pi
-// containment set. Both are absence-guard vocabularies: they say nothing about
-// what a tool MEANS, only where its name may appear.
+// piTokenBindingViolations requires each emitted token to appear as a whole code
+// span in the adapter's binding block.
+func piTokenBindingViolations(spans map[string]bool, tokens []piEmittedRuntimeToken) []string {
+	var out []string
+	for _, tok := range tokens {
+		if tok.token == "" {
+			out = append(out, fmt.Sprintf("%s emitted an empty token — the binding would pass vacuously", tok.source))
+			continue
+		}
+		if !spans[tok.token] {
+			out = append(out, fmt.Sprintf("runtime-binding block has no `%s` code span, the token %s emits; the adapter must name every runtime token Spacedock actually sends", tok.token, tok.source))
+		}
+	}
+	return out
+}
+
+// codexToolTokens and piSubstrateNativeTokens are the tool names that must stay
+// inside their adapter's binding sections — absence-guard vocabularies saying
+// nothing about what a tool MEANS, only where its name may appear.
+//
+// UNCOVERED RUNTIME TOKENS (roborev job 328 finding 4b; captain ruling 2026-07-20).
+// Tokens marked UNCOVERED have NO owner anywhere in this repo: no Go emitter, no
+// build fixture, no live-lane assertion. Each was verified by grepping every
+// non-contractlint Go file. Their prose checks are DELETED rather than retained: a
+// phrase check for a token nothing exercises proves only that we wrote the word,
+// which is the fabricated rigor this entity exists to remove. 0.26.0 ships these
+// gaps knowingly — the entries still bound WHERE the names may appear, but nothing
+// proves WHAT they do. Follow-up: record-uncovered-runtime-tokens.
 var (
 	codexToolTokens = []string{
-		"spawn_agent(",
-		"send_message(",
-		"followup_task(",
-		"wait_agent(",
-		"list_agents(",
-		"send_input",
-		"SendMessage",
-		"interrupt_agent",
+		"spawn_agent(",    // bound by TestCodexSpawnSignatureBindsToolArgs
+		"send_message(",   // UNCOVERED
+		"followup_task(",  // ensigncycle/shared_reviewer_reuse{,_table}_test.go
+		"wait_agent(",     // ensigncycle/codex_single_run_test.go, codex_dispatch_evidence_test.go
+		"list_agents(",    // UNCOVERED
+		"send_input",      // ensigncycle/shared_reviewer_reuse_table_test.go (reuse transcript fixtures)
+		"SendMessage",     // Claude team tool; banned here, owned by the Claude lanes
+		"interrupt_agent", // UNCOVERED
 	}
 	piSubstrateNativeTokens = []string{
-		"subagent(",
-		"intercom(",
-		"member_spawn",
-		"cwd: <resolved repo root>",
-		"acceptance",
+		"subagent(",                 // UNCOVERED as an assertion — appears only as PROMPT text in the pi live lanes
+		"intercom(",                 // UNCOVERED
+		"member_spawn",              // UNCOVERED — absent from teams.go AND from all of internal/ensigncycle
+		"cwd: <resolved repo root>", // UNCOVERED
+		"acceptance",                // piruntime.TestSubagentStageDispatchAddsOnlyPiTransportFields (absence)
 	}
 )
 
@@ -185,9 +249,9 @@ func toolTokenContainmentViolations(span string, tokens []string) []string {
 // guard: host tool names live only where the adapter binds them, so prose
 // elsewhere stays readable by a cold agent on any host. It asserts where a name
 // may appear, never what the tool does — the Codex spawn call is bound by
-// TestCodexSpawnSignatureBindsToolArgs, the Pi tokens by
-// TestPiEmittedRuntimeTokensBindGoSource, and the substrate-native tools by the
-// gated live lanes in internal/ensigncycle.
+// TestCodexSpawnSignatureBindsToolArgs and the Pi tokens by
+// TestPiEmittedRuntimeTokensBindGoSource. Several substrate-native tools have no
+// owner at all; the per-token annotations on the vocabularies below say which.
 func TestRuntimeToolTokensStayInBindingSections(t *testing.T) {
 	codexText := readRepoFile(t, codexFORuntimeRel)
 	_, outsideProbe := extractMarkdownSection(t, codexText, "## Live Tool Surface Probe")
@@ -229,9 +293,7 @@ func TestRuntimeToolTokensStayInBindingSections(t *testing.T) {
 
 // TestToolTokenContainmentGuardDiscriminates is the non-vacuity control:
 // capability-only prose PASSES, while a Codex tool call, a Pi emitted token, and a
-// Pi substrate-native token each RED in a span that must not carry them. An
-// emptied vocabulary or a predicate that stopped comparing fails here rather than
-// waving through an adapter that has leaked tool names into host-neutral prose.
+// Pi substrate-native token each RED in a span that must not carry them.
 func TestToolTokenContainmentGuardDiscriminates(t *testing.T) {
 	piTokens := piContainmentTokens(t)
 	pass := []struct {
@@ -258,6 +320,54 @@ func TestToolTokenContainmentGuardDiscriminates(t *testing.T) {
 	for _, c := range red {
 		if v := toolTokenContainmentViolations(c.span, c.tokens); len(v) == 0 {
 			t.Fatalf("control: the %s was not flagged — the guard stopped biting", c.why)
+		}
+	}
+}
+
+// TestRuntimeBindingGuardsDiscriminate is the non-vacuity control for the three
+// bindings' extractors. Every RED case below is an input the earlier extractors
+// ACCEPTED: unparseable signature text silently skipped, a duplicate declaration
+// collapsed by set comparison, and a token matched as a substring of ordinary
+// prose. A regression restoring any of those tolerances fails here.
+func TestRuntimeBindingGuardsDiscriminate(t *testing.T) {
+	emitted := map[string]string{"task_name": "w", "message": "m", "fork_turns": "none"}
+	goodSig := "`spawn_agent(task_name,message,fork_turns=\"none\")`"
+	if v := codexSpawnSignatureViolations(goodSig, emitted); len(v) != 0 {
+		t.Fatalf("control: the well-formed signature was wrongly flagged: %v", v)
+	}
+	for _, c := range []struct{ why, text string }{
+		{"empty argument entry", "`spawn_agent(task_name,,message,fork_turns=\"none\")`"},
+		{"unparseable argument characters", "`spawn_agent(task_name!!,message,fork_turns=\"none\")`"},
+		{"repeated argument", "`spawn_agent(task_name,task_name,message,fork_turns=\"none\")`"},
+		{"default disagreeing with the emitter", "`spawn_agent(task_name,message,fork_turns=\"all\")`"},
+	} {
+		if v := codexSpawnSignatureViolations(c.text, emitted); len(v) == 0 {
+			t.Fatalf("control: the %s was not flagged — the extractor skipped what it could not parse", c.why)
+		}
+	}
+
+	if dup := repeatedMembers([]string{"worker.spawn", "context-budget"}); len(dup) != 0 {
+		t.Fatalf("control: distinct members were reported as duplicates: %v", dup)
+	}
+	if dup := repeatedMembers([]string{"worker.spawn", "context-budget", "context-budget"}); len(dup) == 0 {
+		t.Fatal("control: a duplicated capability declaration was not reported — set comparison alone would collapse it")
+	}
+
+	tokens := []piEmittedRuntimeToken{{"delegate", "piruntime.TeamsDelegateAction"}}
+	if v := piTokenBindingViolations(codeSpans("map creation to `delegate` here"), tokens); len(v) != 0 {
+		t.Fatalf("control: the `delegate` code span was wrongly flagged: %v", v)
+	}
+	for _, c := range []struct {
+		why    string
+		spans  map[string]bool
+		tokens []piEmittedRuntimeToken
+	}{
+		{"token present only as ordinary prose", codeSpans("we delegate the work to a worker"), tokens},
+		{"token present only inside a larger code span", codeSpans("call `delegate_v2(...)` instead"), tokens},
+		{"empty token from a missing json tag", codeSpans("carries `: \"fresh\"` here"), []piEmittedRuntimeToken{{"", "piruntime.SubagentStageDispatch"}}},
+	} {
+		if v := piTokenBindingViolations(c.spans, c.tokens); len(v) == 0 {
+			t.Fatalf("control: the %s was not flagged — substring matching would have bound it", c.why)
 		}
 	}
 }


### PR DESCRIPTION
Runtime-semantics checks now fail when the runtime actually diverges, instead of when someone rewords the adapter docs.

## What changed

- Bind the Codex spawn signature and Pi runtime tokens to Go declarations that can diverge from the prose.
- Bind the capability set three ways across the codex block, the pi block, and the dispatch core.
- Retain structural guards only where a discriminator control proves they can fail.
- Record nine retired tokens that have no owner, enumerated by script rather than by hand.

## Evidence

- `go test ./...` and `go test ./... -race` pass; `go vet` clean.
- 27/30 planted divergences red, 7 confirmed green on the pre-repair cut; runtime-meaning prose assertions 0, test-function count unchanged.

## Review guidance

Nine runtime tokens ship knowingly uncovered — three hand-audits each missed a different one, so the list is machine-derived and independently reproduced by a second implementation.

---
[841](/spacedock-dev/spacedock/blob/d32a99e103fd9fa399bd6fab08a8ad0516481a18/contractlint-codex-runtime-semantics-retirement.md)
