### PR TITLE
Dev template ships the rigor scar tissue; refit propagates it to commissioned workflows (2ae, 0260)

### DIFF
--- a/fixtures/refit-content-propagation/README.md
+++ b/fixtures/refit-content-propagation/README.md
@@ -1,0 +1,13 @@
+# Refit content-propagation fixture
+
+`site-workflow/` is a dev-shape workflow README as the commission skill emitted it at
+`spacedock@0.25.0`, before the template carried the anti-over-engineering scar tissue.
+It was produced by a dispatched agent driving that revision of the commission skill for
+the mission "a personal-site development workflow", so it is what commission actually
+emits rather than a hand-written approximation: it carries the
+`Verified by: {grep / ...}` example and none of the scar-tissue content.
+
+Drive `skills/refit/SKILL.md` Phase 3b against `site-workflow/` and read the emitted
+README diff. Against a template that has gained content, the diff carries those content
+hunks; against a template that has not, it carries only the `commissioned-by:` stamp line.
+That contrast is the observation the fixture exists for.

--- a/fixtures/refit-content-propagation/site-workflow/README.md
+++ b/fixtures/refit-content-propagation/site-workflow/README.md
@@ -1,0 +1,196 @@
+---
+commissioned-by: spacedock@0.25.0
+entity-type: task
+entity-label: task
+entity-label-plural: tasks
+id-style: sd-b32
+stages:
+  # Stage names must match ^[a-z0-9][a-z0-9-]*[a-z0-9]$ (kebab-case lowercase, no underscores or spaces); `status --validate` rejects others.
+  defaults:
+    worktree: false
+    concurrency: 2
+  states:
+    - name: backlog
+      initial: true
+      gate: true
+    - name: ideation
+      gate: true
+    - name: implementation
+      worktree: true
+    - name: validation
+      worktree: true
+      fresh: true
+      feedback-to: implementation
+      gate: true
+    - name: done
+      terminal: true
+---
+
+# Personal Site Development Workflow
+
+Tasks for the personal site move from a captain-curated backlog through ideation, get built in a dedicated worktree, are independently validated against the acceptance criteria, and land via PR review. The repo-mutation layer is active on `implementation` and `validation`, and the `pr-merge` mod handles the PR lifecycle.
+
+## File Naming
+
+Each task lives as either:
+
+- a flat markdown file `{slug}.md` (default — use this unless the entity produces many artifacts), or
+- a folder `{slug}/` containing `index.md` as the canonical entity file, when the task produces per-stage artifacts (draft versions, transcripts, outputs) that belong alongside the tracker.
+
+Slugs are lowercase, hyphens, no spaces. Example: `my-feature-idea.md` or `my-feature-idea/index.md`. The status scanner recognizes both forms; `--set` and `--archive` resolve the slug either way, and folder entities archive as a whole folder into the workflow's archive directory.
+
+## Schema
+
+Every task file has YAML frontmatter. Fields are documented below; see **Task Template** for a copy-paste starter.
+
+### Field Reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique identifier, format determined by id-style in README frontmatter |
+| `title` | string | Human-readable task name |
+| `status` | enum | One of: backlog, ideation, implementation, validation, done |
+| `source` | string | Where this task came from |
+| `started` | ISO 8601 | When active work began |
+| `completed` | ISO 8601 | When the task reached terminal status |
+| `verdict` | enum | PASSED or REJECTED — set at final stage |
+| `score` | number | Priority score, 0.0–1.0 (optional). Workflows can upgrade to a multi-dimension rubric in their README. |
+| `worktree` | string | Worktree path while a dispatched agent is active, empty otherwise |
+| `issue` | string | GitHub issue reference (e.g., `#42` or `owner/repo#42`). Optional cross-reference, set manually. |
+| `pr` | string | GitHub PR reference (e.g., `#57` or `owner/repo#57`). Set when a PR is created for this entity's worktree branch. |
+
+### ID Style
+
+The `id-style` frontmatter setting controls the operator-facing ID strategy:
+
+- `sequential`: `id` is required and stores the next zero-padded numeric value from `status --next-id`, counting active and archived entities.
+- `sd-b32`: `id` is required and stores the full stable 24-character lowercase SD-B32 stored ID from `status --next-id --id-seed <slug-or-title>`. SD-B32 is Spacedock Base32: SHA-256 digest material formatted with Spacedock's human-safe alphabet `0123456789abcdefghjkmnpqrstvwxyz`. Status tables show shorter display/address prefixes computed from active plus archived entities. `status --boot` reports `ID_STYLE: sd-b32`, `NEXT_ID: {candidate}`, and `MIN_PREFIX: 2`.
+- `slug`: `id` is optional; the effective ID is the entity slug. `status --next-id is not applicable for id-style: slug` because the slug comes from the title.
+
+SD-B32 display/address prefixes can lengthen after another branch adds a colliding prefix, while stored IDs remain stable. Use `status --validate` before trusting workflow state and `status --resolve <ref>` to resolve slugs, stored IDs, or sd-b32 address prefixes.
+
+Copyable README frontmatter examples:
+
+```yaml
+id-style: sequential
+```
+
+```yaml
+id-style: sd-b32
+```
+
+```yaml
+id-style: slug
+```
+
+SD-B32 examples:
+
+| Workflow size | Stored `id` examples | Display/address examples |
+| --- | --- | --- |
+| 10s of entities | `4k9q2m7x8c3v9r5t6w2p0n1h`, `8t5n0p2w6j9r4c8x1m7q3v5k` | `4k`, `8t` |
+| 100s of entities | `9m2c7v4xq8j3h6t0p5w1r8n2`, `9m2cq8j3h6t0p5w1r8v7x4kn` | `9m2c7`, `9m2cq` |
+| 1000s of entities | `v7k3q9x2m5c8h6t0p1w4r8n2`, `v7k3qrv5t9p3j6n2w8c4x1mk` | `v7k3q9`, `v7k3qr` |
+
+Generated IDs make concurrent and offline creation safer because creators do not share a central counter. Migration from existing sequential workflows is manual migration in this release: validate the target style, update README/entity frontmatter deliberately, and defer rewrite automation to a separate tracked task.
+
+## Stages
+
+### `backlog`
+
+A task enters backlog when it is first proposed: a seed description, no design work. Captain-curated holding stage — the gate decides which tasks advance to ideation.
+
+- **Inputs:** The captain's seed note, a GitHub issue, or a retrospective item about the personal site.
+- **Outputs:** A task file with `title`, `source`, and a one-paragraph problem statement in the body; no design work.
+- **Good:** The problem is stated in terms of what a site visitor or the site owner experiences today.
+- **Bad:** Backlog entries that already prescribe an implementation, or entries with no way to tell when they would be done.
+
+### `ideation`
+
+The captain greenlights a task for design: flesh out the problem, propose an approach, define acceptance criteria as entity-level end-state properties with `Verified by:` clauses, and write a test plan that matches the AC's level of abstraction.
+
+- **Inputs:** The backlog problem statement, the current site codebase, and any linked issue.
+- **Outputs:** `## Problem`, `## Proposed approach`, `## Acceptance criteria` (each AC an end-state property with a `Verified by:` clause), `## Test plan`, and `## Out of scope` filled in on the task body.
+- **Good:** Each AC names a property of the finished task and cites a check a future reader can reproduce — a test name, a command, a file path.
+- **Bad:** ACs that restate stage actions ("implement the toggle"), or whose only proof is a review of the task's own prose.
+
+### `implementation`
+
+The design is approved and the deliverable is built in a dedicated worktree on a feature branch — minimal changes that satisfy the AC, self-contained for validation.
+
+- **Inputs:** The approved ideation AC and test plan; the site repo checked out in this task's worktree.
+- **Outputs:** Commits on the task's feature branch satisfying every AC, with the tests named in the test plan present and passing; a PR opened for the branch and recorded on the `pr` field.
+- **Good:** The failing test is written first and watched fail for the right reason; the change is the minimum that satisfies the AC.
+- **Bad:** Scope beyond the AC, changes that leave the main checkout dirty, or a self-report of success with no test or command output behind it.
+
+### `validation`
+
+A `fresh` agent independently verifies the deliverable against the ideation AC, reproducing each `Verified by:` clause rather than trusting the implementation's self-report. The validator checks what was produced; it does not produce it. Either gate-approval to `done` or rejection back to `implementation` with concrete fixes.
+
+- **Inputs:** The ideation AC list and the implementation's branch and PR — read without the implementation agent's context.
+- **Outputs:** A per-AC verdict with the reproduced evidence (command run, exit code, output excerpt) recorded on the task body, and either an approval recommendation or a concrete fix list routed back to `implementation`.
+- **Good:** Every `Verified by:` clause is re-run rather than re-read; a rejection names the specific AC that failed and what evidence would clear it.
+- **Bad:** Writing or fixing code instead of checking it; accepting the implementation's summary as evidence; a rejection with no reproducible failing check.
+
+### `done`
+
+Terminal state: the task's PR is merged (tracked via the `pr` field and the `pr-merge` mod), `completed` set, `verdict: PASSED`, entity archived. Reached via real merge, not a manual flag flip.
+
+- **Inputs:** The validation verdict and the merged PR.
+- **Outputs:** `completed` timestamp set, `verdict: PASSED`, `worktree` cleared, task archived.
+- **Good:** The terminal state is reached because the PR actually merged, so the site's main branch contains the change.
+- **Bad:** Flipping `status: done` by hand while the PR is still open or closed-unmerged.
+
+## Workflow State
+
+Workflow state is read by the first officer at boot. To view current state, dispatch the first officer or run it directly:
+
+```
+spacedock claude
+```
+
+## Task Template
+
+```yaml
+---
+id:
+title: Task title here
+status: backlog
+source:
+started:
+completed:
+verdict:
+score:
+worktree:
+issue:
+pr:
+mod-block:
+---
+
+## Problem
+
+{What is broken or missing, and why it matters now.}
+
+## Proposed approach
+
+{How the implementation will address the problem. Concrete enough that a worker can start.}
+
+## Acceptance criteria
+
+Each AC names a property of the finished task (not a stage action) and how it is verified.
+
+**AC-1 — {End-state property.}**
+Verified by: {grep / test name / file path / command a future reader can reproduce.}
+
+## Test plan
+
+{What tests verify the implementation, estimated cost, whether E2E is needed.}
+
+## Out of scope
+
+{What this task deliberately does not address.}
+```
+
+## Commit Discipline
+
+- Commit status changes at dispatch and merge boundaries
+- Commit task body updates when substantive

--- a/skills/commission/SKILL.md
+++ b/skills/commission/SKILL.md
@@ -423,7 +423,7 @@ Generated IDs make concurrent and offline creation safer because creators do not
 {A sentence describing who sets this status and what it means for an {entity_label} to be in this stage.}
 
 - **Inputs:** {What the worker reads to do this stage's work — be specific to the mission}
-- **Outputs:** {What the worker produces — be specific to the mission. Keep bullets concise and verifiable — these become checklist items at dispatch time. Focus on non-obvious requirements that catch skipping, not obvious actions like "write code." Stage-output bullets become checklist items at dispatch; any entity-level end-state properties the stage produces belong under the entity body's `## Acceptance criteria` heading, not in the stage Outputs.}
+- **Outputs:** {What the worker produces — be specific to the mission. Keep bullets concise and verifiable — these become checklist items at dispatch time. Focus on non-obvious requirements that catch skipping, not obvious actions like "write code." Stage-output bullets become checklist items at dispatch; any entity-level end-state properties the stage produces belong under the entity body's `## Acceptance criteria` heading, not in the stage Outputs. A stage whose rounds consume review findings (implementation with in-stage review rounds, validation, review, evaluation) may carry a triage-before-fixing bullet: classify each review finding as material (fix), correct-but-disproportionate (record a decline, do not fix), or needs-decision (escalate) before acting — so a reviewer's non-material finding does not force a dutiful fix.}
 - **Good:** {Quality criteria for work done in this stage}
 - **Bad:** {Anti-patterns to avoid in this stage}
 
@@ -465,7 +465,7 @@ Brief description of this {entity_label} and what it aims to achieve.
 Each AC names a property of the finished entity (not a stage action) and how it is verified.
 
 **AC-1 — {End-state property.}**
-Verified by: {grep / test name / file path / command a future reader can reproduce.}
+Verified by: {test name / command output or exit code / file the change produces / resulting on-disk state — something outside this {entity_label} body that a future reader can reproduce and that can fail; name the concrete change that would make it fail.}
 ```
 
 ## Commit Discipline

--- a/skills/commission/SKILL.md
+++ b/skills/commission/SKILL.md
@@ -433,6 +433,10 @@ Generated IDs make concurrent and offline creation safer because creators do not
 
 {ONLY include this section if {captain} explicitly requests a multi-dimension rubric. Otherwise omit entirely — the 0.0–1.0 float is self-explanatory from the schema.}
 
+## Workflow-specific rules
+
+{Copy the selected template's own `## Workflow-specific rules` section — its intro sentence and every bullet — adapting only the mission-specific wording. This is the slot each template holds its shape's rules in (proof discipline, the repo-mutation layer, opt-in review disciplines); a README generated without it ships none of them.}
+
 ## Workflow State
 
 Workflow state is read by the first officer at boot. To view current state, dispatch the first officer or run it directly:

--- a/skills/commission/references/templates/development.md
+++ b/skills/commission/references/templates/development.md
@@ -71,13 +71,24 @@ A task enters backlog when it is first proposed: a seed description, no design w
 
 The captain greenlights a task for design: flesh out the problem, propose an approach, define acceptance criteria as entity-level end-state properties with `Verified by:` clauses, and write a test plan that matches the AC's level of abstraction.
 
+- Split each acceptance criterion by how it is verified: **offline** (a test, command, or on-disk state a fresh agent reproduces) or **interactive** (requires a human or a live drive to judge). Declare the split at ideation. A plan that would build a harness to automate an interactive AC is visible here, at the gate, before the harness is built — interactive ACs are validated by a live drive or the captain, not by new automation.
+
 ### `implementation`
 
 The design is approved and the deliverable is built in a dedicated worktree on a feature branch — minimal changes that satisfy the AC, self-contained for validation.
 
+- When consuming a review round's findings, triage before fixing:
+  - **Material** — breaks a value AC, or a declared non-negotiable boundary (safety, security, data-integrity, compatibility) reachable through the supported workflow. Fix it.
+  - **Correct-but-disproportionate** (deferred risk or polish) — substantively right, but no value AC breaks and its trigger is outside the supported/promised workflow. Record a decline; do not fix it. The decline is your licensed disposition, not a dodge: name the finding, its class, and why it is not material (no value AC at risk; trigger outside the promise; the condition that would promote it to material).
+  - **Needs decision** — a genuine product or compatibility fork. Escalate to the first officer; do not resolve it privately.
+
+  Record the disposition — which findings were fixed as material, which were declined and why — in the entity's `### Feedback Cycles` record so the gate sees it. A finding you neither fix nor record is not triaged. **Narrowing an acceptance criterion to make a finding or rejection pass is not a licensed disposition.** Declining a disproportionate finding and narrowing the claim it targets are opposite moves under the same pressure: the first leaves the product unchanged and is yours to make; the second weakens the value the entity promised and is a design-reset event requiring the captain's sign-off, recorded so it is captain-visible — never a task-internal edit.
+
 ### `validation`
 
 A `fresh` agent independently verifies the deliverable against the ideation AC, reproducing each `Verified by:` clause rather than trusting the implementation's self-report. The validator checks what was produced; it does not produce it. Either gate-approval to `done` or rejection back to `implementation` with concrete fixes.
+
+- **Small-change fast path.** Scale the validation checks to the diff's blast radius. A routine, low-blast-radius change (a doc line, a one-line fix, a rename) does not need the full checklist or the detached adversarial audit — the same "routine changes exempt" carve-out the audit already grants, applied to validation as a whole. Match the rigor to the change; a trivial diff over-validated is its own waste.
 
 ### `done`
 
@@ -85,16 +96,20 @@ Terminal state: the task's PR is merged (tracked via the `pr` field and the `pr-
 
 ## Workflow-specific rules
 
-The FO/ensign operating contract already governs generic stage semantics and proof discipline — prefer a code gate over a prose-only rule, prove by exercising rather than re-reading, and reject any AC whose only proof is a review of its own prose. Tasks in a commissioned development workflow inherit these rules from the contract their FO loads at boot; the rules below add only the dev-shape specifics.
+The FO/ensign operating contract already governs generic stage semantics and proof discipline: prefer the cheapest check that can fail — a shipped guard's run, an existing mechanical check, a one-off falsifiable exercise recorded in the report, then the captain's judgment — with new standing enforcement as the last resort rather than the default; prove by exercising rather than re-reading; and reject any AC whose only proof is a review of its own prose. Tasks in a commissioned development workflow inherit these rules from the contract their FO loads at boot; the rules below add only the dev-shape specifics.
 
 - **Repo-mutation worktree layer.** `implementation` and `validation` run in a worktree against the codebase, and `validation` is `fresh` so an independent agent checks the AC. PR state lives on the `pr` field, managed by the `pr-merge` mod — there is no `pr_open` or `awaiting_merge` stage.
+- **No prose-grep over instruction files.** A string, substring, or regex match over an instruction file the model reads (the FO/ensign contract, this README, a skill) never proves a behavioral claim. The matched text was written by the same implementer the check polices, so it asserts only that the file contains what we put in it. A valid paraphrase fails it and an inverted clause passes it. To settle a case, ask whether the expected value comes from outside the file under test; if it does not, the check is a tautology and is banned. A check that binds two independent values that can diverge, such as the plugin manifest's version sharing a major.minor with the binary's version, is legitimate and is not prose-grep. Captain ruling (2026-07-20, verbatim): prose-greps are one-off validation evidence, never committed tests. A grep whose output is pasted into the validation report is legitimate external evidence for that run; the same grep committed as a test is banned — it re-asserts that the file contains what we wrote and cannot fail. What such a grep may be evidence FOR is bounded by honesty, not by category: presence or absence is an existence fact, and a grep establishes it soundly when that fact is itself the claim. When it is not — when the claim is about what a program or an agent actually does, and the words being present says nothing about that — the grep is misleading, and the answer is to express the claim in a form that can be exercised, not to let a grep that technically passes stand in for proof it cannot give.
+- **Evidence must be able to fail.** Each AC's cited evidence names the concrete change that would flip it — the falsifying edit. An author who cannot name what would make the evidence fail has not shown it can fail, and the criterion does not count.
 - **Opt-in proof disciplines (copy into the `validation` stage when commissioning).** These are recommended dev-shape practices, not universal — a non-development workflow's acceptance proof may legitimately be a published artifact, a metric, or a human review. Adopt the ones the mission needs by folding them into the `validation` stage's Outputs and Bad lists:
   - **Test-first authoring** — for a code or fixture deliverable, write the failing test first, watch it fail for the right reason, then write the minimum code to pass. The test is what the gate judges.
   - **External-proof acceptance criteria** — each AC's evidence must come from a check outside the task body (a test, a command's output or exit code, a file the change produces, on-disk state). Reject self-referential ACs whose only proof is review of the task's own prose; if nothing ships, the decision belongs in the roadmap, not a terminal dev task.
-  - **Detached adversarial audit** — for high-stakes surfaces (a front-door launcher, status/guard mutation paths, shipped contract/scaffolding, CI/release machinery), run a read-only audit on a throwaway checkout that tries to refute the validation with an edit the deliverable's own tests should catch. `Material:` findings route back through the validation→implementation feedback flow; "refuted nothing material" is a valid recorded outcome.
+  - **Detached adversarial audit** — for high-stakes surfaces (a front-door launcher, status/guard mutation paths, shipped contract/scaffolding, CI/release machinery), run a read-only audit on a throwaway checkout that tries to refute the validation with an edit the deliverable's own tests should catch. `Material:` findings route back through the validation→implementation feedback flow; "refuted nothing material" is a valid recorded outcome. The audit also fires on AC provenance: when an AC's expected value is derived from the same package's production functions or constants, run the adversarial-edit check on it — that provenance is the tautology tell. Scope it to that provenance form; the broader equality/byte-identity form over-fires on ordinary unit tests.
   - **Live scenario for runtime claims** — when an AC's truth is what an agent or model *does* at runtime, prove it with a scripted live scenario graded on durable before→after state plus observed output, with a negative case that reds the grade. Mark the AC `Verified by: live <ci-run:<id> | session:<path>>`; an offline proxy or a contract-text check proves the watcher or the words, never the runtime behavior.
 
   The generic rationale for each — why a prose-only proof never satisfies a behavioral claim — lives in the FO/ensign contract; the disciplines above are the dev-shape applications a captain opts into.
+
+- **Declaring a posture (optional).** A workflow that wants a single findable answer to "how much engineering does this project want?" may declare it here: project maturity (prototype / product), default test depth, infra-addition policy (may a worker add a CI lane or lint unasked?), and review-finding priority. This is a place to write an existing posture down, not a new required concept — omit it unless the workflow benefits from a stated posture.
 
 ## Workflow State
 
@@ -143,7 +158,7 @@ mod-block:
 Each AC names a property of the finished task (not a stage action) and how it is verified.
 
 **AC-1 — {End-state property.}**
-Verified by: {grep / test name / file path / command a future reader can reproduce.}
+Verified by: {test name / command output or exit code / file the change produces / resulting on-disk state — something outside this task body that a future reader can reproduce and that can fail; name the concrete change that would make it fail.}
 
 ## Test plan
 

--- a/skills/commission/references/templates/experiment.md
+++ b/skills/commission/references/templates/experiment.md
@@ -117,7 +117,7 @@ Terminal state for hypotheses that failed at any tier (`smoke`, `analysis`, or `
 
 ## Workflow-specific rules
 
-The FO/ensign operating contract already governs generic stage semantics and proof discipline — prefer a code gate over a prose-only rule, prove by exercising rather than re-reading, fix success criteria before gathering evidence. Experiments inherit these rules from the contract their FO loads at boot; the rules below add only the experiment-shape specifics.
+The FO/ensign operating contract already governs generic stage semantics and proof discipline: prefer the cheapest check that can fail — a shipped guard's run, an existing mechanical check, a one-off falsifiable exercise recorded in the report, then the captain's judgment — with new standing enforcement as the last resort rather than the default; prove by exercising rather than re-reading; fix success criteria before gathering evidence. Experiments inherit these rules from the contract their FO loads at boot; the rules below add only the experiment-shape specifics.
 
 - **Falsifiable hypothesis, criteria fixed first.** The hypothesis must be falsifiable and its accept/reject success criteria must be written down before any evidence is gathered, so the verdict cannot be rationalized after seeing results.
 - **Tier-gating.** Evidence promotes through `smoke → run → analysis → holdout` and a tier never skips: smoke fails fast before the run is burned, analysis applies the criteria as written, and a decisive smoke or analysis can reject without continuing.

--- a/skills/refit/SKILL.md
+++ b/skills/refit/SKILL.md
@@ -95,7 +95,7 @@ If `{dir}/status` exists, it's a legacy workflow-local status script. The status
 
 ### 3b. README (Show Diff)
 
-1. Generate what the current commission template would produce for this workflow, using the extracted values (mission, stages, schema, etc.).
+1. Re-select the matching template for this workflow's shape (development / experiment / refinement) and generate its FULL body for this workflow, substituting the extracted values (mission, stages, schema). Regenerate the workflow-INDEPENDENT sections too — `## Workflow-specific rules`, the proof/triage bullets, and the `## {Entity} Template` / `Verified by` example — not only the stage prose. These carry the accumulated scaffolding content; a refit that re-renders only the stage values propagates the version stamp but not the content the template gained since this workflow was commissioned.
 2. Diff it against the user's current README.
 3. Present the diff to the captain, noting which differences are likely template changes vs user customizations:
 
@@ -106,6 +106,8 @@ If `{dir}/status` exists, it's a legacy workflow-local status script. The status
 > {diff output}
 >
 > I have NOT modified your README. Review the diff and apply any changes you want manually, or tell me which specific changes to make.
+>
+> Additive sections the current template gained since your workflow was commissioned (new proof/triage bullets, a fixed example) appear as additions in this diff — those are the accumulated scaffolding content, safe to adopt; hunks that touch your customized stage prose are yours to judge.
 
 Do NOT auto-modify the README. The captain decides what to adopt.
 


### PR DESCRIPTION
Sprint 0260-proportionality, member **2ae** (the last member). Carries the sprint's settled wording into the commission templates and the refit skill, so the NEXT workflow starts protected. Re-drafts nothing — verbatim carriage from landed siblings.

## Surface
4 instruction files + 2 fixtures, **+237/−7 (21 net prose lines)** against a ~18-line estimate / 36 tolerance. Zero Go, zero product code, **zero new committed tests/gates/lints**.
- `skills/commission/references/templates/development.md` — the rigor block into the `## Workflow-specific rules` slot + stage-defs (no-prose-grep, evidence-must-fail, materiality taxonomy, cheapest-check, AC split, small-change fast path, declared-posture).
- `skills/commission/SKILL.md` — **§2a now emits the `## Workflow-specific rules` slot** (finishes PR #388's undone wiring; the slot has existed in the templates since 2026-06-16 but §2a never listed it).
- `skills/commission/references/templates/experiment.md`, `skills/refit/SKILL.md` — refit Phase 3b regenerates the full template body so content propagates, not just the version stamp.
- `fixtures/refit-content-propagation/` — the committed fixture the refit drive runs against.

## 🔎 Binding captain condition — the refit delta for human review

Reproducible in one dispatched drive: drive `skills/refit/SKILL.md` Phase 3b against `fixtures/refit-content-propagation/site-workflow/README.md` on this branch. The emitted README diff IS the artifact. Measured:

**Control (pre-fix `main`): 1 changed line — the version stamp only.** Zero scar-tissue content. This is the failure mode 2ae fixes.

**Treatment (this branch): +21 / −2.** The −2 are the old stamp and the old grep-shaped `Verified by`. The +21 carry the whole rigor payload into a freshly-refitted README:
```
+ ## Workflow-specific rules            (whole section — fixture lacked it)
+   cheapest-check-that-can-fail lede + repo-mutation worktree layer
+   No prose-grep over instruction files  (verbatim 2026-07-20 captain ruling)
+   Evidence must be able to fail         (the falsifying-edit rule)
+   opt-in disciplines: test-first / external-proof / detached audit / live-scenario
+ ideation:  offline/interactive AC split
+ implementation: Material / Correct-but-disproportionate / Needs-decision triage
+ validation: Small-change fast path
- Verified by: {grep / test name / file path / …}          ← old, grep-first
+ Verified by: {test name / command output or exit code / … name the concrete
                change that would make it fail.}            ← new, falsifiable
```

## Validation evidence
- **AC-1 (a commissioned workflow carries the rigor) — PASS, proven here:** a dispatched agent drove the branch's `commission` skill with a non-leading prompt into a scratch dir; three independent greps confirm the generated README carries the `## Workflow-specific rules` slot (line 131), the three-class taxonomy, and the fixed `Verified by` (grep-first tautology occurs 0 times). Falsifying change: revert §2a → slot vanishes.
- **AC-2 (refit propagates content) — PASS:** the treatment/control drives above, control moves the wrong way.
- **AC-2 narrowed** (recorded in the entity's FO-owned `### Feedback Cycles`): the control asserts *zero scar-tissue content lines*, not the originally-specified stamp-only 2-line diff — live refit controls carry variable Task-Template scaffolding churn; the load-bearing invariant (zero content lines) holds every run.
- **Roborev branch review:** three medium findings, all declined with grounds recorded — finding 1 answered by the re-lock (2ae references `### Feedback Cycles` by name only, ships none of bw's deferred format); findings 2–3 asked for committed generated-vs-expected fixtures, the frozen-LLM-output anti-pattern this sprint retires.

## Honest caveats for review
- **Commission ADAPTS template prose** (it's an LLM generator): in the AC-1 drive the taxonomy was compressed to one stage sentence and gap-2's provenance trigger was paraphrased away. "Template carries X verbatim" (AC-3, holds) and "every commission emits X verbatim" are different claims — the commissioned artifact is judged by *contains*, which passes. Review the commissioned README for substance, not byte-identity.
- **Piece-4 asymmetry:** after this lands, a commissioned workflow carries 02av's finding-triage rule that `docs/dev` (its own parent) does not, because 02av was parked. Resolves when the 3k advisory-resolution redesign lands. Recorded, not papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)