### PR TITLE
Pi bootstrap prompt parity — match claude/codex warmth; "Use $spacedock:first-officer" is the cold outlier

### DIFF
--- a/.pi/extensions/spacedock.ts
+++ b/.pi/extensions/spacedock.ts
@@ -1,4 +1,4 @@
-// Spacedock pi extension — parent-session skill discovery.
+// Spacedock pi extension — parent-session skill discovery and FO bootstrap.
 //
 // Once `spacedock install --host pi` (or the dev `pi install ./local/path`)
 // registers the Spacedock package in ~/.pi/agent/settings.json `packages`, the
@@ -7,21 +7,82 @@
 // from the package's own `skills/` directory — resolved relative to this
 // extension's location, exactly like the obra/superpowers reference.
 //
-// This replaces the launcher's retired `--skill <repo>/skills/{first-officer,ensign}`
-// flags. Child pi-subagents sessions discover the same skills independently via
-// the package-root scan reading `package.json` `pi.skills` — no cwd dependency.
+// It also commissions the parent session as Spacedock first officer through
+// Pi's context hook. The launcher keeps only its minimal skill-trigger prompt;
+// this extension owns the durable warm/contract bootstrap because context hooks
+// can re-inject after compaction while launch argv prompts cannot.
 
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
 
-export default function registerSpacedockExtension(pi: {
-	on(event: "resources_discover", handler: (event: { type: "resources_discover"; cwd: string; reason: string }) => { skillPaths?: string[] } | void): void;
-}): void {
+const FO_BOOTSTRAP_MARKER = "SPACEDOCK-FO-BOOTSTRAP-v1";
+const FO_BOOTSTRAP_TEXT = `<EXTREMELY_IMPORTANT>\n[${FO_BOOTSTRAP_MARKER}] You are the Spacedock first officer. Load the $spacedock:first-officer skill (skills/first-officer/SKILL.md) and treat it as your operating contract: re-satisfy every load precondition at its trigger (shared core, runtime adapter, write/merge/dispatch cores), re-read durable state before the next workflow effect — the compacted summary is not authoritative. Pi tool mapping: read/write/edit/bash/grep/find/ls; load skills via read; subagent via pi-subagents when available; plans live in plan files / TODO.md.\n</EXTREMELY_IMPORTANT>`;
+
+function messageText(message) {
+	if (Array.isArray(message?.content)) {
+		return message.content
+			.filter((part) => part?.type === "text")
+			.map((part) => String(part?.text ?? ""))
+			.join("");
+	}
+	return String(message?.content ?? "");
+}
+
+function hasStructuralBootstrap(message) {
+	if (message?.role !== "user") return false;
+	const text = messageText(message);
+	return text.startsWith("<EXTREMELY_IMPORTANT>") && text.includes(FO_BOOTSTRAP_MARKER);
+}
+
+function isLeadingCompactionSummary(message) {
+	const text = messageText(message).toLowerCase();
+	return text.includes("compaction") && text.includes("summary");
+}
+
+export default function registerSpacedockExtension(pi) {
+	let injectBootstrap = false;
+
 	pi.on("resources_discover", () => {
 		const extDir = path.dirname(fileURLToPath(import.meta.url));
 		// .pi/extensions/ -> ../.. -> repo root -> skills/
 		const repoRoot = path.resolve(extDir, "..", "..");
 		const skillsDir = path.join(repoRoot, "skills");
 		return { skillPaths: [skillsDir] };
+	});
+
+	pi.on("session_start", () => {
+		injectBootstrap = true;
+	});
+
+	pi.on("session_compact", () => {
+		injectBootstrap = true;
+	});
+
+	pi.on("agent_end", () => {
+		injectBootstrap = false;
+	});
+
+	pi.on("context", (event) => {
+		if (!injectBootstrap) return;
+		if (event.messages.some(hasStructuralBootstrap)) return;
+
+		const bootstrapMessage = {
+			role: "user",
+			content: [{ type: "text", text: FO_BOOTSTRAP_TEXT }],
+			timestamp: Date.now(),
+		};
+
+		let insertAt = 0;
+		while (insertAt < event.messages.length && isLeadingCompactionSummary(event.messages[insertAt])) {
+			insertAt++;
+		}
+
+		return {
+			messages: [
+				...event.messages.slice(0, insertAt),
+				bootstrapMessage,
+				...event.messages.slice(insertAt),
+			],
+		};
 	});
 }

--- a/internal/piruntime/spacedock_extension_test.go
+++ b/internal/piruntime/spacedock_extension_test.go
@@ -1,0 +1,99 @@
+package piruntime
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSpacedockPiExtensionBootstrapBehavior(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to execute the Pi extension behavior harness")
+	}
+
+	repoRoot := findRepoRoot(t)
+	extensionPath := filepath.Join(repoRoot, ".pi", "extensions", "spacedock.ts")
+	extensionSource, err := os.ReadFile(extensionPath)
+	if err != nil {
+		t.Fatalf("read extension: %v", err)
+	}
+
+	tmp := t.TempDir()
+	modulePath := filepath.Join(tmp, "spacedock-extension.mjs")
+	if err := os.WriteFile(modulePath, extensionSource, 0o644); err != nil {
+		t.Fatalf("write harness module: %v", err)
+	}
+
+	harnessPath := filepath.Join(tmp, "harness.mjs")
+	harness := `
+import register from './spacedock-extension.mjs';
+
+const handlers = new Map();
+const pi = { on(event, handler) { handlers.set(event, handler); } };
+register(pi);
+
+const marker = 'SPACEDOCK-FO-BOOTSTRAP-v1';
+const textOf = (message) => Array.isArray(message?.content)
+  ? message.content.filter((part) => part?.type === 'text').map((part) => String(part.text ?? '')).join('')
+  : String(message?.content ?? '');
+const countBootstraps = (messages) => messages.filter((message) => message?.role === 'user' && textOf(message).startsWith('<EXTREMELY_IMPORTANT>') && textOf(message).includes(marker)).length;
+const assert = (condition, message) => { if (!condition) throw new Error(message); };
+
+const resources = handlers.get('resources_discover')({ type: 'resources_discover', cwd: process.cwd(), reason: 'test' });
+assert(resources.skillPaths.length === 1 && resources.skillPaths[0].endsWith('/skills'), 'resources_discover returns the package skills directory');
+
+handlers.get('session_start')({ type: 'session_start' });
+let first = handlers.get('context')({ messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }] });
+assert(countBootstraps(first.messages) === 1, 'session_start injects exactly one structural bootstrap');
+assert(textOf(first.messages[0]).includes('Load the $spacedock:first-officer skill'), 'bootstrap points at the shipped first-officer contract');
+assert(textOf(first.messages[0]).includes('Pi tool mapping: read/write/edit/bash/grep/find/ls'), 'bootstrap includes the Pi tool mapping');
+
+handlers.get('session_compact')({ type: 'session_compact' });
+const compactSummary = { role: 'assistant', content: [{ type: 'text', text: 'Compaction summary mentions SPACEDOCK-FO-BOOTSTRAP-v1 but is not the bootstrap message.' }] };
+let afterCompact = handlers.get('context')({ messages: [compactSummary, { role: 'user', content: [{ type: 'text', text: 'continue' }] }] });
+assert(countBootstraps(afterCompact.messages) === 1, 'summary marker mention does not suppress reinjection');
+assert(afterCompact.messages[0] === compactSummary, 'bootstrap is inserted after the leading compaction summary');
+assert(textOf(afterCompact.messages[1]).startsWith('<EXTREMELY_IMPORTANT>'), 'bootstrap is the first non-summary message after compaction');
+
+handlers.get('session_compact')({ type: 'session_compact' });
+let deduped = handlers.get('context')({ messages: afterCompact.messages });
+assert(deduped === undefined, 'existing structural bootstrap de-duplicates context injection');
+
+handlers.get('agent_end')({ type: 'agent_end' });
+let suppressed = handlers.get('context')({ messages: [{ role: 'user', content: [{ type: 'text', text: 'new turn' }] }] });
+assert(suppressed === undefined, 'agent_end suppresses further bootstrap injection');
+`
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
+		t.Fatalf("write harness: %v", err)
+	}
+
+	cmd := exec.Command(node, harnessPath)
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("extension behavior harness failed: %v\n%s", err, out)
+	}
+}
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir || strings.TrimSpace(dir) == "" {
+			t.Fatal("could not find repo root")
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
Pi first-officer sessions lost their operating contract after compaction; the bootstrap now persists and re-injects like Claude/Codex.

## What changed

- Add context-hook FO bootstrap injection to .pi/extensions/spacedock.ts
- Arm on session_start/session_compact, suppress on agent_end
- Structural de-dup prevents double-inject when summaries mention the marker
- Demote launcher piBootstrapPrompt to a minimal trigger; extension owns commissioning
- Add Node-backed Go behavior test for the extension

## Evidence

- go test ./... and go test ./... -race green, rerun post-rebase
- Live RPC compaction proof: exactly one bootstrap in the first post-compact provider request; launcher-trigger coexistence run clean

---

[7v](/spacedock-dev/spacedock/blob/d6d0613b9646154cdc44d4838229be94cdbe4450/pi-bootstrap-prompt-parity/index.md)