### PR TITLE
Binary-upgrade prompt must be install-source-aware (brew formula, non-brew, sandbox)

### DIFF
--- a/docs/site/reference/command-reference.md
+++ b/docs/site/reference/command-reference.md
@@ -53,7 +53,7 @@ An unsandboxed bootstrap launch carries no safehouse isolation, so per-action pe
 | `spacedock install` | Install the per-host plugin, then run the compatibility check |
 | `spacedock doctor` | Run the compatibility check alone |
 
-Both take `--host claude|codex|pi` (default `claude`). When `doctor` reports the plugin is out of date, refresh it with `spacedock install`. When the plugin is still contract-compatible but a newer one is available, `doctor` and the front-door launch print an opt-in upgrade hint (`run spacedock install --host <host> to refresh`); the hint never blocks the launch. See [Install Spacedock](../get-started/install.md) for the full setup path.
+Both take `--host claude|codex|pi` (default `claude`). When `doctor` reports the plugin is out of date, refresh it with `spacedock install`. When `doctor` reports the **binary** is out of date, it prints the upgrade path that matches how the binary was installed — `brew upgrade spacedock` for a stable Homebrew install, `brew upgrade spacedock@next` for the edge (`@next`) channel, a source rebuild for a non-Homebrew build, and a run-on-host hint when Homebrew isn't reachable (e.g. inside a sandbox). When the plugin is still contract-compatible but a newer one is available, `doctor` and the front-door launch print an opt-in upgrade hint (`run spacedock install --host <host> to refresh`); the hint never blocks the launch. See [Install Spacedock](../get-started/install.md) for the full setup path.
 
 ## Workflow
 

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -269,7 +269,7 @@ func gateHost(ops hostOps, host string, stderr io.Writer) contract.Result {
 	if manifestPath == "" {
 		return contract.Result{Verdict: contract.NoPluginFound}
 	}
-	res := contract.ManifestVerdict(manifestPath, host, displayVersion())
+	res := contract.ManifestVerdict(manifestPath, host, displayVersion(), currentInstallSource())
 	switch res.Verdict {
 	case contract.NoPluginFound, contract.TooOldPlugin:
 		return res

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -56,7 +56,7 @@ func runInit(ctx context.Context, args []string, ops hostOps, stdout, stderr io.
 				fmt.Fprintf(stderr, "spacedock init: could not resolve the installed codex plugin: %v\n", err)
 				return 1
 			}
-			return contract.RunDoctor(resolved, "codex", displayVersion(), stdout, stderr)
+			return contract.RunDoctor(resolved, "codex", displayVersion(), currentInstallSource(), stdout, stderr)
 		}
 		// `install --host codex` drives the install seam (marketplace add + plugin
 		// add, re-pinning the source) and runs doctor — the same programmatic path
@@ -91,7 +91,7 @@ func runDoctor(ctx context.Context, args []string, ops hostOps, stdout, stderr i
 	}
 
 	if manifestPath != "" {
-		return contract.RunDoctor(manifestPath, host, displayVersion(), stdout, stderr)
+		return contract.RunDoctor(manifestPath, host, displayVersion(), currentInstallSource(), stdout, stderr)
 	}
 
 	resolved, err := ops.ResolveManifest(host)
@@ -101,7 +101,7 @@ func runDoctor(ctx context.Context, args []string, ops hostOps, stdout, stderr i
 	}
 	// An empty resolved path is the no-plugin-found report; RunDoctor renders it
 	// from a non-existent path as a non-fatal report.
-	return contract.RunDoctor(resolved, host, displayVersion(), stdout, stderr)
+	return contract.RunDoctor(resolved, host, displayVersion(), currentInstallSource(), stdout, stderr)
 }
 
 // parseInitArgs reads `--host claude|codex` (default claude) and `--check`. A

--- a/internal/cli/install_source.go
+++ b/internal/cli/install_source.go
@@ -1,0 +1,77 @@
+// ABOUTME: Detect how the running spacedock binary was installed (brew stable,
+// ABOUTME: brew edge @next, or non-brew) so the too-old-binary remedy fits the source.
+package cli
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spacedock-dev/spacedock/internal/contract"
+)
+
+// currentInstallSource detects the install source of the running binary, for the
+// too-old-binary remedy. It anchors on the resolved running executable (not the
+// `spacedock` on PATH, which can be a different install) and probes the real
+// `brew` on PATH — the thin production wiring the front door and doctor callers
+// share. Detection stays injectable via detectInstallSource for tests.
+func currentInstallSource() contract.InstallSource {
+	execPath, _ := resolvedLauncherBin()
+	return detectInstallSource(execPath, exec.LookPath, devBranch)
+}
+
+// detectInstallSource classifies how the running binary was installed, so the
+// too-old-binary remedy names the upgrade path that actually applies. It anchors
+// on execPath — the resolved RUNNING binary (resolvedLauncherBin's os.Executable
+// →EvalSymlinks result) — not `command -v spacedock`, because a session launched
+// from a source checkout must classify as its own source, not the brew binary on
+// PATH. A `…/Caskroom/<token>/…` path is a Homebrew install named by <token>
+// (`spacedock`→stable, `spacedock@next`→edge); brewLookPath resolving `brew` is
+// what separates an in-place upgrade from the run-on-host (HostOnly) sandbox case.
+// A resolved non-Caskroom path is a non-brew build; an empty/unresolvable path is
+// the generic fallback. devBranch is threaded for the caller's channel stamp but
+// does NOT pick the formula — the real cask token does (a plain `go build` stamps
+// `next`, which would misread a source build as edge).
+func detectInstallSource(execPath string, brewLookPath func(string) (string, error), devBranch string) contract.InstallSource {
+	token, isCask := caskToken(execPath)
+	if !isCask {
+		if strings.TrimSpace(execPath) == "" {
+			return contract.InstallSource{Kind: contract.SourceUnknown}
+		}
+		return contract.InstallSource{Kind: contract.NonBrew}
+	}
+	var kind contract.SourceKind
+	switch token {
+	case "spacedock":
+		kind = contract.BrewStable
+	case "spacedock@next":
+		kind = contract.BrewEdge
+	default:
+		// A Caskroom path with an unrecognized cask token: fall back to the
+		// generic remedy rather than guessing a formula name.
+		return contract.InstallSource{Kind: contract.SourceUnknown}
+	}
+	hostOnly := false
+	if _, err := brewLookPath("brew"); err != nil {
+		hostOnly = true
+	}
+	return contract.InstallSource{Kind: kind, HostOnly: hostOnly}
+}
+
+// caskToken extracts the Homebrew cask token that owns execPath: the path segment
+// immediately after a `Caskroom` segment (e.g.
+// `/opt/homebrew/Caskroom/spacedock@next/0.26.0-pre0/spacedock` → `spacedock@next`).
+// It reports found=false when the path is empty, carries no `Caskroom` segment, or
+// ends at `Caskroom` with no token following — every non-brew shape.
+func caskToken(execPath string) (token string, found bool) {
+	if strings.TrimSpace(execPath) == "" {
+		return "", false
+	}
+	segments := strings.Split(filepath.ToSlash(execPath), "/")
+	for i, seg := range segments {
+		if seg == "Caskroom" && i+1 < len(segments) {
+			return segments[i+1], true
+		}
+	}
+	return "", false
+}

--- a/internal/cli/install_source_test.go
+++ b/internal/cli/install_source_test.go
@@ -1,0 +1,198 @@
+// ABOUTME: Tables for install-source detection (real resolved path → source kind)
+// ABOUTME: and the end-to-end doctor remedy render per source, plus a live cask smoke.
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/contract"
+)
+
+// brewFound stubs a reachable Homebrew (`brew` resolves); brewMissing stubs the
+// sandbox/minimal case where `brew` is stripped from PATH.
+func brewFound(string) (string, error)   { return "/opt/homebrew/bin/brew", nil }
+func brewMissing(string) (string, error) { return "", errors.New("exec: \"brew\": not found in $PATH") }
+
+// TestDetectInstallSource is AC-3: detectInstallSource classifies the resolved
+// running-binary path. A `…/Caskroom/<token>/…` path is the brew kind named by
+// the token; `brew` unreachable flips a brew kind to HostOnly; a resolved
+// non-Caskroom path is non-brew; an empty path is the generic fallback. The
+// oracle is the input path + brew stub, both external to the code under test.
+func TestDetectInstallSource(t *testing.T) {
+	cases := []struct {
+		name     string
+		execPath string
+		brew     func(string) (string, error)
+		want     contract.InstallSource
+	}{
+		{
+			name:     "edge cask, brew reachable",
+			execPath: "/opt/homebrew/Caskroom/spacedock@next/0.26.0-pre0/spacedock",
+			brew:     brewFound,
+			want:     contract.InstallSource{Kind: contract.BrewEdge},
+		},
+		{
+			name:     "stable cask, brew reachable",
+			execPath: "/usr/local/Caskroom/spacedock/0.25.0/spacedock",
+			brew:     brewFound,
+			want:     contract.InstallSource{Kind: contract.BrewStable},
+		},
+		{
+			name:     "edge cask, brew stripped (sandbox)",
+			execPath: "/opt/homebrew/Caskroom/spacedock@next/0.26.0-pre0/spacedock",
+			brew:     brewMissing,
+			want:     contract.InstallSource{Kind: contract.BrewEdge, HostOnly: true},
+		},
+		{
+			name:     "source checkout build",
+			execPath: "/Users/x/git/spacedock/spacedock",
+			brew:     brewFound,
+			want:     contract.InstallSource{Kind: contract.NonBrew},
+		},
+		{
+			name:     "unknown cask token falls back",
+			execPath: "/opt/homebrew/Caskroom/spacedock@beta/0.1.0/spacedock",
+			brew:     brewFound,
+			want:     contract.InstallSource{Kind: contract.SourceUnknown},
+		},
+		{
+			name:     "unresolvable path",
+			execPath: "",
+			brew:     brewFound,
+			want:     contract.InstallSource{Kind: contract.SourceUnknown},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := detectInstallSource(c.execPath, c.brew, devBranch)
+			if got != c.want {
+				t.Fatalf("detectInstallSource(%q) = %+v, want %+v", c.execPath, got, c.want)
+			}
+		})
+	}
+}
+
+// TestTooOldBinaryRemedyRendersPerSource is AC-1/AC-2 end-to-end: for each install
+// source, a too-old-binary manifest driven through contract.RunDoctor emits the
+// remedy that matches the source. It proves src threads the whole doctor path
+// (verdict → message → remedy), and that no edge/non-brew row carries the bare
+// stable command (word-boundary matched). The manifest version (0.99.0 > the
+// 0.1.0 binary) forces the too-old-binary verdict; the source is the moving
+// oracle, external to the message.
+func TestTooOldBinaryRemedyRendersPerSource(t *testing.T) {
+	dir := t.TempDir()
+	manifest := filepath.Join(dir, "plugin.json")
+	mustWrite(t, manifest, `{"version":"0.99.0"}`+"\n")
+	const oldBinary = "0.1.0"
+
+	// bareStable matches the stable command only when `spacedock` is the whole
+	// token — `brew upgrade spacedock@next` must NOT satisfy it (AC-2).
+	bareStable := regexp.MustCompile(`brew upgrade spacedock(\s|$)`)
+
+	cases := []struct {
+		name         string
+		src          contract.InstallSource
+		wantContains []string
+		wantAbsent   []string
+		wantStable   bool // whether the bare stable command should be present
+	}{
+		{
+			name:         "brew stable",
+			src:          contract.InstallSource{Kind: contract.BrewStable},
+			wantContains: []string{"brew upgrade spacedock", "spacedock install"},
+			wantStable:   true,
+		},
+		{
+			name:         "brew edge",
+			src:          contract.InstallSource{Kind: contract.BrewEdge},
+			wantContains: []string{"brew upgrade spacedock@next", "spacedock install"},
+			wantStable:   false,
+		},
+		{
+			name:         "non-brew",
+			src:          contract.InstallSource{Kind: contract.NonBrew},
+			wantContains: []string{"go build -o spacedock", "spacedock install"},
+			wantAbsent:   []string{"brew upgrade"},
+			wantStable:   false,
+		},
+		{
+			name:         "sandbox host-only",
+			src:          contract.InstallSource{Kind: contract.BrewEdge, HostOnly: true},
+			wantContains: []string{"on your host", "brew upgrade spacedock@next"},
+			wantStable:   false,
+		},
+		// The SourceUnknown arm through RunDoctor is covered by the contract
+		// package's TestTooOldBinaryRemedyLeadsWithBrew — not repeated here.
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := contract.RunDoctor(manifest, "claude", oldBinary, c.src, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("exit = %d, want 1 (stderr=%q)", code, stderr.String())
+			}
+			out := stderr.String()
+			for _, want := range c.wantContains {
+				if !strings.Contains(out, want) {
+					t.Fatalf("remedy for %s must contain %q: %q", c.name, want, out)
+				}
+			}
+			for _, absent := range c.wantAbsent {
+				if strings.Contains(out, absent) {
+					t.Fatalf("remedy for %s must NOT contain %q: %q", c.name, absent, out)
+				}
+			}
+			if got := bareStable.MatchString(out); got != c.wantStable {
+				t.Fatalf("remedy for %s: bare stable `brew upgrade spacedock` present=%v, want %v: %q", c.name, got, c.wantStable, out)
+			}
+		})
+	}
+}
+
+// TestLiveInstalledBinaryRemedyMatchesCask is the machine-grounded value check:
+// on a box where the PATH `spacedock` resolves under a Homebrew Caskroom segment,
+// the in-process detector + remedy render name that cask's own formula — so a
+// `@next` box gets `brew upgrade spacedock@next`, never the bare stable command.
+// It reads the REAL resolved path (not a fixture) and skips when the PATH binary
+// is not a Caskroom install, keeping the suite portable per "no hidden machine
+// dependencies". It grounds on the running machine yet exercises THIS code's
+// detection+render in-process (not the possibly-stale installed binary).
+func TestLiveInstalledBinaryRemedyMatchesCask(t *testing.T) {
+	bin, err := exec.LookPath("spacedock")
+	if err != nil {
+		t.Skip("spacedock not on PATH; live cask smoke requires the installed binary")
+	}
+	resolved, err := filepath.EvalSymlinks(bin)
+	if err != nil {
+		t.Skipf("cannot resolve %s through symlinks: %v", bin, err)
+	}
+	token, isCask := caskToken(resolved)
+	if !isCask {
+		t.Skipf("PATH spacedock (%s) is not a Caskroom install; nothing to assert", resolved)
+	}
+	if token != "spacedock" && token != "spacedock@next" {
+		t.Skipf("PATH spacedock cask token %q is not a known channel; nothing to assert", token)
+	}
+	src := detectInstallSource(resolved, exec.LookPath, devBranch)
+	if src.Kind != contract.BrewStable && src.Kind != contract.BrewEdge {
+		t.Fatalf("Caskroom path %s classified as %+v, want a brew kind", resolved, src)
+	}
+
+	dir := t.TempDir()
+	manifest := filepath.Join(dir, "plugin.json")
+	mustWrite(t, manifest, `{"version":"999.0.0"}`+"\n")
+	var stdout, stderr bytes.Buffer
+	if code := contract.RunDoctor(manifest, "claude", "0.1.0", src, &stdout, &stderr); code != 1 {
+		t.Fatalf("doctor exit = %d, want 1 (stderr=%q)", code, stderr.String())
+	}
+	wantFormula := "brew upgrade " + token
+	if !strings.Contains(stderr.String(), wantFormula) {
+		t.Fatalf("remedy for cask token %q must name %q: %q", token, wantFormula, stderr.String())
+	}
+}

--- a/internal/cli/upgrade_from_stale_test.go
+++ b/internal/cli/upgrade_from_stale_test.go
@@ -51,7 +51,7 @@ func TestUpgradeFromStaleMovesToGreen(t *testing.T) {
 	// The stale install resolves to the too-old-plugin verdict (exit 1) — the
 	// dead-end this entity fixes.
 	staleManifest := resolveClaudeManifestEnv(t, claudeBin, env)
-	staleVerdict := contract.ManifestVerdict(staleManifest, "claude", displayVersion())
+	staleVerdict := contract.ManifestVerdict(staleManifest, "claude", displayVersion(), contract.InstallSource{})
 	if staleVerdict.Verdict != contract.TooOldPlugin {
 		t.Fatalf("stale install verdict = %v, want too-old-plugin (message=%q)", staleVerdict.Verdict, staleVerdict.Message)
 	}
@@ -72,7 +72,7 @@ func TestUpgradeFromStaleMovesToGreen(t *testing.T) {
 
 	// Doctor now reports compatible (exit 0) — the install moved off the stale plugin.
 	upgradedManifest := resolveClaudeManifestEnv(t, claudeBin, env)
-	upgradedVerdict := contract.ManifestVerdict(upgradedManifest, "claude", displayVersion())
+	upgradedVerdict := contract.ManifestVerdict(upgradedManifest, "claude", displayVersion(), contract.InstallSource{})
 	if upgradedVerdict.Verdict != contract.Compatible {
 		t.Fatalf("after upgrade, verdict = %v, want compatible (message=%q)", upgradedVerdict.Verdict, upgradedVerdict.Message)
 	}

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -97,19 +97,20 @@ func ParseMajorMinor(v string) (major, minor int, ok bool) {
 // manifest is absent), not here — Compare always has a raw plugin version to
 // evaluate.
 func Compare(host, pluginVersion, binaryVersion string) Result {
-	return compareNamed(host, "", pluginVersion, binaryVersion)
+	return compareNamed(host, "", pluginVersion, binaryVersion, InstallSource{})
 }
 
 // compareNamed is Compare with an optional manifest path woven into the
-// malformed-version message so a packaging bug names the offending file.
-func compareNamed(host, manifestPath, pluginVersion, binaryVersion string) Result {
+// malformed-version message so a packaging bug names the offending file, and the
+// detected install source that tailors the too-old-binary remedy.
+func compareNamed(host, manifestPath, pluginVersion, binaryVersion string, src InstallSource) Result {
 	bMajor, bMinor, bOk := ParseMajorMinor(binaryVersion)
 	if !bOk {
 		// A binary version with no parseable major.minor can only be an
 		// integer-era source build (`dev`, pre-D3 embed) — treated as too-old,
 		// with the existing remedy's "build from source" arm doubling as the
 		// rebuild hint.
-		return Result{Verdict: TooOldBinary, Message: mismatchMessage(binaryVersion, pluginVersion, "Upgrade the binary to continue.", tooOldBinaryRemedy())}
+		return Result{Verdict: TooOldBinary, Message: mismatchMessage(binaryVersion, pluginVersion, "Upgrade the binary to continue.", tooOldBinaryRemedy(src))}
 	}
 	pMajor, pMinor, pOk := ParseMajorMinor(pluginVersion)
 	if !pOk {
@@ -127,7 +128,7 @@ func compareNamed(host, manifestPath, pluginVersion, binaryVersion string) Resul
 	}
 	switch {
 	case bMajor < pMajor || (bMajor == pMajor && bMinor < pMinor):
-		return Result{Verdict: TooOldBinary, Message: mismatchMessage(binaryVersion, pluginVersion, "Upgrade the binary to continue.", tooOldBinaryRemedy())}
+		return Result{Verdict: TooOldBinary, Message: mismatchMessage(binaryVersion, pluginVersion, "Upgrade the binary to continue.", tooOldBinaryRemedy(src))}
 	case bMajor > pMajor || (bMajor == pMajor && bMinor > pMinor):
 		return Result{Verdict: TooOldPlugin, Message: mismatchMessage(binaryVersion, pluginVersion, "Update the plugin to continue.", tooOldPluginRemedy(host))}
 	default:
@@ -219,13 +220,60 @@ func mismatchMessage(binaryVersion, pluginVersion, direction, remedy string) str
 		binaryVersion, pluginVersion, direction, remedy)
 }
 
-// tooOldBinaryRemedy is the pinned too-old-binary remedy block: it leads with the
-// Homebrew upgrade, keeps the source-build fallback, and names the binary-vs-plugin
-// distinction (refreshing the plugin instead is a different command).
-func tooOldBinaryRemedy() string {
-	return "  Upgrade via Homebrew: brew upgrade spacedock\n" +
-		"  Or build from source: go build -o spacedock ./cmd/spacedock\n" +
-		"  Or refresh the plugin instead: spacedock install"
+// SourceKind identifies how the running binary was installed, selecting the
+// too-old-binary upgrade instruction that actually applies.
+type SourceKind int
+
+const (
+	// SourceUnknown is the safe fallback: the install source could not be
+	// determined, so the remedy offers the generic three-way block.
+	SourceUnknown SourceKind = iota
+	// BrewStable is a Homebrew install of the stable `spacedock` cask.
+	BrewStable
+	// BrewEdge is a Homebrew install of the edge `spacedock@next` cask — a
+	// separate cask token, so `brew upgrade spacedock` is the wrong command.
+	BrewEdge
+	// NonBrew is a source build, a downloaded release, or a proxy `go install` —
+	// `brew upgrade` does not apply; the binary must be rebuilt or re-downloaded.
+	NonBrew
+)
+
+// InstallSource carries the detected install source the too-old-binary remedy
+// switches on. HostOnly is set when the binary is Homebrew-owned but `brew` is
+// not reachable in the current execution context (a sandbox or minimal env), so
+// the upgrade must be run on the host rather than in place. The zero value
+// {SourceUnknown, false} reproduces the generic remedy — the reason the public
+// Compare signature stays untouched.
+type InstallSource struct {
+	Kind     SourceKind
+	HostOnly bool
+}
+
+// tooOldBinaryRemedy renders the too-old-binary remedy for the detected install
+// source: the right brew formula for a Homebrew install, a source rebuild for a
+// non-brew build, and a run-on-host hint when Homebrew is unreachable (HostOnly).
+// The SourceUnknown zero value reproduces the generic three-way block. Every arm
+// keeps the binary-vs-plugin distinction line — refreshing the plugin instead is
+// a different command than upgrading the binary.
+func tooOldBinaryRemedy(src InstallSource) string {
+	const refresh = "  Or refresh the plugin instead: spacedock install"
+	switch src.Kind {
+	case BrewStable, BrewEdge:
+		formula := "spacedock"
+		if src.Kind == BrewEdge {
+			formula = "spacedock@next"
+		}
+		if src.HostOnly {
+			return "  Homebrew isn't reachable here (e.g. a sandbox). Upgrade on your host, then relaunch: brew upgrade " + formula + "\n" + refresh
+		}
+		return "  Upgrade via Homebrew: brew upgrade " + formula + "\n" + refresh
+	case NonBrew:
+		return "  Rebuild from source: go build -o spacedock ./cmd/spacedock (or re-download the latest release)\n" + refresh
+	default: // SourceUnknown
+		return "  Upgrade via Homebrew: brew upgrade spacedock\n" +
+			"  Or build from source: go build -o spacedock ./cmd/spacedock\n" +
+			refresh
+	}
 }
 
 // tooOldPluginRemedy is the pinned too-old-plugin remedy line, parameterized by

--- a/internal/contract/doctor.go
+++ b/internal/contract/doctor.go
@@ -49,10 +49,12 @@ func ManifestVersion(manifestPath string) (string, error) {
 // yields NoPluginFound; an unparseable manifest JSON yields a MalformedVersion
 // Result naming the parse error. The plugin's display version (from the manifest)
 // and the binary's display version (threaded in by the cli caller) are woven into
-// the user-facing message. The front door inspects the verdict directly (a
-// non-empty path to a missing file is NoPluginFound, NOT compatible); RunDoctor
-// maps the same verdict to an exit code and stream.
-func ManifestVerdict(manifestPath, host, binaryVersion string) Result {
+// the user-facing message. src is the detected install source that tailors the
+// too-old-binary remedy (the zero value reproduces the generic block). The front
+// door inspects the verdict directly (a non-empty path to a missing file is
+// NoPluginFound, NOT compatible); RunDoctor maps the same verdict to an exit code
+// and stream.
+func ManifestVerdict(manifestPath, host, binaryVersion string, src InstallSource) Result {
 	pluginVersion, err := readManifest(manifestPath)
 	if errors.Is(err, errNoManifest) {
 		return Result{Verdict: NoPluginFound, Message: noPluginMessage(host)}
@@ -60,17 +62,18 @@ func ManifestVerdict(manifestPath, host, binaryVersion string) Result {
 	if err != nil {
 		return Result{Verdict: MalformedVersion, Message: fmt.Sprintf("error: %s", err)}
 	}
-	return compareNamed(host, manifestPath, pluginVersion, binaryVersion)
+	return compareNamed(host, manifestPath, pluginVersion, binaryVersion, src)
 }
 
 // RunDoctor reports the compatibility verdict for the manifest at manifestPath
 // against binaryVersion, for the named host. binaryVersion is the binary's
-// display version threaded in for the user-facing message. A compatible verdict
+// display version threaded in for the user-facing message; src is the detected
+// install source that tailors the too-old-binary remedy. A compatible verdict
 // and a no-plugin-found report exit 0 (the report is non-fatal-by-default); every
 // mismatch (too-old-binary, too-old-plugin, malformed-version) exits 1 with the
 // pinned remedy on stderr.
-func RunDoctor(manifestPath, host, binaryVersion string, stdout, stderr io.Writer) int {
-	res := ManifestVerdict(manifestPath, host, binaryVersion)
+func RunDoctor(manifestPath, host, binaryVersion string, src InstallSource, stdout, stderr io.Writer) int {
+	res := ManifestVerdict(manifestPath, host, binaryVersion, src)
 	switch res.Verdict {
 	case Compatible:
 		fmt.Fprintln(stdout, res.Message)

--- a/internal/contract/doctor_test.go
+++ b/internal/contract/doctor_test.go
@@ -61,7 +61,7 @@ func TestDoctorVerdicts(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			manifestPath := filepath.Join("testdata", c.manifest)
-			code := RunDoctor(manifestPath, c.host, binaryVersionForTest, &stdout, &stderr)
+			code := RunDoctor(manifestPath, c.host, binaryVersionForTest, InstallSource{}, &stdout, &stderr)
 			if code != c.wantExit {
 				t.Fatalf("exit = %d, want %d (stdout=%q stderr=%q)", code, c.wantExit, stdout.String(), stderr.String())
 			}
@@ -80,7 +80,7 @@ func TestDoctorVerdicts(t *testing.T) {
 func TestDoctorMalformedNamesManifest(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	manifestPath := filepath.Join("testdata", "malformed-version.json")
-	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, &stdout, &stderr)
+	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, InstallSource{}, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}

--- a/internal/contract/version_message_test.go
+++ b/internal/contract/version_message_test.go
@@ -46,7 +46,7 @@ func TestMismatchShowsVersionsNotContract(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			manifestPath := filepath.Join("testdata", c.manifest)
-			code := RunDoctor(manifestPath, "claude", binaryVersionForTest, &stdout, &stderr)
+			code := RunDoctor(manifestPath, "claude", binaryVersionForTest, InstallSource{}, &stdout, &stderr)
 			if code != 1 {
 				t.Fatalf("exit = %d, want 1 (stderr=%q)", code, stderr.String())
 			}
@@ -73,7 +73,7 @@ func TestMismatchShowsVersionsNotContract(t *testing.T) {
 func TestCompatibleShowsVersions(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	manifestPath := filepath.Join("testdata", "compatible.json")
-	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, &stdout, &stderr)
+	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, InstallSource{}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
@@ -95,7 +95,7 @@ func TestCompatibleShowsVersions(t *testing.T) {
 func TestTooOldBinaryRemedyLeadsWithBrew(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	manifestPath := filepath.Join("testdata", "too-old-binary.json")
-	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, &stdout, &stderr)
+	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, InstallSource{}, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
@@ -109,4 +109,62 @@ func TestTooOldBinaryRemedyLeadsWithBrew(t *testing.T) {
 	if strings.Contains(out, "@next") {
 		t.Fatalf("too-old-binary remedy must not pin a channel branch (the removed @branch shorthand): %q", out)
 	}
+}
+
+// TestTooOldBinaryRemedyPerSource drives the remedy generator over the
+// install-source matrix, asserting each source names the instruction that
+// actually applies (AC-1) and that the edge/non-brew/host-only arms carry NO bare
+// stable `brew upgrade spacedock` command (AC-2, word-boundary matched so
+// `brew upgrade spacedock@next` does not count). The SourceUnknown arm is pinned
+// byte-for-byte (AC-4). The oracle — the source Kind — lives outside the message,
+// so a generator that ignored its input fails.
+func TestTooOldBinaryRemedyPerSource(t *testing.T) {
+	// bareStable matches the stable command only when `spacedock` is the whole
+	// token — `brew upgrade spacedock@next` must NOT satisfy it.
+	bareStable := regexp.MustCompile(`brew upgrade spacedock(\s|$)`)
+
+	t.Run("brew-edge names the @next formula, no bare stable", func(t *testing.T) {
+		got := tooOldBinaryRemedy(InstallSource{Kind: BrewEdge})
+		if !strings.Contains(got, "brew upgrade spacedock@next") {
+			t.Fatalf("edge remedy must name `brew upgrade spacedock@next`: %q", got)
+		}
+		if bareStable.MatchString(got) {
+			t.Fatalf("edge remedy must NOT carry the bare stable `brew upgrade spacedock`: %q", got)
+		}
+		if !strings.Contains(got, "spacedock install") {
+			t.Fatalf("edge remedy must keep the plugin-refresh line: %q", got)
+		}
+	})
+
+	t.Run("non-brew rebuilds from source, no brew line", func(t *testing.T) {
+		got := tooOldBinaryRemedy(InstallSource{Kind: NonBrew})
+		if !strings.Contains(got, "go build -o spacedock ./cmd/spacedock") {
+			t.Fatalf("non-brew remedy must name a source rebuild: %q", got)
+		}
+		if strings.Contains(got, "brew upgrade") {
+			t.Fatalf("non-brew remedy must carry NO brew line: %q", got)
+		}
+	})
+
+	t.Run("host-only tells the user to upgrade on the host", func(t *testing.T) {
+		got := tooOldBinaryRemedy(InstallSource{Kind: BrewEdge, HostOnly: true})
+		if !strings.Contains(got, "on your host") {
+			t.Fatalf("host-only remedy must tell the user to upgrade on the host: %q", got)
+		}
+		if !strings.Contains(got, "brew upgrade spacedock@next") {
+			t.Fatalf("host-only edge remedy must still name the @next formula (run on host): %q", got)
+		}
+		if bareStable.MatchString(got) {
+			t.Fatalf("host-only edge remedy must NOT carry the bare stable command: %q", got)
+		}
+	})
+
+	t.Run("source-unknown reproduces the generic block byte-for-byte", func(t *testing.T) {
+		want := "  Upgrade via Homebrew: brew upgrade spacedock\n" +
+			"  Or build from source: go build -o spacedock ./cmd/spacedock\n" +
+			"  Or refresh the plugin instead: spacedock install"
+		if got := tooOldBinaryRemedy(InstallSource{}); got != want {
+			t.Fatalf("SourceUnknown remedy changed:\n got=%q\nwant=%q", got, want)
+		}
+	})
 }


### PR DESCRIPTION
Edge-channel (`spacedock@next`) users hit an out-of-date binary and were told to run `brew upgrade spacedock` — the wrong formula — leaving them stuck.

## What changed
- Thread a detected install source into the single too-old-binary remedy generator.
- Emit `brew upgrade spacedock@next` for edge and `brew upgrade spacedock` for stable.
- Emit a source-rebuild hint for non-brew builds and a run-on-host hint for sandboxes.
- Detect the source from the resolved Caskroom token, with no `brew` subprocess.

## Evidence
- `go test ./...` + `-race`: all packages passed; 5/5 ACs mutation-tested, `Compare` untouched.
- Live: the built binary's real `doctor` emits the detected NonBrew remedy end-to-end.

## Review guidance
- `internal/cli/frontdoor.go` gateHost source-threading — the high-stakes surface; proven live + detached-audited.

---
[vz](/spacedock-dev/spacedock/blob/26b02d69926ee24454b4a3bfd4d555c2da46ee55/upgrade-remedy-install-source-aware.md)
