### PR TITLE
Give four tautological tests independent oracles

### DIFF
--- a/internal/ensigncycle/pty_session_test.go
+++ b/internal/ensigncycle/pty_session_test.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fileLineSource is the pty lineSource: it tails the FO's session jsonl, returning
@@ -379,9 +380,18 @@ func TestFOSessionPinning(t *testing.T) {
 	t.Run("activeSessionFile_would_flip_to_teammate", func(t *testing.T) {
 		// The bug being fixed: the newest-assistant-bearing heuristic picks the
 		// teammate (this is WHY the by-id pin is required, not activeSessionFile).
-		// The teammate file is written second, so it is the newest.
+		// Both files carry assistant entries, so activeSessionFile's tiebreak is
+		// mod-time recency; pin the teammate provably newer than the FO file with
+		// os.Chtimes so the flip is deterministic (coarse fs timestamps could tie).
+		base := time.Now()
+		if err := os.Chtimes(foPath, base.Add(-2*time.Second), base.Add(-2*time.Second)); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(teammatePath, base, base); err != nil {
+			t.Fatal(err)
+		}
 		if active := activeSessionFile(dir); active != teammatePath {
-			t.Logf("activeSessionFile = %q (teammate=%q); the by-id pin is what avoids this flip", active, teammatePath)
+			t.Errorf("activeSessionFile = %q, want teammate %q — the naive newest-assistant heuristic must pick the teammate, which is WHY the by-id pin is required", active, teammatePath)
 		}
 	})
 

--- a/internal/status/boot_probe_parity_test.go
+++ b/internal/status/boot_probe_parity_test.go
@@ -109,7 +109,9 @@ func TestBootTeamStateProbeConfinement(t *testing.T) {
 	}
 
 	blockNil, _ := teamStateBlock(bootNil)
-	wantNil := "TEAM_STATE\npresent: false\nhint: " + teamStateNeutralHint
+	// Hand-copied literal oracle (the current teamStateNeutralHint value), independent
+	// of the constant the render reads, so emptying that constant is caught.
+	wantNil := "TEAM_STATE\npresent: false\nhint: no active team runtime detected"
 	if blockNil != wantNil {
 		t.Fatalf("nil-probe TEAM_STATE:\n got %q\nwant %q", blockNil, wantNil)
 	}

--- a/internal/status/native_new_test.go
+++ b/internal/status/native_new_test.go
@@ -139,8 +139,11 @@ func TestNewFolderForm(t *testing.T) {
 	if !strings.Contains(written, "id: "+want) {
 		t.Fatalf("folder entity missing minted id %q:\n%s", want, written)
 	}
-	// Byte-identity: the written file equals STDIN with the id line inserted.
-	wantBytes := string(stampID([]byte(newBody), want))
+	// Byte-identity: the written file equals STDIN with the id line inserted
+	// immediately before the closing --- of the frontmatter. The expected bytes are
+	// reconstructed independently of stampID (an anchored splice on the last
+	// frontmatter line) so a stampID splice-offset regression is caught.
+	wantBytes := strings.Replace(newBody, "source: roadmap\n---", "source: roadmap\nid: "+want+"\n---", 1)
 	if written != wantBytes {
 		t.Fatalf("folder entity not byte-identical to STDIN+id-stamp\n--- got ---\n%q\n--- want ---\n%q", written, wantBytes)
 	}

--- a/internal/status/zz_independent_parity_test.go
+++ b/internal/status/zz_independent_parity_test.go
@@ -548,8 +548,10 @@ func TestIndNewAtomicCreate(t *testing.T) {
 					t.Errorf("[%s] seed missing minted id line %q:\n%s", name, wantLine, string(seed))
 				}
 				// Seed must equal STDIN with exactly the id-stamp added (byte-identity
-				// of every other line — AC-5 preservation), verified by reconstructing.
-				wantSeed := string(stampID([]byte(body), expectedID))
+				// of every other line — AC-5 preservation), verified by reconstructing
+				// the expected bytes independently of stampID (an anchored splice on the
+				// last frontmatter line) so a stampID splice-offset regression is caught.
+				wantSeed := strings.Replace(body, "source: roadmap\n---", "source: roadmap\nid: "+expectedID+"\n---", 1)
 				if string(seed) != wantSeed {
 					t.Errorf("[%s] seed not STDIN+id-stamp:\ngot=%q\nwant=%q", name, string(seed), wantSeed)
 				}


### PR DESCRIPTION
Four tests in internal/ensigncycle and internal/status asserted nothing that could fail — a real regression passed them silently until now.

## What changed
- Give the FO-session pinning test a real failure path with a deterministic os.Chtimes fixture.
- Replace the native-new and independent-parity mirror assertions with hand-built literals independent of stampID.
- Replace the boot-probe hint mirror with a literal oracle.

## Evidence
- Each fixed test goes RED under its exposing mutation and GREEN reverted; pre-fix it stayed GREEN (tautology confirmed, now closed).
- go test ./... + -race green; test-file-only, no production change.

---
[mp](/spacedock-dev/spacedock/blob/1217714eafec70c31cc1edbff8acc85c28ac6214/tautological-test-fixes.md)
