### PR TITLE
Ensure the automatic pre0 tag push triggers its release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,24 +388,32 @@ jobs:
 
       # Always-cut-pre0 (latest-line stable tag only, same advance gate): auto-cut
       # an ANNOTATED vX.(Y+1).0-pre0 tag ON THE GREENED RELEASE COMMIT (the SHA
-      # e2e-gate already greened and the stable stamp resolved) and push it via the
-      # re-triggering PAT. That tag's own release run resolves the SAME green e2e
-      # run (same commit), builds+publishes the X.(Y+1)-minor edge binary, and
-      # bumps the spacedock@next cask — closing the post-stable-cut window in
-      # minutes instead of waiting for the next hand-cut prerelease. The tag MUST be
-      # annotated with a non-empty body: the release-notes extraction step
-      # (above, in goreleaser) hard-errors on a lightweight/empty-body tag before
-      # the binary builds. The push MUST use the PAT: a push authenticated with the
-      # default GITHUB_TOKEN deliberately does NOT trigger further workflow runs, so
-      # the pre0 build would never start. Recursion terminates at one level — the
-      # pre0 tag routes to the prerelease path, whose edge-advance-decision skips
-      # (pre0 < next's pre1), so it neither re-tags nor rewinds `next`.
+      # e2e-gate already greened and the stable stamp resolved) and push it over
+      # SSH with the EDGE_RELEASE_DEPLOY_KEY write deploy key. That tag's own
+      # release run resolves the SAME green e2e run (same commit), builds+publishes
+      # the X.(Y+1)-minor edge binary, and bumps the spacedock@next cask — closing
+      # the post-stable-cut window in minutes instead of waiting for the next
+      # hand-cut prerelease. The tag MUST be annotated with a non-empty body: the
+      # release-notes extraction step (above, in goreleaser) hard-errors on a
+      # lightweight/empty-body tag before the binary builds. The push MUST use a
+      # trigger-capable credential: GitHub creates NO workflow run for a push
+      # authenticated by the default GITHUB_TOKEN or — as the v0.25.0 and v0.26.0
+      # cuts showed — the cross-repo tap PAT, so the pre0 build would never start; a
+      # repo-scoped SSH deploy key is the one credential GitHub never suppresses for
+      # triggering. The step then verifies a release.yml run was created for the
+      # pre0 tag and fails edge-advance loudly if none appears, so a suppressed
+      # credential can never leave the edge binary silently behind. Recursion
+      # terminates at one level — the pre0 tag routes to the prerelease path, whose
+      # edge-advance-decision skips (pre0 < next's pre1), so it neither re-tags nor
+      # rewinds `next`.
       - name: Auto-cut the edge prerelease tag on the greened release commit
         if: "!contains(github.ref, '-') && steps.decision.outputs.advance == 'true'"
         env:
-          # PAT (HOMEBREW_TAP_TOKEN-class) so the tag push RE-TRIGGERS release.yml;
-          # the default GITHUB_TOKEN cannot fire a workflow from within a run.
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # Write deploy key (SSH) so the tag push is trigger-capable and creates
+          # the pre0 release.yml run; GH_TOKEN is the read-only Actions-API
+          # credential the verify-or-fail poll uses.
+          EDGE_RELEASE_DEPLOY_KEY: ${{ secrets.EDGE_RELEASE_DEPLOY_KEY }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           RELEASE_COMMIT="$(git rev-list -1 "$GITHUB_REF_NAME")"
@@ -416,4 +424,29 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$PRE0_TAG" "$RELEASE_COMMIT" -m "$PRE0_BODY"
-          git push "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PRE0_TAG"
+          # Push over SSH with the write deploy key — the one credential GitHub
+          # never suppresses for triggering, so the pre0 release.yml run fires.
+          mkdir -p ~/.ssh
+          printf '%s\n' "$EDGE_RELEASE_DEPLOY_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes" \
+            git push "git@github.com:${GITHUB_REPOSITORY}.git" "$PRE0_TAG"
+          # Verify-or-fail: confirm the push created a release.yml run for the pre0
+          # tag. A workflow-suppressed credential lands the ref but fires no run, so
+          # fail edge-advance loudly instead of leaving the edge binary behind.
+          VERIFY_TIMEOUT=120
+          deadline=$((SECONDS + VERIFY_TIMEOUT))
+          while :; do
+            runs="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/release.yml/runs?event=push&per_page=50" \
+              --jq "[.workflow_runs[] | select(.head_branch==\"${PRE0_TAG}\")] | length" 2>/dev/null || echo 0)"
+            if [ "${runs:-0}" -gt 0 ]; then
+              echo "::notice::pre0 tag $PRE0_TAG created ${runs} release.yml run(s)"
+              break
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::pre0 tag $PRE0_TAG push created no release.yml run within ${VERIFY_TIMEOUT}s; the push credential is workflow-suppressed. Failing edge-advance so the edge binary is not left silently behind." >&2
+              exit 1
+            fi
+            sleep 10
+          done

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -178,14 +178,19 @@ rare conflict here cannot unwind or block the release that already published):
   (`spacedock-release dev-preversion X.Y.Z`) so the edge line never masquerades
   as the stable version it just shipped, and the calendar key is bumped — then an
   ANNOTATED `vX.(Y+1).0-pre0` tag is auto-created **on the greened release commit**
-  and pushed (via the re-triggering tap PAT). That prerelease tag's own release
-  run reuses the greened commit's e2e-gate pass, builds+publishes the `X.(Y+1)`-minor
-  edge binary, and bumps the `spacedock@next` cask — so the edge binary's minor
-  catches up to the skills' gate line within minutes instead of waiting for the
-  next hand-cut prerelease. The auto-tag MUST be annotated with a non-empty body
-  (the release-notes extraction step rejects a lightweight tag), and MUST be
-  pushed with the PAT (a `GITHUB_TOKEN` push does not fire the pre0 build). Expect
-  two GitHub releases per stable cut.
+  and pushed over SSH with a dedicated write **deploy key**
+  (`EDGE_RELEASE_DEPLOY_KEY`), scoped to this repo. That prerelease tag's own
+  release run reuses the greened commit's e2e-gate pass, builds+publishes the
+  `X.(Y+1)`-minor edge binary, and bumps the `spacedock@next` cask — so the edge
+  binary's minor catches up to the skills' gate line within minutes instead of
+  waiting for the next hand-cut prerelease. The auto-tag MUST be annotated with a
+  non-empty body (the release-notes extraction step rejects a lightweight tag).
+  The push MUST use a trigger-capable credential: a `GITHUB_TOKEN` push — and, as
+  observed on the v0.25.0 and v0.26.0 cuts, the cross-repo tap PAT — does NOT
+  create the pre0 `release.yml` run, so the step pushes with the deploy key and
+  then **verifies a run was created for the pre0 tag, failing `edge-advance`
+  loudly if none appears** rather than leaving the edge binary silently behind.
+  Expect two GitHub releases per stable cut.
 - **Old-line / patch (`vX.Y.1`, or any tag whose target edge version is not
   strictly greater than `next`'s current manifest version):** the whole
   `edge-advance` job SKIPS (`spacedock-release edge-advance-decision` prints

--- a/internal/release/edge_advance_wiring_test.go
+++ b/internal/release/edge_advance_wiring_test.go
@@ -152,8 +152,10 @@ func TestReleaseWorkflowEdgeAdvanceDecisionGates(t *testing.T) {
 // `git rev-list -1 "$GITHUB_REF_NAME"`, not next's tip — so the pre0 run reuses
 // the existing green e2e run), creates an ANNOTATED tag with a non-empty body (a
 // lightweight/empty-body tag reds the release-notes extraction step before the
-// binary builds), and pushes via the re-triggering PAT (a GITHUB_TOKEN push does
-// not fire the pre0 build).
+// binary builds), pushes it with a trigger-capable credential — the
+// EDGE_RELEASE_DEPLOY_KEY SSH deploy key, NOT the workflow-suppressed default
+// GITHUB_TOKEN (which lands the ref but fires no run) — and then verifies a
+// release.yml run was created for the pre0 tag, failing loudly if none appears.
 func assertAlwaysCutPre0(workflow string) error {
 	job := edgeAdvanceJob(workflow)
 	if job == nil {
@@ -172,16 +174,23 @@ func assertAlwaysCutPre0(workflow string) error {
 
 	var tagCmd, pushCmd string
 	derivesGreenedSHA, assignsBody := false, false
+	verifiesRun, failsOnMiss := false, false
 	for _, command := range executableShellCommands(pre0.run) {
 		switch {
 		case strings.HasPrefix(command, "git tag "):
 			tagCmd = command
-		case strings.HasPrefix(command, "git push"):
+		case strings.Contains(command, "git push"):
 			pushCmd = command
 		case command == `RELEASE_COMMIT="$(git rev-list -1 "$GITHUB_REF_NAME")"`:
 			derivesGreenedSHA = true
 		case strings.HasPrefix(command, `PRE0_BODY="`) && command != `PRE0_BODY=""`:
 			assignsBody = true
+		}
+		if strings.Contains(command, "actions/workflows/release.yml/runs") && strings.Contains(command, "PRE0_TAG") {
+			verifiesRun = true
+		}
+		if strings.Contains(command, "exit 1") {
+			failsOnMiss = true
 		}
 	}
 	if tagCmd == "" {
@@ -202,8 +211,17 @@ func assertAlwaysCutPre0(workflow string) error {
 	if pushCmd == "" {
 		return fmt.Errorf("auto-pre0 step runs no `git push` command")
 	}
-	if !strings.Contains(pushCmd, "HOMEBREW_TAP_TOKEN") {
-		return fmt.Errorf("auto-pre0 push does not use the re-triggering PAT (HOMEBREW_TAP_TOKEN); a GITHUB_TOKEN push would not fire the pre0 build: %q", pushCmd)
+	if strings.Contains(pushCmd, "GITHUB_TOKEN") {
+		return fmt.Errorf("auto-pre0 push authenticates with the default GITHUB_TOKEN (workflow-suppressed — lands the ref but fires no release.yml run): %q", pushCmd)
+	}
+	if !strings.Contains(pushCmd, `git@github.com:${GITHUB_REPOSITORY}.git`) {
+		return fmt.Errorf("auto-pre0 push does not use the trigger-capable deploy-key SSH transport git@github.com:${GITHUB_REPOSITORY}.git: %q", pushCmd)
+	}
+	if !verifiesRun {
+		return fmt.Errorf("auto-pre0 step has no release.yml run-verification poll keyed on the pre0 tag — a suppressed credential would leave the edge binary silently behind")
+	}
+	if !failsOnMiss {
+		return fmt.Errorf("auto-pre0 step's verify poll never exits non-zero when no run is found — a suppressed credential would pass silently")
 	}
 	return nil
 }
@@ -256,8 +274,9 @@ func tagCmdTarget(tagCmd string) string {
 // TestReleaseWorkflowAlwaysCutPre0 locks AC-4 against the on-disk release.yml.
 // The adversarial twins: (a) retarget the tag from the greened RELEASE_COMMIT to
 // next's tip; (b) drop -a/-m to make it a lightweight tag; (c) move the step to
-// the prerelease path (recursion); (d) push via GITHUB_TOKEN instead of the PAT.
-// Each must red.
+// the prerelease path (recursion); (d) push via the workflow-suppressed
+// GITHUB_TOKEN instead of the trigger-capable deploy key; (e) neuter the
+// verify-or-fail run poll. Each must red.
 func TestReleaseWorkflowAlwaysCutPre0(t *testing.T) {
 	workflow := readWorkflow(t, "release.yml")
 	if err := assertAlwaysCutPre0(workflow); err != nil {
@@ -298,14 +317,25 @@ func TestReleaseWorkflowAlwaysCutPre0(t *testing.T) {
 		t.Fatal("always-cut-pre0 guard accepted an auto-pre0 step on the prerelease path (recursion)")
 	}
 
-	// (d) push via GITHUB_TOKEN instead of the re-triggering PAT.
+	// (d) push via the workflow-suppressed GITHUB_TOKEN instead of the deploy key.
 	wrongToken := strings.Replace(workflow,
-		`git push "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PRE0_TAG"`,
+		`git push "git@github.com:${GITHUB_REPOSITORY}.git" "$PRE0_TAG"`,
 		`git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PRE0_TAG"`, 1)
 	if wrongToken == workflow {
-		t.Fatal("fixture workflow missing the auto-pre0 PAT push line to swap")
+		t.Fatal("fixture workflow missing the auto-pre0 deploy-key push line to swap")
 	}
 	if err := assertAlwaysCutPre0(wrongToken); err == nil {
-		t.Fatal("always-cut-pre0 guard accepted a pre0 tag pushed via GITHUB_TOKEN (would not re-trigger)")
+		t.Fatal("always-cut-pre0 guard accepted a pre0 tag pushed via GITHUB_TOKEN (would not fire the pre0 run)")
+	}
+
+	// (e) neuter the verify-or-fail poll → a suppressed credential passes silently.
+	noVerify := strings.Replace(workflow,
+		"actions/workflows/release.yml/runs",
+		"actions/workflows/DISABLED.yml/runs", 1)
+	if noVerify == workflow {
+		t.Fatal("fixture workflow missing the auto-pre0 verify poll to neuter")
+	}
+	if err := assertAlwaysCutPre0(noVerify); err == nil {
+		t.Fatal("always-cut-pre0 guard accepted an auto-pre0 step whose verify poll no longer queries release.yml runs")
 	}
 }


### PR DESCRIPTION
A stable cut's auto-generated edge binary silently lagged: the pre0 tag push used a workflow-suppressed credential, so no release run fired.

## What changed
- Push the pre0 tag over SSH with a repo-scoped deploy key (trigger-capable), replacing the suppressed cross-repo tap PAT.
- Add a verify-or-fail poll that reds edge-advance if no pre0 run appears.
- Rewrite the false "PAT re-triggers" comment and the releasing doc.

## Evidence
- Spike: runner-embedded deploy-key push fired a run; GITHUB_TOKEN push fired zero.
- Detached audit reds the guard on all 4 claim-breaking edits incl. the root-cause tap PAT; go test ./internal/release/... green.

---
[5aq](/spacedock-dev/spacedock/blob/fd924f852e5d995a7ca534e01a12108a8b325c3c/auto-pre0-tag-push-release-trigger/index.md)
