### PR TITLE
Binary-upgrade prompt must name spacedock@next for edge-cask installs

### DIFF
--- a/internal/cli/edge_cask.go
+++ b/internal/cli/edge_cask.go
@@ -1,0 +1,37 @@
+// ABOUTME: Detect whether the running spacedock binary is the Homebrew edge
+// ABOUTME: (spacedock@next) cask, so the too-old-binary remedy names that formula.
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// runningEdgeCask reports whether the resolved running binary was installed from
+// the Homebrew edge cask (`spacedock@next`). It anchors on the resolved executable
+// (resolvedLauncherBin's os.Executable→EvalSymlinks), not the `spacedock` on PATH,
+// so a session launched from a source checkout or the stable cask is not misread
+// as edge.
+func runningEdgeCask() bool {
+	execPath, ok := resolvedLauncherBin()
+	if !ok {
+		return false
+	}
+	return isEdgeCaskPath(execPath)
+}
+
+// isEdgeCaskPath reports whether execPath resolves under a Homebrew
+// `Caskroom/spacedock@next/` segment — the edge cask's staged location (e.g.
+// `/opt/homebrew/Caskroom/spacedock@next/0.26.0-pre0/spacedock`). Any other path
+// (the stable `spacedock` cask, a source checkout, an empty path) reports false,
+// leaving the too-old-binary remedy on its unchanged `brew upgrade spacedock`
+// default.
+func isEdgeCaskPath(execPath string) bool {
+	segments := strings.Split(filepath.ToSlash(execPath), "/")
+	for i, seg := range segments {
+		if seg == "Caskroom" && i+1 < len(segments) {
+			return segments[i+1] == "spacedock@next"
+		}
+	}
+	return false
+}

--- a/internal/cli/edge_cask_test.go
+++ b/internal/cli/edge_cask_test.go
@@ -1,0 +1,28 @@
+// ABOUTME: Table test for isEdgeCaskPath — the resolved-path check that flips the
+// ABOUTME: too-old-binary remedy to the spacedock@next formula for an edge install.
+package cli
+
+import "testing"
+
+// TestIsEdgeCaskPath checks that only a resolved path under a
+// `Caskroom/spacedock@next/` segment is classified as the edge cask; the stable
+// cask, a source checkout, and an empty path are not.
+func TestIsEdgeCaskPath(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"edge cask", "/opt/homebrew/Caskroom/spacedock@next/0.26.0-pre0/spacedock", true},
+		{"stable cask", "/usr/local/Caskroom/spacedock/0.25.0/spacedock", false},
+		{"source checkout", "/Users/x/git/spacedock/spacedock", false},
+		{"empty path", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isEdgeCaskPath(c.path); got != c.want {
+				t.Fatalf("isEdgeCaskPath(%q) = %v, want %v", c.path, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/cli/frontdoor.go
+++ b/internal/cli/frontdoor.go
@@ -269,7 +269,7 @@ func gateHost(ops hostOps, host string, stderr io.Writer) contract.Result {
 	if manifestPath == "" {
 		return contract.Result{Verdict: contract.NoPluginFound}
 	}
-	res := contract.ManifestVerdict(manifestPath, host, displayVersion())
+	res := contract.ManifestVerdict(manifestPath, host, displayVersion(), runningEdgeCask())
 	switch res.Verdict {
 	case contract.NoPluginFound, contract.TooOldPlugin:
 		return res

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -56,7 +56,7 @@ func runInit(ctx context.Context, args []string, ops hostOps, stdout, stderr io.
 				fmt.Fprintf(stderr, "spacedock init: could not resolve the installed codex plugin: %v\n", err)
 				return 1
 			}
-			return contract.RunDoctor(resolved, "codex", displayVersion(), stdout, stderr)
+			return contract.RunDoctor(resolved, "codex", displayVersion(), runningEdgeCask(), stdout, stderr)
 		}
 		// `install --host codex` drives the install seam (marketplace add + plugin
 		// add, re-pinning the source) and runs doctor — the same programmatic path
@@ -91,7 +91,7 @@ func runDoctor(ctx context.Context, args []string, ops hostOps, stdout, stderr i
 	}
 
 	if manifestPath != "" {
-		return contract.RunDoctor(manifestPath, host, displayVersion(), stdout, stderr)
+		return contract.RunDoctor(manifestPath, host, displayVersion(), runningEdgeCask(), stdout, stderr)
 	}
 
 	resolved, err := ops.ResolveManifest(host)
@@ -101,7 +101,7 @@ func runDoctor(ctx context.Context, args []string, ops hostOps, stdout, stderr i
 	}
 	// An empty resolved path is the no-plugin-found report; RunDoctor renders it
 	// from a non-existent path as a non-fatal report.
-	return contract.RunDoctor(resolved, host, displayVersion(), stdout, stderr)
+	return contract.RunDoctor(resolved, host, displayVersion(), runningEdgeCask(), stdout, stderr)
 }
 
 // parseInitArgs reads `--host claude|codex` (default claude) and `--check`. A

--- a/internal/cli/upgrade_from_stale_test.go
+++ b/internal/cli/upgrade_from_stale_test.go
@@ -51,7 +51,7 @@ func TestUpgradeFromStaleMovesToGreen(t *testing.T) {
 	// The stale install resolves to the too-old-plugin verdict (exit 1) — the
 	// dead-end this entity fixes.
 	staleManifest := resolveClaudeManifestEnv(t, claudeBin, env)
-	staleVerdict := contract.ManifestVerdict(staleManifest, "claude", displayVersion())
+	staleVerdict := contract.ManifestVerdict(staleManifest, "claude", displayVersion(), false)
 	if staleVerdict.Verdict != contract.TooOldPlugin {
 		t.Fatalf("stale install verdict = %v, want too-old-plugin (message=%q)", staleVerdict.Verdict, staleVerdict.Message)
 	}
@@ -72,7 +72,7 @@ func TestUpgradeFromStaleMovesToGreen(t *testing.T) {
 
 	// Doctor now reports compatible (exit 0) — the install moved off the stale plugin.
 	upgradedManifest := resolveClaudeManifestEnv(t, claudeBin, env)
-	upgradedVerdict := contract.ManifestVerdict(upgradedManifest, "claude", displayVersion())
+	upgradedVerdict := contract.ManifestVerdict(upgradedManifest, "claude", displayVersion(), false)
 	if upgradedVerdict.Verdict != contract.Compatible {
 		t.Fatalf("after upgrade, verdict = %v, want compatible (message=%q)", upgradedVerdict.Verdict, upgradedVerdict.Message)
 	}

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -97,19 +97,21 @@ func ParseMajorMinor(v string) (major, minor int, ok bool) {
 // manifest is absent), not here — Compare always has a raw plugin version to
 // evaluate.
 func Compare(host, pluginVersion, binaryVersion string) Result {
-	return compareNamed(host, "", pluginVersion, binaryVersion)
+	return compareNamed(host, "", pluginVersion, binaryVersion, false)
 }
 
 // compareNamed is Compare with an optional manifest path woven into the
-// malformed-version message so a packaging bug names the offending file.
-func compareNamed(host, manifestPath, pluginVersion, binaryVersion string) Result {
+// malformed-version message so a packaging bug names the offending file, and an
+// edgeCask flag that names the `spacedock@next` formula in the too-old-binary
+// remedy when the running binary is the edge cask install.
+func compareNamed(host, manifestPath, pluginVersion, binaryVersion string, edgeCask bool) Result {
 	bMajor, bMinor, bOk := ParseMajorMinor(binaryVersion)
 	if !bOk {
 		// A binary version with no parseable major.minor can only be an
 		// integer-era source build (`dev`, pre-D3 embed) — treated as too-old,
 		// with the existing remedy's "build from source" arm doubling as the
 		// rebuild hint.
-		return Result{Verdict: TooOldBinary, Message: mismatchMessage(binaryVersion, pluginVersion, "Upgrade the binary to continue.", tooOldBinaryRemedy())}
+		return Result{Verdict: TooOldBinary, Message: mismatchMessage(binaryVersion, pluginVersion, "Upgrade the binary to continue.", tooOldBinaryRemedy(edgeCask))}
 	}
 	pMajor, pMinor, pOk := ParseMajorMinor(pluginVersion)
 	if !pOk {
@@ -127,7 +129,7 @@ func compareNamed(host, manifestPath, pluginVersion, binaryVersion string) Resul
 	}
 	switch {
 	case bMajor < pMajor || (bMajor == pMajor && bMinor < pMinor):
-		return Result{Verdict: TooOldBinary, Message: mismatchMessage(binaryVersion, pluginVersion, "Upgrade the binary to continue.", tooOldBinaryRemedy())}
+		return Result{Verdict: TooOldBinary, Message: mismatchMessage(binaryVersion, pluginVersion, "Upgrade the binary to continue.", tooOldBinaryRemedy(edgeCask))}
 	case bMajor > pMajor || (bMajor == pMajor && bMinor > pMinor):
 		return Result{Verdict: TooOldPlugin, Message: mismatchMessage(binaryVersion, pluginVersion, "Update the plugin to continue.", tooOldPluginRemedy(host))}
 	default:
@@ -221,9 +223,17 @@ func mismatchMessage(binaryVersion, pluginVersion, direction, remedy string) str
 
 // tooOldBinaryRemedy is the pinned too-old-binary remedy block: it leads with the
 // Homebrew upgrade, keeps the source-build fallback, and names the binary-vs-plugin
-// distinction (refreshing the plugin instead is a different command).
-func tooOldBinaryRemedy() string {
-	return "  Upgrade via Homebrew: brew upgrade spacedock\n" +
+// distinction (refreshing the plugin instead is a different command). edgeCask
+// names the edge `spacedock@next` cask as the upgrade target when the running
+// binary was installed from it: that cask is a separate Homebrew token, so a plain
+// `brew upgrade spacedock` is a no-op for an @next install. edgeCask=false leaves
+// the block unchanged.
+func tooOldBinaryRemedy(edgeCask bool) string {
+	formula := "spacedock"
+	if edgeCask {
+		formula = "spacedock@next"
+	}
+	return "  Upgrade via Homebrew: brew upgrade " + formula + "\n" +
 		"  Or build from source: go build -o spacedock ./cmd/spacedock\n" +
 		"  Or refresh the plugin instead: spacedock install"
 }

--- a/internal/contract/doctor.go
+++ b/internal/contract/doctor.go
@@ -49,10 +49,12 @@ func ManifestVersion(manifestPath string) (string, error) {
 // yields NoPluginFound; an unparseable manifest JSON yields a MalformedVersion
 // Result naming the parse error. The plugin's display version (from the manifest)
 // and the binary's display version (threaded in by the cli caller) are woven into
-// the user-facing message. The front door inspects the verdict directly (a
+// the user-facing message. edgeCask names the `spacedock@next` formula in the
+// too-old-binary remedy when the running binary is the edge cask install (false
+// leaves the remedy unchanged). The front door inspects the verdict directly (a
 // non-empty path to a missing file is NoPluginFound, NOT compatible); RunDoctor
 // maps the same verdict to an exit code and stream.
-func ManifestVerdict(manifestPath, host, binaryVersion string) Result {
+func ManifestVerdict(manifestPath, host, binaryVersion string, edgeCask bool) Result {
 	pluginVersion, err := readManifest(manifestPath)
 	if errors.Is(err, errNoManifest) {
 		return Result{Verdict: NoPluginFound, Message: noPluginMessage(host)}
@@ -60,17 +62,19 @@ func ManifestVerdict(manifestPath, host, binaryVersion string) Result {
 	if err != nil {
 		return Result{Verdict: MalformedVersion, Message: fmt.Sprintf("error: %s", err)}
 	}
-	return compareNamed(host, manifestPath, pluginVersion, binaryVersion)
+	return compareNamed(host, manifestPath, pluginVersion, binaryVersion, edgeCask)
 }
 
 // RunDoctor reports the compatibility verdict for the manifest at manifestPath
 // against binaryVersion, for the named host. binaryVersion is the binary's
-// display version threaded in for the user-facing message. A compatible verdict
+// display version threaded in for the user-facing message; edgeCask names the
+// `spacedock@next` formula in the too-old-binary remedy when the running binary is
+// the edge cask install. A compatible verdict
 // and a no-plugin-found report exit 0 (the report is non-fatal-by-default); every
 // mismatch (too-old-binary, too-old-plugin, malformed-version) exits 1 with the
 // pinned remedy on stderr.
-func RunDoctor(manifestPath, host, binaryVersion string, stdout, stderr io.Writer) int {
-	res := ManifestVerdict(manifestPath, host, binaryVersion)
+func RunDoctor(manifestPath, host, binaryVersion string, edgeCask bool, stdout, stderr io.Writer) int {
+	res := ManifestVerdict(manifestPath, host, binaryVersion, edgeCask)
 	switch res.Verdict {
 	case Compatible:
 		fmt.Fprintln(stdout, res.Message)

--- a/internal/contract/doctor_test.go
+++ b/internal/contract/doctor_test.go
@@ -61,7 +61,7 @@ func TestDoctorVerdicts(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			manifestPath := filepath.Join("testdata", c.manifest)
-			code := RunDoctor(manifestPath, c.host, binaryVersionForTest, &stdout, &stderr)
+			code := RunDoctor(manifestPath, c.host, binaryVersionForTest, false, &stdout, &stderr)
 			if code != c.wantExit {
 				t.Fatalf("exit = %d, want %d (stdout=%q stderr=%q)", code, c.wantExit, stdout.String(), stderr.String())
 			}
@@ -80,7 +80,7 @@ func TestDoctorVerdicts(t *testing.T) {
 func TestDoctorMalformedNamesManifest(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	manifestPath := filepath.Join("testdata", "malformed-version.json")
-	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, &stdout, &stderr)
+	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}

--- a/internal/contract/version_message_test.go
+++ b/internal/contract/version_message_test.go
@@ -46,7 +46,7 @@ func TestMismatchShowsVersionsNotContract(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			manifestPath := filepath.Join("testdata", c.manifest)
-			code := RunDoctor(manifestPath, "claude", binaryVersionForTest, &stdout, &stderr)
+			code := RunDoctor(manifestPath, "claude", binaryVersionForTest, false, &stdout, &stderr)
 			if code != 1 {
 				t.Fatalf("exit = %d, want 1 (stderr=%q)", code, stderr.String())
 			}
@@ -73,7 +73,7 @@ func TestMismatchShowsVersionsNotContract(t *testing.T) {
 func TestCompatibleShowsVersions(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	manifestPath := filepath.Join("testdata", "compatible.json")
-	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, &stdout, &stderr)
+	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
 	}
@@ -95,7 +95,7 @@ func TestCompatibleShowsVersions(t *testing.T) {
 func TestTooOldBinaryRemedyLeadsWithBrew(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	manifestPath := filepath.Join("testdata", "too-old-binary.json")
-	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, &stdout, &stderr)
+	code := RunDoctor(manifestPath, "claude", binaryVersionForTest, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
@@ -108,5 +108,35 @@ func TestTooOldBinaryRemedyLeadsWithBrew(t *testing.T) {
 	}
 	if strings.Contains(out, "@next") {
 		t.Fatalf("too-old-binary remedy must not pin a channel branch (the removed @branch shorthand): %q", out)
+	}
+}
+
+// TestTooOldBinaryRemedyEdgeChannel is the captain's @next regression: when the
+// running binary is the edge (`spacedock@next`) cask, the too-old-binary remedy
+// must name `brew upgrade spacedock@next` and NOT the bare stable `brew upgrade
+// spacedock` (word-boundary matched, so `@next` does not satisfy the stable form).
+// For any other install (edgeCask=false) the block is byte-for-byte unchanged.
+func TestTooOldBinaryRemedyEdgeChannel(t *testing.T) {
+	// bareStable matches the stable command only when `spacedock` is the whole
+	// token — `brew upgrade spacedock@next` must NOT satisfy it.
+	bareStable := regexp.MustCompile(`brew upgrade spacedock(\s|$)`)
+
+	edge := tooOldBinaryRemedy(true)
+	if !strings.Contains(edge, "brew upgrade spacedock@next") {
+		t.Fatalf("edge remedy must name `brew upgrade spacedock@next`: %q", edge)
+	}
+	if bareStable.MatchString(edge) {
+		t.Fatalf("edge remedy must NOT carry the bare stable `brew upgrade spacedock`: %q", edge)
+	}
+	if !strings.Contains(edge, "spacedock install") {
+		t.Fatalf("edge remedy must keep the plugin-refresh line: %q", edge)
+	}
+
+	// edgeCask=false reproduces the pinned block byte-for-byte.
+	want := "  Upgrade via Homebrew: brew upgrade spacedock\n" +
+		"  Or build from source: go build -o spacedock ./cmd/spacedock\n" +
+		"  Or refresh the plugin instead: spacedock install"
+	if got := tooOldBinaryRemedy(false); got != want {
+		t.Fatalf("non-edge remedy must be byte-for-byte unchanged:\n got=%q\nwant=%q", got, want)
 	}
 }


### PR DESCRIPTION
A user on the @next edge cask hit the too-old-binary prompt and was told `brew upgrade spacedock` — the wrong formula — leaving them stuck.

## What changed
- Emit `brew upgrade spacedock@next` when the running binary is the spacedock@next cask; every other install's remedy is byte-for-byte unchanged.
- Detect the edge cask from the resolved binary's Caskroom token; thread one bool through the remedy path (Compare signature unchanged).

## Evidence
- Value proven live: a staged @next-cask binary emits the @next remedy; guards mutation-tested; go test ./... + -race green.

---
[vz](/spacedock-dev/spacedock/blob/f75a31b3543300168e79557427469ad2903c411f/upgrade-remedy-install-source-aware.md)
