### PR TITLE
Make state commit include folder-form entity artifacts

### DIFF
--- a/docs/site/reference/command-reference.md
+++ b/docs/site/reference/command-reference.md
@@ -71,4 +71,13 @@ The first officer runs these against workflow state as it moves entities; you op
 | `spacedock state` | Manage a [split-root workflow](../advanced/split-root-state.md)'s state checkout (`state init` resumes one on a fresh clone, `state new` births one) |
 | `spacedock completion` | Print a bash or zsh completion script |
 
+### `state commit`
+
+`spacedock state commit <slug>` commits and synchronizes one entity from a
+split-root state checkout. The operand is one canonical top-level entity slug,
+not a nested path. A flat entity commits exactly `<slug>.md`; a folder-form entity
+commits every changed, new, or deleted non-ignored path below `<slug>/`, including
+reports and artifacts. Dirty sibling entities and unrelated top-level state paths
+remain untouched.
+
 [Operate a workflow](../running-workflows/operating.md) covers how the first officer uses `status` on your behalf. Run `spacedock status --help` (and the same for each command) for the full flag list, the mutation guards, and the exit codes.

--- a/internal/cli/state_commit_test.go
+++ b/internal/cli/state_commit_test.go
@@ -286,6 +286,68 @@ func TestStateCommitFolderIncludesWholeEntity(t *testing.T) {
 	}
 }
 
+// TestStateCommitFolderDeletion pins the Roborev deletion finding: the tracked
+// index identifies a folder entity even after it disappears from the worktree,
+// so deleting only index.md or the complete folder remains committable.
+func TestStateCommitFolderDeletion(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		removeAll bool
+		wantNames []string
+	}{
+		{name: "index", wantNames: []string{"deleted-folder/index.md"}},
+		{name: "complete folder", removeAll: true, wantNames: []string{"deleted-folder/artifacts/evidence.md", "deleted-folder/index.md"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, workflow, _, _ := twoHostStateWorkflow(t)
+			checkout := filepath.Join(workflow, ".spacedock-state")
+			host := filepath.Dir(filepath.Dir(workflow))
+			const slug = "deleted-folder"
+
+			writeFolderFile(t, workflow, slug, "index.md", "---\nstatus: implementation\n---\n# Deleted Folder\n")
+			writeFolderFile(t, workflow, slug, "artifacts/evidence.md", "tracked evidence\n")
+			git(t, checkout, "add", "--", slug)
+			git(t, checkout, "commit", "-q", "-m", "seed deletable folder", "--", slug)
+			git(t, checkout, "push", "-q", "origin", "HEAD")
+
+			if tc.removeAll {
+				if err := os.RemoveAll(filepath.Join(checkout, slug)); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.Remove(filepath.Join(checkout, slug, "index.md")); err != nil {
+				t.Fatal(err)
+			}
+			if code, _, errOut := runStateCommitCmd(t, host, workflow, slug, "-m", "delete folder paths"); code != 0 {
+				t.Fatalf("tracked folder deletion should commit; exit=%d stderr=%q", code, errOut)
+			}
+			gotNames := strings.Fields(git(t, checkout, "show", "--name-only", "--pretty=format:", "HEAD"))
+			if strings.Join(gotNames, "\n") != strings.Join(tc.wantNames, "\n") {
+				t.Fatalf("folder deletion paths mismatch\nwant: %q\n got: %q", tc.wantNames, gotNames)
+			}
+			if porcelain := strings.TrimSpace(git(t, checkout, "status", "--porcelain", "--", slug)); porcelain != "" {
+				t.Fatalf("folder deletion should leave target clean; porcelain=%q", porcelain)
+			}
+		})
+	}
+}
+
+// TestStateCommitFlatDeletion retains the exact flat-file commit unit when the
+// tracked file itself has been deleted from the worktree.
+func TestStateCommitFlatDeletion(t *testing.T) {
+	_, workflow, _, _ := twoHostStateWorkflow(t)
+	checkout := filepath.Join(workflow, ".spacedock-state")
+	host := filepath.Dir(filepath.Dir(workflow))
+	if err := os.Remove(filepath.Join(checkout, "first-task.md")); err != nil {
+		t.Fatal(err)
+	}
+	if code, _, errOut := runStateCommitCmd(t, host, workflow, "first-task", "-m", "delete flat entity"); code != 0 {
+		t.Fatalf("tracked flat deletion should commit; exit=%d stderr=%q", code, errOut)
+	}
+	if got := strings.TrimSpace(git(t, checkout, "show", "--name-only", "--pretty=format:", "HEAD")); got != "first-task.md" {
+		t.Fatalf("flat deletion should commit exactly first-task.md; got %q", got)
+	}
+}
+
 // TestStateCommitFolderMultiWriterHappyPath pins AC-5's disjoint-entity case:
 // folder entities (including their artifacts) remain separate rebase units.
 func TestStateCommitFolderMultiWriterHappyPath(t *testing.T) {

--- a/internal/cli/state_commit_test.go
+++ b/internal/cli/state_commit_test.go
@@ -63,6 +63,19 @@ func writeEntity(t *testing.T, workflowDir, slug, body string) {
 	}
 }
 
+// writeFolderFile writes a file below a folder-form entity in the workflow's
+// state checkout, creating parent directories as needed.
+func writeFolderFile(t *testing.T, workflowDir, slug, rel, body string) {
+	t.Helper()
+	path := filepath.Join(workflowDir, ".spacedock-state", slug, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // runStateCommitCmd runs `spacedock state commit slug` for workflowDir and returns
 // the exit code plus captured stdout/stderr.
 func runStateCommitCmd(t *testing.T, hostDir, workflowDir, slug string, extra ...string) (code int, stdout, stderr string) {
@@ -191,16 +204,209 @@ func TestStateCommitIsPathScoped(t *testing.T) {
 		t.Fatalf("commit should succeed; got exit=%d stderr=%q", code, errOut)
 	}
 	// The commit lists ONLY the entity path.
-	names := git(t, checkoutA, "show", "--name-only", "--pretty=format:", "HEAD")
-	if !strings.Contains(names, "first-task.md") {
-		t.Fatalf("commit should include first-task.md; name-only:\n%s", names)
-	}
-	if strings.Contains(names, "sibling-junk.md") {
-		t.Fatalf("path-scoped commit must NOT sweep the sibling; name-only:\n%s", names)
+	names := strings.Fields(git(t, checkoutA, "show", "--name-only", "--pretty=format:", "HEAD"))
+	if len(names) != 1 || names[0] != "first-task.md" {
+		t.Fatalf("flat-form commit should contain exactly first-task.md; names=%q", names)
 	}
 	// The sibling stays untracked.
 	if porcelain := git(t, checkoutA, "status", "--porcelain"); !strings.Contains(porcelain, "sibling-junk.md") {
 		t.Fatalf("sibling should remain untracked after the scoped commit; porcelain:\n%s", porcelain)
+	}
+}
+
+// TestStateCommitFolderIncludesWholeEntity pins AC-1 through AC-3: a folder-form
+// entity is one commit unit. Its index, tracked report modification, tracked
+// deletion, and untracked artifact land together while flat/folder siblings and
+// unrelated top-level dirt remain untouched. Artifact-only dirt is not a false
+// no-op, and a clean rerun is the existing no-op.
+func TestStateCommitFolderIncludesWholeEntity(t *testing.T) {
+	_, workflowA, _, _ := twoHostStateWorkflow(t)
+	checkout := filepath.Join(workflowA, ".spacedock-state")
+	host := filepath.Dir(filepath.Dir(workflowA))
+	const slug = "folder-task"
+
+	writeFolderFile(t, workflowA, slug, "index.md", "---\nstatus: ideation\n---\n# Folder\n")
+	writeFolderFile(t, workflowA, slug, "reports/review.md", "baseline report\n")
+	writeFolderFile(t, workflowA, slug, "artifacts/obsolete.md", "remove me\n")
+	git(t, checkout, "add", "--", slug)
+	git(t, checkout, "commit", "-q", "-m", "seed folder entity", "--", slug)
+	git(t, checkout, "push", "-q", "origin", "HEAD")
+
+	writeFolderFile(t, workflowA, slug, "index.md", "---\nstatus: implementation\n---\n# Folder\n")
+	writeFolderFile(t, workflowA, slug, "reports/review.md", "updated tracked report\n")
+	writeFolderFile(t, workflowA, slug, "artifacts/evidence.md", "new evidence\n")
+	if err := os.Remove(filepath.Join(checkout, slug, "artifacts", "obsolete.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(checkout, "flat-sibling.md"), []byte("untracked flat sibling\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeFolderFile(t, workflowA, "folder-sibling", "index.md", "untracked folder sibling\n")
+	if err := os.WriteFile(filepath.Join(checkout, "unrelated.txt"), []byte("untracked top-level path\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code, _, errOut := runStateCommitCmd(t, host, workflowA, slug, "-m", "folder: scoped"); code != 0 {
+		t.Fatalf("folder commit should succeed; exit=%d stderr=%q", code, errOut)
+	}
+	wantNames := []string{
+		"folder-task/artifacts/evidence.md",
+		"folder-task/artifacts/obsolete.md",
+		"folder-task/index.md",
+		"folder-task/reports/review.md",
+	}
+	gotNames := strings.Fields(git(t, checkout, "show", "--name-only", "--pretty=format:", "HEAD"))
+	if strings.Join(gotNames, "\n") != strings.Join(wantNames, "\n") {
+		t.Fatalf("folder commit paths mismatch\nwant: %q\n got: %q", wantNames, gotNames)
+	}
+	porcelain := git(t, checkout, "status", "--porcelain")
+	for _, dirty := range []string{"flat-sibling.md", "folder-sibling/", "unrelated.txt"} {
+		if !strings.Contains(porcelain, dirty) {
+			t.Fatalf("sibling dirt %q should remain after scoped commit; porcelain:\n%s", dirty, porcelain)
+		}
+	}
+	if strings.Contains(porcelain, slug+"/") {
+		t.Fatalf("target folder should be clean after scoped commit; porcelain:\n%s", porcelain)
+	}
+
+	writeFolderFile(t, workflowA, slug, "artifacts/evidence.md", "artifact-only update\n")
+	headBefore := strings.TrimSpace(git(t, checkout, "rev-parse", "HEAD"))
+	if code, _, errOut := runStateCommitCmd(t, host, workflowA, slug, "-m", "folder: artifact only"); code != 0 {
+		t.Fatalf("artifact-only commit should succeed; exit=%d stderr=%q", code, errOut)
+	}
+	if headAfter := strings.TrimSpace(git(t, checkout, "rev-parse", "HEAD")); headAfter == headBefore {
+		t.Fatal("artifact-only folder dirt must advance HEAD, not return a false no-op")
+	}
+	if got := strings.TrimSpace(git(t, checkout, "show", "--name-only", "--pretty=format:", "HEAD")); got != slug+"/artifacts/evidence.md" {
+		t.Fatalf("artifact-only commit should contain exactly the artifact; got %q", got)
+	}
+	code, stdout, errOut := runStateCommitCmd(t, host, workflowA, slug, "--json")
+	if code != 0 || !strings.Contains(stdout, `"result": "no-op"`) {
+		t.Fatalf("clean rerun should be no-op; exit=%d stdout=%q stderr=%q", code, stdout, errOut)
+	}
+}
+
+// TestStateCommitFolderMultiWriterHappyPath pins AC-5's disjoint-entity case:
+// folder entities (including their artifacts) remain separate rebase units.
+func TestStateCommitFolderMultiWriterHappyPath(t *testing.T) {
+	bare, workflowA, workflowB, stateBranch := twoHostStateWorkflow(t)
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+	hostB := filepath.Dir(filepath.Dir(workflowB))
+
+	writeFolderFile(t, workflowA, "alpha-folder", "index.md", "---\nstatus: ideation\n---\n# Alpha\n")
+	writeFolderFile(t, workflowA, "alpha-folder", "artifacts/a.md", "alpha evidence\n")
+	if code, _, errOut := runStateCommitCmd(t, hostA, workflowA, "alpha-folder", "-m", "A: add folder"); code != 0 {
+		t.Fatalf("A folder commit should succeed; exit=%d stderr=%q", code, errOut)
+	}
+
+	writeFolderFile(t, workflowB, "beta-folder", "index.md", "---\nstatus: ideation\n---\n# Beta\n")
+	writeFolderFile(t, workflowB, "beta-folder", "artifacts/b.md", "beta evidence\n")
+	if code, _, errOut := runStateCommitCmd(t, hostB, workflowB, "beta-folder", "-m", "B: add folder"); code != 0 {
+		t.Fatalf("B folder commit should rebase and push; exit=%d stderr=%q", code, errOut)
+	}
+	checkoutB := filepath.Join(workflowB, ".spacedock-state")
+	if merges := strings.TrimSpace(git(t, checkoutB, "log", "--merges", "--oneline")); merges != "" {
+		t.Fatalf("disjoint folder commits should retain linear history; merges:\n%s", merges)
+	}
+	for _, path := range []string{"alpha-folder/artifacts/a.md", "beta-folder/artifacts/b.md"} {
+		if got := showOriginFile(t, bare, stateBranch, path); !strings.Contains(got, "evidence") {
+			t.Fatalf("origin should contain %s; got %q", path, got)
+		}
+	}
+}
+
+// TestStateCommitFolderConflictHalts pins AC-5's same-folder case: concurrent
+// edits to any shared nested path halt cleanly and name that path.
+func TestStateCommitFolderConflictHalts(t *testing.T) {
+	bare, workflowA, workflowB, stateBranch := twoHostStateWorkflow(t)
+	checkoutA := filepath.Join(workflowA, ".spacedock-state")
+	checkoutB := filepath.Join(workflowB, ".spacedock-state")
+	hostA := filepath.Dir(filepath.Dir(workflowA))
+	hostB := filepath.Dir(filepath.Dir(workflowB))
+	const slug = "shared-folder"
+	const report = "reports/review.md"
+
+	writeFolderFile(t, workflowA, slug, "index.md", "---\nstatus: implementation\n---\n# Shared\n")
+	writeFolderFile(t, workflowA, slug, report, "baseline\n")
+	git(t, checkoutA, "add", "--", slug)
+	git(t, checkoutA, "commit", "-q", "-m", "seed shared folder", "--", slug)
+	git(t, checkoutA, "push", "-q", "origin", stateBranch)
+	git(t, checkoutB, "pull", "-q", "--rebase", "origin", stateBranch)
+
+	writeFolderFile(t, workflowA, slug, report, "host A\n")
+	if code, _, errOut := runStateCommitCmd(t, hostA, workflowA, slug, "-m", "A: report"); code != 0 {
+		t.Fatalf("A report commit should succeed; exit=%d stderr=%q", code, errOut)
+	}
+	writeFolderFile(t, workflowB, slug, report, "host B\n")
+	code, _, errOut := runStateCommitCmd(t, hostB, workflowB, slug, "-m", "B: report")
+	if code != 3 {
+		t.Fatalf("same-folder nested conflict should HALT; exit=%d stderr=%q", code, errOut)
+	}
+	if !strings.Contains(errOut, slug+"/"+report) {
+		t.Fatalf("HALT should name nested conflicting path; stderr:\n%s", errOut)
+	}
+	if porcelain := strings.TrimSpace(git(t, checkoutB, "status", "--porcelain")); porcelain != "" {
+		t.Fatalf("HALT should abort rebase cleanly; porcelain=%q", porcelain)
+	}
+	localReport, err := os.ReadFile(filepath.Join(checkoutB, slug, report))
+	if err != nil || string(localReport) != "host B\n" {
+		t.Fatalf("HALT must preserve the local writer's nested edit; body=%q err=%v", localReport, err)
+	}
+	if got := showOriginFile(t, bare, stateBranch, slug+"/"+report); got != "host A\n" {
+		t.Fatalf("origin must preserve peer's nested edit; got %q", got)
+	}
+}
+
+// TestStateCommitRejectsNoncanonicalSlugWithoutSideEffects pins AC-6. The
+// operand is one top-level entity slug, never an absolute/traversal/nested path.
+func TestStateCommitRejectsNoncanonicalSlugWithoutSideEffects(t *testing.T) {
+	bare, workflowA, _, stateBranch := twoHostStateWorkflow(t)
+	checkout := filepath.Join(workflowA, ".spacedock-state")
+	host := filepath.Dir(filepath.Dir(workflowA))
+	writeFolderFile(t, workflowA, "folder-task", "index.md", "---\nstatus: ideation\n---\n# Folder\n")
+	writeFolderFile(t, workflowA, "folder-task", "artifacts/evidence.md", "evidence\n")
+	git(t, checkout, "add", "--", "folder-task")
+	git(t, checkout, "commit", "-q", "-m", "seed nested target", "--", "folder-task")
+	git(t, checkout, "push", "-q", "origin", stateBranch)
+
+	cases := []string{
+		"folder-task/artifacts/evidence",
+		`folder-task\artifacts\evidence`,
+		"roborev-workflow-setup-skill/artifacts/roborev-setup-skill/SKILL",
+		".", "..", "../folder-task", "/folder-task", filepath.Join(checkout, "folder-task"),
+	}
+	evidencePath := filepath.Join(checkout, "folder-task", "artifacts", "evidence.md")
+	for _, slug := range cases {
+		t.Run(slug, func(t *testing.T) {
+			headBefore := strings.TrimSpace(git(t, checkout, "rev-parse", "HEAD"))
+			indexBefore := git(t, checkout, "diff", "--cached", "--binary")
+			worktreeBefore := git(t, checkout, "status", "--porcelain=v1", "--untracked-files=all")
+			originBefore := strings.TrimSpace(git(t, bare, "rev-parse", stateBranch))
+			bytesBefore, err := os.ReadFile(evidencePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			code, _, errOut := runStateCommitCmd(t, host, workflowA, slug)
+			if code == 0 || !strings.Contains(errOut, "invalid entity slug") {
+				t.Fatalf("noncanonical slug should fail clearly; slug=%q exit=%d stderr=%q", slug, code, errOut)
+			}
+			if got := strings.TrimSpace(git(t, checkout, "rev-parse", "HEAD")); got != headBefore {
+				t.Fatalf("invalid slug changed HEAD: before=%s after=%s", headBefore, got)
+			}
+			if got := git(t, checkout, "diff", "--cached", "--binary"); got != indexBefore {
+				t.Fatalf("invalid slug changed index\nbefore=%q\nafter=%q", indexBefore, got)
+			}
+			if got := git(t, checkout, "status", "--porcelain=v1", "--untracked-files=all"); got != worktreeBefore {
+				t.Fatalf("invalid slug changed worktree\nbefore=%q\nafter=%q", worktreeBefore, got)
+			}
+			if got, err := os.ReadFile(evidencePath); err != nil || string(got) != string(bytesBefore) {
+				t.Fatalf("invalid slug changed worktree bytes: before=%q after=%q err=%v", bytesBefore, got, err)
+			}
+			if got := strings.TrimSpace(git(t, bare, "rev-parse", stateBranch)); got != originBefore {
+				t.Fatalf("invalid slug changed origin: before=%s after=%s", originBefore, got)
+			}
+		})
 	}
 }
 

--- a/internal/cli/state_commit_test.go
+++ b/internal/cli/state_commit_test.go
@@ -348,6 +348,89 @@ func TestStateCommitFlatDeletion(t *testing.T) {
 	}
 }
 
+// TestStateCommitTreatsSlugAsLiteralGitPathspec pins Roborev job 537: Git
+// pathspec metacharacters are valid filename characters, not permission to sweep
+// matching sibling entities or resolve a nonexistent wildcard alias.
+func TestStateCommitTreatsSlugAsLiteralGitPathspec(t *testing.T) {
+	t.Run("existing metacharacter slug", func(t *testing.T) {
+		bare, workflow, _, stateBranch := twoHostStateWorkflow(t)
+		checkout := filepath.Join(workflow, ".spacedock-state")
+		host := filepath.Dir(filepath.Dir(workflow))
+		const slug = ":(glob)scope*"
+		const target = ":(glob)scope*.md"
+		const trackedSibling = "scope-leak.md"
+		const untrackedSibling = "scope-new.md"
+
+		for path, body := range map[string]string{
+			target:         "---\nstatus: ideation\n---\n# Literal Star\n",
+			trackedSibling: "---\nstatus: ideation\n---\n# Tracked Sibling\n",
+		} {
+			if err := os.WriteFile(filepath.Join(checkout, path), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		git(t, checkout, "--literal-pathspecs", "add", "--", target, trackedSibling)
+		git(t, checkout, "--literal-pathspecs", "commit", "-q", "-m", "seed literal pathspec", "--", target, trackedSibling)
+		git(t, checkout, "push", "-q", "origin", stateBranch)
+
+		if err := os.WriteFile(filepath.Join(checkout, target), []byte("---\nstatus: implementation\n---\n# Literal Star\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(checkout, trackedSibling), []byte("dirty tracked sibling\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(checkout, untrackedSibling), []byte("dirty untracked sibling\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if code, _, errOut := runStateCommitCmd(t, host, workflow, slug, "-m", "literal metacharacter slug"); code != 0 {
+			t.Fatalf("metacharacter slug should commit literally; exit=%d stderr=%q", code, errOut)
+		}
+		if got := strings.TrimSpace(git(t, checkout, "show", "--name-only", "--pretty=format:", "HEAD")); got != target {
+			t.Fatalf("metacharacter slug should commit exactly %q; got %q", target, got)
+		}
+		porcelain := git(t, checkout, "status", "--porcelain", "--untracked-files=all")
+		for _, sibling := range []string{trackedSibling, untrackedSibling} {
+			if !strings.Contains(porcelain, sibling) {
+				t.Fatalf("matching sibling %q should remain dirty; porcelain:\n%s", sibling, porcelain)
+			}
+		}
+		if got := showOriginFile(t, bare, stateBranch, trackedSibling); !strings.Contains(got, "Tracked Sibling") {
+			t.Fatalf("origin tracked sibling should retain baseline; got %q", got)
+		}
+		if _, ok := gitOK(t, bare, "cat-file", "-e", stateBranch+":"+untrackedSibling); ok {
+			t.Fatalf("untracked matching sibling %q must not reach origin", untrackedSibling)
+		}
+	})
+
+	t.Run("nonexistent wildcard alias", func(t *testing.T) {
+		bare, workflow, _, stateBranch := twoHostStateWorkflow(t)
+		checkout := filepath.Join(workflow, ".spacedock-state")
+		host := filepath.Dir(filepath.Dir(workflow))
+		writeEntity(t, workflow, "wildcard-match", "---\nstatus: ideation\n---\n# Sibling\n")
+		git(t, checkout, "add", "--", "wildcard-match.md")
+		git(t, checkout, "commit", "-q", "-m", "seed wildcard sibling", "--", "wildcard-match.md")
+		git(t, checkout, "push", "-q", "origin", stateBranch)
+		writeEntity(t, workflow, "wildcard-match", "---\nstatus: implementation\n---\n# Dirty Sibling\n")
+		headBefore := strings.TrimSpace(git(t, checkout, "rev-parse", "HEAD"))
+		originBefore := strings.TrimSpace(git(t, bare, "rev-parse", stateBranch))
+
+		code, _, errOut := runStateCommitCmd(t, host, workflow, ":(glob)wildcard*")
+		if code == 0 || !strings.Contains(errOut, "no entity") {
+			t.Fatalf("nonexistent wildcard alias should not resolve; exit=%d stderr=%q", code, errOut)
+		}
+		if got := strings.TrimSpace(git(t, checkout, "rev-parse", "HEAD")); got != headBefore {
+			t.Fatalf("wildcard alias changed HEAD: before=%s after=%s", headBefore, got)
+		}
+		if got := strings.TrimSpace(git(t, bare, "rev-parse", stateBranch)); got != originBefore {
+			t.Fatalf("wildcard alias changed origin: before=%s after=%s", originBefore, got)
+		}
+		if porcelain := git(t, checkout, "status", "--porcelain"); !strings.Contains(porcelain, "wildcard-match.md") {
+			t.Fatalf("matching sibling should remain dirty; porcelain:\n%s", porcelain)
+		}
+	})
+}
+
 // TestStateCommitFolderMultiWriterHappyPath pins AC-5's disjoint-entity case:
 // folder entities (including their artifacts) remain separate rebase units.
 func TestStateCommitFolderMultiWriterHappyPath(t *testing.T) {

--- a/internal/cli/state_sync.go
+++ b/internal/cli/state_sync.go
@@ -258,7 +258,7 @@ func peerCommitSHA(checkout, branch string) string {
 // form (via runGit) has no rendered command string for a weak model to paraphrase.
 func commitEntityPathScoped(checkout, entityPath, msg string) (ok bool, output string) {
 	rel := relToCheckout(checkout, entityPath)
-	if ok, out := runGitRetryLock(checkout, "add", "--", rel); !ok {
+	if ok, out := runGitRetryLock(checkout, "add", "-A", "--", rel); !ok {
 		return false, out
 	}
 	// Nothing staged for this entity → clean no-op success.
@@ -326,9 +326,10 @@ func conflictingPaths(checkout string) []string {
 }
 
 // resolveEntityCommitPath finds the commit unit for slug under checkout. Folder
-// form wins, matching canonical entity discovery, and commits the whole folder;
-// flat form commits only `{slug}.md`. EntitySlug remains the authority for the
-// slug represented by either discovered path.
+// form wins when present, matching canonical entity discovery, and commits the
+// whole folder; flat form commits only `{slug}.md`. A tracked candidate remains
+// resolvable after deletion so the exact same commit unit can record its removal.
+// EntitySlug remains the authority for the slug represented by either path.
 func resolveEntityCommitPath(checkout, slug string) (string, bool) {
 	nested := filepath.Join(checkout, slug, "index.md")
 	if fileExists(nested) && status.EntitySlug(nested) == slug {
@@ -338,7 +339,18 @@ func resolveEntityCommitPath(checkout, slug string) (string, bool) {
 	if fileExists(flat) && status.EntitySlug(flat) == slug {
 		return flat, true
 	}
+	if gitTracksPath(checkout, nested) && status.EntitySlug(nested) == slug {
+		return filepath.Dir(nested), true
+	}
+	if gitTracksPath(checkout, flat) && status.EntitySlug(flat) == slug {
+		return flat, true
+	}
 	return "", false
+}
+
+func gitTracksPath(checkout, path string) bool {
+	ok, _ := runGit(checkout, "ls-files", "--error-unmatch", "--", relToCheckout(checkout, path))
+	return ok
 }
 
 // validStateEntitySlug accepts the filesystem-level slug shape canonical entity

--- a/internal/cli/state_sync.go
+++ b/internal/cli/state_sync.go
@@ -258,14 +258,15 @@ func peerCommitSHA(checkout, branch string) string {
 // form (via runGit) has no rendered command string for a weak model to paraphrase.
 func commitEntityPathScoped(checkout, entityPath, msg string) (ok bool, output string) {
 	rel := relToCheckout(checkout, entityPath)
-	if ok, out := runGitRetryLock(checkout, "add", "-A", "--", rel); !ok {
+	pathspec := literalGitPathspec(rel)
+	if ok, out := runGitRetryLock(checkout, "add", "-A", "--", pathspec); !ok {
 		return false, out
 	}
 	// Nothing staged for this entity → clean no-op success.
-	if clean, _ := runGit(checkout, "diff", "--cached", "--quiet", "--", rel); clean {
+	if clean, _ := runGit(checkout, "diff", "--cached", "--quiet", "--", pathspec); clean {
 		return true, ""
 	}
-	ok, out := runGitRetryLock(checkout, "commit", "-m", msg, "--", rel)
+	ok, out := runGitRetryLock(checkout, "commit", "-m", msg, "--", pathspec)
 	if !ok {
 		return false, out
 	}
@@ -349,8 +350,12 @@ func resolveEntityCommitPath(checkout, slug string) (string, bool) {
 }
 
 func gitTracksPath(checkout, path string) bool {
-	ok, _ := runGit(checkout, "ls-files", "--error-unmatch", "--", relToCheckout(checkout, path))
+	ok, _ := runGit(checkout, "ls-files", "--error-unmatch", "--", literalGitPathspec(relToCheckout(checkout, path)))
 	return ok
+}
+
+func literalGitPathspec(path string) string {
+	return ":(literal)" + path
 }
 
 // validStateEntitySlug accepts the filesystem-level slug shape canonical entity

--- a/internal/cli/state_sync.go
+++ b/internal/cli/state_sync.go
@@ -251,8 +251,9 @@ func peerCommitSHA(checkout, branch string) string {
 	return strings.TrimSpace(out)
 }
 
-// commitEntityPathScoped stages and commits exactly entityPath (never `add -A`),
-// retrying the staging on index.lock contention. It returns (true, "") for a
+// commitEntityPathScoped stages and commits exactly entityPath with `add -A`
+// restricted to its literal pathspec, retrying staging on index.lock contention.
+// It returns (true, "") for a
 // clean no-op (nothing staged for the entity → success), (true, output) for a
 // landed commit, and (false, output) on a real git failure. The `git -C` argv
 // form (via runGit) has no rendered command string for a weak model to paraphrase.

--- a/internal/cli/state_sync.go
+++ b/internal/cli/state_sync.go
@@ -45,7 +45,7 @@ func emitSync(stdout io.Writer, jsonOut bool, res syncResult, code int) int {
 }
 
 // runStateCommit implements `spacedock state commit <slug>`. It resolves <slug> to
-// its entity file under the split-root state checkout, then runs the path-scoped
+// its entity commit unit under the split-root state checkout, then runs the path-scoped
 // commit → push → on-reject pull --rebase → re-push sequence. A same-entity rebase
 // conflict HALTS: the rebase is aborted (clean tree restored), no force-push is
 // ever issued, and the verb exits 3 with the conflicting path named — so a caller
@@ -68,7 +68,7 @@ func runStateCommit(ctx context.Context, args []string, env []string, dir string
 		}, 0)
 	}
 
-	entityPath, ok := resolveEntityPath(checkout, slug)
+	entityPath, ok := resolveEntityCommitPath(checkout, slug)
 	if !ok {
 		fmt.Fprintf(stderr, "spacedock state commit: no entity %q under %s (looked for %s.md and %s/index.md)\n", slug, checkout, slug, slug)
 		return 1
@@ -325,19 +325,29 @@ func conflictingPaths(checkout string) []string {
 	return paths
 }
 
-// resolveEntityPath finds the entity file for slug under checkout, returning the
-// absolute path. It accepts both the flat `{slug}.md` and the directory
-// `{slug}/index.md` entity layouts (matching loadEntityFrontmatter's scan).
-func resolveEntityPath(checkout, slug string) (string, bool) {
+// resolveEntityCommitPath finds the commit unit for slug under checkout. Folder
+// form wins, matching canonical entity discovery, and commits the whole folder;
+// flat form commits only `{slug}.md`. EntitySlug remains the authority for the
+// slug represented by either discovered path.
+func resolveEntityCommitPath(checkout, slug string) (string, bool) {
+	nested := filepath.Join(checkout, slug, "index.md")
+	if fileExists(nested) && status.EntitySlug(nested) == slug {
+		return filepath.Dir(nested), true
+	}
 	flat := filepath.Join(checkout, slug+".md")
-	if fileExists(flat) {
+	if fileExists(flat) && status.EntitySlug(flat) == slug {
 		return flat, true
 	}
-	nested := filepath.Join(checkout, slug, "index.md")
-	if fileExists(nested) {
-		return nested, true
-	}
 	return "", false
+}
+
+// validStateEntitySlug accepts the filesystem-level slug shape canonical entity
+// discovery can expose: one visible top-level name, never a path alias. It does
+// not impose a separate character grammar on otherwise valid entity filenames.
+func validStateEntitySlug(slug string) bool {
+	return slug != "" && slug != "." && slug != ".." &&
+		!filepath.IsAbs(slug) && !strings.HasPrefix(slug, ".") &&
+		!strings.ContainsAny(slug, `/\\`) && filepath.Clean(slug) == slug
 }
 
 // relToCheckout returns entityPath relative to checkout for the path-scoped git
@@ -415,6 +425,10 @@ func parseStateCommitArgs(args []string, dir string, stderr io.Writer) (slug, wo
 	}
 	if slug == "" {
 		fmt.Fprintln(stderr, "spacedock state commit: missing required <slug> argument")
+		return "", "", "", false, 2
+	}
+	if !validStateEntitySlug(slug) {
+		fmt.Fprintf(stderr, "spacedock state commit: invalid entity slug %q (expected one canonical top-level slug, not a path)\n", slug)
 		return "", "", "", false, 2
 	}
 	workflowDir, code = resolveWorkflowDir(workflowDir, dir, stderr)


### PR DESCRIPTION
Folder-form state commits now preserve every entity artifact without sweeping sibling state, making canonical gate packages durable in one command.

## What changed

- Stage complete folder entities with literal Git pathspecs.
- Include tracked deletions and new nested artifacts.
- Reject path-bearing aliases before any state mutation.
- Document flat and folder commit units.

## Evidence

- 18/18 normal and 18/18 race packages passed after rebase.
- 6/6 value criteria passed; live five-file package dogfood committed exactly.

## Review guidance

Review `internal/cli/state_sync.go` for literal pathspec scoping and deletion fallback.

---
[vn](/spacedock-dev/spacedock/blob/30a72ce3/docs/dev/.spacedock-state/state-commit-folder-entity-scope/index.md)
