### PR TITLE
Workflow-declared section reads assemble stage context by pointer

### DIFF
--- a/docs/site/concepts/workflows-and-entities.md
+++ b/docs/site/concepts/workflows-and-entities.md
@@ -34,6 +34,22 @@ stages:
 ---
 ```
 
+A stage can also select ordered context from other README sections:
+
+```yaml
+stages:
+  defaults:
+    context-sections:
+      - Constraint Authority
+```
+
+`context-sections` contains exact README heading text. A stage-specific list replaces the default, and
+`[]` clears it. `dispatch build` validates every selection before spawn; the worker's existing
+`show-stage-def` read returns the stage definition followed by those sections in declaration order. Selected
+sections normalize newline boundaries to LF, drop trailing blank lines, use one blank line between sections,
+and end stdout with one LF. The read uses the then-current valid README; an invalid current selection fails
+before stage work. Workflows without the field keep existing output unchanged.
+
 ## Each work item is one file
 
 An entity lives as a flat file `{slug}.md`, or a folder `{slug}/index.md` when reports and artifacts accumulate beside it. The body is the human-readable record: the problem, the approach, the acceptance criteria, and the stage reports. On top sits YAML frontmatter, the machine-readable state: the item's id, its current stage, its outcome. The [frontmatter contract](../reference/frontmatter-contract.md) has the fields and the schemas that define them.

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -394,9 +394,17 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 	if !isFile(readmePath) {
 		return buildError(stderr, 1, "workflow README not found at '%s'", readmePath)
 	}
+	readmeData, err := os.ReadFile(readmePath)
+	if err != nil {
+		return buildError(stderr, 1, "failed to read workflow README %q: %s", readmePath, err)
+	}
+	if _, err := status.StageContextSections(readmeData, stage); err != nil {
+		return buildError(stderr, 1, "workflow README %q, stage %q: %s", readmePath, stage, err)
+	}
+	readmeFields := status.ParseFrontmatterData(readmeData)
 
 	// Parse workflow stages + defaults.
-	stages, stageDefaults := status.ParseStagesWithDefaults(readmePath)
+	stages, stageDefaults := status.ParseStagesWithDefaultsData(readmeData)
 	if stages == nil {
 		return buildError(stderr, 1, "no stages block found in %s", readmePath)
 	}
@@ -490,7 +498,10 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 	// isolates CODE only — the entity body stays at the FO-passed entity_path.
 	// stateCheckout is the resolved absolute state-checkout dir (workflowDir/<state>),
 	// the git repo where the entity body lives; "" when the workflow is single-root.
-	stateCheckout := splitRootStateCheckout(workflowDir)
+	var stateCheckout string
+	if mode, relPath, err := status.ClassifyState(readmeFields["state"]); err == nil && mode == status.StateSplitRoot {
+		stateCheckout = filepath.Join(workflowDir, relPath)
+	}
 	splitRoot := stateCheckout != ""
 
 	// stateBranch is the orphan state branch peers push/pull on a split-root
@@ -504,7 +515,10 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 	// degrades to local-only. Probed once here so both guidance callers below agree.
 	var stateRemotePresent bool
 	if splitRoot {
-		stateBranch, _ = status.StateBranch(workflowDir)
+		stateBranch = strings.TrimSpace(readmeFields["state-branch"])
+		if stateBranch == "" {
+			stateBranch = "spacedock-state/" + filepath.Base(filepath.Clean(workflowDir))
+		}
 		stateRemotePresent = stateHasOrigin(stateCheckout)
 	}
 
@@ -534,7 +548,7 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 	// still decomposes; short names pass through byte-identical.
 	workerKey := strings.ReplaceAll(subagentType, ":", "-")
 	slug := status.EntitySlug(entityPath)
-	idStyle := status.ParseFrontmatter(readmePath)["id-style"]
+	idStyle := readmeFields["id-style"]
 	derivedName := capWorkerName(workerKey, slug, stage, entityFields["id"], idStyle)
 
 	// Rule 7: Name length and safety.
@@ -551,13 +565,13 @@ func runBuildFields(probe claudeteam.TeamStateProbe, opts buildOptions, fields m
 			derivedName, stage, namePattern.String())
 	}
 
-	// Extract the stage subsection (validates the README heading parses).
-	stageSubsection, err := extractStageSubsection(readmePath, stage)
+	// Preflight this immutable README version before writing a dispatch artifact.
+	stageSubsection, err := resolveStageContext(readmeData, stage)
 	if err != nil {
 		if she, ok := err.(*stageHeadingError); ok {
 			return buildError(stderr, 1, "%s", she.msg)
 		}
-		return buildError(stderr, 1, "%s", err)
+		return buildError(stderr, 1, "workflow README %q, stage %q: %s", readmePath, stage, err)
 	}
 	if stageSubsection == "" {
 		return buildError(stderr, 1, "stage '%s' heading not found in %s", stage, readmePath)

--- a/internal/dispatch/build_stage_discipline_delivery_test.go
+++ b/internal/dispatch/build_stage_discipline_delivery_test.go
@@ -3,9 +3,12 @@
 package dispatch
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
 )
 
 // devDisciplineSentinel is a freshly-minted token written ONLY into the fixture
@@ -141,5 +144,169 @@ func TestBuildStageDisciplineRidesFetchNotInlineAssignment(t *testing.T) {
 	}
 	if strings.Contains(plain.stdout, devDisciplineSentinel) {
 		t.Errorf("perturbation control: show-stage-def validation (no sentinel planted) returned the sentinel:\n%s", plain.stdout)
+	}
+}
+
+func TestDeclaredContextBuildAndHostNeutralFetch(t *testing.T) {
+	root := t.TempDir()
+	readme := "---\nentity-type: task\nid-style: slug\nstages:\n  defaults:\n" +
+		"    context-sections: [Pølicy]\n  states:\n    - name: ideation\n      initial: true\n---\n" +
+		"# Workflow\n\n### ideation\r\nstage β\r\n\r\n## Pølicy\r\nα\rβ\u0085γ\r\n \t\r\n## Unrelated\nnope\n"
+	writeFile(t, filepath.Join(root, "README.md"), readme)
+	entityPath := filepath.Join(root, "thing.md")
+	writeFile(t, entityPath, entityFM("Thing", "ideation", ""))
+	gitInit(t, root)
+
+	for _, host := range []string{"claude", "codex", "pi"} {
+		t.Run(host, func(t *testing.T) {
+			req := mergeStdin(map[string]any{
+				"schema_version": 2, "entity_path": entityPath, "workflow_dir": root,
+				"stage": "ideation", "checklist": []string{"- prove context"},
+			}, nil)
+			built := runNative(req, "build", "--workflow-dir", root, "--host", host)
+			if built.exit != 0 {
+				t.Fatalf("build exit=%d stderr=%q", built.exit, built.stderr)
+			}
+			var envelope struct {
+				Fetch []string `json:"fetch_commands"`
+			}
+			if err := json.Unmarshal([]byte(built.stdout), &envelope); err != nil {
+				t.Fatal(err)
+			}
+			if len(envelope.Fetch) != 1 || !strings.Contains(envelope.Fetch[0], "show-stage-def") {
+				t.Fatalf("fetch commands = %#v, want one show-stage-def pointer", envelope.Fetch)
+			}
+			got := runNative("", "show-stage-def", "--workflow-dir", root, "--stage", "ideation")
+			want := "### ideation\nstage β\n\n## Pølicy\nα\nβ\nγ\n"
+			if got.exit != 0 || got.stdout != want {
+				t.Fatalf("show-stage-def exit=%d stderr=%q\n got=%q\nwant=%q", got.exit, got.stderr, got.stdout, want)
+			}
+		})
+	}
+}
+
+func TestDeclaredContextInheritanceReplacementAndClear(t *testing.T) {
+	root := t.TempDir()
+	readme := "---\nstages:\n  defaults:\n    context-sections: [Authority]\n  states:\n" +
+		"    - name: inherited\n    - name: replaced\n      context-sections: [Safety, Authority]\n" +
+		"    - name: cleared\n      context-sections: []\n---\n# Workflow\n\n" +
+		"### inherited\ninherited body\n\n### replaced\nreplacement body\n\n### cleared\nclear body\n\n" +
+		"## Authority\nauthority\n\n## Safety\nsafety\n\n## Unrelated\nnever\n"
+	writeFile(t, filepath.Join(root, "README.md"), readme)
+	cases := map[string]string{
+		"inherited": "### inherited\ninherited body\n\n## Authority\nauthority\n",
+		"replaced":  "### replaced\nreplacement body\n\n## Safety\nsafety\n\n## Authority\nauthority\n",
+		"cleared":   "### cleared\nclear body\n",
+	}
+	for stage, want := range cases {
+		got := runNative("", "show-stage-def", "--workflow-dir", root, "--stage", stage)
+		if got.exit != 0 || got.stdout != want {
+			t.Fatalf("%s exit=%d stderr=%q\n got=%q\nwant=%q", stage, got.exit, got.stderr, got.stdout, want)
+		}
+	}
+}
+
+func TestDeclaredContextInvalidBuildPreflight(t *testing.T) {
+	cases := []struct {
+		name, declaration, body, want string
+	}{
+		{"malformed", "context-sections: [", "## Authority\nok\n", "malformed YAML"},
+		{"wrong kind", "context-sections: Authority", "## Authority\nok\n", "want sequence"},
+		{"missing", "context-sections: [Missing]", "## Authority\nok\n", `selector "Missing" matches 0 headings`},
+		{"repeated", "context-sections: [Authority, Authority]", "## Authority\nok\n", `repeated selector "Authority"`},
+		{"ambiguous", "context-sections: [Authority]", "## Authority\none\n## Authority\ntwo\n", "matches 2 headings"},
+		{"parent contains stage", "context-sections: [Parent]", "## Parent\n### ideation\nwork\n## End\n", "overlap"},
+		{"child inside stage", "context-sections: [Child]", "### ideation\nwork\n#### Child\ninside\n## End\n", "overlap"},
+		{"selected parent child", "context-sections: [Parent, Child]", "### ideation\nwork\n## Parent\n### Child\ninside\n## End\n", "overlap"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			readme := "---\nentity-type: task\nid-style: slug\nstages:\n  defaults:\n    worktree: false\n" +
+				"    " + tc.declaration + "\n  states:\n    - name: ideation\n      initial: true\n---\n# Workflow\n\n" + tc.body
+			if !strings.Contains(tc.body, "### ideation") {
+				readme += "\n### ideation\nwork\n"
+			}
+			writeFile(t, filepath.Join(root, "README.md"), readme)
+			entityPath := filepath.Join(root, "thing.md")
+			writeFile(t, entityPath, entityFM("Thing", "ideation", ""))
+			gitInit(t, root)
+			req := mergeStdin(map[string]any{
+				"schema_version": 2, "entity_path": entityPath, "workflow_dir": root,
+				"stage": "ideation", "checklist": []string{"- x"},
+			}, nil)
+			got := runNative(req, "build", "--workflow-dir", root)
+			if got.exit == 0 || !strings.Contains(got.stderr, tc.want) ||
+				!strings.Contains(got.stderr, filepath.Join(root, "README.md")) ||
+				!strings.Contains(got.stderr, "ideation") {
+				t.Fatalf("exit=%d stdout=%q stderr=%q, want failure containing %q, path, and stage",
+					got.exit, got.stdout, got.stderr, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeclaredContextLiveReadAdoptsValidAndRejectsInvalidCurrent(t *testing.T) {
+	root := t.TempDir()
+	readme := func(declaration, authority, body string) string {
+		return "---\nentity-type: task\nid-style: slug\nstages:\n  states:\n    - name: ideation\n      " +
+			declaration + "\n---\n# Workflow\n\n" + body + "\n## Authority\n" + authority + "\n"
+	}
+	path := filepath.Join(root, "README.md")
+	writeFile(t, path, readme("context-sections: [Authority]", "authority-v1", "### ideation\nwork"))
+	entityPath := filepath.Join(root, "thing.md")
+	writeFile(t, entityPath, entityFM("Thing", "ideation", ""))
+	gitInit(t, root)
+	req := mergeStdin(map[string]any{
+		"schema_version": 2, "entity_path": entityPath, "workflow_dir": root,
+		"stage": "ideation", "checklist": []string{"- x"},
+	}, nil)
+	if got := runNative(req, "build", "--workflow-dir", root); got.exit != 0 {
+		t.Fatalf("v1 build exit=%d stderr=%q", got.exit, got.stderr)
+	}
+
+	writeFile(t, path, readme("context-sections: [Authority]", "authority-v2", "### ideation\nwork"))
+	if got := runNative("", "show-stage-def", "--workflow-dir", root, "--stage", "ideation"); got.exit != 0 ||
+		!strings.Contains(got.stdout, "authority-v2") || strings.Contains(got.stdout, "authority-v1") {
+		t.Fatalf("valid current edit not adopted: exit=%d stdout=%q stderr=%q", got.exit, got.stdout, got.stderr)
+	}
+	for name, current := range map[string]string{
+		"wrong-kind": readme("context-sections: Authority", "authority-v3", "### ideation\nwork"),
+		"missing":    readme("context-sections: [Missing]", "authority-v3", "### ideation\nwork"),
+		"overlap":    readme("context-sections: [Parent]", "authority-v3", "## Parent\n### ideation\nwork\n## End"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			writeFile(t, path, current)
+			got := runNative("", "show-stage-def", "--workflow-dir", root, "--stage", "ideation")
+			if got.exit == 0 || got.stdout != "" {
+				t.Fatalf("invalid current edit exit=%d stdout=%q stderr=%q", got.exit, got.stdout, got.stderr)
+			}
+		})
+	}
+}
+
+func TestMixedRawSpanReconciliationAndFencedStageCompatibility(t *testing.T) {
+	fenced := []byte("```md\n### ideation\n\nfenced-body\n```\n### ideation\nreal\n")
+	got, span, err := extractStageSubsectionBytes(fenced, "ideation")
+	if err != nil || got != "### ideation\n\nfenced-body\n```" ||
+		string(fenced[span.start:span.end]) != "### ideation\n\nfenced-body\n```\n" {
+		t.Fatalf("fenced legacy result=%q span=%+v slice=%q err=%v", got, span, fenced[span.start:span.end], err)
+	}
+
+	mixed := []byte("## Pärent\r\nα\r\n### `build` *(captain)*\rstage β\vcontinuation\r\n\r\n#### Child\r\nchild γ\r\r## Sibling\r\nδ\r\n")
+	_, stage, err := extractStageSubsectionBytes(mixed, "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spans, err := status.FindSectionSpans(mixed, []string{"Pärent", "Child", "Sibling"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := sourceSpan{spans[0].Start, spans[0].End}
+	child := sourceSpan{spans[1].Start, spans[1].End}
+	sibling := sourceSpan{spans[2].Start, spans[2].End}
+	if !spansIntersect(stage, parent) || !spansIntersect(stage, child) ||
+		spansIntersect(stage, sibling) || spansIntersect(parent, sibling) {
+		t.Fatalf("unexpected intersection matrix: stage=%+v spans=%+v", stage, spans)
 	}
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -351,7 +351,7 @@ func printShowStageDefUsage(w io.Writer) {
 	fmt.Fprint(w, `Usage:
   spacedock dispatch show-stage-def --workflow-dir DIR --stage STAGE
 
-Print the workflow README section for a stage.
+Print a stage's workflow README section followed by its declared context sections.
 
 Flags:
   --workflow-dir DIR   Workflow definition directory containing README.md.

--- a/internal/dispatch/showstagedef.go
+++ b/internal/dispatch/showstagedef.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
+
+	"github.com/spacedock-dev/spacedock/internal/status"
 )
 
 // headingDecorationChars are the inline-markdown decoration characters stripped
@@ -60,6 +63,8 @@ type stageHeadingError struct{ msg string }
 
 func (e *stageHeadingError) Error() string { return e.msg }
 
+type sourceSpan struct{ start, end int }
+
 // extractStageSubsection returns the full ### {stage} subsection from a workflow
 // README. Heading match is permissive: any `###` line whose first content token
 // (after stripping “ ` “, `*`, `_`, `~` and treating `(` / `[` as token
@@ -73,7 +78,15 @@ func extractStageSubsection(readmePath, stage string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	subsection, _, err := extractStageSubsectionBytes(data, stage)
+	return subsection, err
+}
+
+// extractStageSubsectionBytes preserves the legacy rendered subsection while
+// also returning its structural raw source span from the same immutable buffer.
+func extractStageSubsectionBytes(data []byte, stage string) (string, sourceSpan, error) {
 	lines := splitTextLines(string(data))
+	starts := textLineStarts(data)
 
 	start := -1
 	for i, line := range lines {
@@ -87,7 +100,7 @@ func extractStageSubsection(readmePath, stage string) (string, error) {
 			tokens := headingTokens(line)
 			if len(tokens) > 0 && containsToken(tokens, stage) {
 				stripped := strings.TrimSpace(line)
-				return "", &stageHeadingError{msg: fmt.Sprintf(
+				return "", sourceSpan{}, &stageHeadingError{msg: fmt.Sprintf(
 					"stage heading at line %d mentions '%s' "+
 						"but does not parse as a stage heading: %s. "+
 						"The stage name must be the first content token of the "+
@@ -97,7 +110,7 @@ func extractStageSubsection(readmePath, stage string) (string, error) {
 					i+1, stage, pyRepr(stripped))}
 			}
 		}
-		return "", nil
+		return "", sourceSpan{}, nil
 	}
 
 	end := len(lines)
@@ -108,10 +121,16 @@ func extractStageSubsection(readmePath, stage string) (string, error) {
 			break
 		}
 	}
-	for end > start && strings.TrimSpace(lines[end-1]) == "" {
-		end--
+	rawEnd := len(data)
+	if end < len(starts) {
+		rawEnd = starts[end]
 	}
-	return strings.Join(lines[start:end], "\n"), nil
+	renderEnd := end
+	for renderEnd > start && strings.TrimSpace(lines[renderEnd-1]) == "" {
+		renderEnd--
+	}
+	return strings.Join(lines[start:renderEnd], "\n"),
+		sourceSpan{start: starts[start], end: rawEnd}, nil
 }
 
 // containsToken reports whether token is in tokens, matching Python's
@@ -169,6 +188,88 @@ func splitTextLines(text string) []string {
 	return lines
 }
 
+// textLineStarts maps splitTextLines' full separator set to source byte
+// coordinates. The manual decoder consumes CRLF atomically, avoiding the
+// double-advance bug a range-based mapper introduces.
+func textLineStarts(data []byte) []int {
+	if len(data) == 0 {
+		return nil
+	}
+	starts := []int{0}
+	for i := 0; i < len(data); {
+		r, width := utf8.DecodeRune(data[i:])
+		next := i + width
+		if lineBoundary(r) {
+			if r == '\r' && next < len(data) && data[next] == '\n' {
+				next++
+			}
+			if next < len(data) {
+				starts = append(starts, next)
+			}
+		}
+		i = next
+	}
+	return starts
+}
+
+// resolveStageContext assembles the mandatory legacy stage subsection followed
+// by declared fence-safe sections, all resolved from one README buffer.
+func resolveStageContext(data []byte, stage string) (string, error) {
+	subsection, stageSpan, err := extractStageSubsectionBytes(data, stage)
+	if err != nil || subsection == "" {
+		return subsection, err
+	}
+	selectors, err := status.StageContextSections(data, stage)
+	if err != nil {
+		return "", err
+	}
+	if len(selectors) == 0 {
+		return subsection, nil
+	}
+	seen := map[string]bool{}
+	for _, selector := range selectors {
+		if seen[selector] {
+			return "", fmt.Errorf("repeated selector %q", selector)
+		}
+		seen[selector] = true
+	}
+	sections, err := status.FindSectionSpans(data, selectors)
+	if err != nil {
+		return "", err
+	}
+	for i, section := range sections {
+		span := sourceSpan{section.Start, section.End}
+		if spansIntersect(stageSpan, span) {
+			return "", overlapError("stage "+stage, stageSpan, section.Heading, span)
+		}
+		for j := 0; j < i; j++ {
+			other := sourceSpan{sections[j].Start, sections[j].End}
+			if spansIntersect(other, span) {
+				return "", overlapError(sections[j].Heading, other, section.Heading, span)
+			}
+		}
+	}
+
+	parts := []string{subsection}
+	for _, section := range sections {
+		lines := splitTextLines(string(data[section.Start:section.End]))
+		for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+			lines = lines[:len(lines)-1]
+		}
+		parts = append(parts, strings.Join(lines, "\n"))
+	}
+	return strings.Join(parts, "\n\n"), nil
+}
+
+func spansIntersect(a, b sourceSpan) bool {
+	return a.start < b.end && b.start < a.end
+}
+
+func overlapError(aName string, a sourceSpan, bName string, b sourceSpan) error {
+	return fmt.Errorf("overlap: %q [%d,%d) intersects %q [%d,%d)",
+		aName, a.start, a.end, bName, b.start, b.end)
+}
+
 // runShowStageDef emits the README's ### {stage} subsection on stdout. Exit 0
 // with stdout on success; exit 1 with a parser diagnostic on a malformed or
 // missing heading or an unresolvable workflow dir / README. Matches
@@ -184,13 +285,18 @@ func runShowStageDef(workflowDir, stage string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	subsection, err := extractStageSubsection(readmePath, stage)
+	data, err := os.ReadFile(readmePath)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
+	subsection, err := resolveStageContext(data, stage)
 	if err != nil {
 		if she, ok := err.(*stageHeadingError); ok {
 			fmt.Fprintf(stderr, "error: %s\n", she.msg)
 			return 1
 		}
-		fmt.Fprintf(stderr, "error: %s\n", err)
+		fmt.Fprintf(stderr, "error: workflow README %q, stage %q: %s\n", readmePath, stage, err)
 		return 1
 	}
 	if subsection == "" {

--- a/internal/status/frontmatter.go
+++ b/internal/status/frontmatter.go
@@ -85,6 +85,11 @@ func ParseFrontmatter(path string) map[string]string {
 	return parseFrontmatterContent(data)
 }
 
+// ParseFrontmatterData parses one immutable in-memory buffer.
+func ParseFrontmatterData(data []byte) map[string]string {
+	return parseFrontmatterContent(data)
+}
+
 // parseFrontmatterContent is ParseFrontmatter over in-memory bytes.
 func parseFrontmatterContent(data []byte) map[string]string {
 	fields := map[string]string{}

--- a/internal/status/section_read.go
+++ b/internal/status/section_read.go
@@ -19,6 +19,14 @@ type heading struct {
 	level  int
 	offset int // 1-based line number of the heading line
 	lines  int // section line count, so Read(offset, lines) returns exactly it
+	start  int // raw half-open source span, populated by scanHeadingSpans
+	end    int
+}
+
+// SectionSpan is one selected fence-safe heading section in raw README coordinates.
+type SectionSpan struct {
+	Heading    string
+	Start, End int
 }
 
 // sectionRead is the parsed result of reading a markdown file: its frontmatter,
@@ -79,6 +87,63 @@ func scanHeadings(lines []string) []heading {
 	}
 	assignSectionLines(headings, len(lines))
 	return headings
+}
+
+// FindSectionSpans resolves selectors in declaration order against the existing
+// fence-safe heading scanner. Missing and ambiguous exact heading text fail.
+func FindSectionSpans(data []byte, selectors []string) ([]SectionSpan, error) {
+	headings := scanHeadingSpans(data)
+	result := make([]SectionSpan, 0, len(selectors))
+	for _, selector := range selectors {
+		var matches []heading
+		for _, h := range headings {
+			if h.text == selector {
+				matches = append(matches, h)
+			}
+		}
+		if len(matches) != 1 {
+			return nil, fmt.Errorf("selector %q matches %d headings", selector, len(matches))
+		}
+		h := matches[0]
+		result = append(result, SectionSpan{Heading: h.text, Start: h.start, End: h.end})
+	}
+	return result, nil
+}
+
+func scanHeadingSpans(data []byte) []heading {
+	headings := scanHeadings(splitLines(string(data)))
+	starts := rawLineStarts(data)
+	for i := range headings {
+		startLine := headings[i].offset - 1
+		endLine := startLine + headings[i].lines
+		headings[i].start = starts[startLine]
+		headings[i].end = len(data)
+		if endLine < len(starts) {
+			headings[i].end = starts[endLine]
+		}
+	}
+	return headings
+}
+
+// rawLineStarts maps splitLines' CR/LF line model back to source bytes. CRLF is
+// one boundary and an EOF boundary does not create a trailing logical line.
+func rawLineStarts(data []byte) []int {
+	if len(data) == 0 {
+		return nil
+	}
+	starts := []int{0}
+	for i := 0; i < len(data); i++ {
+		if data[i] != '\r' && data[i] != '\n' {
+			continue
+		}
+		if data[i] == '\r' && i+1 < len(data) && data[i+1] == '\n' {
+			i++
+		}
+		if i+1 < len(data) {
+			starts = append(starts, i+1)
+		}
+	}
+	return starts
 }
 
 // assignSectionLines fills each heading's `lines` by the level-aware ownership

--- a/internal/status/section_read_test.go
+++ b/internal/status/section_read_test.go
@@ -113,6 +113,35 @@ func TestReadFencedHeadingsSkipped(t *testing.T) {
 	}
 }
 
+func TestFindSectionSpansUsesFenceSafeHeadingOwnership(t *testing.T) {
+	data := []byte("## Pärent\r\nα\r\n### Child\rβ\r\n## Sibling\r\nbody\vcontinued\n```md\n## Fenced\n```\n")
+	spans, err := FindSectionSpans(data, []string{"Sibling", "Pärent", "Child"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSlices := []string{
+		"## Sibling\r\nbody\vcontinued\n```md\n## Fenced\n```\n",
+		"## Pärent\r\nα\r\n### Child\rβ\r\n",
+		"### Child\rβ\r\n",
+	}
+	for i, span := range spans {
+		if got := string(data[span.Start:span.End]); got != wantSlices[i] {
+			t.Fatalf("span[%d] %s [%d,%d) slice = %q, want %q",
+				i, span.Heading, span.Start, span.End, got, wantSlices[i])
+		}
+	}
+	if _, err := FindSectionSpans(data, []string{"Fenced"}); err == nil ||
+		!strings.Contains(err.Error(), "matches 0 headings") {
+		t.Fatalf("fenced selector error = %v, want missing", err)
+	}
+
+	ambiguous := []byte("## Same\none\n## Same\ntwo\n")
+	if _, err := FindSectionSpans(ambiguous, []string{"Same"}); err == nil ||
+		!strings.Contains(err.Error(), "matches 2 headings") {
+		t.Fatalf("ambiguous selector error = %v", err)
+	}
+}
+
 // TestReadEntityRefResolvesLikeResolve (AC4) drives the runner: a valid slug
 // yields the map for that entity's file, and an unknown ref exits 1 with the
 // resolver's error shape.

--- a/internal/status/stages.go
+++ b/internal/status/stages.go
@@ -3,6 +3,7 @@
 package status
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"strconv"
@@ -58,6 +59,12 @@ func ParseStagesWithDefaults(path string) ([]Stage, map[string]string) {
 	if err != nil {
 		return nil, map[string]string{}
 	}
+	return ParseStagesWithDefaultsData(data)
+}
+
+// ParseStagesWithDefaultsData is ParseStagesWithDefaults over one immutable
+// in-memory README buffer.
+func ParseStagesWithDefaultsData(data []byte) ([]Stage, map[string]string) {
 	stagesNode := stagesNodeFromFrontmatter(data)
 	if stagesNode == nil {
 		return nil, map[string]string{}
@@ -98,6 +105,75 @@ func ParseStagesWithDefaults(path string) ([]Stage, map[string]string) {
 		return nil, defaults
 	}
 	return result, defaults
+}
+
+// StageContextSections parses optional ordered context-sections strictly.
+// A stage-local list replaces defaults; an explicit empty list clears them.
+func StageContextSections(data []byte, stage string) ([]string, error) {
+	slice := frontmatterSlice(data)
+	if len(slice) == 0 {
+		return nil, nil
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(slice, &doc); err != nil {
+		return nil, fmt.Errorf("malformed YAML: %w", err)
+	}
+	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, nil
+	}
+	stages := mappingValue(doc.Content[0], "stages")
+	if stages == nil {
+		return nil, nil
+	}
+	if stages.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("stages: want mapping")
+	}
+
+	effective, present, err := contextSectionsValue(mappingValue(stages, "defaults"), "stages.defaults")
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		effective = nil
+	}
+	states := mappingValue(stages, "states")
+	if states == nil {
+		return effective, nil
+	}
+	if states.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("stages.states: want sequence")
+	}
+	for i, item := range states.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		values, declared, err := contextSectionsValue(item, fmt.Sprintf("stages.states[%d]", i))
+		if err != nil {
+			return nil, err
+		}
+		name := mappingValue(item, "name")
+		if name != nil && name.Kind == yaml.ScalarNode && name.Value == stage && declared {
+			effective = values
+		}
+	}
+	return effective, nil
+}
+func contextSectionsValue(mapping *yaml.Node, path string) ([]string, bool, error) {
+	node := mappingValue(mapping, "context-sections")
+	if node == nil {
+		return nil, false, nil
+	}
+	if node.Kind != yaml.SequenceNode {
+		return nil, true, fmt.Errorf("%s.context-sections: want sequence", path)
+	}
+	values := make([]string, 0, len(node.Content))
+	for i, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			return nil, true, fmt.Errorf("%s.context-sections[%d]: want scalar item", path, i)
+		}
+		values = append(values, item.Value)
+	}
+	return values, true, nil
 }
 
 // stagesNodeFromFrontmatter parses the in-fence frontmatter slice and returns

--- a/internal/status/stages_test.go
+++ b/internal/status/stages_test.go
@@ -5,6 +5,8 @@ package status
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -126,5 +128,55 @@ stages:
 	path := writeTemp(t, readme)
 	if stages := parseStagesBlock(path); stages != nil {
 		t.Fatalf("expected nil for empty states, got %+v", stages)
+	}
+}
+
+func TestStageContextSectionsTriStateAndStrictKinds(t *testing.T) {
+	readme := []byte(`---
+stages:
+  defaults:
+    context-sections: [Authority, Safety]
+  states:
+    - name: inherited
+    - name: cleared
+      context-sections: []
+    - name: replaced
+      context-sections: [Safety, Authority]
+---
+`)
+	cases := []struct {
+		stage string
+		want  []string
+	}{
+		{"inherited", []string{"Authority", "Safety"}},
+		{"cleared", []string{}},
+		{"replaced", []string{"Safety", "Authority"}},
+	}
+	for _, tc := range cases {
+		got, err := StageContextSections(readme, tc.stage)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.stage, err)
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("%s = %#v, want %#v", tc.stage, got, tc.want)
+		}
+	}
+
+	bad := []struct {
+		name   string
+		readme string
+		want   string
+	}{
+		{"malformed yaml", "---\nstages: [\n---\n", "malformed YAML"},
+		{"scalar", "---\nstages:\n  defaults:\n    context-sections: Authority\n---\n", "want sequence"},
+		{"mapping item", "---\nstages:\n  states:\n    - name: x\n      context-sections: [{name: Authority}]\n---\n", "want scalar item"},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := StageContextSections([]byte(tc.readme), "x")
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want containing %q", err, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Workers receive stage-specific workflow policy without duplicating that policy into every stage contract.

## What changed

- Add ordered context-sections metadata with tri-state inheritance.
- Resolve selected README spans from one shared buffer.
- Reject missing, ambiguous, or overlapping selections before dispatch.
- Preserve byte-identical behavior for undeclared workflows.
- Document workflow authoring behavior.

## Evidence

- Local verification: 5/5 required checks passed.
- Runtime Live E2E: 5/5 required host jobs passed at `396c92a3`.

---
[0c](/spacedock-dev/spacedock/blob/ae743dce6b9aae129aa1410879b9fcea47c064c5/workflow-declared-section-reads/index.md)