### PR TITLE
Scrub foreign runtime markers from live Claude journeys

### DIFF
--- a/internal/ensigncycle/claude_live_runner_test.go
+++ b/internal/ensigncycle/claude_live_runner_test.go
@@ -199,6 +199,16 @@ func runClaudeRecordedGateLifecycleScenario(t *testing.T, runner liveDriver, sce
 		runner = copied
 	}
 	result := runner.run(t, scenario, fixture.root, recordedGatePrompt(fixture.root))
+	writeFile(t, filepath.Join(result.artifactDir, "command.log"), readFile(t, commandLog))
+	commandLog = filepath.Join(result.artifactDir, "command.log")
+	if strings.Contains(result.stream, "multiple runtime markers are set (CODEX_THREAD_ID, CLAUDECODE)") {
+		t.Fatalf("recorded gate lifecycle hit mixed-marker ambiguity\nArtifacts: %s", result.artifactDir)
+	}
+	for _, line := range strings.Split(readFile(t, commandLog), "\n") {
+		if strings.Contains(line, "\tdispatch build ") && (strings.Contains(line, " --host ") || strings.Contains(line, " --host=")) {
+			t.Fatalf("recorded gate lifecycle recovered with an explicit host: %s\nArtifacts: %s", line, result.artifactDir)
+		}
+	}
 	if copied, ok := runner.(claudeLiveRunner); ok && (!strings.Contains(result.stream, copied.pluginDir) || !strings.Contains(result.stream, "# First Officer Gate Lifecycle")) {
 		t.Fatalf("recorded gate lifecycle did not load the copied skill body\nArtifacts: %s", result.artifactDir)
 	}

--- a/internal/ensigncycle/codex_liveenv_test.go
+++ b/internal/ensigncycle/codex_liveenv_test.go
@@ -119,6 +119,22 @@ func TestCodexLiveEnvOmitsEmptyAPIKey(t *testing.T) {
 	}
 }
 
+func TestCodexLiveEnvDropsForeignRuntimeMarkers(t *testing.T) {
+	for key, value := range map[string]string{"CODEX_THREAD_ID": "codex", "CLAUDECODE": "claude", "PI_CODING_AGENT": "pi",
+		"PI_CODING_AGENT_DIR": "/parent/pi", "CODEX_HOME": "/parent/codex", "HOME": "/parent/home", "OPENAI_API_KEY": "parent-key", "PATH": "/parent/bin"} {
+		t.Setenv(key, value)
+	}
+
+	env := codexLiveEnv("/target/codex", "/target/home", "/spacedock/bin", "target-key")
+
+	want := map[string]string{"CLAUDECODE": "", "PI_CODING_AGENT": "", "PI_CODING_AGENT_DIR": "",
+		"CODEX_THREAD_ID": "codex", "CODEX_HOME": "/target/codex", "HOME": "/target/home",
+		"OPENAI_API_KEY": "target-key", "PATH": "/spacedock/bin" + string(os.PathListSeparator) + "/parent/bin"}
+	for key, value := range want {
+		assertEnvValue(t, env, key, value)
+	}
+}
+
 func TestCodexLiveHomeParentUsesUserCacheOutsideSystemTemp(t *testing.T) {
 	cacheDir := filepath.Join(string(os.PathSeparator), "home", "runner", ".cache")
 	parent, err := codexLiveIsolatedHomeParent(cacheDir)
@@ -174,7 +190,8 @@ func TestCodexLiveHomeParentCandidatesRejectArtifactRootInsidePluginCheckout(t *
 }
 
 func codexLiveEnv(codexHome, home, pathPrefix, openAIAPIKey string) []string {
-	env := cleanEnviron("CODEX_HOME", "HOME", "OPENAI_API_KEY", "CLAUDECODE")
+	env := cleanEnviron("CODEX_HOME", "HOME", "OPENAI_API_KEY", "PATH",
+		"CLAUDECODE", "PI_CODING_AGENT", "PI_CODING_AGENT_DIR")
 	path := os.Getenv("PATH")
 	if pathPrefix != "" {
 		path = pathPrefix + string(os.PathListSeparator) + path

--- a/internal/ensigncycle/liveenv_decision_test.go
+++ b/internal/ensigncycle/liveenv_decision_test.go
@@ -27,6 +27,20 @@ func envValue(env []string, key string) (string, bool) {
 	return "", false
 }
 
+func assertEnvValue(t *testing.T, env []string, key, want string) {
+	t.Helper()
+	prefix := key + "="
+	var values []string
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			values = append(values, strings.TrimPrefix(kv, prefix))
+		}
+	}
+	if (want == "" && len(values) != 0) || (want != "" && (len(values) != 1 || values[0] != want)) {
+		t.Errorf("%s = %q, want exactly %q", key, values, want)
+	}
+}
+
 // TestDecideClaudeEnv covers the pure decision tree directly: it returns the
 // chosen auth mode (and OAuth token) from explicit inputs, with no skip/abort
 // and no temp dir, so all three branches — including the neither-credential
@@ -240,5 +254,35 @@ func TestIsolatedClaudeEnvAPIKeyPath(t *testing.T) {
 	}
 	if home == fakeHome {
 		t.Errorf("HOME = %q must be a fresh dir, not the real home %q", home, fakeHome)
+	}
+}
+
+func TestIsolatedClaudeEnvDropsForeignRuntimeMarkers(t *testing.T) {
+	for _, tc := range []struct{ name, token, credential, credentialValue string }{
+		{"api-key", "", "ANTHROPIC_API_KEY", "api-key"}, {"oauth", "oauth-token", "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeHome := t.TempDir()
+			if tc.token != "" {
+				writeFile(t, filepath.Join(fakeHome, ".claude", "benchmark-token"), tc.token)
+			}
+			for key, value := range map[string]string{"ANTHROPIC_API_KEY": "api-key", "CLAUDECODE": "parent-claude", "CODEX_THREAD_ID": "codex",
+				"PI_CODING_AGENT": "pi", "PI_CODING_AGENT_DIR": "/parent/pi", "CLAUDE_CONFIG_DIR": "/target/claude", "PATH": "/parent/bin"} {
+				t.Setenv(key, value)
+			}
+
+			env := isolatedClaudeEnv(t, fakeHome)
+
+			for key, want := range map[string]string{
+				"CLAUDECODE": "", "CODEX_THREAD_ID": "", "PI_CODING_AGENT": "", "PI_CODING_AGENT_DIR": "",
+				"CLAUDE_CONFIG_DIR": "/target/claude", "PATH": "/parent/bin", tc.credential: tc.credentialValue} {
+				assertEnvValue(t, env, key, want)
+			}
+			if home, _ := envValue(env, "HOME"); home == fakeHome {
+				t.Errorf("HOME = %q, want an isolated value", home)
+			} else {
+				assertEnvValue(t, env, "HOME", home)
+			}
+		})
 	}
 }

--- a/internal/ensigncycle/liveenv_test.go
+++ b/internal/ensigncycle/liveenv_test.go
@@ -142,12 +142,14 @@ func isolatedClaudeEnv(t *testing.T, realHome string) []string {
 	switch decision.mode {
 	case authOAuthToken:
 		// Operator-local: drop the API key so the OAuth token is authoritative.
-		env := cleanEnviron("CLAUDECODE", "HOME", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR")
+		env := cleanEnviron("CLAUDECODE", "CODEX_THREAD_ID", "PI_CODING_AGENT", "PI_CODING_AGENT_DIR",
+			"HOME", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR")
 		env = append(env, "HOME="+cleanHome, "CLAUDE_CODE_OAUTH_TOKEN="+decision.oauthToken, "CLAUDE_CONFIG_DIR="+configDir)
 		return env
 	case authAPIKey:
 		// CI: pass ANTHROPIC_API_KEY through against the fresh HOME.
-		env := cleanEnviron("CLAUDECODE", "HOME", "CLAUDE_CONFIG_DIR")
+		env := cleanEnviron("CLAUDECODE", "CODEX_THREAD_ID", "PI_CODING_AGENT", "PI_CODING_AGENT_DIR",
+			"HOME", "CLAUDE_CONFIG_DIR")
 		env = append(env, "HOME="+cleanHome, "CLAUDE_CONFIG_DIR="+configDir)
 		return env
 	default:

--- a/internal/ensigncycle/pi_live_runner_test.go
+++ b/internal/ensigncycle/pi_live_runner_test.go
@@ -243,7 +243,10 @@ func seedPiLiveAuth(t *testing.T, piHome, realHome, openAIAPIKey, required strin
 }
 
 func piLiveEnv(piHome, sessionDir, cleanHome, binaryDir, piSubagentsRoot string) []string {
-	env := os.Environ()
+	env := cleanEnviron(
+		"CODEX_THREAD_ID", "CLAUDECODE", "HOME", "PI_CODING_AGENT_DIR",
+		"PI_CODING_AGENT_SESSION_DIR", "PI_SUBAGENTS_PACKAGE_ROOT", "PI_OFFLINE",
+	)
 	env = append(env,
 		"HOME="+cleanHome,
 		"PI_CODING_AGENT_DIR="+piHome,
@@ -252,6 +255,25 @@ func piLiveEnv(piHome, sessionDir, cleanHome, binaryDir, piSubagentsRoot string)
 		"PI_OFFLINE=1",
 	)
 	return withBinaryOnPath(env, filepath.Join(binaryDir, "spacedock"))
+}
+
+func TestPiLiveEnvDropsForeignRuntimeMarkers(t *testing.T) {
+	for key, value := range map[string]string{"CODEX_THREAD_ID": "codex", "CLAUDECODE": "claude", "PI_CODING_AGENT": "pi", "PI_CODING_AGENT_DIR": "/parent/pi",
+		"PI_CODING_AGENT_SESSION_DIR": "/parent/sessions", "PI_SUBAGENTS_PACKAGE_ROOT": "/parent/package",
+		"PI_OFFLINE": "0", "HOME": "/parent/home", "OPENAI_API_KEY": "key", "PATH": "/parent/bin"} {
+		t.Setenv(key, value)
+	}
+
+	env := piLiveEnv("/target/pi", "/target/sessions", "/target/home", "/spacedock/bin", "/target/package")
+
+	want := map[string]string{"CODEX_THREAD_ID": "", "CLAUDECODE": "",
+		"PI_CODING_AGENT": "pi", "PI_CODING_AGENT_DIR": "/target/pi",
+		"PI_CODING_AGENT_SESSION_DIR": "/target/sessions", "PI_SUBAGENTS_PACKAGE_ROOT": "/target/package",
+		"PI_OFFLINE": "1", "HOME": "/target/home", "OPENAI_API_KEY": "key",
+		"PATH": "/spacedock/bin" + string(os.PathListSeparator) + "/parent/bin"}
+	for key, value := range want {
+		assertEnvValue(t, env, key, value)
+	}
 }
 
 func piSubagentsPackageRoot(t *testing.T) string {

--- a/internal/ensigncycle/recorded_gate_lifecycle_test.go
+++ b/internal/ensigncycle/recorded_gate_lifecycle_test.go
@@ -57,7 +57,7 @@ func assertRecordedGateLifecycle(o recordedGateObservation) error {
 		}
 	}
 	if o.dispatch.builds != 1 {
-		return fmt.Errorf("successful successor dispatch builds = %d, want 1", o.dispatch.builds)
+		return fmt.Errorf("successor dispatch build attempts = %d, want 1", o.dispatch.builds)
 	}
 	if o.dispatch.durableEffects != 1 {
 		return fmt.Errorf("new durable successor effects = %d, want 1", o.dispatch.durableEffects)
@@ -195,7 +195,7 @@ func TestRecordedGateLifecycleRealCLIReplay(t *testing.T) {
 		t.Fatal(err)
 	}
 	validLog := readFile(t, commandLog)
-	for name, log := range map[string]string{"zero-build": strings.Replace(validLog, "exit=0\tdispatch build ", "exit=0\tignored build ", 1), "build-before-consume": strings.Replace(validLog, "exit=0\tgate consume ", "exit=0\tignored consume ", 1) + "\nexit=0\tgate consume late", "missing-ancestry": strings.Replace(validLog, "dispatch-head\t", "missing-head\t", 1)} {
+	for name, log := range map[string]string{"zero-build": strings.Replace(validLog, "begin\tdispatch build ", "begin\tignored build ", 1), "build-before-consume": strings.Replace(validLog, "exit=0\tgate consume ", "exit=0\tignored consume ", 1) + "\nexit=0\tgate consume late", "missing-ancestry": strings.Replace(validLog, "dispatch-head\t", "missing-head\t", 1)} {
 		writeFile(t, commandLog, log)
 		requireRecordedGate(t, assertRecordedGateLifecycle(recordedGateLiveObservation(t, fixture, before, commandLog, readFile(t, fixture.gateReview))) != nil, "%s control qualified", name)
 	}
@@ -666,7 +666,7 @@ func procedureEvents(skill string) []string {
 	return events
 }
 func recordedGatePrompt(workflowRoot string) string {
-	return fmt.Sprintf("Use $spacedock:first-officer for this whole run.\n\nWorkflow directory: %s\nEngage only `recorded-gate-task` under this delegated conn: %s\nApprove its retained validation package and continue until the handoff worker records %s in durable state, then stop.", workflowRoot, recordedGateDirective, recordedGateDispatchMarker)
+	return fmt.Sprintf("Use $spacedock:first-officer for this whole run.\n\nWorkflow directory: %s\nEngage only `recorded-gate-task` under this delegated conn: %s\nDo not pass `--host` to `dispatch build`.\nApprove its retained validation package and continue until the handoff worker records %s in durable state, then stop.", workflowRoot, recordedGateDirective, recordedGateDispatchMarker)
 }
 
 func writeRecordedGateLoggingShim(t *testing.T, binary, logPath string) string {
@@ -840,7 +840,7 @@ func recordedGateLiveObservation(t *testing.T, fixture recordedGateFixture, befo
 		if strings.HasPrefix(line, "exit=0\tgate consume ") {
 			consumed = true
 		}
-		if strings.HasPrefix(line, "exit=0\tdispatch build ") && !strings.Contains(line, " --help") {
+		if strings.HasPrefix(line, "begin\tdispatch build ") && !strings.Contains(line, " --help") {
 			builds++
 			ordered = ordered && consumed
 		}

--- a/internal/ensigncycle/recorded_gate_lifecycle_test.go
+++ b/internal/ensigncycle/recorded_gate_lifecycle_test.go
@@ -32,10 +32,10 @@ const (
 )
 
 type recordedGateDispatchProof struct {
-	builds         int
-	durableEffects int
-	ordered        bool
-	committed      bool
+	builds, successfulBuilds int
+	durableEffects           int
+	ordered                  bool
+	committed                bool
 }
 
 type recordedGateObservation struct {
@@ -56,8 +56,8 @@ func assertRecordedGateLifecycle(o recordedGateObservation) error {
 			return fmt.Errorf("gate lifecycle event %d = %q, want %q", i+1, got, want)
 		}
 	}
-	if o.dispatch.builds != 1 {
-		return fmt.Errorf("successor dispatch build attempts = %d, want 1", o.dispatch.builds)
+	if o.dispatch.builds != 1 || o.dispatch.successfulBuilds != 1 {
+		return fmt.Errorf("successor dispatch build attempts/successes = %d/%d, want 1/1", o.dispatch.builds, o.dispatch.successfulBuilds)
 	}
 	if o.dispatch.durableEffects != 1 {
 		return fmt.Errorf("new durable successor effects = %d, want 1", o.dispatch.durableEffects)
@@ -195,7 +195,7 @@ func TestRecordedGateLifecycleRealCLIReplay(t *testing.T) {
 		t.Fatal(err)
 	}
 	validLog := readFile(t, commandLog)
-	for name, log := range map[string]string{"zero-build": strings.Replace(validLog, "begin\tdispatch build ", "begin\tignored build ", 1), "build-before-consume": strings.Replace(validLog, "exit=0\tgate consume ", "exit=0\tignored consume ", 1) + "\nexit=0\tgate consume late", "missing-ancestry": strings.Replace(validLog, "dispatch-head\t", "missing-head\t", 1)} {
+	for name, log := range map[string]string{"zero-build": strings.Replace(validLog, "begin\tdispatch build ", "begin\tignored build ", 1), "failed-build": strings.Replace(validLog, "exit=0\tdispatch build ", "exit=1\tdispatch build ", 1), "build-before-consume": strings.Replace(validLog, "exit=0\tgate consume ", "exit=0\tignored consume ", 1) + "\nexit=0\tgate consume late", "missing-ancestry": strings.Replace(validLog, "dispatch-head\t", "missing-head\t", 1)} {
 		writeFile(t, commandLog, log)
 		requireRecordedGate(t, assertRecordedGateLifecycle(recordedGateLiveObservation(t, fixture, before, commandLog, readFile(t, fixture.gateReview))) != nil, "%s control qualified", name)
 	}
@@ -605,7 +605,7 @@ func TestRecordedGateLifecycleProvenanceAndPresentationMutants(t *testing.T) {
 			"id: resolution:spacedock:docs-dev:3k:validation:1\nbriefing: " + recordedGateBriefingID + "\n" +
 			"by: agent:first-officer\n                decision: approve\n                reason: " + recordedGateReason + "\n" +
 			"target-stage: handoff\n                state: consumed\n## Stage Report: handoff\n\n- DONE: Successor dispatch followed decision: approve.",
-		dispatch:     recordedGateDispatchProof{builds: 1, durableEffects: 1, ordered: true, committed: true},
+		dispatch:     recordedGateDispatchProof{builds: 1, successfulBuilds: 1, durableEffects: 1, ordered: true, committed: true},
 		gateReview:   recordedGateReview(),
 		expectedNext: "handoff",
 	}
@@ -833,16 +833,20 @@ func TestRecordedGateReviewExtractorsRequireOneOrderedRootReview(t *testing.T) {
 func recordedGateLiveObservation(t *testing.T, fixture recordedGateFixture, before, commandLog, review string) recordedGateObservation {
 	t.Helper()
 	log := readFile(t, commandLog)
-	builds, consumed, ordered := 0, false, true
+	builds, successfulBuilds, consumed, ordered := 0, 0, false, true
 	ordered = strings.Count(log, "exit=0\tgate --help") == 1 && strings.Index(log, "exit=0\tgate record ") > strings.Index(log, "exit=0\tgate --help")
-	dispatchHead := ""
+	dispatchHead, buildCommand := "", ""
 	for _, line := range strings.Split(log, "\n") {
 		if strings.HasPrefix(line, "exit=0\tgate consume ") {
 			consumed = true
 		}
 		if strings.HasPrefix(line, "begin\tdispatch build ") && !strings.Contains(line, " --help") {
 			builds++
+			buildCommand = strings.TrimPrefix(line, "begin\t")
 			ordered = ordered && consumed
+		}
+		if strings.HasPrefix(line, "exit=0\tdispatch build ") && strings.TrimPrefix(line, "exit=0\t") == buildCommand {
+			successfulBuilds++
 		}
 		if strings.HasPrefix(line, "dispatch-head\t") {
 			dispatchHead = strings.TrimPrefix(line, "dispatch-head\t")
@@ -863,7 +867,7 @@ func recordedGateLiveObservation(t *testing.T, fixture recordedGateFixture, befo
 	return recordedGateObservation{
 		events: recordedGateEventsFromCommandLog(log), before: before, after: after,
 		dispatch: recordedGateDispatchProof{
-			builds: builds, durableEffects: effects, ordered: ordered,
+			builds: builds, successfulBuilds: successfulBuilds, durableEffects: effects, ordered: ordered,
 			committed: recordedGateCommittedBeforeDispatch(t, fixture, closeCommit, consumedCommit, dispatchHead, strings.Join(commits, " ")),
 		},
 		gateReview: review, expectedNext: "handoff",


### PR DESCRIPTION
Live host journeys now derive the selected runtime without explicit-host recovery while preserving production ambiguity refusal.

## What changed

- Scrub foreign detector keys from Claude, Codex, and Pi child environments.
- Preserve target credentials, PATH, HOME, and host state exactly once.
- Require a matching successful exit for the recorded-gate dispatch build.
- Add contaminated-environment and retained-effect failed-build controls.

## Evidence

- Repository gates: 2/2 passed.
- Acceptance criteria: 4/4 reproduced by independent validation.

---
[v3v](/spacedock-dev/spacedock/blob/7a36806c380472519ea3da4050447d7e2d66c4e0/live-claude-runner-scrub-foreign-runtime-markers/index.md)
