### PR TITLE
Clean recorded-gate lifecycle proof hygiene before v1

### DIFF
--- a/internal/contractlint/layering_restore_test.go
+++ b/internal/contractlint/layering_restore_test.go
@@ -182,17 +182,13 @@ func TestNoUnexpectedPRViewScanIntroduced(t *testing.T) {
 // If the mod ever stopped carrying the token this control reds. Modeled on
 // TestPortabilityCheckDiscriminatesHostSpecific's load-bearing-exclusion assertion.
 func TestPRViewAllowListIsLoadBearing(t *testing.T) {
-	for path, want := range map[string]string{
-		filepath.Join(repoRoot(t), "mods", "pr-merge.md"):                 "valid merged sentinel (`pr-merge:` or `local-merge:`)",
-		filepath.Join(repoRoot(t), "docs", "dev", "_mods", "pr-merge.md"): "reconciled-from-shipped: 0.12.3|valid merged sentinel (`pr-merge:` or `local-merge:`)",
-		filepath.Join(skillsRoot(t), "fo-gate-lifecycle", "SKILL.md"):     "terminal current status resumes the existing merge ceremony",
-	} {
-		data := readFileString(t, path)
-		if wants := strings.Split(want, "|"); !strings.Contains(data, wants[0]) || len(wants) > 1 && !strings.Contains(data, wants[1]) {
-			t.Errorf("%s must contain %q", path, want)
-		} else if strings.HasSuffix(path, filepath.Join("mods", "pr-merge.md")) && !strings.Contains(data, "gh pr view") {
-			t.Errorf("%s no longer carries the load-bearing `gh pr view` scan", path)
-		}
+	path := filepath.Join(repoRoot(t), "mods", "pr-merge.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read pr-merge mod %s: %v", path, err)
+	}
+	if !strings.Contains(string(data), "gh pr view") {
+		t.Error("positive control missing: mods/pr-merge.md no longer carries `gh pr view` — the allow-list entry is no longer load-bearing")
 	}
 }
 

--- a/internal/ensigncycle/claude_live_runner_test.go
+++ b/internal/ensigncycle/claude_live_runner_test.go
@@ -275,6 +275,9 @@ func runClaudeGateGuardrailScenario(t *testing.T, runner liveDriver, scenario sh
 	runner = runner.withStubPATH(shimDir)
 
 	result := runner.run(t, scenario, workflowRoot, gatePrompt(workflowRoot))
+	if _, err := os.Stat(filepath.Join(fixture.stateRoot, "_archive", "recorded-gate-task", "index.md")); !os.IsNotExist(err) {
+		t.Fatalf("recorded-gate-task was archived while waiting at the gate; stat err=%v", err)
+	}
 	after := readFile(t, fixture.entity)
 	if err := assertGateHeld(before, after, recordedGateReviewFromClaudeStream(result.stream)); err != nil {
 		t.Fatalf("%v\nFinal message:\n%s\nArtifacts: %s", err, result.finalMessage, result.artifactDir)

--- a/internal/ensigncycle/codex_live_runner_test.go
+++ b/internal/ensigncycle/codex_live_runner_test.go
@@ -207,15 +207,15 @@ func runCodexGateGuardrailScenario(t *testing.T, runner codexLiveRunner, scenari
 	if err != nil {
 		t.Fatalf("%v\nArtifacts: %s", err, result.artifactDir)
 	}
+	if _, err := os.Stat(filepath.Join(fixture.stateRoot, "_archive", "recorded-gate-task", "index.md")); !os.IsNotExist(err) {
+		t.Fatalf("recorded-gate-task was archived while waiting at the gate; stat err=%v", err)
+	}
 	after := readFile(t, fixture.entity)
 	if err := assertGateHeld(before, after, recordedGateReviewFromCodexJSONL(result.jsonl)); err != nil {
 		t.Fatalf("%v\nFinal message:\n%s\nArtifacts: %s", err, result.finalMessage, result.artifactDir)
 	}
 	if err := assertRecordedGateHoldLog(readFile(t, commandLog)); err != nil {
 		t.Fatalf("%v\nArtifacts: %s", err, result.artifactDir)
-	}
-	if resolveRecordedGateEntity(fixture) != after {
-		t.Fatal("recorded-gate-task was archived while waiting at the gate")
 	}
 	emitCodexScenarioMetrics(t, scenario, result)
 }

--- a/internal/ensigncycle/recorded_gate_lifecycle_test.go
+++ b/internal/ensigncycle/recorded_gate_lifecycle_test.go
@@ -565,37 +565,6 @@ func TestRecordedGateLifecycleAC7ResumeMatrix(t *testing.T) {
 		}
 	})
 }
-func TestRecordedGateLifecycleCommandTextMutants(t *testing.T) {
-	root := recordedGateRepoRoot(t)
-	original := readFile(t, filepath.Join(root, "skills", "fo-gate-lifecycle", "SKILL.md"))
-	if events := procedureEvents(original); strings.Join(events, ",") != strings.Join(recordedGateRequiredEvents, ",") {
-		t.Fatalf("shipped skill baseline trace=%v, want %v", events, recordedGateRequiredEvents)
-	}
-	commands := []struct {
-		event, command string
-	}{
-		{"briefing-record", "gate record ENTITY --briefing BRIEFING"},
-		{"decision-record", "gate record ENTITY --decision approve|revise|hold"},
-		{"consume", "gate consume ENTITY"},
-	}
-	for _, tc := range commands {
-		t.Run(tc.event, func(t *testing.T) {
-			at := strings.Index(original, tc.command)
-			if at < 0 {
-				t.Fatalf("shipped skill has no %s command", tc.event)
-			}
-			mutant := original[:at] + original[at+len(tc.command):]
-			if tc.event == "decision-record" {
-				mutant = strings.ReplaceAll(original, tc.command, "")
-			}
-			copyPath := filepath.Join(t.TempDir(), "skills", "fo-gate-lifecycle", "SKILL.md")
-			writeFile(t, copyPath, mutant)
-			if events := procedureEvents(readFile(t, copyPath)); strings.Join(events, ",") == strings.Join(recordedGateRequiredEvents, ",") {
-				t.Fatalf("copied shipped-skill %s deletion kept the structural command-text check green: %v", tc.event, events)
-			}
-		})
-	}
-}
 func TestRecordedGateLifecycleProvenanceAndPresentationMutants(t *testing.T) {
 	valid := recordedGateObservation{
 		events: append([]string(nil), recordedGateRequiredEvents...),
@@ -647,24 +616,6 @@ func authorizeRecordedGateDispatch(events []string, entity, successor string) er
 	return nil
 }
 
-func procedureEvents(skill string) []string {
-	needles := []struct{ event, needle string }{
-		{"briefing-record", "gate record ENTITY --briefing"},
-		{"decision-record", "gate record ENTITY --decision"},
-		{"consume", "gate consume ENTITY"},
-	}
-	var events []string
-	from := 0
-	for _, item := range needles {
-		at := strings.Index(skill[from:], item.needle)
-		if at < 0 {
-			continue
-		}
-		events = append(events, item.event)
-		from += at + len(item.needle)
-	}
-	return events
-}
 func recordedGatePrompt(workflowRoot string) string {
 	return fmt.Sprintf("Use $spacedock:first-officer for this whole run.\n\nWorkflow directory: %s\nEngage only `recorded-gate-task` under this delegated conn: %s\nDo not pass `--host` to `dispatch build`.\nApprove its retained validation package and continue until the handoff worker records %s in durable state, then stop.", workflowRoot, recordedGateDirective, recordedGateDispatchMarker)
 }


### PR DESCRIPTION
Recorded-gate lifecycle proof now relies on executable outcomes and diagnoses archival before reading stale active state.

## What changed

- Remove the tautological command-text mutant and orphaned parser.
- Replace the shipped-prose map with a structural PR-view discriminator.
- Check archive absence before Codex and Claude active-entity reads.
- Preserve all executable lifecycle and terminal-dispatch controls.

## Evidence

- Rebased focused gates: 3/3 passed.
- Acceptance criteria: 4/4 reproduced by independent validation.

---
[fh](/spacedock-dev/spacedock/blob/b1f515b5af835cf178a8abea6b67549860c4da02/recorded-gate-lifecycle-proof-hygiene/index.md)
