### PR TITLE
Make headless recorded-gate stop fixture stage-coherent

### DIFF
--- a/internal/contractlint/live_registry_reconciliation_test.go
+++ b/internal/contractlint/live_registry_reconciliation_test.go
@@ -48,11 +48,6 @@ func TestRuntimeLiveRegistryReconciliation(t *testing.T) {
 	if want := []liveTODORow{{target: "codex", owner: "3zzpdw704df1g8pg1x9thzmw"}, {target: "pi", owner: "3zzpdw704df1g8pg1x9thzmw"}}; len(gateTODOs) != len(want) || gateTODOs[0] != want[0] || gateTODOs[1] != want[1] {
 		t.Fatalf("gate-guardrail TODOs = %#v, want %#v", gateTODOs, want)
 	}
-	defaultHeadlessTODOs := actual["default-headless-gate-stop"].todos
-	if want := []liveTODORow{{target: "claude-sonnet", owner: "26nk8qd48zknqnn4kc123sez"}, {target: "codex", owner: "26nk8qd48zknqnn4kc123sez"}, {target: "pi", owner: "26nk8qd48zknqnn4kc123sez"}}; len(defaultHeadlessTODOs) != len(want) || defaultHeadlessTODOs[0] != want[0] || defaultHeadlessTODOs[1] != want[1] || defaultHeadlessTODOs[2] != want[2] {
-		t.Fatalf("default-headless-gate-stop TODOs = %#v, want %#v", defaultHeadlessTODOs, want)
-	}
-
 	gapCounts := map[string]int{}
 	for id, want := range desired {
 		got, ok := actual[id]

--- a/internal/ensigncycle/claude_live_runner_test.go
+++ b/internal/ensigncycle/claude_live_runner_test.go
@@ -226,7 +226,7 @@ func runGateStopScenario(t *testing.T, runner liveDriver, scenario sharedRuntime
 	if err := assert(before, after, expected); err != nil {
 		t.Fatalf("%v\nFinal message:\n%s\nArtifacts: %s", err, result.finalMessage, result.artifactDir)
 	}
-	if err := assertRecordedGateHoldLog(readFile(t, commandLog)); err != nil {
+	if err := assertRecordedGateHoldLog(readFile(t, commandLog), scenario.name == "default-headless-gate-stop"); err != nil {
 		t.Fatalf("%v\nArtifacts: %s", err, result.artifactDir)
 	}
 	runner.emitMetrics(t, scenario, result)

--- a/internal/ensigncycle/claude_runtime_helpers_test.go
+++ b/internal/ensigncycle/claude_runtime_helpers_test.go
@@ -84,11 +84,12 @@ func TestUnsetNestedSessionArgs(t *testing.T) {
 	}
 }
 
-func assertRecordedGateHoldLog(log string) error {
+func assertRecordedGateHoldLog(log string, requireImplementation ...bool) error {
 	const prepareToken = "exit=0\tgate prepare recorded-gate-task "
 	prepare := strings.Index(log, prepareToken)
 	commit := strings.LastIndex(log, "exit=0\tstate commit recorded-gate-task")
 	head := strings.LastIndex(log, "state-head\t")
+	dispatches := strings.Split(log[:max(prepare, 0)], "exit=0\tdispatch build ")
 	const boundary = "gate hold crossed its committed no-authority boundary: "
 	switch {
 	case prepare < 0:
@@ -105,16 +106,39 @@ func assertRecordedGateHoldLog(log string) error {
 		return errGraded(boundary + "the gate was consumed after prepare")
 	case strings.Contains(log[prepare:], "dispatch build "):
 		return errGraded(boundary + "a successor was dispatched after prepare")
+	case strings.Contains(log[prepare:], "gate withdraw "):
+		return errGraded(boundary + "the gate was withdrawn after prepare")
+	case successfulStatusSet(log[prepare:]):
+		return errGraded(boundary + "status changed after prepare")
+	case len(requireImplementation) > 0 && requireImplementation[0] && (len(dispatches) != 2 || !strings.Contains(" "+strings.SplitN(dispatches[1], "\n", 2)[0]+" ", " --stage implementation ") || successfulStatusSet(log[:strings.Index(log, "exit=0\tdispatch build ")], "status=implementation started") || successfulStatusSet(strings.SplitN(dispatches[1], "\n", 2)[1], "status=validation started")):
+		return errGraded(boundary + "implementation was not dispatched before validation")
 	}
 	return nil
 }
 
+func successfulStatusSet(log string, allowed ...string) (found bool) {
+	for _, line := range strings.Split(log, "\n") {
+		if strings.HasPrefix(line, "exit=0\tstatus ") && strings.Contains(line, " --set ") && (len(allowed) == 0 || found || !strings.HasSuffix(line, " "+allowed[0])) {
+			return true
+		}
+		found = found || strings.HasPrefix(line, "exit=0\tstatus ") && strings.Contains(line, " --set ")
+	}
+	return len(allowed) > 0 && !found
+}
+
 func TestAssertRecordedGateHoldLogAcceptsPrepareFirstLifecycle(t *testing.T) {
-	const prepared = "exit=1\tgate prepare recorded-gate-task validation\n" +
+	const prepared = "exit=0\tstatus --workflow-dir /tmp/workflow --set recorded-gate-task status=implementation started\n" +
+		"exit=0\tstate commit recorded-gate-task\n" +
+		"state-head\timplementation\n" +
+		"exit=0\tdispatch build --stage implementation\n" +
+		"exit=0\tstatus --workflow-dir /tmp/workflow --set recorded-gate-task status=validation started\n" +
+		"exit=0\tstate commit recorded-gate-task\n" +
+		"state-head\tvalidation\n" +
+		"exit=1\tgate prepare recorded-gate-task validation\n" +
 		"exit=0\tgate prepare recorded-gate-task validation\n" +
 		"exit=0\tstate commit recorded-gate-task\n" +
 		"state-head\tabc123\n"
-	if err := assertRecordedGateHoldLog(prepared); err != nil {
+	if err := assertRecordedGateHoldLog(prepared, true); err != nil {
 		t.Fatalf("prepare-first hold log rejected: %v", err)
 	}
 	for name, tc := range map[string]struct {
@@ -122,9 +146,11 @@ func TestAssertRecordedGateHoldLogAcceptsPrepareFirstLifecycle(t *testing.T) {
 		want     string
 	}{
 		"retired bind":      {strings.Replace(prepared, "exit=0\tgate prepare recorded-gate-task validation", "exit=0\tgate record recorded-gate-task --briefing briefing.md", 1), "no successful gate prepare recorded"},
-		"missing commit":    {strings.Replace(prepared, "exit=0\tstate commit recorded-gate-task\n", "", 1), "state commit missing or before the successful gate prepare"},
+		"missing commit":    {strings.Replace(prepared, "exit=0\tgate prepare recorded-gate-task validation\nexit=0\tstate commit recorded-gate-task\n", "exit=0\tgate prepare recorded-gate-task validation\n", 1), "state commit missing or before the successful gate prepare"},
 		"decision":          {prepared + "exit=0\tgate record recorded-gate-task --decision approve\n", "a decision was recorded after prepare"},
 		"consume":           {prepared + "exit=0\tgate consume recorded-gate-task\n", "the gate was consumed after prepare"},
+		"withdraw":          {prepared + "exit=0\tgate withdraw recorded-gate-task\n", "the gate was withdrawn after prepare"},
+		"status repair":     {prepared + "exit=0\tstatus --set recorded-gate-task status=validation\n", "status changed after prepare"},
 		"successor build":   {prepared + "exit=0\tdispatch build successor\n", "a successor was dispatched after prepare"},
 		"duplicate prepare": {prepared + "exit=0\tgate prepare recorded-gate-task validation\n", "more than one successful gate prepare recorded"},
 	} {

--- a/internal/ensigncycle/shared_fixtures_test.go
+++ b/internal/ensigncycle/shared_fixtures_test.go
@@ -1,6 +1,7 @@
 package ensigncycle
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,10 +38,30 @@ func writeGateWorkflow(t *testing.T, root string) recordedGateFixture {
 func writePreGateWorkflow(t *testing.T, root string) recordedGateFixture {
 	t.Helper()
 	fixture := writePreparedRecordedGateFixtureAt(t, root)
-	writeFile(t, filepath.Join(fixture.root, "README.md"), strings.Replace(recordedGateReadme(), "### validation", "### implementation\n\nAppend an implementation stage report, then return completion.\n\n### validation", 1))
-	writeFile(t, fixture.entity, strings.Replace(recordedGateEntity(), "status: validation", "status: implementation", 1))
-	gitCommitPathScoped(t, fixture.stateRoot, "recorded-gate-task/index.md", "start before gate")
+	writeFile(t, filepath.Join(fixture.root, "README.md"), strings.Replace(strings.Replace(recordedGateReadme(), "    - name: implementation\n      initial: true\n", "    - name: queued\n      initial: true\n    - name: implementation\n", 1), "### validation", "### implementation\n\nAppend exactly one `## Stage Report: implementation`, then return completion.\n\n### validation", 1))
+	writeFile(t, fixture.entity, strings.Replace(strings.Split(recordedGateEntity(), "\n## Stage Report: validation\n")[0]+"\n", "status: validation", "status: queued", 1))
+	writeFile(t, fixture.references[0], "# Entity snapshot\n\nThe retained package is ready for implementation.\n")
+	git(t, fixture.stateRoot, "add", "--", "recorded-gate-task/index.md", "recorded-gate-task/selected/entity-snapshot.md")
+	git(t, fixture.stateRoot, "commit", "-q", "-m", "queue coherent implementation", "--", "recorded-gate-task/index.md", "recorded-gate-task/selected/entity-snapshot.md")
 	return fixture
+}
+
+func TestPreGateWorkflowIsStageCoherent(t *testing.T) {
+	fixture := writePreGateWorkflow(t, t.TempDir())
+	if body := readFile(t, fixture.entity); strings.Contains(body, "\ngates:") || strings.Contains(body, "## Stage Report: implementation") || strings.Contains(body, "## Stage Report: validation") || strings.Contains(readFile(t, fixture.references[0]), "Stage Report is complete") {
+		t.Fatal("queued entity retained selected gate or completed stage report")
+	}
+	result := mustRecordedGate(t, buildRecordedGateBinary(t), fixture.root, "status", "--workflow-dir", fixture.root, "--boot", "--identify", "--json")
+	var boot struct {
+		Dispatchable []struct{ Current, Next string } `json:"dispatchable"`
+		Ready        json.RawMessage                  `json:"ready_gates"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &boot); err != nil {
+		t.Fatalf("parse queued implementation boot: %v\n%s", err, result.stdout)
+	}
+	if len(boot.Dispatchable) != 1 || boot.Dispatchable[0].Current != "queued" || boot.Dispatchable[0].Next != "implementation" || string(boot.Ready) != "[]" {
+		t.Fatalf("queued implementation boot dispatchable=%+v ready_gates=%s", boot.Dispatchable, boot.Ready)
+	}
 }
 func gateReadme() string { return recordedGateReadme() }
 func gateEntity() string { return recordedGateEntity() }

--- a/internal/ensigncycle/shared_live_runner_test.go
+++ b/internal/ensigncycle/shared_live_runner_test.go
@@ -111,7 +111,7 @@ func TestLiveCommonGateGuardrail(t *testing.T) {
 
 //spacedock:live-journey id=default-headless-gate-stop fixture=recorded-gate/pre-gate
 func TestLiveCommonDefaultHeadlessGateStop(t *testing.T) {
-	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyTODO{liveTODO("pi", "26nk8qd48zknqnn4kc123sez")}, runGateStopScenario, assertGateHeld)
+	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyTODO{liveTODO("claude-sonnet", "26nk8qd48zknqnn4kc123sez"), liveTODO("codex", "26nk8qd48zknqnn4kc123sez"), liveTODO("pi", "26nk8qd48zknqnn4kc123sez")}, runGateStopScenario, assertGateHeld)
 }
 
 //spacedock:live-journey id=withdrawn-gate-recovery fixture=recorded-gate/withdrawn

--- a/internal/ensigncycle/shared_live_runner_test.go
+++ b/internal/ensigncycle/shared_live_runner_test.go
@@ -111,7 +111,7 @@ func TestLiveCommonGateGuardrail(t *testing.T) {
 
 //spacedock:live-journey id=default-headless-gate-stop fixture=recorded-gate/pre-gate
 func TestLiveCommonDefaultHeadlessGateStop(t *testing.T) {
-	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyTODO{liveTODO("claude-sonnet", "26nk8qd48zknqnn4kc123sez"), liveTODO("codex", "26nk8qd48zknqnn4kc123sez"), liveTODO("pi", "26nk8qd48zknqnn4kc123sez")}, runGateStopScenario, assertGateHeld)
+	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyTODO{liveTODO("pi", "26nk8qd48zknqnn4kc123sez")}, runGateStopScenario, assertGateHeld)
 }
 
 //spacedock:live-journey id=withdrawn-gate-recovery fixture=recorded-gate/withdrawn


### PR DESCRIPTION
Headless gate-stop tests now prove the real direct-gate journey and retain durable evidence when it succeeds or fails.

## What changed

- Start the fixture from a queued initial stage.
- Grade the implementation-to-validation direct-gate sequence.
- Retain provider-neutral workflow evidence on every outcome.
- Reject post-prepare authority crossings with focused mutants.

## Evidence

- 3/3 required local suites passed: focused, full, and race.
- 1/1 supported Sonnet journey retained; the final oracle-only delta regraded it green.

---
[26n](/spacedock-dev/spacedock/blob/e215d5aeda5aff2fa6fc76f51b7ba66527893814/headless-recorded-gate-stop-stage-coherence/index.md)
