### PR TITLE
Simplify the unreleased v1 gate-state schema

### DIFF
--- a/docs/schema/entity.mdschema.yml
+++ b/docs/schema/entity.mdschema.yml
@@ -110,7 +110,7 @@
         "semantics": "closed canonical-v1 binary-owned durable gate records: logical gates, ordered stable attempts, one Briefing binding per attempt, optional reasoned withdrawal, and the exact adopted Resolution; the known opaque application subtree is owned by the application layer",
         "writer": "spacedock gate prepare|withdraw|record|consume",
         "invariants": [
-          "gates.current selects one logical gate and the last ordered attempt in each record is current",
+          "entity status selects exactly one record by stage; duplicate stage records fail closed and the last ordered attempt is current",
           "open attempts may replace their one briefing binding",
           "neither withdrawal nor Resolution means open; withdrawal alone means withdrawn; Resolution alone means closed; withdrawn and closed attempts are frozen",
           "withdrawal is request-backed and carries only fixed agent:first-officer attribution, a UTC timestamp, and a nonblank reason",
@@ -123,7 +123,7 @@
       "review-round": {
         "type": "mapping",
         "fields": ["id", "stage", "cycle", "briefing"],
-        "briefing_fields": ["id", "digest", "digest-domain", "room-ref"],
+        "briefing_fields": ["id", "digest", "room-ref"],
         "semantics": "current pointer to one immutable complete advisory Review & Gate room; exact replay is a no-op and divergent reuse fails closed",
         "writer": "spacedock gate record --round",
         "invariants": [

--- a/docs/specs/gate-resolution-frontmatter-contract.md
+++ b/docs/specs/gate-resolution-frontmatter-contract.md
@@ -68,8 +68,6 @@ The binary accepts and emits one canonical `gates:` shape:
 ```yaml
 gates:
   version: 1
-  current:
-    gate: gate:example:sample:validation
   records:
     - id: gate:example:sample:validation
       stage: validation
@@ -78,7 +76,6 @@ gates:
           briefing:
             id: briefing:sample-validation-1a
             digest: sha256:3333333333333333333333333333333333333333333333333333333333333333
-            digest-domain: canonical-bytes
             request-digest: sha256:4444444444444444444444444444444444444444444444444444444444444444
             room-ref: ./review/validation/briefing-1
           provider-evidence:
@@ -101,19 +98,20 @@ gates:
 `records` and `attempts` are ordered. The last attempt in a record is current. An
 attempt is open when both `withdrawal` and `resolution` are absent, withdrawn when only
 `withdrawal` is present, and closed when only `resolution` is present. Withdrawn and
-closed attempts are frozen. `gates.current.gate` selects the logical gate eligible for
-later application. These facts remove any need for separate attempt pointers, sequence
+closed attempts are frozen. Entity `status` selects exactly one record by its `stage`;
+duplicate stage records fail closed. The last ordered attempt in that record is current
+and eligible for later application. These facts remove any need for separate attempt pointers, sequence
 numbers, lineage pointers, or explicit lifecycle state.
 
 The binary-owned model is closed: unsupported fields inside `gates` fail validation.
-In particular, the pilot-only `gates.current.attempt`, `current-attempt`, `sequence`,
+In particular, the pilot-only attempt selector, `current-attempt`, `sequence`,
 `previous-attempt`, and explicit attempt `state` encodings are rejected. There is no
 migration or compatibility rewrite. The `application` field is the typed one-use
 lifecycle boundary owned by the application layer on the same canonical-v1 writer surface.
 
-Every Briefing binding includes an id, SHA-256 digest, the `canonical-bytes` digest
-domain, and an exact file or room reference. `canonical-bytes` is SHA-256 over RFC
-8785/JCS canonical Briefing JSON bytes. A request-backed room additionally freezes its
+Every Briefing binding includes an id, canonical SHA-256 digest, and an exact file or room
+reference. Version 1 digests are unconditionally RFC 8785/JCS canonical Briefing JSON
+bytes. A request-backed room additionally freezes its
 request digest; that request names the canonical Briefing with a clean room-relative
 locator, id, and digest. No reader infers a canonical basename.
 
@@ -189,7 +187,7 @@ Before either ordinary close, the recorder resolves authoritative current status
 workflow taxonomy and requires a nonterminal `gate: true` stage. The bound Briefing must use the canonical v1 stage-qualified identity and name that same stage. Malformed identity, mismatch, or non-actionable stage fails before Resolution construction and leaves entity bytes unchanged.
 
 Cross-logical-gate re-entry is ordinary: workflow stage selects the target record even
-when `gates.current.gate` names a different closed gate. The successful write selects the
+when another stage's closed gate is retained in history. The successful write selects the
 target record but does not modify either record's earlier closures.
 
 ## Room-backed Result association
@@ -316,8 +314,8 @@ outside `gates` and the Markdown body are preserved byte-for-byte. The per-entit
 rejects concurrent recorder writers; there is no retry, lease, daemon, or recovery
 protocol.
 
-The model enforces unique gate, attempt, Briefing, and Resolution ids; a resolvable
-current logical gate; non-empty attempt histories; exact Resolution-to-Briefing binding;
+The model enforces unique gate, stage, attempt, Briefing, and Resolution ids; a unique
+status-matched logical gate when one exists; non-empty attempt histories; exact Resolution-to-Briefing binding;
 and portable `approve`, `revise`, or `hold` decisions. `revise` and `hold` require a
 reason or an included same-Briefing Annotation. Withdrawals require fixed
 `agent:first-officer` attribution, a UTC timestamp, a nonblank reason, and a valid
@@ -347,7 +345,7 @@ decision; it does not authenticate chat or apply the result.
 
 ## Explicitly outside v1
 
-- Prototype-format compatibility, `raw-file-pin`, migration, and arbitrary
+- Prototype-format compatibility, migration, and arbitrary
   unknown-field preservation inside `gates`.
 - Presentation-channel execution, transport, UI, and evidence production beyond the
   opaque prepared-room handoff.
@@ -361,7 +359,7 @@ decision; it does not authenticate chat or apply the result.
 The release tests must fail if any of these outcomes regress:
 
 1. Open/rebind/close/successor behavior changes, or a successor mutates a frozen closure.
-2. Cross-gate re-entry targets global selection instead of current workflow stage.
+2. Cross-gate re-entry follows current workflow stage rather than historical records.
 3. A prototype field or arbitrary unknown binary-owned field becomes readable or writable.
 4. A stale, invalid, or lock-contended write changes the entity.
 5. A canonical write changes bytes outside `gates` or alters opaque application data.

--- a/internal/cli/gate_test.go
+++ b/internal/cli/gate_test.go
@@ -1150,13 +1150,13 @@ func unboundGateRoomFixture(t *testing.T) (root, entity, room string) {
 	}
 	writeFile(t, entity, "---\nstatus: validation\ntitle: Task\ngates:\n"+
 		"  version: 1\n"+
-		"  current: {gate: 'gate:docs-dev:3k:validation'}\n"+
+		""+
 		"  records:\n"+
 		"    - id: gate:docs-dev:3k:validation\n"+
 		"      stage: validation\n"+
 		"      attempts:\n"+
 		"        - id: gate-attempt:3k-validation-1\n"+
-		"          briefing: {id: 'briefing:docs-dev:3k:validation:attempt-1:revision-1', digest: '"+briefingDigest+"', digest-domain: canonical-bytes, request-digest: '"+requestDigest+"', room-ref: ./review/validation/briefing-1}\n"+
+		"          briefing: {id: 'briefing:docs-dev:3k:validation:attempt-1:revision-1', digest: '"+briefingDigest+"', request-digest: '"+requestDigest+"', room-ref: ./review/validation/briefing-1}\n"+
 		"---\n# Task\n")
 	return root, entity, room
 }
@@ -1269,7 +1269,7 @@ func semanticDecisionFixture(t *testing.T) (root, entity string) {
 	root = t.TempDir()
 	writeFile(t, filepath.Join(root, "README.md"), "---\nid-style: slug\nstages:\n  states:\n    - name: validation\n      initial: true\n      gate: true\n    - name: done\n      terminal: true\n---\n# Workflow\n")
 	entity = filepath.Join(root, "task.md")
-	writeFile(t, entity, "---\nstatus: validation\ngates:\n  version: 1\n  current:\n    gate: gate:docs-dev:3k:validation\n  records:\n    - id: gate:docs-dev:3k:validation\n      stage: validation\n      attempts:\n        - id: gate-attempt:3k-validation-1\n          briefing:\n            id: briefing:docs-dev:3k:validation:attempt-1:revision-1\n            digest: sha256:0a54f1baec0120c1c93523e6900a6ce28e025c570289e5dfa9835e28099042ac\n            digest-domain: canonical-bytes\n            room-ref: ./review/validation/briefing-1\ntitle: Task\n---\n# Task\n")
+	writeFile(t, entity, "---\nstatus: validation\ngates:\n  version: 1\n  records:\n    - id: gate:docs-dev:3k:validation\n      stage: validation\n      attempts:\n        - id: gate-attempt:3k-validation-1\n          briefing:\n            id: briefing:docs-dev:3k:validation:attempt-1:revision-1\n            digest: sha256:0a54f1baec0120c1c93523e6900a6ce28e025c570289e5dfa9835e28099042ac\n            room-ref: ./review/validation/briefing-1\ntitle: Task\n---\n# Task\n")
 	briefing := filepath.Join(root, "review", "validation", "briefing-1", "briefing.json")
 	if err := os.MkdirAll(filepath.Dir(briefing), 0o755); err != nil {
 		t.Fatal(err)
@@ -1283,7 +1283,7 @@ func gateRecordCoherenceCLIFixture(t *testing.T, currentStage, briefingID, stage
 	root = t.TempDir()
 	writeFile(t, filepath.Join(root, "README.md"), "---\nid-style: slug\nstages:\n  states:\n    - name: "+currentStage+"\n"+stageFlags+"    - name: next\n---\n# Workflow\n")
 	entity = filepath.Join(root, "task.md")
-	writeFile(t, entity, "---\nstatus: "+currentStage+"\ngates:\n  version: 1\n  current:\n    gate: gate:task:"+currentStage+"\n  records:\n    - id: gate:task:"+currentStage+"\n      stage: "+currentStage+"\n      attempts:\n        - id: gate-attempt:task-"+currentStage+"-1\n          briefing:\n            id: "+briefingID+"\n            digest: sha256:"+strings.Repeat("1", 64)+"\n            digest-domain: canonical-bytes\n            room-ref: ./review/"+currentStage+"/briefing-1\ntitle: Task\n---\n# Task\n")
+	writeFile(t, entity, "---\nstatus: "+currentStage+"\ngates:\n  version: 1\n  records:\n    - id: gate:task:"+currentStage+"\n      stage: "+currentStage+"\n      attempts:\n        - id: gate-attempt:task-"+currentStage+"-1\n          briefing:\n            id: "+briefingID+"\n            digest: sha256:"+strings.Repeat("1", 64)+"\n            room-ref: ./review/"+currentStage+"/briefing-1\ntitle: Task\n---\n# Task\n")
 	return root, entity
 }
 
@@ -1304,7 +1304,7 @@ func crossGateFixture(t *testing.T) (root, entity, briefing string) {
 	writeFile(t, filepath.Join(root, "README.md"), "---\nid-style: slug\nstages:\n  states:\n    - name: ideation\n      initial: true\n    - name: validation\n---\n# Workflow\n")
 	entity = filepath.Join(root, "durable-gate-approval-pending-blockers.md")
 	digest := func(char string) string { return "sha256:" + strings.Repeat(char, 64) }
-	writeFile(t, entity, "---\nstatus: ideation\ngates:\n  version: 1\n  current:\n    gate: gate:docs-dev:3k:validation\n  records:\n    - id: gate:docs-dev:3k:ideation\n      stage: ideation\n      attempts:\n        - id: gate-attempt:3k-ideation-9\n          briefing:\n            id: briefing:ideation:9\n            digest: "+digest("1")+"\n            digest-domain: canonical-bytes\n            room-ref: ./review/ideation/9\n          resolution:\n            type: Resolution\n            id: resolution:ideation:9\n            briefing: briefing:ideation:9\n            by: person:captain\n            at: 2026-07-22T00:00:00Z\n            decision: approve\n          application:\n            action: advance\n            target-stage: validation\n            state: pending\n            blockers: [{id: blocker:preserve-me, state: unsatisfied}]\n    - id: gate:docs-dev:3k:validation\n      stage: validation\n      attempts:\n        - id: gate-attempt:3k-validation-1\n          briefing:\n            id: briefing:validation:1\n            digest: "+digest("2")+"\n            digest-domain: canonical-bytes\n            room-ref: ./review/validation/1\n          resolution:\n            type: Resolution\n            id: resolution:validation:1\n            briefing: briefing:validation:1\n            by: person:captain\n            at: 2026-07-22T00:00:00Z\n            decision: revise\n            reason: Re-enter ideation.\nsprint: durable-decisions\ntitle: Task\n---\n# Task\n")
+	writeFile(t, entity, "---\nstatus: ideation\ngates:\n  version: 1\n  records:\n    - id: gate:docs-dev:3k:ideation\n      stage: ideation\n      attempts:\n        - id: gate-attempt:3k-ideation-9\n          briefing:\n            id: briefing:ideation:9\n            digest: "+digest("1")+"\n            room-ref: ./review/ideation/9\n          resolution:\n            type: Resolution\n            id: resolution:ideation:9\n            briefing: briefing:ideation:9\n            by: person:captain\n            at: 2026-07-22T00:00:00Z\n            decision: approve\n          application:\n            action: advance\n            target-stage: validation\n            state: pending\n            blockers: [{id: blocker:preserve-me, state: unsatisfied}]\n    - id: gate:docs-dev:3k:validation\n      stage: validation\n      attempts:\n        - id: gate-attempt:3k-validation-1\n          briefing:\n            id: briefing:validation:1\n            digest: "+digest("2")+"\n            room-ref: ./review/validation/1\n          resolution:\n            type: Resolution\n            id: resolution:validation:1\n            briefing: briefing:validation:1\n            by: person:captain\n            at: 2026-07-22T00:00:00Z\n            decision: revise\n            reason: Re-enter ideation.\nsprint: durable-decisions\ntitle: Task\n---\n# Task\n")
 	briefing = filepath.Join(root, "review", "ideation", "briefing-18", "briefing.json")
 	if err := os.MkdirAll(filepath.Dir(briefing), 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/cli/terminal_consume_test.go
+++ b/internal/cli/terminal_consume_test.go
@@ -187,14 +187,6 @@ func TestTerminalDeliveryFailureReworkRoundTrip(t *testing.T) {
 	if got := gateApplicationStates(t, entity); !slices.Equal(got, []string{"superseded"}) {
 		t.Fatalf("--rework application states = %v, want [superseded]", got)
 	}
-	doc, _, err := gates.Read(entity)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if doc.Current.Gate != "gate:task:validation" {
-		t.Fatalf("--rework moved gates.current: %q", doc.Current.Gate)
-	}
-
 	// Rework; re-enter the gated stage through the normal lifecycle.
 	if code, out, errOut := terminalInvoke(t, root, "status", "--workflow-dir", root, "--set", "task", "status=validation"); code != 0 {
 		t.Fatalf("re-enter validation exit=%d stdout=%q stderr=%q", code, out, errOut)

--- a/internal/ensigncycle/gate_assert_impl_test.go
+++ b/internal/ensigncycle/gate_assert_impl_test.go
@@ -65,7 +65,7 @@ func assertGateHeld(before, after string, expected gateHeldExpectation) error {
 	}
 	var selected *gates.GateRecord
 	for i := range doc.Records {
-		if doc.Records[i].ID == doc.Current.Gate {
+		if doc.Records[i].Stage == "validation" {
 			selected = &doc.Records[i]
 			break
 		}

--- a/internal/ensigncycle/gate_assert_test.go
+++ b/internal/ensigncycle/gate_assert_test.go
@@ -22,8 +22,6 @@ func staticGateHeldExpectation() gateHeldExpectation {
 func recordedGateHeldEntity() string {
 	gates := "gates:\n" +
 		"  version: 1\n" +
-		"  current:\n" +
-		"    gate: gate:docs-dev:3k:validation\n" +
 		"  records:\n" +
 		"    - id: gate:docs-dev:3k:validation\n" +
 		"      stage: validation\n" +
@@ -32,7 +30,6 @@ func recordedGateHeldEntity() string {
 		"          briefing:\n" +
 		"            id: " + recordedGateBriefingID + "\n" +
 		"            digest: " + recordedGateDigest + "\n" +
-		"            digest-domain: canonical-bytes\n" +
 		"            room-ref: rooms/validation/attempt-1/revision-1\n"
 	return strings.Replace(recordedGateEntity(), "---\n# Recorded Gate Task", gates+"---\n# Recorded Gate Task", 1)
 }

--- a/internal/ensigncycle/recorded_gate_lifecycle_test.go
+++ b/internal/ensigncycle/recorded_gate_lifecycle_test.go
@@ -105,7 +105,8 @@ func assertRecordedGateLifecycle(o recordedGateObservation) error {
 		value string
 		count int
 	}{
-		{"gate identity", "gate: " + gateID, 1},
+		{"gate record identity", "id: " + gateID, 1},
+		{"gate record stage", "stage: validation", 1},
 		{"attempt identity", "id: " + attemptID, 1},
 		{"briefing identity", "id: " + briefingID, 1},
 		{"briefing resolution link", "briefing: " + briefingID, 1},
@@ -723,7 +724,7 @@ func TestRecordedGateLifecycleProvenanceMutants(t *testing.T) {
 	valid := recordedGateObservation{
 		events: append([]string(nil), recordedGateRequiredEvents...),
 		before: "status: validation",
-		after: "status: handoff\ngate: gate:recorded-gate-task:validation\nid: gate-attempt:recorded-gate-task-validation-1\n" +
+		after: "status: handoff\nid: gate:recorded-gate-task:validation\nstage: validation\nid: gate-attempt:recorded-gate-task-validation-1\n" +
 			"id: " + recordedGateBriefingID + "\ndigest: " + recordedGateDigest + "\n" +
 			"id: resolution:spacedock:recorded-gate-task:validation:1\nbriefing: " + recordedGateBriefingID + "\n" +
 			"by: agent:first-officer\n                decision: approve\n                reason: " + recordedGateReason + "\n" +

--- a/internal/ensigncycle/shared_round_recording_test.go
+++ b/internal/ensigncycle/shared_round_recording_test.go
@@ -138,11 +138,11 @@ func assertRejectionRoundGateBoundary(entityPath, wantStatus string) error {
 	if wantStatus != "validation" {
 		return fmt.Errorf("round-only state contains an ordinary gate record; `gate record --round` must retain only advisory review-round state")
 	}
-	if len(doc.Records) != 1 || doc.Current.Gate != "gate:rejection-task:validation" {
+	if len(doc.Records) != 1 || doc.Records[0].Stage != "validation" {
 		return fmt.Errorf("final gate selection does not identify exactly one rejection-task validation gate")
 	}
 	record := doc.Records[0]
-	if record.ID != doc.Current.Gate || record.Stage != "validation" || len(record.Attempts) != 1 {
+	if record.Stage != "validation" || len(record.Attempts) != 1 {
 		return fmt.Errorf("selected validation gate does not contain exactly one attempt")
 	}
 	attempt := record.Attempts[0]
@@ -300,7 +300,7 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 	for _, control := range []struct{ entity, want string }{
 		{strings.Replace(openGateEntity, "              briefing:\n", "              state: open\n              briefing:\n", 1), "malformed final validation gate"},
 		{strings.Replace(openGateEntity, rejectionPreparedBriefingID, rejectionBriefingID, 1), "validation/1 advisory round was retained as a gate attempt"},
-		{strings.ReplaceAll(openGateEntity, "gate:rejection-task:validation", "gate:rejection-task:wrong"), "final gate selection does not identify"},
+		{strings.Replace(openGateEntity, "      stage: validation", "      stage: wrong", 1), "final gate selection does not identify"},
 	} {
 		writeFile(t, entityPath, control.entity)
 		if err := assertRejectionRecordedRound(root, entityPath, "validation", true); err == nil ||

--- a/internal/gates/application.go
+++ b/internal/gates/application.go
@@ -20,14 +20,8 @@ func EvaluateEligibility(doc *Document, status string, reviewedInputCurrent bool
 	if doc == nil {
 		return result
 	}
-	var record *GateRecord
-	for i := range doc.Records {
-		if doc.Records[i].ID == doc.Current.Gate {
-			record = &doc.Records[i]
-			break
-		}
-	}
-	if record == nil || len(record.Attempts) == 0 {
+	record, err := recordForStage(doc, status)
+	if err != nil || len(record.Attempts) == 0 {
 		return result
 	}
 	attempt := &record.Attempts[len(record.Attempts)-1]
@@ -103,7 +97,7 @@ func eligibilityFileAt(path, workflowDir string) (Eligibility, error) {
 		return Eligibility{}, err
 	}
 	inputState := reviewedInputUnknown
-	if record := findRecord(doc, doc.Current.Gate); record != nil && len(record.Attempts) > 0 {
+	if record, err := recordForStage(doc, status); err == nil && len(record.Attempts) > 0 {
 		inputState = inspectReviewedInput(path, record.Attempts[len(record.Attempts)-1].Briefing)
 	}
 	result := EvaluateEligibility(doc, status, inputState == reviewedInputCurrent)
@@ -140,9 +134,9 @@ func ConsumeAt(path, workflowDir string) (ConsumeResult, error) {
 	if err != nil {
 		return ConsumeResult{}, err
 	}
-	record := findRecord(doc, doc.Current.Gate)
+	record, recordErr := recordForStage(doc, status)
 	inputState := reviewedInputUnknown
-	if record != nil && len(record.Attempts) > 0 {
+	if recordErr == nil && len(record.Attempts) > 0 {
 		inputState = inspectReviewedInput(path, record.Attempts[len(record.Attempts)-1].Briefing)
 	}
 	eligibility := EvaluateEligibility(doc, status, inputState == reviewedInputCurrent)
@@ -252,21 +246,16 @@ func inspectReviewedInput(entityPath string, binding Briefing) reviewedInputChec
 	path := filepath.Join(filepath.Dir(entityPath), filepath.FromSlash(binding.RoomRef))
 	var digest string
 	var err error
-	switch binding.DigestDomain {
-	case "canonical-bytes":
-		var data []byte
-		if binding.RequestDigest == "" {
-			data, err = os.ReadFile(path)
-		} else {
-			data, _, err = boundBriefingBytes(entityPath, binding)
-		}
-		if err != nil {
-			return reviewedInputUnknown
-		}
-		digest, err = CanonicalDigest(data)
-	default:
+	var data []byte
+	if binding.RequestDigest == "" {
+		data, err = os.ReadFile(path)
+	} else {
+		data, _, err = boundBriefingBytes(entityPath, binding)
+	}
+	if err != nil {
 		return reviewedInputUnknown
 	}
+	digest, err = CanonicalDigest(data)
 	if err == nil && digest == binding.Digest {
 		return reviewedInputCurrent
 	}

--- a/internal/gates/application_test.go
+++ b/internal/gates/application_test.go
@@ -129,9 +129,9 @@ func TestRecordRequiresCanonicalBriefingAtActionableCurrentStage(t *testing.T) {
 
 func TestRecordCanonicalSuccessorAndCrossGateReentry(t *testing.T) {
 	root, entity := recordStageFixture(t, "ideation", "briefing:org:task:ideation:attempt-2:revision-3", "      gate: true\n")
-	validationRecord := "    - id: gate:task:validation\n      stage: validation\n      attempts:\n        - id: gate-attempt:task-validation-1\n          briefing: {id: 'briefing:task:validation:attempt-1:revision-1', digest: 'sha256:" + strings.Repeat("2", 64) + "', digest-domain: canonical-bytes, room-ref: ./review/validation/briefing-1}\n          resolution: {type: Resolution, id: resolution:validation:1, briefing: 'briefing:task:validation:attempt-1:revision-1', by: person:captain, at: now, decision: revise, reason: rework}\n"
-	ideationPrior := "        - id: gate-attempt:task-ideation-1\n          briefing: {id: 'briefing:task:ideation:attempt-1:revision-1', digest: 'sha256:" + strings.Repeat("3", 64) + "', digest-domain: canonical-bytes, room-ref: ./review/ideation/briefing-1}\n          resolution: {type: Resolution, id: resolution:ideation:1, briefing: 'briefing:task:ideation:attempt-1:revision-1', by: person:captain, at: now, decision: hold, reason: wait}\n"
-	body := strings.Replace(readFile(t, entity), "current: {gate: 'gate:task:ideation'}", "current: {gate: 'gate:task:validation'}", 1)
+	validationRecord := "    - id: gate:task:validation\n      stage: validation\n      attempts:\n        - id: gate-attempt:task-validation-1\n          briefing: {id: 'briefing:task:validation:attempt-1:revision-1', digest: 'sha256:" + strings.Repeat("2", 64) + "', room-ref: ./review/validation/briefing-1}\n          resolution: {type: Resolution, id: resolution:validation:1, briefing: 'briefing:task:validation:attempt-1:revision-1', by: person:captain, at: now, decision: revise, reason: rework}\n"
+	ideationPrior := "        - id: gate-attempt:task-ideation-1\n          briefing: {id: 'briefing:task:ideation:attempt-1:revision-1', digest: 'sha256:" + strings.Repeat("3", 64) + "', room-ref: ./review/ideation/briefing-1}\n          resolution: {type: Resolution, id: resolution:ideation:1, briefing: 'briefing:task:ideation:attempt-1:revision-1', by: person:captain, at: now, decision: hold, reason: wait}\n"
+	body := readFile(t, entity)
 	body = strings.Replace(body, "    - id: gate:task:ideation\n", validationRecord+"    - id: gate:task:ideation\n", 1)
 	body = strings.Replace(body, "        - id: gate-attempt:task-ideation-2\n", ideationPrior+"        - id: gate-attempt:task-ideation-2\n", 1)
 	if err := os.WriteFile(entity, []byte(body), 0o644); err != nil {
@@ -149,9 +149,6 @@ func TestRecordCanonicalSuccessorAndCrossGateReentry(t *testing.T) {
 	doc, _, err = Read(entity)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if doc.Current.Gate != "gate:task:ideation" {
-		t.Fatalf("current gate = %q, want re-entered ideation", doc.Current.Gate)
 	}
 	if got := marshalAttempt(t, doc.Records[0].Attempts[0]); got != validationBefore {
 		t.Fatal("cross-gate re-entry modified the formerly selected validation record")
@@ -322,7 +319,7 @@ func TestEightCanonicalApplicationShapesReplayByteIdentical(t *testing.T) {
 			if tc.decision != "approve" {
 				reason = "\n            reason: recorded rationale"
 			}
-			source := "---\nstatus: ideation\ngates:\n  version: 1\n  current:\n    gate: gate:replay\n  records:\n    - id: gate:replay\n      stage: ideation\n      attempts:\n        - id: attempt:replay-" + string(rune('a'+i)) + "\n          briefing:\n            id: briefing:replay\n            digest: sha256:" + strings.Repeat("1", 64) + "\n            digest-domain: canonical-bytes\n            room-ref: ./review\n          resolution:\n            type: Resolution\n            id: resolution:replay\n            briefing: briefing:replay\n            by: person:captain\n            at: 2026-07-22T00:00:00Z\n            decision: " + tc.decision + reason + "\n          application:\n            " + tc.application + "\n---\n# Replay\n"
+			source := "---\nstatus: ideation\ngates:\n  version: 1\n  records:\n    - id: gate:replay\n      stage: ideation\n      attempts:\n        - id: attempt:replay-" + string(rune('a'+i)) + "\n          briefing:\n            id: briefing:replay\n            digest: sha256:" + strings.Repeat("1", 64) + "\n            room-ref: ./review\n          resolution:\n            type: Resolution\n            id: resolution:replay\n            briefing: briefing:replay\n            by: person:captain\n            at: 2026-07-22T00:00:00Z\n            decision: " + tc.decision + reason + "\n          application:\n            " + tc.application + "\n---\n# Replay\n"
 			doc, _, err := readData([]byte(source))
 			if err != nil {
 				t.Fatal(err)
@@ -362,10 +359,10 @@ func TestEightCanonicalApplicationShapesReplayByteIdentical(t *testing.T) {
 
 func eligibleDocument() *Document {
 	blockers := []Blocker{}
-	return &Document{Version: 1, Current: Selection{Gate: "gate:task:ideation"}, Records: []GateRecord{{
+	return &Document{Version: 1, Records: []GateRecord{{
 		ID: "gate:task:ideation", Stage: "ideation", Attempts: []Attempt{{
 			ID:          "attempt:1",
-			Briefing:    Briefing{ID: "briefing:1", Digest: "sha256:" + strings.Repeat("1", 64), DigestDomain: "canonical-bytes", RoomRef: "./review"},
+			Briefing:    Briefing{ID: "briefing:1", Digest: "sha256:" + strings.Repeat("1", 64), RoomRef: "./review"},
 			Resolution:  &Resolution{Type: "Resolution", ID: "resolution:1", Briefing: "briefing:1", By: "person:captain", At: "now", Decision: "approve"},
 			Application: &Application{Action: "advance", TargetStage: "implementation", State: "pending", Blockers: &blockers},
 		}},
@@ -398,13 +395,12 @@ func applicationWorkflow(t *testing.T) (string, string) {
 	}
 	entityBytes := "---\nstatus: ideation\ntitle: Preserve formatting\ngates:\n" +
 		"  version: 1\n" +
-		"  current: {gate: 'gate:task:ideation'}\n" +
 		"  records:\n" +
 		"    - id: gate:task:ideation\n" +
 		"      stage: ideation\n" +
 		"      attempts:\n" +
 		"        - id: gate-attempt:task-ideation-1\n" +
-		"          briefing: {id: 'briefing:task:ideation:attempt-1:revision-1', digest: '" + digest + "', digest-domain: canonical-bytes, room-ref: ./review/ideation/briefing-1/briefing.json}\n" +
+		"          briefing: {id: 'briefing:task:ideation:attempt-1:revision-1', digest: '" + digest + "', room-ref: ./review/ideation/briefing-1/briefing.json}\n" +
 		"---\n# Task\nBody.\n"
 	if err := os.WriteFile(entity, []byte(entityBytes), 0o644); err != nil {
 		t.Fatal(err)
@@ -421,8 +417,8 @@ func recordStageFixture(t *testing.T, status, briefingID, stageFlags string) (st
 	}
 	entity := filepath.Join(root, "task.md")
 	digest := "sha256:" + strings.Repeat("1", 64)
-	records := "    - id: gate:task:" + status + "\n      stage: " + status + "\n      attempts:\n        - id: gate-attempt:task-" + status + "-2\n          briefing: {id: '" + briefingID + "', digest: '" + digest + "', digest-domain: canonical-bytes, room-ref: ./review/" + status + "/briefing-2}\n"
-	body := "---\nstatus: " + status + "\ngates:\n  version: 1\n  current: {gate: 'gate:task:" + status + "'}\n  records:\n" + records + "---\n# Task\n"
+	records := "    - id: gate:task:" + status + "\n      stage: " + status + "\n      attempts:\n        - id: gate-attempt:task-" + status + "-2\n          briefing: {id: '" + briefingID + "', digest: '" + digest + "', room-ref: ./review/" + status + "/briefing-2}\n"
+	body := "---\nstatus: " + status + "\ngates:\n  version: 1\n  records:\n" + records + "---\n# Task\n"
 	if err := os.WriteFile(entity, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -516,7 +512,7 @@ func TestTerminalSpendAndReworkGuardReuse(t *testing.T) {
 	// A second spend is impossible: the once-consumed application is not
 	// pending, so eligibility refuses it before any writer runs.
 	consumedDoc := *doc
-	consumed := EvaluateEligibility(&consumedDoc, "implementation", true)
+	consumed := EvaluateEligibility(&consumedDoc, "ideation", true)
 	if consumed.Eligible || consumed.Condition != "consumed" {
 		t.Fatalf("re-spend eligibility = %#v, want fail-closed consumed", consumed)
 	}

--- a/internal/gates/delivery.go
+++ b/internal/gates/delivery.go
@@ -29,7 +29,10 @@ func FinalizeTerminalApproval(path, workflowDir, verdict, completedStamp string)
 		return "", err
 	}
 	defer unlock()
-	record := findRecord(doc, doc.Current.Gate)
+	record, err := recordForStage(doc, status)
+	if err != nil {
+		return "", err
+	}
 	attempt := &record.Attempts[len(record.Attempts)-1]
 	attempt.Application.State = "consumed"
 	if err := validateApplicationMutation(oldNode, doc, attempt.ID, "pending", "consumed"); err != nil {
@@ -49,7 +52,7 @@ func FinalizeTerminalApproval(path, workflowDir, verdict, completedStamp string)
 // back for rework: in ONE locked compare-before-replace candidate it writes
 // application.state pending→superseded (the same guarded mutation the drift
 // path uses) and status := the record stage's validated declared feedback-to.
-// gates.current is untouched; the superseded attempt is frozen history —
+// the superseded attempt is frozen history —
 // re-entry runs a successor attempt with a fresh approval. verdict/completed
 // are never written pre-delivery.
 //
@@ -68,7 +71,10 @@ func SupersedeTerminalApproval(path, workflowDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	record := findRecord(doc, doc.Current.Gate)
+	record, err := recordForStage(doc, status)
+	if err != nil {
+		return "", err
+	}
 	attempt := &record.Attempts[len(record.Attempts)-1]
 	attempt.Application.State = "superseded"
 	if err := validateApplicationMutation(oldNode, doc, attempt.ID, "pending", "superseded"); err != nil {
@@ -171,7 +177,10 @@ func lockPendingTerminalApproval(path, workflowDir string) (unlock func(), doc *
 	if err != nil {
 		return fail(err)
 	}
-	record := findRecord(doc, doc.Current.Gate)
+	record, err := recordForStage(doc, status)
+	if err != nil {
+		return fail(err)
+	}
 	inputState := reviewedInputUnknown
 	if record != nil && len(record.Attempts) > 0 {
 		inputState = inspectReviewedInput(path, record.Attempts[len(record.Attempts)-1].Briefing)

--- a/internal/gates/delivery_test.go
+++ b/internal/gates/delivery_test.go
@@ -90,9 +90,6 @@ func TestFinalizeTerminalApprovalOneLockedReplacement(t *testing.T) {
 			t.Fatalf("final entity missing %q:\n%s", want, finalBytes)
 		}
 	}
-	if doc.Current.Gate != "gate:task:ideation" {
-		t.Fatalf("finalize moved gates.current: %q", doc.Current.Gate)
-	}
 	if !strings.Contains(string(finalBytes), "Body.\n") {
 		t.Fatalf("finalize disturbed the entity body:\n%s", finalBytes)
 	}
@@ -193,14 +190,6 @@ func TestSupersedeTerminalApprovalRoutesDeclaredFeedback(t *testing.T) {
 			t.Fatalf("--rework wrote terminal field %q pre-delivery:\n%s", banned, finalBytes)
 		}
 	}
-	doc, _, err := Read(entity)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if doc.Current.Gate != "gate:task:ideation" {
-		t.Fatalf("--rework moved gates.current: %q", doc.Current.Gate)
-	}
-
 	// Refusal matrix: each malformed declaration refuses closed, byte-clean.
 	for _, tc := range []struct {
 		name       string

--- a/internal/gates/gates_test.go
+++ b/internal/gates/gates_test.go
@@ -106,6 +106,15 @@ func TestCurrentStageReadinessFailClosedTable(t *testing.T) {
 			a.Resolution.Decision, a.Resolution.Reason = "revise", "changes requested"
 			a.Application = &Application{Action: "feedback", TargetStage: "ideation", State: "pending"}
 		}, want: "feedback-pending"},
+		{name: "older terminal approval cannot override newer rejection", status: "ideation", doc: eligibleDocument(), mutate: func(d *Document) {
+			d.Records[0].Attempts[0].Application.TargetStage = "done"
+			newer := cloneDocument(t, d).Records[0].Attempts[0]
+			newer.ID, newer.Briefing.ID = "attempt:a-2", "briefing:a-2"
+			newer.Resolution.ID, newer.Resolution.Briefing = "resolution:a-2", newer.Briefing.ID
+			newer.Resolution.Decision, newer.Resolution.Reason = "revise", "changes requested"
+			newer.Application = &Application{Action: "feedback", TargetStage: "ideation", State: "pending"}
+			d.Records[0].Attempts = append(d.Records[0].Attempts, newer)
+		}, want: "feedback-pending"},
 		{name: "consumed approval", status: "ideation", doc: eligibleDocument(), mutate: setApplicationState("consumed"), want: "consumed"},
 		{name: "superseded approval", status: "ideation", doc: eligibleDocument(), mutate: setApplicationState("superseded"), want: "superseded"},
 		{name: "not applicable hold", status: "ideation", doc: eligibleDocument(), mutate: func(d *Document) {
@@ -140,15 +149,38 @@ func TestCurrentStageReadinessFailClosedTable(t *testing.T) {
 	}
 }
 
+func TestDuplicateStageRecordsFailClosedAndPreserveBytes(t *testing.T) {
+	doc := eligibleDocument()
+	duplicate := cloneDocument(t, doc).Records[0]
+	duplicate.ID = "gate:duplicate"
+	doc.Records = append(doc.Records, duplicate)
+	if got := CurrentStageReadiness(doc, "ideation", []ReadinessStage{{Name: "ideation", Gate: true}}); got != "invalid" {
+		t.Fatalf("duplicate-stage readiness = %q, want invalid", got)
+	}
+	body, err := yaml.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gatesBlock := "  " + strings.ReplaceAll(strings.TrimSuffix(string(body), "\n"), "\n", "\n  ") + "\n"
+	entity := writeEntity(t, "status: ideation\ngates:\n"+gatesBlock)
+	before := readFile(t, entity)
+	if _, _, err := Read(entity); err == nil || !strings.Contains(err.Error(), "multiple logical gates claim workflow stage ideation") {
+		t.Fatalf("duplicate-stage read error = %v, want ambiguity refusal", err)
+	}
+	if got := readFile(t, entity); got != before {
+		t.Fatal("duplicate-stage refusal changed entity bytes")
+	}
+}
+
 func TestPrototypeAndUnknownGateShapesFailClosed(t *testing.T) {
 	base := "status: ideation\n" + canonicalOpenGates()
 	cases := map[string]string{
-		"global attempt pointer":   strings.Replace(base, "    gate: gate:a\n", "    gate: gate:a\n    attempt: attempt:a-1\n", 1),
 		"record attempt pointer":   strings.Replace(base, "      stage: ideation\n", "      stage: ideation\n      current-attempt: attempt:a-1\n", 1),
 		"attempt sequence":         strings.Replace(base, "        - id: attempt:a-1\n", "        - id: attempt:a-1\n          sequence: 1\n", 1),
 		"attempt lineage":          strings.Replace(base, "        - id: attempt:a-1\n", "        - id: attempt:a-1\n          previous-attempt: attempt:a-0\n", 1),
 		"attempt state":            strings.Replace(base, "        - id: attempt:a-1\n", "        - id: attempt:a-1\n          state: open\n", 1),
-		"unknown gates field":      strings.Replace(base, "  current:\n", "  shadow: prototype\n  current:\n", 1),
+		"global attempt pointer":   strings.Replace(base, "  records:\n", "  current:\n    gate: gate:a\n  records:\n", 1),
+		"unknown gates field":      strings.Replace(base, "  records:\n", "  shadow: prototype\n  records:\n", 1),
 		"unknown record field":     strings.Replace(base, "      stage: ideation\n", "      stage: ideation\n      note: prototype\n", 1),
 		"unknown attempt field":    strings.Replace(base, "        - id: attempt:a-1\n", "        - id: attempt:a-1\n          note: prototype\n", 1),
 		"unknown briefing field":   strings.Replace(base, "            room-ref: ./room\n", "            room-ref: ./room\n            note: prototype\n", 1),
@@ -168,14 +200,14 @@ func TestPrototypeAndUnknownGateShapesFailClosed(t *testing.T) {
 	}
 }
 
-func TestLegacyRawFilePinDigestDomainFailsClosed(t *testing.T) {
-	entity := writeEntity(t, strings.Replace(canonicalOpenGates(), "digest-domain: canonical-bytes", "digest-domain: raw-file-pin", 1))
+func TestDigestDomainFieldFailsClosed(t *testing.T) {
+	entity := writeEntity(t, strings.Replace(canonicalOpenGates(), "            room-ref: ./room", "            room-ref: ./room\n            digest-domain: canonical-bytes", 1))
 	before := readFile(t, entity)
-	if _, _, err := Read(entity); err == nil || !strings.Contains(err.Error(), `unknown digest-domain "raw-file-pin"`) {
-		t.Fatalf("raw-file-pin read error = %v, want canonical-v1 refusal", err)
+	if _, _, err := Read(entity); err == nil || !strings.Contains(err.Error(), "field") {
+		t.Fatalf("digest-domain read error = %v, want canonical-v1 refusal", err)
 	}
 	if got := readFile(t, entity); got != before {
-		t.Fatal("rejected raw-file-pin read changed entity")
+		t.Fatal("rejected digest-domain read changed entity")
 	}
 }
 
@@ -200,7 +232,7 @@ func TestWriterCASValidationAtomicityAndLock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	doc.Current.Gate = "gate:missing"
+	doc.Records[0].Stage = ""
 	before := readFile(t, entity)
 	if err := writeDocument(entity, expected, doc); err == nil {
 		t.Fatal("invalid rebuilt document was accepted")
@@ -233,7 +265,7 @@ func TestExactCanonicalBriefingIsIndependentAssociationInventory(t *testing.T) {
 		t.Fatal(err)
 	}
 	entity := filepath.Join(filepath.Dir(room), "entity.md")
-	binding := Briefing{ID: "briefing:docs-dev:3k:validation:attempt-1:revision-1", Digest: "sha256:0a54f1baec0120c1c93523e6900a6ce28e025c570289e5dfa9835e28099042ac", DigestDomain: "canonical-bytes", RoomRef: "./room/briefing.json"}
+	binding := Briefing{ID: "briefing:docs-dev:3k:validation:attempt-1:revision-1", Digest: "sha256:0a54f1baec0120c1c93523e6900a6ce28e025c570289e5dfa9835e28099042ac", RoomRef: "./room/briefing.json"}
 	manifest, err := boundBriefingManifest(entity, binding)
 	if err != nil {
 		t.Fatal(err)
@@ -340,7 +372,7 @@ func completeBriefing(id, question string) string {
 }
 
 func canonicalOpenGates() string {
-	return "gates:\n  version: 1\n  current:\n    gate: gate:a\n  records:\n    - id: gate:a\n      stage: ideation\n      attempts:\n        - id: attempt:a-1\n          briefing:\n            id: briefing:a-1\n            digest: sha256:" + strings.Repeat("1", 64) + "\n            digest-domain: canonical-bytes\n            room-ref: ./room\n"
+	return "gates:\n  version: 1\n  records:\n    - id: gate:a\n      stage: ideation\n      attempts:\n        - id: attempt:a-1\n          briefing:\n            id: briefing:a-1\n            digest: sha256:" + strings.Repeat("1", 64) + "\n            room-ref: ./room\n"
 }
 
 func canonicalClosedFrontmatter() string {
@@ -348,7 +380,7 @@ func canonicalClosedFrontmatter() string {
 }
 
 func canonicalTwoGateFrontmatter() string {
-	return "status: ideation\ntitle: Task\ngates:\n  version: 1\n  current:\n    gate: gate:docs-dev:3k:validation\n  records:\n    - id: gate:docs-dev:3k:ideation\n      stage: ideation\n      attempts:\n        - id: gate-attempt:3k-ideation-9\n          briefing:\n            id: briefing:ideation:9\n            digest: sha256:" + strings.Repeat("1", 64) + "\n            digest-domain: canonical-bytes\n            room-ref: ./review/ideation/9\n          resolution:\n            type: Resolution\n            id: resolution:ideation:9\n            briefing: briefing:ideation:9\n            by: person:captain\n            at: 2026-07-22T00:00:00Z\n            decision: approve\n          application:\n            action: advance\n            target-stage: implementation\n            state: pending\n            blockers:\n              - id: blocker:preserve-me\n                state: unsatisfied\n    - id: gate:docs-dev:3k:validation\n      stage: validation\n      attempts:\n        - id: gate-attempt:3k-validation-1\n          briefing:\n            id: briefing:validation:1\n            digest: sha256:" + strings.Repeat("2", 64) + "\n            digest-domain: canonical-bytes\n            room-ref: ./review/validation/1\n          resolution:\n            type: Resolution\n            id: resolution:validation:1\n            briefing: briefing:validation:1\n            by: person:captain\n            at: 2026-07-22T00:00:00Z\n            decision: revise\n            reason: Re-enter ideation.\n"
+	return "status: ideation\ntitle: Task\ngates:\n  version: 1\n  records:\n    - id: gate:docs-dev:3k:ideation\n      stage: ideation\n      attempts:\n        - id: gate-attempt:3k-ideation-9\n          briefing:\n            id: briefing:ideation:9\n            digest: sha256:" + strings.Repeat("1", 64) + "\n            room-ref: ./review/ideation/9\n          resolution:\n            type: Resolution\n            id: resolution:ideation:9\n            briefing: briefing:ideation:9\n            by: person:captain\n            at: 2026-07-22T00:00:00Z\n            decision: approve\n          application:\n            action: advance\n            target-stage: implementation\n            state: pending\n            blockers:\n              - id: blocker:preserve-me\n                state: unsatisfied\n    - id: gate:docs-dev:3k:validation\n      stage: validation\n      attempts:\n        - id: gate-attempt:3k-validation-1\n          briefing:\n            id: briefing:validation:1\n            digest: sha256:" + strings.Repeat("2", 64) + "\n            room-ref: ./review/validation/1\n          resolution:\n            type: Resolution\n            id: resolution:validation:1\n            briefing: briefing:validation:1\n            by: person:captain\n            at: 2026-07-22T00:00:00Z\n            decision: revise\n            reason: Re-enter ideation.\n"
 }
 
 func readFile(t *testing.T, path string) string {

--- a/internal/gates/io.go
+++ b/internal/gates/io.go
@@ -66,7 +66,11 @@ func SummaryFileAt(path, workflowDir string) (Summary, error) {
 	if err := validateRetainedAuthority(path, workflowDir, doc); err != nil {
 		return Summary{}, err
 	}
-	return CurrentSummary(doc), nil
+	status, err := entityStatus(path)
+	if err != nil {
+		return Summary{}, err
+	}
+	return CurrentSummary(doc, status), nil
 }
 
 func validateRetainedAuthority(entityPath, workflowDir string, doc *Document) error {

--- a/internal/gates/model.go
+++ b/internal/gates/model.go
@@ -16,12 +16,7 @@ var declineDispositionRE = regexp.MustCompile(`^class: correct-but-disproportion
 
 type Document struct {
 	Version int          `yaml:"version" json:"version"`
-	Current Selection    `yaml:"current" json:"current"`
 	Records []GateRecord `yaml:"records" json:"records"`
-}
-
-type Selection struct {
-	Gate string `yaml:"gate" json:"gate"`
 }
 
 type GateRecord struct {
@@ -85,7 +80,6 @@ type Feedback struct {
 type Briefing struct {
 	ID            string `yaml:"id" json:"id"`
 	Digest        string `yaml:"digest" json:"digest"`
-	DigestDomain  string `yaml:"digest-domain" json:"digest-domain"`
 	RequestDigest string `yaml:"request-digest,omitempty" json:"request-digest,omitempty"`
 	RoomRef       string `yaml:"room-ref" json:"room-ref"`
 }
@@ -176,14 +170,14 @@ func CurrentStageReadiness(doc *Document, status string, stages []ReadinessStage
 	if doc == nil {
 		return "validating"
 	}
-	var record *GateRecord
-	for i := range doc.Records {
-		if doc.Records[i].ID == doc.Current.Gate {
-			record = &doc.Records[i]
-			break
+	record, err := recordForStage(doc, status)
+	if err != nil {
+		if strings.Contains(err.Error(), "no logical gate") {
+			return "validating"
 		}
+		return "invalid"
 	}
-	if record == nil || record.Stage != status || len(record.Attempts) == 0 {
+	if len(record.Attempts) == 0 {
 		return "validating"
 	}
 	attempt := &record.Attempts[len(record.Attempts)-1]
@@ -246,11 +240,7 @@ func Validate(doc *Document) error {
 	if doc.Version != 1 {
 		return fmt.Errorf("gates.version must be 1")
 	}
-	if doc.Current.Gate == "" {
-		return fmt.Errorf("gates.current must name a gate")
-	}
-	gateIDs, attemptIDs, briefingIDs, resolutionIDs := map[string]bool{}, map[string]bool{}, map[string]bool{}, map[string]bool{}
-	selected := false
+	gateIDs, stages, attemptIDs, briefingIDs, resolutionIDs := map[string]bool{}, map[string]bool{}, map[string]bool{}, map[string]bool{}, map[string]bool{}
 	for ri := range doc.Records {
 		r := &doc.Records[ri]
 		pendingApplications := 0
@@ -258,9 +248,10 @@ func Validate(doc *Document) error {
 			return fmt.Errorf("record %d has missing or duplicate identity or no attempts", ri+1)
 		}
 		gateIDs[r.ID] = true
-		if r.ID == doc.Current.Gate {
-			selected = true
+		if stages[r.Stage] {
+			return fmt.Errorf("multiple logical gates claim workflow stage %s", r.Stage)
 		}
+		stages[r.Stage] = true
 		for ai := range r.Attempts {
 			a := &r.Attempts[ai]
 			if a.ID == "" || attemptIDs[a.ID] {
@@ -271,9 +262,6 @@ func Validate(doc *Document) error {
 				return fmt.Errorf("attempt %s has invalid or duplicate briefing binding", a.ID)
 			}
 			briefingIDs[a.Briefing.ID] = true
-			if a.Briefing.DigestDomain != "canonical-bytes" {
-				return fmt.Errorf("attempt %s has unknown digest-domain %q", a.ID, a.Briefing.DigestDomain)
-			}
 			if a.Briefing.RequestDigest != "" && !digestRE.MatchString(a.Briefing.RequestDigest) {
 				return fmt.Errorf("attempt %s has invalid request-digest", a.ID)
 			}
@@ -327,9 +315,6 @@ func Validate(doc *Document) error {
 		if pendingApplications > 1 {
 			return fmt.Errorf("gate %s carries more than one pending application", r.ID)
 		}
-	}
-	if !selected {
-		return fmt.Errorf("gates.current pointer does not resolve to one logical gate")
 	}
 	return nil
 }
@@ -386,12 +371,14 @@ func validateResolution(r *Resolution, briefingID string) error {
 	return nil
 }
 
-func CurrentSummary(doc *Document) Summary {
-	for i := range doc.Records {
-		r := &doc.Records[i]
-		if r.ID != doc.Current.Gate || len(r.Attempts) == 0 {
-			continue
-		}
+func CurrentSummary(doc *Document, stage ...string) Summary {
+	var r *GateRecord
+	if len(stage) > 0 {
+		r, _ = recordForStage(doc, stage[0])
+	} else if len(doc.Records) == 1 {
+		r = &doc.Records[0]
+	}
+	if r != nil && len(r.Attempts) > 0 {
 		a := &r.Attempts[len(r.Attempts)-1]
 		s := Summary{Gate: r.ID, Attempt: a.ID, State: attemptState(a), Briefing: a.Briefing.ID}
 		if a.Resolution != nil {

--- a/internal/gates/operation.go
+++ b/internal/gates/operation.go
@@ -197,7 +197,11 @@ func RecordSemanticSummary(entityPath string, input RecordInput) (Summary, error
 	if err != nil {
 		return Summary{}, err
 	}
-	return CurrentSummary(doc), nil
+	stage, err := entityStatus(entityPath)
+	if err != nil {
+		return Summary{}, err
+	}
+	return CurrentSummary(doc, stage), nil
 }
 
 // Withdraw retires the selected request-backed prepared attempt without
@@ -226,12 +230,9 @@ func Withdraw(entityPath string, input WithdrawInput) (Summary, error) {
 	if err := validateRetainedAuthority(entityPath, workflowDir, doc); err != nil {
 		return Summary{}, err
 	}
-	doc, oldNode, record, attempt, err := currentStageAttempt(entityPath, workflowDir)
+	doc, oldNode, _, attempt, err := currentStageAttempt(entityPath, workflowDir)
 	if err != nil {
 		return Summary{}, err
-	}
-	if doc.Current.Gate != record.ID {
-		return Summary{}, fmt.Errorf("current workflow stage does not match gates.current selection")
 	}
 	if state := attemptState(attempt); state != "open" {
 		return Summary{}, fmt.Errorf("attempt %s is frozen %s", attempt.ID, state)
@@ -260,7 +261,11 @@ func Withdraw(entityPath string, input WithdrawInput) (Summary, error) {
 	if err := writeDocument(entityPath, oldNode, doc); err != nil {
 		return Summary{}, err
 	}
-	return CurrentSummary(doc), nil
+	stage, err := entityStatus(entityPath)
+	if err != nil {
+		return Summary{}, err
+	}
+	return CurrentSummary(doc, stage), nil
 }
 
 func recordRoomLocked(entityPath string, input RecordInput) error {
@@ -476,7 +481,7 @@ func findRecord(doc *Document, id string) *GateRecord {
 }
 
 func sameBinding(left, right Briefing) bool {
-	return left.ID == right.ID && left.Digest == right.Digest && left.DigestDomain == right.DigestDomain &&
+	return left.ID == right.ID && left.Digest == right.Digest &&
 		left.RequestDigest == right.RequestDigest && left.RoomRef == right.RoomRef
 }
 
@@ -545,7 +550,6 @@ func closeAttempt(entityPath, workflowDir string, doc *Document, oldNode *yaml.N
 	}
 	attempt.Resolution = resolution
 	attempt.Application = application
-	doc.Current.Gate = record.ID
 	if err := Validate(doc); err != nil {
 		return err
 	}
@@ -816,9 +820,6 @@ func validateGateRoomRequest(briefingPath string, binding Briefing, gateID, atte
 }
 
 func boundBriefingManifest(entityPath string, binding Briefing) (*briefingManifest, error) {
-	if binding.DigestDomain != "canonical-bytes" {
-		return nil, fmt.Errorf("Result association requires a canonical-bytes Briefing binding")
-	}
 	data, _, err := boundBriefingBytes(entityPath, binding)
 	if err != nil {
 		return nil, err

--- a/internal/gates/prepare.go
+++ b/internal/gates/prepare.go
@@ -222,7 +222,6 @@ func Prepare(entityPath string, input PrepareInput) (PrepareResult, error) {
 	binding := Briefing{
 		ID:            briefingID,
 		Digest:        briefingDigest,
-		DigestDomain:  "canonical-bytes",
 		RequestDigest: requestDigest,
 		RoomRef:       roomRef,
 	}
@@ -258,7 +257,6 @@ func Prepare(entityPath string, input PrepareInput) (PrepareResult, error) {
 		}
 		record.Attempts = append(record.Attempts, Attempt{ID: attemptID, Briefing: binding})
 	}
-	doc.Current.Gate = gateID
 	if err := Validate(doc); err != nil {
 		if created {
 			rollbackPreparedRoom(room, createdParents)

--- a/internal/gates/prepare_test.go
+++ b/internal/gates/prepare_test.go
@@ -384,7 +384,7 @@ func TestWithdrawRefusalsLeaveEntityRoomAndLockBytesClean(t *testing.T) {
 	})
 
 	t.Run("stale current selection", func(t *testing.T) {
-		workflow, state, entity, artifact, _ := prepareFixture(t, "folder")
+		workflow, _, entity, artifact, _ := prepareFixture(t, "folder")
 		if _, err := Prepare(entity, PrepareInput{WorkflowDir: workflow, Question: "Advance?", Artifact: artifact, Summary: "candidate"}); err != nil {
 			t.Fatal(err)
 		}
@@ -397,21 +397,15 @@ func TestWithdrawRefusalsLeaveEntityRoomAndLockBytesClean(t *testing.T) {
 				ID: "gate-attempt:task-other-1",
 				Briefing: Briefing{
 					ID: "briefing:task:other:attempt-1:revision-1", Digest: "sha256:" + strings.Repeat("3", 64),
-					DigestDomain: "canonical-bytes", RoomRef: "./other",
+					RoomRef: "./other",
 				},
 			}},
 		})
-		doc.Current.Gate = "gate:task:other"
 		if err := writeDocument(entity, oldNode, doc); err != nil {
 			t.Fatal(err)
 		}
-		before := treeDigest(t, state)
-		if _, err := Withdraw(entity, WithdrawInput{WorkflowDir: workflow, Reason: "stale"}); err == nil ||
-			!strings.Contains(err.Error(), "does not match gates.current") {
-			t.Fatalf("stale-selection withdrawal = %v", err)
-		}
-		if got := treeDigest(t, state); got != before {
-			t.Fatal("stale-selection refusal changed state tree")
+		if _, err := Withdraw(entity, WithdrawInput{WorkflowDir: workflow, Reason: "stale"}); err != nil {
+			t.Fatalf("status-derived withdrawal = %v", err)
 		}
 	})
 }
@@ -456,8 +450,9 @@ func TestPrepareUsesSlugIdentityWhenEntityHasNoStoredID(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if doc.Current.Gate != "gate:task:validation" {
-				t.Fatalf("gate=%q", doc.Current.Gate)
+			record, err := recordForStage(doc, "validation")
+			if err != nil || record.ID != "gate:task:validation" {
+				t.Fatalf("status-derived gate=%v/%q", err, record.ID)
 			}
 		})
 	}

--- a/internal/gates/round.go
+++ b/internal/gates/round.go
@@ -68,7 +68,7 @@ func loadValidateRound(entityDir, room, briefingPath, logPath string, want *Brie
 	if err != nil {
 		return result, err
 	}
-	if want != nil && (want.ID != result.Manifest.ID || want.Digest != result.Digest || want.DigestDomain != "canonical-bytes") {
+	if want != nil && (want.ID != result.Manifest.ID || want.Digest != result.Digest) {
 		return result, fmt.Errorf("review-round pointer does not bind the retained Briefing")
 	}
 	if err := verifyRoundArtifacts(entityDir, room, result.Manifest); err != nil {
@@ -96,7 +96,7 @@ func recordRoundLockedWith(entityPath string, input RecordInput, beforePublish f
 		return err
 	}
 	pointer := RoundPointer{ID: fmt.Sprintf("round:%s:%s:%d", location.entityID, location.stage, location.cycle), Stage: location.stage, Cycle: location.cycle,
-		Briefing: Briefing{ID: inputRound.Manifest.ID, Digest: inputRound.Digest, DigestDomain: "canonical-bytes",
+		Briefing: Briefing{ID: inputRound.Manifest.ID, Digest: inputRound.Digest,
 			RoomRef: fmt.Sprintf("./review/%s/round-%d", location.stage, location.cycle)}}
 	if _, statErr := os.Lstat(location.room); location.pointer.ID == pointer.ID && os.IsNotExist(statErr) {
 		return fmt.Errorf("round identity already has a pointer without its immutable room")
@@ -162,14 +162,13 @@ func readRoundPointerData(data []byte) (RoundPointer, error) {
 	}
 	var pointer RoundPointer
 	briefingNode := mappingValue(node, "briefing")
-	if len(node.Content) != 8 || briefingNode == nil || len(briefingNode.Content) != 8 {
+	if len(node.Content) != 8 || briefingNode == nil || len(briefingNode.Content) != 6 {
 		return RoundPointer{}, fmt.Errorf("entity has invalid review-round pointer")
 	}
 	err = node.Decode(&pointer)
 	wantRoom := fmt.Sprintf("./review/%s/round-%d", pointer.Stage, pointer.Cycle)
 	if err != nil || pointer.ID == "" || !roundStageRE.MatchString(pointer.Stage) || pointer.Cycle < 1 ||
-		pointer.Briefing.ID == "" || !digestRE.MatchString(pointer.Briefing.Digest) ||
-		pointer.Briefing.DigestDomain != "canonical-bytes" || pointer.Briefing.RoomRef != wantRoom {
+		pointer.Briefing.ID == "" || !digestRE.MatchString(pointer.Briefing.Digest) || pointer.Briefing.RoomRef != wantRoom {
 		return RoundPointer{}, fmt.Errorf("entity has invalid review-round pointer")
 	}
 	return pointer, nil

--- a/internal/gates/round_test.go
+++ b/internal/gates/round_test.go
@@ -712,8 +712,6 @@ func advisoryRoundFixtureAt(t *testing.T, root string) (string, string, string, 
 		"custom: preserve-me\n" +
 		"gates:\n" +
 		"  version: 1\n" +
-		"  current:\n" +
-		"    gate: gate:task:ideation\n" +
 		"  records:\n" +
 		"    - id: gate:task:ideation\n" +
 		"      stage: ideation\n" +
@@ -722,7 +720,6 @@ func advisoryRoundFixtureAt(t *testing.T, root string) (string, string, string, 
 		"          briefing:\n" +
 		"            id: briefing:task:ideation:1\n" +
 		"            digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" +
-		"            digest-domain: canonical-bytes\n" +
 		"            room-ref: ./review/ideation/briefing-1\n" +
 		"title: Task\n" +
 		"---\n" +

--- a/internal/gates/testdata/advisory-round/recorded-entity.md
+++ b/internal/gates/testdata/advisory-round/recorded-entity.md
@@ -4,8 +4,6 @@ status: implementation
 custom: preserve-me
 gates:
   version: 1
-  current:
-    gate: gate:task:ideation
   records:
     - id: gate:task:ideation
       stage: ideation
@@ -14,7 +12,6 @@ gates:
           briefing:
             id: briefing:task:ideation:1
             digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-            digest-domain: canonical-bytes
             room-ref: ./review/ideation/briefing-1
 title: Task
 review-round:
@@ -24,7 +21,6 @@ review-round:
     briefing:
         id: briefing:3j:implementation:round-1
         digest: sha256:006c419cc260eac142a2a038037d4d8a8d80156f7b1f7224b3be6eab682a0698
-        digest-domain: canonical-bytes
         room-ref: ./review/implementation/round-1
 ---
 # Task

--- a/internal/status/boot_identify_test.go
+++ b/internal/status/boot_identify_test.go
@@ -52,10 +52,10 @@ stages:
 
 func openGateEntity(slug, status, score string) string {
 	return "---\nid: " + slug + "\nstatus: " + status + "\nscore: " + score + "\ngates:\n" +
-		"  version: 1\n  current: {gate: 'gate:" + slug + ":" + status + "'}\n  records:\n" +
+		"  version: 1\n  records:\n" +
 		"    - id: gate:" + slug + ":" + status + "\n      stage: " + status + "\n      attempts:\n" +
 		"        - id: gate-attempt:" + slug + "-" + status + "-1\n" +
-		"          briefing: {id: 'briefing:" + slug + ":" + status + ":attempt-1', digest: 'sha256:" + strings.Repeat("1", 64) + "', digest-domain: canonical-bytes, room-ref: ./review/" + status + "/briefing-1}\n" +
+		"          briefing: {id: 'briefing:" + slug + ":" + status + ":attempt-1', digest: 'sha256:" + strings.Repeat("1", 64) + "', room-ref: ./review/" + status + "/briefing-1}\n" +
 		"---\n# " + slug + "\n"
 }
 
@@ -69,8 +69,8 @@ func approvedGateEntity(slug, status, target, score string) string {
 
 func withdrawnGateEntity(slug, status, score string) string {
 	body := strings.TrimSuffix(openGateEntity(slug, status, score), "---\n# "+slug+"\n")
-	body = strings.Replace(body, "digest-domain: canonical-bytes, room-ref:",
-		"digest-domain: canonical-bytes, request-digest: 'sha256:"+strings.Repeat("2", 64)+"', room-ref:", 1)
+	body = strings.Replace(body, "room-ref:",
+		"request-digest: 'sha256:"+strings.Repeat("2", 64)+"', room-ref:", 1)
 	return body +
 		"          withdrawal: {by: 'agent:first-officer', at: '2026-07-26T11:30:00.123456Z', reason: 'candidate is stale'}\n" +
 		"---\n# " + slug + "\n"
@@ -236,7 +236,7 @@ func TestBootIdentifyReadyGates(t *testing.T) {
 	}
 }
 
-func TestBootReadyGatesRequiresCurrentStageSelection(t *testing.T) {
+func TestBootReadyGatesUsesStatusDerivedSelection(t *testing.T) {
 	def, state := buildSplitRoot(t, identifyReadyGatesReadme, nil)
 	room := filepath.Join(state, "review", "validation", "briefing-1")
 	writeFile(t, filepath.Join(room, "briefing.json"),
@@ -252,28 +252,13 @@ func TestBootReadyGatesRequiresCurrentStageSelection(t *testing.T) {
 	}
 	entity := filepath.Join(state, "mf.md")
 	writeFile(t, entity, "---\nid: mf\nstatus: validation\ngates:\n"+
-		"  version: 1\n  current: {gate: 'gate:mf:ideation'}\n  records:\n"+
+		"  version: 1\n  records:\n"+
 		"    - id: gate:mf:ideation\n      stage: ideation\n      attempts:\n"+
-		"        - id: gate-attempt:mf-ideation-1\n          briefing: {id: 'briefing:mf:ideation:attempt-1', digest: 'sha256:"+strings.Repeat("2", 64)+"', digest-domain: canonical-bytes, room-ref: ./review/ideation/briefing-1}\n"+
+		"        - id: gate-attempt:mf-ideation-1\n          briefing: {id: 'briefing:mf:ideation:attempt-1', digest: 'sha256:"+strings.Repeat("2", 64)+"', room-ref: ./review/ideation/briefing-1}\n"+
 		"    - id: gate:mf:validation\n      stage: validation\n      attempts:\n"+
-		"        - id: gate-attempt:mf-validation-1\n          briefing: {id: 'briefing:mf:validation:attempt-1', digest: '"+digest+"', digest-domain: canonical-bytes, room-ref: ./review/validation/briefing-1}\n"+
+		"        - id: gate-attempt:mf-validation-1\n          briefing: {id: 'briefing:mf:validation:attempt-1', digest: '"+digest+"', room-ref: ./review/validation/briefing-1}\n"+
 		"---\n# MF\n")
 
-	before := identifyReadyRows(t, def)
-	if before != "[]" {
-		t.Fatalf("stale old-stage selection scheduled mf: %s", before)
-	}
-	body, err := os.ReadFile(entity)
-	if err != nil {
-		t.Fatal(err)
-	}
-	selected := strings.Replace(string(body), "current: {gate: 'gate:mf:ideation'}", "current: {gate: 'gate:mf:validation'}", 1)
-	if selected == string(body) {
-		t.Fatal("current-stage selection fixture was not updated")
-	}
-	if err := os.WriteFile(entity, []byte(selected), 0o644); err != nil {
-		t.Fatal(err)
-	}
 	after := identifyReadyRows(t, def)
 	want := `[{"id":"mf","slug":"mf","current":"validation","readiness":"awaiting-captain"}]`
 	if after != want {
@@ -315,10 +300,10 @@ func TestBootReadyGateTerminalApprovalPersistsAtConsumeUntilDeliveryEnvelope(t *
 		t.Fatal(err)
 	}
 	writeFile(t, entity, "---\nid: 2n\nstatus: validation\ngates:\n"+
-		"  version: 1\n  current: {gate: 'gate:2n:validation'}\n  records:\n"+
+		"  version: 1\n  records:\n"+
 		"    - id: gate:2n:validation\n      stage: validation\n      attempts:\n"+
 		"        - id: gate-attempt:2n-validation-1\n"+
-		"          briefing: {id: 'briefing:2n:validation:attempt-1:revision-1', digest: '"+digest+"', digest-domain: canonical-bytes, room-ref: ./review/validation/briefing-1/briefing.json}\n"+
+		"          briefing: {id: 'briefing:2n:validation:attempt-1:revision-1', digest: '"+digest+"', room-ref: ./review/validation/briefing-1/briefing.json}\n"+
 		"---\n# 2n\n")
 	if _, _, err := gates.Read(entity); err != nil {
 		t.Fatal(err)
@@ -373,7 +358,7 @@ func TestBootReadyGatesFailClosedLifecycleControls(t *testing.T) {
 		"feedback.md":   feedback,
 		"consumed.md":   consumed,
 		"superseded.md": superseded,
-		"malformed.md":  "---\nstatus: validation\ngates:\n  version: 1\n  current: {gate: missing}\n  records: []\n---\n",
+		"malformed.md":  "---\nstatus: validation\ngates:\n  version: 1\n  records: []\n---\n",
 		"terminal.md":   openGateEntity("terminal", "done", "100"),
 		"ordinary.md":   openGateEntity("ordinary", "implementation", "100"),
 	})

--- a/internal/status/discover.go
+++ b/internal/status/discover.go
@@ -215,7 +215,7 @@ func scanEntitiesActive(directory string, stderr io.Writer) []*entity {
 func newEntity(fields map[string]string, slug, path, scope string) *entity {
 	doc, _, gateErr := gates.Read(path)
 	if gateErr == nil {
-		summary := gates.CurrentSummary(doc)
+		summary := gates.CurrentSummary(doc, fields["status"])
 		fields["gate"] = summary.Gate
 		fields["gate-attempt"] = summary.Attempt
 		fields["gate-state"] = summary.State

--- a/internal/status/gates_coexist_test.go
+++ b/internal/status/gates_coexist_test.go
@@ -30,7 +30,7 @@ func TestStatusTextAndJSONProjectApprovedPendingApplication(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(room, "briefing.json"), briefing, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	body := "---\nid: task\nstatus: ideation\ntitle: Task\ngates:\n  version: 1\n  current: {gate: 'gate:task:ideation'}\n  records:\n    - id: gate:task:ideation\n      stage: ideation\n      attempts:\n        - id: attempt:task-1\n          briefing: {id: 'briefing:task:1', digest: '" + digest + "', digest-domain: canonical-bytes, room-ref: ./review/ideation/briefing-1/briefing.json}\n          resolution: {type: Resolution, id: 'resolution:task-1', briefing: 'briefing:task:1', by: 'person:captain', at: '2026-07-22T00:00:00Z', decision: approve}\n          application: {action: advance, target-stage: implementation, state: pending, blockers: []}\n---\n# Task\n"
+	body := "---\nid: task\nstatus: ideation\ntitle: Task\ngates:\n  version: 1\n  records:\n    - id: gate:task:ideation\n      stage: ideation\n      attempts:\n        - id: attempt:task-1\n          briefing: {id: 'briefing:task:1', digest: '" + digest + "', room-ref: ./review/ideation/briefing-1/briefing.json}\n          resolution: {type: Resolution, id: 'resolution:task-1', briefing: 'briefing:task:1', by: 'person:captain', at: '2026-07-22T00:00:00Z', decision: approve}\n          application: {action: advance, target-stage: implementation, state: pending, blockers: []}\n---\n# Task\n"
 	if err := os.WriteFile(filepath.Join(root, "task.md"), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestStatusTextAndJSONProjectAllRecordedResolutionStates(t *testing.T) {
 		if decision != "approve" {
 			reason = ", reason: 'recorded reason'"
 		}
-		body := "---\nstatus: ideation\ntitle: " + decision + "\ngates:\n  version: 1\n  current: {gate: 'gate:" + decision + "'}\n  records:\n    - id: gate:" + decision + "\n      stage: ideation\n      attempts:\n        - id: attempt:" + decision + "-1\n          briefing: {id: 'briefing:" + decision + "-1', digest: 'sha256:" + strings.Repeat("2", 64) + "', digest-domain: canonical-bytes, room-ref: ./review}\n          resolution: {type: Resolution, id: 'resolution:" + decision + "-1', briefing: 'briefing:" + decision + "-1', by: 'person:captain', at: '2026-07-22T00:00:00Z', decision: " + decision + reason + "}\n---\n"
+		body := "---\nstatus: ideation\ntitle: " + decision + "\ngates:\n  version: 1\n  records:\n    - id: gate:" + decision + "\n      stage: ideation\n      attempts:\n        - id: attempt:" + decision + "-1\n          briefing: {id: 'briefing:" + decision + "-1', digest: 'sha256:" + strings.Repeat("2", 64) + "', room-ref: ./review}\n          resolution: {type: Resolution, id: 'resolution:" + decision + "-1', briefing: 'briefing:" + decision + "-1', by: 'person:captain', at: '2026-07-22T00:00:00Z', decision: " + decision + reason + "}\n---\n"
 		if err := os.WriteFile(filepath.Join(root, decision+".md"), []byte(body), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -164,7 +164,7 @@ func TestStatusTextAndJSONProjectAllRecordedResolutionStates(t *testing.T) {
 
 func TestUnrelatedSetPreservesGatesAndStatusProjectsResolution(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "task.md")
-	body := "---\nid: task\nstatus: ideation\nscore: '0.5'\ngates:\n  version: 1\n  current: {gate: 'gate:design'}\n  records:\n    - id: gate:design\n      stage: ideation\n      attempts:\n        - id: attempt:design-1\n          briefing: {id: 'briefing:design-1', digest: 'sha256:" + strings.Repeat("1", 64) + "', digest-domain: canonical-bytes, room-ref: ./review}\n          resolution: {type: Resolution, id: 'resolution:design-1', briefing: 'briefing:design-1', by: 'person:captain', at: '2026-07-22T00:00:00Z', decision: hold, reason: 'wait'}\n          application: {action: none, state: not-applicable}\n---\n# Task\n"
+	body := "---\nid: task\nstatus: ideation\nscore: '0.5'\ngates:\n  version: 1\n  records:\n    - id: gate:design\n      stage: ideation\n      attempts:\n        - id: attempt:design-1\n          briefing: {id: 'briefing:design-1', digest: 'sha256:" + strings.Repeat("1", 64) + "', room-ref: ./review}\n          resolution: {type: Resolution, id: 'resolution:design-1', briefing: 'briefing:design-1', by: 'person:captain', at: '2026-07-22T00:00:00Z', decision: hold, reason: 'wait'}\n          application: {action: none, state: not-applicable}\n---\n# Task\n"
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/skills/fo-gate-lifecycle/SKILL.md
+++ b/skills/fo-gate-lifecycle/SKILL.md
@@ -17,7 +17,7 @@ Load before engaged gate action. It grants no writes; read `fo-write-core.md` be
 | `gate record` | Closes that attempt from one semantic source; never advances status. |
 | `gate consume` | Applies one eligible approval; terminal targets route unspent to merge guard. |
 
-**Boot projection.** Use actionable `ready_gates` from `status --boot --identify --json`. Engage row `slug`; read its entity, never infer readiness from stage. `awaiting-captain` is open; `withdrawn-awaiting-prepare` needs its successor prepared; `approved-awaiting-merge`/`approved-awaiting-advance` are unblocked. Retained authority for resume/present must match current status; prior-stage authority is history. If no selected attempt (omitted `validating`) or it mismatches, prepare current stage and present only its emitted binding.
+**Boot projection.** Use actionable `ready_gates` from `status --boot --identify --json`. Engage row `slug`; read its entity and resolve the unique record whose `stage` equals status. `awaiting-captain` is open; `withdrawn-awaiting-prepare` needs its successor prepared; `approved-awaiting-merge`/`approved-awaiting-advance` are unblocked. Retained authority for resume/present must match current status; prior-stage authority is history. If no matching attempt (omitted `validating`) or it is ambiguous, prepare current stage and present only its emitted binding.
 
 **Prepare and bind.** Resolve `${SPACEDOCK_BIN:-spacedock}`. Select a Markdown gate-review Artifact and References, author its concise summary, then commit selections. Supply judgment and paths; never author JSON, ids, digests, Git-root locators, or room coordinates. Paths use launch cwd.
 


### PR DESCRIPTION
Derive active v1 gate authority from entity status so stale approvals cannot control workflow decisions.

## What changed
- Remove the stored gate pointer and digest-domain metadata.
- Enforce one gate record per stage and last-attempt authority.
- Update gate application, delivery, status, and I/O consumers.
- Add stale-approval and terminal-delivery lifecycle coverage.
- Align schema, specification, and First Officer documentation.

## Evidence
- Focused suites, `go test ./...`, and `go test ./... -race` passed.
- Detached delivery audit, formatting, and diff checks passed.

---
[jc](/spacedock-dev/spacedock/blob/45063d7c6427b9d22d15b320999225b502056066/simplify-gate-state-v1-schema/index.md)