### PR TITLE
Add a shared, persisting git-scaffold test helper to close the identity-config gap

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -19,7 +19,6 @@ stages:
       model: opus
     - name: implementation
       worktree: true
-      concurrency: 8
       context-sections:
         - Review-finding disposition
     - name: validation

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -19,6 +19,7 @@ stages:
       model: opus
     - name: implementation
       worktree: true
+      concurrency: 8
       context-sections:
         - Review-finding disposition
     - name: validation

--- a/internal/cli/decoupling_behavior_test.go
+++ b/internal/cli/decoupling_behavior_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // TestStableChannelDecoupledFromBranchHead is the load-bearing AC-1 proof: a
@@ -104,7 +106,7 @@ func buildPluginGitRepo(t *testing.T, root string) string {
 	mustMkdir(t, filepath.Join(root, "skills", "demo"))
 
 	writePluginVersion(t, root, "0.0.1")
-	git(t, root, "init", "-q", "-b", "next")
+	testgit.InitRepo(t, root, "-q", "-b", "next")
 	git(t, root, "add", "-A")
 	git(t, root, "commit", "-q", "-m", "v0.0.1")
 	git(t, root, "tag", "v0.0.1")

--- a/internal/cli/gate_test.go
+++ b/internal/cli/gate_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spacedock-dev/spacedock/internal/gates"
 	"github.com/spacedock-dev/spacedock/internal/status"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 func TestGateWithdrawCLIUsesExactGrammarAndImplicitFirstOfficerAttribution(t *testing.T) {
@@ -159,9 +160,7 @@ func gatePrepareCLIFixture(t *testing.T) (workflow, state, artifact string) {
 	if err := os.MkdirAll(workflow, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	git(t, mainRoot, "init", "-q")
-	git(t, mainRoot, "config", "user.name", "Spacedock Test")
-	git(t, mainRoot, "config", "user.email", "spacedock@example.invalid")
+	testgit.InitRepo(t, mainRoot, "-q")
 	writeFile(t, filepath.Join(workflow, "README.md"), "---\nid-style: slug\nstate: .state\nstages:\n  states:\n    - name: validation\n      initial: true\n      gate: true\n    - name: done\n      terminal: true\n---\n# Workflow\n")
 	artifact = filepath.Join(mainRoot, "gate-review.md")
 	writeFile(t, artifact, "# Review\n")
@@ -172,9 +171,7 @@ func gatePrepareCLIFixture(t *testing.T) (workflow, state, artifact string) {
 	if err := os.MkdirAll(state, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	git(t, state, "init", "-q")
-	git(t, state, "config", "user.name", "Spacedock Test")
-	git(t, state, "config", "user.email", "spacedock@example.invalid")
+	testgit.InitRepo(t, state, "-q")
 	writeFile(t, filepath.Join(state, "task.md"), "---\nid: task\nstatus: validation\ntitle: Task\n---\n# Task\n")
 	git(t, state, "add", ".")
 	git(t, state, "commit", "-q", "-m", "state fixture")

--- a/internal/cli/merge_test.go
+++ b/internal/cli/merge_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/spacedock-dev/spacedock/internal/status"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // stageMergeFixture copies a status-package merge fixture into a fresh
@@ -41,15 +42,13 @@ func stageMergeFixture(t *testing.T, fixture string) string {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	// Set a PERSISTENT local identity on the temp repo. The verb's own commits
-	// (commitArchiveMove) run plain `git commit` without `-c`, so they must resolve
-	// an identity from the repo's config — independent of global/system config and
-	// git's auto-detection. A CI lane with no global identity and auto-detection
-	// disabled would otherwise exit-128 the verb's commit.
+	// InitRepo persists a PERSISTENT local identity on the temp repo. The verb's own
+	// commits (commitArchiveMove) run plain `git commit` without `-c`, so they must
+	// resolve an identity from the repo's config — independent of global/system
+	// config and git's auto-detection. A CI lane with no global identity and
+	// auto-detection disabled would otherwise exit-128 the verb's commit.
+	testgit.InitRepo(t, dst, "-q")
 	for _, args := range [][]string{
-		{"init", "-q"},
-		{"config", "user.email", "test@example.com"},
-		{"config", "user.name", "spacedock-test"},
 		{"add", "-A"},
 		{"commit", "-q", "-m", "seed"},
 	} {

--- a/internal/cli/state_from_root_test.go
+++ b/internal/cli/state_from_root_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/spacedock-dev/spacedock/internal/status"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // TestStateReadyFromRootResolves pins AC-1: bare `state ready`, run with the repo
@@ -167,7 +168,7 @@ func TestStateVerbsFromRootRefuseAmbiguousWorkflows(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	git(t, root, "init", "-q")
+	testgit.InitRepo(t, root, "-q")
 	git(t, root, "add", "-A")
 	git(t, root, "commit", "-q", "-m", "two commissioned workflows")
 
@@ -219,9 +220,7 @@ func setupStandaloneSplitWorkflow(t *testing.T, root, relPath, slug string) (wor
 	if err := os.MkdirAll(checkout, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	git(t, checkout, "init", "-q")
-	git(t, checkout, "config", "user.email", "t@t")
-	git(t, checkout, "config", "user.name", "t")
+	testgit.InitRepo(t, checkout, "-q")
 	git(t, checkout, "branch", "-M", "spacedock-state/"+filepath.Base(workflowDir))
 	if err := os.WriteFile(filepath.Join(checkout, slug+".md"),
 		[]byte("---\nstatus: ideation\n---\n# "+slug+"\n"), 0o644); err != nil {

--- a/internal/cli/state_init_test.go
+++ b/internal/cli/state_init_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/spacedock-dev/spacedock/internal/status"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // splitWorkflowReadme is a commissioned split-root README declaring the state
@@ -240,7 +241,7 @@ func TestStateInitInlineNoOp(t *testing.T) {
 		[]byte("---\ncommissioned-by: spacedock@1\nid-style: slug\nstate: $inline\nstages:\n  states:\n    - name: ideation\n      initial: true\n    - name: done\n      terminal: true\n---\n\n# Inline WF\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	git(t, root, "init", "-q")
+	testgit.InitRepo(t, root, "-q")
 	git(t, root, "add", "-A")
 	git(t, root, "commit", "-q", "-m", "init")
 

--- a/internal/cli/state_new_test.go
+++ b/internal/cli/state_new_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/spacedock-dev/spacedock/internal/status"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // writeSplitReadmeRepo sets up the PRE-birth state `state new` onboards: a cloned
@@ -224,9 +225,7 @@ func TestStateNewRefusesAlreadyBirthed(t *testing.T) {
 func TestStateNewNoRemoteBestEffort(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	root := t.TempDir()
-	git(t, root, "init", "-q")
-	git(t, root, "config", "user.email", "t@t")
-	git(t, root, "config", "user.name", "t")
+	testgit.InitRepo(t, root, "-q")
 	workflowDir := filepath.Join(root, "docs", "dev")
 	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -267,7 +266,7 @@ func TestStateNewInlineErrors(t *testing.T) {
 		[]byte("---\ncommissioned-by: spacedock@1\nid-style: slug\nstate: $inline\nstages:\n  states:\n    - name: ideation\n      initial: true\n    - name: done\n      terminal: true\n---\n\n# Inline WF\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	git(t, root, "init", "-q")
+	testgit.InitRepo(t, root, "-q")
 	git(t, root, "add", "-A")
 	git(t, root, "commit", "-q", "-m", "init")
 

--- a/internal/cli/state_ready_test.go
+++ b/internal/cli/state_ready_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/spacedock-dev/spacedock/internal/status"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // runStateReadyCmd runs `spacedock state ready` for workflowDir and returns the
@@ -133,7 +134,7 @@ func TestStateReadyInlineNoOp(t *testing.T) {
 		[]byte("---\ncommissioned-by: spacedock@1\nid-style: slug\nstate: $inline\nstages:\n  states:\n    - name: ideation\n      initial: true\n    - name: done\n      terminal: true\n---\n\n# Inline WF\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	git(t, root, "init", "-q")
+	testgit.InitRepo(t, root, "-q")
 	git(t, root, "add", "-A")
 	git(t, root, "commit", "-q", "-m", "init")
 

--- a/internal/cli/terminal_consume_test.go
+++ b/internal/cli/terminal_consume_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/spacedock-dev/spacedock/internal/gates"
 	"github.com/spacedock-dev/spacedock/internal/status"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // terminalWorkflowOpts shapes the terminal-boundary CLI fixture.
@@ -56,10 +57,8 @@ func terminalCLIWorkflow(t *testing.T, opts terminalWorkflowOpts) (root, entity 
 	writeFile(t, filepath.Join(root, "gate-review.md"), "# Review\n")
 	entity = filepath.Join(root, "task.md")
 	writeFile(t, entity, "---\nid: task\nstatus: validation\ntitle: Task\n---\n# Task\n")
+	testgit.InitRepo(t, root, "-q")
 	for _, args := range [][]string{
-		{"init", "-q"},
-		{"config", "user.email", "test@example.com"},
-		{"config", "user.name", "spacedock-test"},
 		{"add", "-A"},
 		{"commit", "-q", "-m", "seed"},
 	} {

--- a/internal/contractlint/git_scaffold_guard_test.go
+++ b/internal/contractlint/git_scaffold_guard_test.go
@@ -1,0 +1,254 @@
+// ABOUTME: AC-1's git-scaffold-init guard -- every non-bare `git ... init` site
+// ABOUTME: in internal/**/*_test.go must go through testgit.InitRepo; bare-repo inits are exempt.
+package contractlint
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// gitScaffoldExemptPkg is the one directory allowed to hand-roll `git init`
+// calls directly: it is testgit.InitRepo's own implementation and its
+// falsifiability tests, which intentionally scaffold a repo WITHOUT InitRepo as
+// the negative case. Every other non-bare `git init` site under internal/ must
+// call testgit.InitRepo instead.
+const gitScaffoldExemptPkg = "internal/testgit"
+
+// TestNoHandRolledGitInitOutsideTestgit is AC-1's guard: it walks
+// internal/**/*_test.go and fails, listing file:line, for any non-bare
+// `git ... init` invocation that isn't routed through testgit.InitRepo.
+// `git init --bare` sites are excluded -- a bare repo never authors a commit,
+// so it is not in the identity-config bug class this entity closes. The
+// offender count is the moving baseline AC-1 measures: it must go from ~34
+// (before migration) to 0 (after), and a future hand-rolled fixture reds this
+// guard instead of silently reopening the hole.
+func TestNoHandRolledGitInitOutsideTestgit(t *testing.T) {
+	offenders := sweepHandRolledGitInit(t, repoRoot(t))
+	for _, o := range offenders {
+		t.Errorf("%s hand-rolls a git init scaffold -- use testgit.InitRepo instead so identity is always persisted (see internal/testgit)", o)
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("git-scaffold guard: %d non-bare `git init` site(s) outside testgit.InitRepo; the count must be zero", len(offenders))
+	}
+}
+
+// sweepHandRolledGitInit returns sorted "file:line" locations, outside
+// gitScaffoldExemptPkg, of non-bare `git init` invocations in *_test.go files
+// under internal/.
+func sweepHandRolledGitInit(t *testing.T, repoRootDir string) []string {
+	t.Helper()
+	internalDir := filepath.Join(repoRootDir, "internal")
+	var offenders []string
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(internalDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(repoRootDir, path)
+		if relErr != nil {
+			return relErr
+		}
+		if d.IsDir() {
+			if rel == gitScaffoldExemptPkg {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		f, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		for _, pos := range handRolledGitInitPositions(f) {
+			p := fset.Position(pos)
+			offenders = append(offenders, rel+":"+strconv.Itoa(p.Line))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sweep git-init scaffolds under %s: %v", internalDir, err)
+	}
+	return sortedUnique(offenders)
+}
+
+// handRolledGitInitPositions returns the positions of every non-bare git-init
+// scaffold site in f: a direct call that runs `git init` (or `--bare` init,
+// excluded below), and a `{"init", ...}` subcommand-table entry of the shape
+// used by the file-local `for _, args := range [][]string{...}` helpers.
+func handRolledGitInitPositions(f *ast.File) []token.Pos {
+	var positions []token.Pos
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.CallExpr:
+			if pos, ok := directGitInitCallPosition(node); ok {
+				positions = append(positions, pos)
+			}
+		case *ast.RangeStmt:
+			positions = append(positions, gitInitSubcommandTablePositions(node)...)
+		}
+		return true
+	})
+	return positions
+}
+
+// gitInitSubcommandTablePositions handles the file-local helper shape
+// `for _, args := range [][]string{ {"init", "-q"}, {"add", "-A"}, ... } { ... }`
+// where a subcommand-argv table is ranged over and each entry fed to a git
+// call. It returns the position of any "init"-headed entry, gated on the loop
+// body actually invoking git -- otherwise an unrelated `[][]string` test table
+// (e.g. a CLI-args-per-subtest table) would false-positive on a coincidental
+// `{"init", ...}` entry that has nothing to do with git.
+func gitInitSubcommandTablePositions(rng *ast.RangeStmt) []token.Pos {
+	lit, ok := rng.X.(*ast.CompositeLit)
+	if !ok {
+		return nil
+	}
+	arr, ok := lit.Type.(*ast.ArrayType)
+	if !ok {
+		return nil
+	}
+	if _, ok := arr.Elt.(*ast.ArrayType); !ok {
+		return nil
+	}
+	if !rangeBodyInvokesGit(rng.Body) {
+		return nil
+	}
+	var positions []token.Pos
+	for _, elt := range lit.Elts {
+		if pos, ok := gitInitSubcommandLiteralPosition(elt); ok {
+			positions = append(positions, pos)
+		}
+	}
+	return positions
+}
+
+// rangeBodyInvokesGit reports whether body contains a call recognized as a
+// direct git invocation (see calleeArgsIfGitCall), regardless of its
+// subcommand -- the signal that a ranged subcommand table feeds an actual git
+// call rather than an unrelated string-table.
+func rangeBodyInvokesGit(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok {
+			if _, ok := calleeArgsIfGitCall(call); ok {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// calleeArgsIfGitCall reports whether call is a direct git invocation --
+// either `exec.Command("git", ...)` or a local wrapper whose name contains
+// "git" (e.g. `git`, `gitC`, `gitOutput`, `mustGit`) -- and if so returns the
+// argument list carrying the git subcommand (with a leading "git" literal
+// stripped for the exec.Command form).
+func calleeArgsIfGitCall(call *ast.CallExpr) ([]ast.Expr, bool) {
+	var calleeName string
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		calleeName = fn.Sel.Name
+	case *ast.Ident:
+		calleeName = fn.Name
+	default:
+		return nil, false
+	}
+	args := call.Args
+	if calleeName == "Command" && len(args) > 0 && basicLitString(args[0]) == "git" {
+		return args[1:], true
+	}
+	if strings.Contains(strings.ToLower(calleeName), "git") {
+		return args, true
+	}
+	return nil, false
+}
+
+// directGitInitCallPosition reports the position of the "init" argument in
+// call, if call is a direct git invocation (see calleeArgsIfGitCall) carrying
+// a literal "init" subcommand and no sibling "--bare".
+func directGitInitCallPosition(call *ast.CallExpr) (token.Pos, bool) {
+	args, isGitCall := calleeArgsIfGitCall(call)
+	if !isGitCall {
+		return token.NoPos, false
+	}
+
+	subcommand, subcommandPos, ok := gitSubcommandLiteral(args)
+	if !ok || subcommand != "init" {
+		return token.NoPos, false
+	}
+	for _, arg := range args {
+		if basicLitString(arg) == "--bare" {
+			return token.NoPos, false
+		}
+	}
+	return subcommandPos, true
+}
+
+// gitSubcommandLiteral scans args in order for the git subcommand literal --
+// the first string literal not consumed as part of a `-C <dir>` or
+// `-c <key>=<value>` global-option pair (both of which take exactly one
+// following value and may precede the subcommand). Non-literal args (e.g. a
+// `*testing.T` or a path variable) are skipped positionally.
+func gitSubcommandLiteral(args []ast.Expr) (string, token.Pos, bool) {
+	for i := 0; i < len(args); i++ {
+		lit, ok := args[i].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			continue
+		}
+		s := basicLitString(args[i])
+		if s == "-C" || s == "-c" {
+			i++ // skip this flag's value too
+			continue
+		}
+		return s, lit.Pos(), true
+	}
+	return "", token.NoPos, false
+}
+
+// gitInitSubcommandLiteralPosition reports the position of an "init" element
+// heading a `[]string{"init", ...}` composite literal (typed, or type-elided as
+// a nested element of a `[][]string{...}` table) -- the subcommand-table shape
+// the file-local range-based init helpers use. A sibling "--bare" excludes it.
+func gitInitSubcommandLiteralPosition(elt ast.Expr) (token.Pos, bool) {
+	lit, ok := elt.(*ast.CompositeLit)
+	if !ok {
+		return token.NoPos, false
+	}
+	if lit.Type != nil {
+		if _, ok := lit.Type.(*ast.ArrayType); !ok {
+			return token.NoPos, false
+		}
+	}
+	if len(lit.Elts) == 0 {
+		return token.NoPos, false
+	}
+	first, ok := lit.Elts[0].(*ast.BasicLit)
+	if !ok || first.Kind != token.STRING || basicLitString(lit.Elts[0]) != "init" {
+		return token.NoPos, false
+	}
+	for _, elt := range lit.Elts[1:] {
+		if basicLitString(elt) == "--bare" {
+			return token.NoPos, false
+		}
+	}
+	return first.Pos(), true
+}
+
+// basicLitString returns expr's unquoted string value, or "" if expr is not a
+// string BasicLit.
+func basicLitString(expr ast.Expr) string {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return ""
+	}
+	return strings.Trim(lit.Value, "`\"")
+}

--- a/internal/dispatch/parity_harness_test.go
+++ b/internal/dispatch/parity_harness_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/spacedock-dev/spacedock/internal/claudeteam"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // runResult is one run's three channels.
@@ -80,8 +81,8 @@ func readDispatchBody(t *testing.T, path string) string {
 // gitInit initializes a git repo at dir so find_git_root resolves there.
 func gitInit(t *testing.T, dir string) {
 	t.Helper()
+	testgit.InitRepo(t, dir, "-q")
 	for _, args := range [][]string{
-		{"init", "-q"},
 		{"-c", "user.email=t@t", "-c", "user.name=t", "add", "-A"},
 		{"-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "init"},
 	} {
@@ -97,10 +98,7 @@ func gitInit(t *testing.T, dir string) {
 // not add/commit, so it works on an empty directory.
 func gitInitBare(t *testing.T, dir string) {
 	t.Helper()
-	cmd := exec.Command("git", "-C", dir, "init", "-q")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git init: %v\n%s", err, out)
-	}
+	testgit.InitRepo(t, dir, "-q")
 }
 
 // gitAddOrigin adds a named `origin` remote to the repo at dir, pointing at a

--- a/internal/dispatch/reconcile_test.go
+++ b/internal/dispatch/reconcile_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/spacedock-dev/spacedock/internal/claudeteam"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // reconcileFixture is one self-contained fixture that holds a tmp HOME (so the
@@ -595,9 +596,7 @@ func teamConfigJSONWithSession(name, leadSessionID string, members []claudeteam.
 // origin (a local file:// remote at a sibling dir) and a "next" branch.
 func repoGitInit(t *testing.T, dir string) {
 	t.Helper()
-	mustGit(t, dir, "init", "-q", "-b", "main")
-	mustGit(t, dir, "config", "user.email", "t@t")
-	mustGit(t, dir, "config", "user.name", "t")
+	testgit.InitRepo(t, dir, "-q", "-b", "main")
 	writeFile(t, filepath.Join(dir, "seed.txt"), "seed\n")
 	mustGit(t, dir, "add", "-A")
 	mustGit(t, dir, "commit", "-q", "-m", "seed")

--- a/internal/ensigncycle/cycle_test.go
+++ b/internal/ensigncycle/cycle_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spacedock-dev/spacedock/internal/claudeteam"
 	"github.com/spacedock-dev/spacedock/internal/dispatch"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // The cycle exercises the deterministic seams on both sides of the LLM: the
@@ -322,7 +323,7 @@ func gitCommitPathScoped(t *testing.T, root, rel, msg string) {
 // find_git_root resolves there and HEAD exists for the path-scoped commit.
 func gitInit(t *testing.T, dir string) {
 	t.Helper()
-	git(t, dir, "init", "-q")
+	testgit.InitRepo(t, dir, "-q")
 	git(t, dir, "add", "-A")
 	git(t, dir, "commit", "-q", "-m", "init")
 }

--- a/internal/ensigncycle/live_test.go
+++ b/internal/ensigncycle/live_test.go
@@ -5,7 +5,6 @@
 package ensigncycle
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // This is the live analog of TestEnsignCycleMechanicalOutputs (cycle_test.go).
@@ -413,10 +414,7 @@ func cachedLivePluginDir(t *testing.T, repo string) string {
 		}
 		// git init so the FO's `git rev-parse --show-toplevel` resolves to this
 		// workflow-free root, not an enclosing checkout that has a docs/dev.
-		if out, gitErr := exec.Command("git", "-C", staged, "init", "-q").CombinedOutput(); gitErr != nil {
-			livePluginErr = fmt.Errorf("git init staged plugin: %v: %s", gitErr, out)
-			return
-		}
+		testgit.InitRepo(t, staged, "-q")
 		livePluginPath = staged
 	})
 	if livePluginErr != nil {

--- a/internal/ensigncycle/liveassert_unit_test.go
+++ b/internal/ensigncycle/liveassert_unit_test.go
@@ -5,6 +5,8 @@ package ensigncycle
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // These run under the DEFAULT build tags (no //go:build live) so `go test ./...`
@@ -92,7 +94,7 @@ func TestSomeCommitNamesOnly(t *testing.T) {
 		root := t.TempDir()
 		writeFile(t, filepath.Join(root, "README.md"), "readme")
 		writeFile(t, filepath.Join(root, "make-it-work.md"), "entity")
-		git(t, root, "init", "-q")
+		testgit.InitRepo(t, root, "-q")
 
 		// One commit that adds README.md AND make-it-work.md together (sibling
 		// sweep) — the incomplete cycle's non-path-scoped commit.

--- a/internal/gates/prepare_test.go
+++ b/internal/gates/prepare_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1069,8 +1070,7 @@ func prepareFixture(t *testing.T, form string) (workflow, state, entity, artifac
 		t.Fatal(err)
 	}
 	mainRoot := filepath.Dir(filepath.Dir(workflow))
-	prepareGitRun(t, mainRoot, "init", "-q")
-	prepareGitIdentity(t, mainRoot)
+	testgit.InitRepo(t, mainRoot, "-q")
 	if err := os.WriteFile(filepath.Join(workflow, "README.md"), []byte("---\nid-style: slug\nstate: ../../../state\nstages:\n  states:\n    - name: validation\n      initial: true\n      gate: true\n    - name: implementation\n    - name: done\n      terminal: true\n    - name: contradictory\n      gate: true\n      terminal: true\n---\n# Workflow\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -1085,8 +1085,7 @@ func prepareFixture(t *testing.T, form string) (workflow, state, entity, artifac
 	if err := os.MkdirAll(state, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	prepareGitRun(t, state, "init", "-q")
-	prepareGitIdentity(t, state)
+	testgit.InitRepo(t, state, "-q")
 	switch form {
 	case "folder":
 		entity = filepath.Join(state, "task", "index.md")
@@ -1108,12 +1107,6 @@ func prepareFixture(t *testing.T, form string) (workflow, state, entity, artifac
 	prepareGitRun(t, state, "add", ".")
 	prepareGitRun(t, state, "commit", "-q", "-m", "state fixture")
 	return workflow, state, entity, artifact, reference
-}
-
-func prepareGitIdentity(t *testing.T, dir string) {
-	t.Helper()
-	prepareGitRun(t, dir, "config", "user.name", "Spacedock Test")
-	prepareGitRun(t, dir, "config", "user.email", "spacedock@example.invalid")
 }
 
 func prepareGitRun(t *testing.T, dir string, args ...string) {

--- a/internal/gitsource/source_test.go
+++ b/internal/gitsource/source_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 func TestInspectAndResolveUseExactLocalGitObjectsAcrossMovedRoots(t *testing.T) {
@@ -241,9 +243,7 @@ func initRepository(t *testing.T, name string, files map[string]string) string {
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	gitRun(t, root, "init", "-q")
-	gitRun(t, root, "config", "user.name", "Spacedock Test")
-	gitRun(t, root, "config", "user.email", "spacedock@example.invalid")
+	testgit.InitRepo(t, root, "-q")
 	for name, body := range files {
 		path := filepath.Join(root, filepath.FromSlash(name))
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/release/claude_candidate_binary_workflow_test.go
+++ b/internal/release/claude_candidate_binary_workflow_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 func TestClaudeLiveInstallsExactCandidateOutsideCheckout(t *testing.T) {
@@ -174,7 +176,7 @@ func candidateFixture(t *testing.T) (string, string) {
 		}
 		return strings.TrimSpace(string(out))
 	}
-	git("init", "-q")
+	testgit.InitRepo(t, checkout, "-q")
 	git("add", ".")
 	git("commit", "-qm", "fixture")
 	return checkout, git("rev-parse", "HEAD")

--- a/internal/release/edge_advance_noregress_test.go
+++ b/internal/release/edge_advance_noregress_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // patchNoRegressFixture builds the AC-3 scenario in a temp git repo: `next` has
@@ -64,9 +66,7 @@ func newPatchNoRegressFixture(t *testing.T) patchNoRegressFixture {
 	}
 	const foProse = "skills/first-officer/references/first-officer-shared-core.md"
 
-	git("init", "-q")
-	git("config", "user.email", "test@example.com")
-	git("config", "user.name", "test")
+	testgit.InitRepo(t, dir, "-q")
 
 	// Shared ancestor both the old release line and `next` descend from.
 	write(".claude-plugin/plugin.json", pluginJSON("0.24.0-pre1"))

--- a/internal/release/edge_reconcile_test.go
+++ b/internal/release/edge_reconcile_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // edgeReconcileResult carries the SHAs and merge output a reconcile-fixture run
@@ -79,9 +81,7 @@ func runEdgeReconcileFixture(t *testing.T, tag string) edgeReconcileResult {
 	const preCutCalendar = "0.0.2026050101"
 	marketplaceJSON := "{\n  \"name\": \"spacedock-edge\",\n  \"plugins\": [\n    {\n      \"name\": \"spacedock\",\n      \"version\": \"" + preCutCalendar + "\"\n    }\n  ]\n}\n"
 
-	git("init", "-q")
-	git("config", "user.email", "test@example.com")
-	git("config", "user.name", "test")
+	testgit.InitRepo(t, dir, "-q")
 
 	// Base commit — the shared ancestor `next` and `main` both descend from.
 	write(".claude-plugin/plugin.json", pluginJSON("0.23.0-pre1"))

--- a/internal/release/notes_extract_test.go
+++ b/internal/release/notes_extract_test.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // TestAnnotatedTagBodyRoundTrips locks AC-3's seam in a throwaway `git init`
@@ -31,9 +33,7 @@ func TestAnnotatedTagBodyRoundTrips(t *testing.T) {
 		return string(out)
 	}
 
-	git("init", "-q")
-	git("config", "user.email", "test@example.com")
-	git("config", "user.name", "test")
+	testgit.InitRepo(t, dir, "-q")
 	git("commit", "-q", "--allow-empty", "-m", "seed")
 
 	body := "A clean release.\n- feat: the user value\n- fix: the other thing"
@@ -84,9 +84,7 @@ func TestReleaseYAMLGuardRejectsEmptyBody(t *testing.T) {
 		}
 		return string(out)
 	}
-	git("init", "-q")
-	git("config", "user.email", "test@example.com")
-	git("config", "user.name", "test")
+	testgit.InitRepo(t, dir, "-q")
 	git("commit", "-q", "--allow-empty", "-m", "seed")
 
 	// Lightweight, subject-only annotated, and empty-second-`-m` annotated tags

--- a/internal/statesync/publish_test.go
+++ b/internal/statesync/publish_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 func git(t *testing.T, dir string, args ...string) string {
@@ -28,9 +30,7 @@ func publishedRepo(t *testing.T) (repo, bare, branch string) {
 	t.Helper()
 	repo = t.TempDir()
 	bare = filepath.Join(t.TempDir(), "origin.git")
-	git(t, repo, "init", "-q")
-	git(t, repo, "config", "user.email", "test@example.com")
-	git(t, repo, "config", "user.name", "test")
+	testgit.InitRepo(t, repo, "-q")
 	if err := os.WriteFile(filepath.Join(repo, "task.md"), []byte("state\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/status/boot_identify_test.go
+++ b/internal/status/boot_identify_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/spacedock-dev/spacedock/internal/gates"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // identifyPRReadme declares a split-root slug workflow whose implementation stage
@@ -376,9 +377,7 @@ func TestBootIdentifyIsSideEffectFree(t *testing.T) {
 		"add-login.md": "---\nstatus: implementation\npr: \"#42\"\n---\n",
 	})
 	// The state checkout is a real git repo so HEAD/tree can be diffed.
-	gitC(t, state, "init", "-q")
-	gitC(t, state, "config", "user.email", "t@t")
-	gitC(t, state, "config", "user.name", "t")
+	testgit.InitRepo(t, state, "-q")
 	gitC(t, state, "add", "-A")
 	gitC(t, state, "commit", "-q", "-m", "seed")
 

--- a/internal/status/boot_orphan_abs_test.go
+++ b/internal/status/boot_orphan_abs_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // bootOrphanReadme defines a single worktree-bearing stage so --boot renders an
@@ -57,9 +59,7 @@ func orphanExistence(boot string) (dir, branch string) {
 // yielding a non-existent path and DIR_EXISTS=no.
 func TestBootAbsoluteWorktreeDirExists(t *testing.T) {
 	root := t.TempDir()
-	if out, err := exec.Command("git", "-C", root, "init").CombinedOutput(); err != nil {
-		t.Fatalf("git init: %v (%s)", err, out)
-	}
+	testgit.InitRepo(t, root)
 	// An absolute worktree path that exists but is OUTSIDE the git root, so a
 	// filepath.Join(git_root, wt) would point at a non-existent nested path.
 	absWorktree := t.TempDir()
@@ -125,9 +125,7 @@ stages:
 func buildSplitRootWorktreeFixture(t *testing.T) (defDir, wtDir string) {
 	t.Helper()
 	coderoot := t.TempDir()
-	gitC(t, coderoot, "init")
-	gitC(t, coderoot, "config", "user.email", "test@example.com")
-	gitC(t, coderoot, "config", "user.name", "test")
+	testgit.InitRepo(t, coderoot)
 	// A worktree needs a committed HEAD to branch from.
 	writeFile(t, filepath.Join(coderoot, "seed.txt"), "seed\n")
 	gitC(t, coderoot, "add", "seed.txt")
@@ -204,9 +202,7 @@ func TestBootSplitRootWorktreeExistence(t *testing.T) {
 // the two roots are the same dir), confirming no regression.
 func TestBootSingleRootWorktreeExistence(t *testing.T) {
 	root := t.TempDir()
-	gitC(t, root, "init")
-	gitC(t, root, "config", "user.email", "test@example.com")
-	gitC(t, root, "config", "user.name", "test")
+	testgit.InitRepo(t, root)
 	writeFile(t, filepath.Join(root, "seed.txt"), "seed\n")
 	gitC(t, root, "add", "seed.txt")
 	gitC(t, root, "commit", "-m", "seed")

--- a/internal/status/boot_sandbox_test.go
+++ b/internal/status/boot_sandbox_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 const sandboxBootReadme = `---
@@ -35,7 +37,7 @@ stages:
 func sandboxBootFixture(t *testing.T, inside, available bool) (root string, env []string) {
 	t.Helper()
 	root = t.TempDir()
-	gitC(t, root, "init")
+	testgit.InitRepo(t, root)
 	writeFile(t, filepath.Join(root, "README.md"), sandboxBootReadme)
 	writeFile(t, filepath.Join(root, ".safehouse"), "profile")
 	pathDir := t.TempDir()

--- a/internal/status/boot_state_remote_test.go
+++ b/internal/status/boot_state_remote_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // initStateRepoWithOrigin turns an existing state checkout dir into a real git
@@ -15,9 +17,7 @@ import (
 // `remote get-url origin`, network-free), so the bare upstream needs no content.
 func initStateRepoWithOrigin(t *testing.T, stateDir string) {
 	t.Helper()
-	gitC(t, stateDir, "init", "-q")
-	gitC(t, stateDir, "config", "user.email", "t@t")
-	gitC(t, stateDir, "config", "user.name", "t")
+	testgit.InitRepo(t, stateDir, "-q")
 	upstream := filepath.Join(t.TempDir(), "upstream.git")
 	gitC(t, t.TempDir(), "init", "-q", "--bare", upstream)
 	gitC(t, stateDir, "remote", "add", "origin", upstream)

--- a/internal/status/entered_stage_test.go
+++ b/internal/status/entered_stage_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 const enteredStageReadme = `---
@@ -284,9 +286,7 @@ func buildEnteredStageFixture(t *testing.T, body string) (def, state, entity str
 	t.Helper()
 	def, state = buildSplitRoot(t, enteredStageReadme, map[string]string{"entered-task.md": body})
 	entity = filepath.Join(state, "entered-task.md")
-	gitC(t, state, "init", "-q")
-	gitC(t, state, "config", "user.email", "test@example.com")
-	gitC(t, state, "config", "user.name", "test")
+	testgit.InitRepo(t, state, "-q")
 	gitC(t, state, "add", "--", "entered-task.md")
 	gitC(t, state, "commit", "-q", "-m", "seed entered stage", "--", "entered-task.md")
 	return def, state, entity

--- a/internal/status/merge_guard_foreign_cwd_test.go
+++ b/internal/status/merge_guard_foreign_cwd_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // mergeGuardWorktreeReadme declares a split-root workflow whose terminal
@@ -41,9 +43,7 @@ stages:
 func buildMergeGuardForeignCwdFixture(t *testing.T) (coderoot, defDir, wtDir string) {
 	t.Helper()
 	coderoot = t.TempDir()
-	gitC(t, coderoot, "init")
-	gitC(t, coderoot, "config", "user.email", "test@example.com")
-	gitC(t, coderoot, "config", "user.name", "spacedock-test")
+	testgit.InitRepo(t, coderoot)
 
 	defDir = filepath.Join(coderoot, "docs", "dev")
 	writeFile(t, filepath.Join(defDir, "README.md"), mergeGuardWorktreeReadme)
@@ -53,9 +53,7 @@ func buildMergeGuardForeignCwdFixture(t *testing.T) (coderoot, defDir, wtDir str
 	state := filepath.Join(defDir, ".spacedock-state")
 	writeFile(t, filepath.Join(state, "010-repro.md"),
 		"---\nid: \"010\"\nstatus: implementation\n---\n# Repro entity\n")
-	gitC(t, state, "init")
-	gitC(t, state, "config", "user.email", "test@example.com")
-	gitC(t, state, "config", "user.name", "spacedock-test")
+	testgit.InitRepo(t, state)
 	gitC(t, state, "add", "010-repro.md")
 	gitC(t, state, "commit", "-q", "-m", "seed")
 	gitC(t, state, "branch", "-M", "spacedock-state/dev")

--- a/internal/status/mutation_test.go
+++ b/internal/status/mutation_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // stageFixture copies the named testdata workflow into a fresh git-initialized
@@ -103,16 +105,14 @@ func cpTree(t *testing.T, src, dst string) {
 
 func gitInit(t *testing.T, dir string) {
 	t.Helper()
-	// Set a PERSISTENT local identity on the temp repo (not just an ephemeral `-c` on
-	// the seed commit). The verb's own commits (commitArchiveMove) run plain `git
-	// commit` without `-c`, so they must resolve an identity from the repo's config —
-	// independent of global/system config and git's auto-detection. A CI lane with no
-	// global identity and auto-detection disabled (e.g. user.useConfigOnly) would
-	// otherwise exit-128 the verb's commit.
+	// InitRepo persists a PERSISTENT local identity on the temp repo (not just an
+	// ephemeral `-c` on the seed commit). The verb's own commits (commitArchiveMove)
+	// run plain `git commit` without `-c`, so they must resolve an identity from the
+	// repo's config — independent of global/system config and git's auto-detection.
+	// A CI lane with no global identity and auto-detection disabled (e.g.
+	// user.useConfigOnly) would otherwise exit-128 the verb's commit.
+	testgit.InitRepo(t, dir, "-q")
 	for _, args := range [][]string{
-		{"init", "-q"},
-		{"config", "user.email", "test@example.com"},
-		{"config", "user.name", "spacedock-test"},
 		{"add", "-A"},
 		{"commit", "-q", "-m", "init"},
 	} {

--- a/internal/status/state_origin_test.go
+++ b/internal/status/state_origin_test.go
@@ -6,22 +6,15 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // gitInit initializes a bare-minimum git repo at dir so a remote query resolves
 // there. No remote is added, so `git remote get-url origin` exits non-zero.
 func gitInitNoRemote(t *testing.T, dir string) {
 	t.Helper()
-	for _, args := range [][]string{
-		{"init", "-q"},
-		{"config", "user.email", "t@t"},
-		{"config", "user.name", "t"},
-	} {
-		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
-	}
+	testgit.InitRepo(t, dir, "-q")
 }
 
 // TestStateHasOriginNoRemote (detection unit, seeds AC-1/AC-2 false path): a

--- a/internal/status/worktree_overlay_test.go
+++ b/internal/status/worktree_overlay_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // buildWorktreeBacked materializes a NON-split-root workflow in a git repo with
@@ -35,8 +37,8 @@ func buildWorktreeBacked(t *testing.T, readme, pipelineEntity, worktreeEntity st
 // overlay's find_git_root resolves to root.
 func gitInitWorktreeFixture(t *testing.T, dir string) {
 	t.Helper()
+	testgit.InitRepo(t, dir, "-q")
 	for _, args := range [][]string{
-		{"init", "-q"},
 		{"-c", "user.email=t@t", "-c", "user.name=t", "add", "-A"},
 		{"-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "init"},
 	} {

--- a/internal/testgit/testgit.go
+++ b/internal/testgit/testgit.go
@@ -1,0 +1,27 @@
+// Package testgit scaffolds throwaway git repositories for tests.
+package testgit
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// InitRepo initializes a git repo at dir and persists user.name/user.email in
+// the repo's own config, so a later plain `git commit` -- including one run by
+// the code under test -- resolves an identity without the host's ambient git
+// config. Extra args are appended to `git init` (e.g. "-b", "main").
+func InitRepo(t testing.TB, dir string, initArgs ...string) {
+	t.Helper()
+	runGit(t, dir, append([]string{"init"}, initArgs...)...)
+	runGit(t, dir, "config", "user.name", "Spacedock Test")
+	runGit(t, dir, "config", "user.email", "spacedock@example.invalid")
+}
+
+func runGit(t testing.TB, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/internal/testgit/testgit_test.go
+++ b/internal/testgit/testgit_test.go
@@ -1,0 +1,79 @@
+package testgit
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// scrubbedIdentityEnv disables git's ambient/global identity fallback so a
+// subprocess commit can only succeed if the repo itself carries a persisted
+// user.name/user.email. HOME-scrubbing alone is not sufficient: git falls back
+// to auto-detecting user.email from username@hostname, which succeeds on a
+// developer machine and only fails on a runner with a different hostname
+// shape. user.useConfigOnly=true removes that fallback deterministically.
+func scrubbedIdentityEnv() []string {
+	return append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=user.useConfigOnly",
+		"GIT_CONFIG_VALUE_0=true",
+	)
+}
+
+func commitWithScrubbedIdentity(dir string) error {
+	cmd := exec.Command("git", "commit", "--allow-empty", "-m", "scrubbed-identity probe")
+	cmd.Dir = dir
+	cmd.Env = scrubbedIdentityEnv()
+	return cmd.Run()
+}
+
+// TestInitRepoSurvivesScrubbedIdentity is AC-3's positive case: a repo
+// scaffolded by InitRepo persists identity in its own config, so a plain
+// commit succeeds even with no ambient identity available to the subprocess.
+func TestInitRepoSurvivesScrubbedIdentity(t *testing.T) {
+	dir := t.TempDir()
+	InitRepo(t, dir)
+
+	if err := commitWithScrubbedIdentity(dir); err != nil {
+		t.Fatalf("commit in InitRepo'd repo under scrubbed identity: %v", err)
+	}
+}
+
+// TestPlainGitInitFailsUnderScrubbedIdentity is AC-3's paired negative case.
+// Without it, the positive case above would pass on any developer machine via
+// hostname auto-detection -- the exact way the original bug escaped local
+// testing. A repo made by a bare `git init` (no InitRepo call, no persisted
+// identity) must fail the same commit.
+func TestPlainGitInitFailsUnderScrubbedIdentity(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	if err := commitWithScrubbedIdentity(dir); err == nil {
+		t.Fatal("commit in a plain git-init repo (no InitRepo) unexpectedly succeeded under scrubbed identity -- falsifiability check failed")
+	}
+}
+
+// TestInitRepoPersistsUserEmailInRepoConfig asserts the identity resolves
+// from the repo's own local config after a single InitRepo call, not from
+// any inherited/global config.
+func TestInitRepoPersistsUserEmailInRepoConfig(t *testing.T) {
+	dir := t.TempDir()
+	InitRepo(t, dir)
+
+	cmd := exec.Command("git", "config", "--local", "user.email")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git config --local user.email: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(out)), "spacedock@example.invalid"; got != want {
+		t.Fatalf("git config --local user.email = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Adds a shared git-scaffold test helper so fixtures can no longer silently omit persisted git identity, the exact gap that broke CI once already.

## What changed
- Add `internal/testgit.InitRepo` persisting git identity in one call.
- Migrate 38 hand-rolled git-init scaffold sites across 9 packages to it.
- Add a contractlint guard failing on any future hand-rolled git init.
- Delete the now-orphaned `prepareGitIdentity` helper in internal/gates.

## Evidence
- `go test ./...` and `go test ./... -race`: 20/20 packages passed.
- contractlint guard reproduced 38->0 offenders from a clean merge-base baseline, not taken on faith.

---
[zf](/spacedock-dev/spacedock/blob/4fcdf2c46a7e3ea5156422655bf24cfc7f32dddf/shared-git-scaffold-helper.md)