### PR TITLE
Migrate PR #600's 7 fixtures to testgit.InitRepo

### DIFF
--- a/internal/cli/gate_ceremony_count_test.go
+++ b/internal/cli/gate_ceremony_count_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spacedock-dev/spacedock/internal/gates"
 	"github.com/spacedock-dev/spacedock/internal/status"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // gateCeremonyReadme declares the measured shape: a gate:true ideation stage
@@ -68,9 +69,7 @@ func gateCeremonyFixture(t *testing.T) (mainRoot, workflowDir, entityPath, check
 	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	git(t, mainRoot, "init", "-q")
-	git(t, mainRoot, "config", "user.name", "Spacedock Test")
-	git(t, mainRoot, "config", "user.email", "spacedock@example.invalid")
+	testgit.InitRepo(t, mainRoot, "-q")
 	writeFile(t, filepath.Join(workflowDir, "README.md"), gateCeremonyReadme)
 	artifact := filepath.Join(mainRoot, "gate-review.md")
 	writeFile(t, artifact, "# Review\n\nReady to proceed to implementation.\n")
@@ -81,9 +80,7 @@ func gateCeremonyFixture(t *testing.T) (mainRoot, workflowDir, entityPath, check
 	if err := os.MkdirAll(statePath, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	git(t, statePath, "init", "-q")
-	git(t, statePath, "config", "user.name", "Spacedock Test")
-	git(t, statePath, "config", "user.email", "spacedock@example.invalid")
+	testgit.InitRepo(t, statePath, "-q")
 	writeFile(t, filepath.Join(statePath, "task.md"), "---\nid: task\nstatus: ideation\ntitle: Task\nstarted:\nworktree:\n---\n# Task\n")
 	git(t, statePath, "add", ".")
 	git(t, statePath, "commit", "-q", "-m", "state fixture")

--- a/internal/cli/gate_consume_sync_test.go
+++ b/internal/cli/gate_consume_sync_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spacedock-dev/spacedock/internal/gates"
 	"github.com/spacedock-dev/spacedock/internal/status"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // TestGateConsumeFlagRejectsNonApproveDecisionBeforeWrite pins mechanism 2's
@@ -130,9 +131,7 @@ func gatedTerminalSplitRootFixture(t *testing.T) (hostClone, workflowDir string)
 	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	git(t, hostClone, "init", "-q")
-	git(t, hostClone, "config", "user.name", "Spacedock Test")
-	git(t, hostClone, "config", "user.email", "spacedock@example.invalid")
+	testgit.InitRepo(t, hostClone, "-q")
 	writeFile(t, filepath.Join(workflowDir, "README.md"), "---\nid-style: slug\nstate: .spacedock-state\nstages:\n  states:\n    - name: validation\n      initial: true\n      gate: true\n    - name: done\n      terminal: true\n---\n# Terminal Fixture\n")
 	git(t, hostClone, "add", ".")
 	git(t, hostClone, "commit", "-q", "-m", "main fixture")
@@ -141,9 +140,7 @@ func gatedTerminalSplitRootFixture(t *testing.T) (hostClone, workflowDir string)
 	if err := os.MkdirAll(statePath, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	git(t, statePath, "init", "-q")
-	git(t, statePath, "config", "user.name", "Spacedock Test")
-	git(t, statePath, "config", "user.email", "spacedock@example.invalid")
+	testgit.InitRepo(t, statePath, "-q")
 	writeFile(t, filepath.Join(statePath, "task.md"), "---\nid: task\nstatus: validation\ntitle: Task\n---\n# Task\n")
 	git(t, statePath, "add", ".")
 	git(t, statePath, "commit", "-q", "-m", "state fixture")
@@ -382,9 +379,7 @@ func staleableGatedSplitRootFixture(t *testing.T) (workflowDir, checkout, briefi
 	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	git(t, mainRoot, "init", "-q")
-	git(t, mainRoot, "config", "user.name", "Spacedock Test")
-	git(t, mainRoot, "config", "user.email", "spacedock@example.invalid")
+	testgit.InitRepo(t, mainRoot, "-q")
 	writeFile(t, filepath.Join(workflowDir, "README.md"), gateCeremonyReadme)
 	git(t, mainRoot, "add", ".")
 	git(t, mainRoot, "commit", "-q", "-m", "main fixture")
@@ -393,9 +388,7 @@ func staleableGatedSplitRootFixture(t *testing.T) (workflowDir, checkout, briefi
 	if err := os.MkdirAll(checkout, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	git(t, checkout, "init", "-q")
-	git(t, checkout, "config", "user.name", "Spacedock Test")
-	git(t, checkout, "config", "user.email", "spacedock@example.invalid")
+	testgit.InitRepo(t, checkout, "-q")
 
 	briefing = filepath.Join(checkout, "review", "ideation", "briefing-1", "briefing.json")
 	if err := os.MkdirAll(filepath.Dir(briefing), 0o755); err != nil {

--- a/internal/dispatch/build_stamp_test.go
+++ b/internal/dispatch/build_stamp_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/spacedock-dev/spacedock/internal/status"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // stampFixture builds a single-repo split-root workflow: a main repo with a
@@ -27,9 +28,7 @@ func stampFixture(t *testing.T, status_, worktreeStage string, worktree bool) (m
 	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	runGitFatal(t, mainRepo, "init", "-q")
-	runGitFatal(t, mainRepo, "config", "user.email", "t@t")
-	runGitFatal(t, mainRepo, "config", "user.name", "t")
+	testgit.InitRepo(t, mainRepo, "-q")
 
 	workflowDir = filepath.Join(mainRepo, "docs", "dev")
 	writeFile(t, filepath.Join(workflowDir, "README.md"), readmeWorktree(true))


### PR DESCRIPTION
Fixes a red `main`: PR #600's own test fixtures never migrated to the shared git-scaffold helper, so the new guard flags them.

## What changed
- Migrate 7 hand-rolled `git init` scaffold sites to `testgit.InitRepo`.
- No assertion or fixture-content changes beyond the init/identity substitution.

## Evidence
- `go test ./internal/contractlint/...` (git-scaffold guard): 0/7 offenders remaining.
- `go test ./...` and `go test ./... -race`: full suite green.

---
[69c](/spacedock-dev/spacedock/blob/40a749db3fcfb24b4e096000fe9cc516c4e2fcf9/migrate-pr600-fixtures-to-testgit.md)