### PR TITLE
Make status --where robust and discoverable (#314)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -603,18 +603,23 @@ Examples:
 // the hand-rolled router did — cobra never consumes, reorders, or validates a
 // status flag (AC-5).
 func newStatusCommand(ctx context.Context, env []string, dir string, stdin io.Reader, stdout, stderr io.Writer, runner status.Runner) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:                "status [args]",
 		Short:              "Show or update workflow state",
 		GroupID:            "workflow",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if wantsHelp(args) {
+				return cmd.Help()
+			}
 			if code := runStatus(ctx, args, env, dir, stdin, stdout, stderr, runner); code != 0 {
 				return exitCodeError{code}
 			}
 			return nil
 		},
 	}
+	setStatusHelp(cmd, stdout)
+	return cmd
 }
 
 // newNewCommand wires `spacedock new [--folder] SLUG` as a pure alias for

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -180,6 +180,49 @@ Examples:
 	})
 }
 
+// setStatusHelp installs a per-command help renderer for `status`: the query
+// flag surface instead of the root's grouped menu (cobra walks to the parent
+// HelpFunc only when a child has none). It names --where as THE entity query,
+// the one-clause-per-flag AND rule (a repeated-clause string is an error, not an
+// AND — the #314 fix), the canonical known-field list, and --archived's
+// active-plus-archived semantics (it composes with --where; it does not swap
+// scope) — the discoverability surface `status --help` did not previously
+// provide (before this, RunE had no wantsHelp guard, so --help fell through to
+// the entity listing).
+func setStatusHelp(cmd *cobra.Command, w io.Writer) {
+	cmd.SetHelpFunc(func(c *cobra.Command, _ []string) {
+		fmt.Fprint(w, c.Short+`
+
+Usage:
+  spacedock status --workflow-dir DIR [query flags]
+
+Query flags:
+  --where FIELD=VALUE  Filter entities — THE entity query; repeat the flag to AND clauses
+  --archived           Include archived entities (active PLUS archived, not archived-only)
+  --fields a,b,c       Project to these fields    --all-fields  Show every stored field
+  --next               Dispatchable entities      --boot        Startup roll-up
+  --resolve REF        Resolve slug/id/prefix     --next-id     Preview the next id
+  --validate           Check workflow state       --json        Machine-readable output
+
+Operators (one clause per flag):
+  field=value   equals             field!=value  not equals
+  field=        field is empty     field!=       field is non-empty
+
+Repeat --where to AND clauses. Two clauses in one string is an error, not an AND.
+
+Known fields are this workflow's entity frontmatter keys plus the canonical set
+(id, slug, status, title, score, source, worktree, pr, started, completed,
+verdict, mod-block, archived, issue). An unknown field is an error that lists them.
+
+Examples:
+  spacedock status --workflow-dir docs/dev --where status=ideation
+  spacedock status --workflow-dir docs/dev --where sprint=X --where 'sprint-readiness!=defer'
+  spacedock status --workflow-dir docs/dev --where sprint=X --archived
+  spacedock status --workflow-dir docs/dev --where sprint=X --archived --fields slug,status,verdict,archived
+`)
+	})
+}
+
 // setMergeHelp installs a per-command help renderer for `merge`: the `guard`
 // subcommand synopsis, its flag surface, and the three-phase ceremony it drives,
 // instead of the root's grouped menu (cobra walks to the parent HelpFunc only when

--- a/internal/cli/status_help_test.go
+++ b/internal/cli/status_help_test.go
@@ -1,0 +1,57 @@
+// ABOUTME: AC-3 `status --help` coverage — the query-flag synopsis renders
+// ABOUTME: instead of the entity listing that ran there before the wantsHelp guard.
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestStatusHelpRendersQuerySynopsisNotEntityListing pins AC-3: `spacedock
+// status --help` exits 0, prints help instead of running the entity listing
+// (no default-table header), and states the four discoverability facts —
+// --where named as THE entity query, the one-clause-per-flag AND rule, the
+// canonical known-field list, and --archived as active-plus-archived (not a
+// scope swap). Before the wantsHelp guard, this invocation ran the listing
+// (exit 0, entity rows) instead of printing help.
+func TestStatusHelpRendersQuerySynopsisNotEntityListing(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"status", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"THE entity query",
+		"Repeat --where to AND clauses",
+		"id, slug, status, title, score, source, worktree, pr, started, completed,\nverdict, mod-block, archived, issue",
+		"active PLUS archived, not archived-only",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("status --help missing %q:\n%s", want, out)
+		}
+	}
+	// Neither the default table header nor the top-level grouped menu should
+	// leak through: this is `status`'s own help, not the entity listing or the
+	// root's menu.
+	if strings.Contains(out, "ID     SLUG") {
+		t.Errorf("status --help ran the entity listing instead of printing help:\n%s", out)
+	}
+	if strings.Contains(out, "Launch") {
+		t.Errorf("status --help leaked the top-level grouped menu (Launch header):\n%s", out)
+	}
+}
+
+// TestStatusShortHelpFlagAlsoRendersHelp locks that -h is equivalent to --help
+// for status, matching wantsHelp's shared recognition of both spellings.
+func TestStatusShortHelpFlagAlsoRendersHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"status", "-h"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "THE entity query") {
+		t.Errorf("status -h missing query synopsis:\n%s", stdout.String())
+	}
+}

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -493,6 +493,9 @@ func runRead(probe claudeteam.TeamStateProbe, roots roots, args []string, e env,
 	applyEffectiveIDs(entities, idStyle, allEntities)
 	materializeGateEligibility(entities, roots.definitionDir, explicitFields, allFieldsFlag, whereFilters)
 	materializeSuppressedBy(entities, stages, explicitFields, whereFilters)
+	if err := validateWhereFields(entities, whereFilters); err != nil {
+		return errExit(stderr, err.Error())
+	}
 	entities = applyFilters(entities, whereFilters)
 
 	switch {

--- a/internal/status/parse.go
+++ b/internal/status/parse.go
@@ -4,6 +4,8 @@ package status
 
 import (
 	"fmt"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -169,6 +171,21 @@ type whereFilter struct {
 
 const whereSyntaxHelp = "--where requires an operator: use 'field = value', 'field != value', 'field !=' (non-empty), or 'field =' (empty)"
 
+// whereOperatorRe matches one --where operator. `!=` is listed first so the
+// leftmost-first alternation consumes it whole at a given position instead of
+// matching its trailing `=` as a second, spurious operator.
+var whereOperatorRe = regexp.MustCompile(`!=|=`)
+
+// countWhereOperators counts the operators in a single --where argument. A
+// well-formed clause has exactly one; more than one means the argument is the
+// compound-in-one-string shape (e.g. "sprint=A sprint-readiness!=defer") rather
+// than a single clause — Check A of the #314 fix (see docs/dev/.spacedock-state
+// status-where-robust-and-discoverable.md). All four compound shapes named in
+// AC-1 count 2 here, regardless of which operator each half uses.
+func countWhereOperators(whereArg string) int {
+	return len(whereOperatorRe.FindAllStringIndex(whereArg, -1))
+}
+
 // parseWhereFilters parses all --where clauses. Matches parse_where_filters.
 func parseWhereFilters(args []string) ([]whereFilter, error) {
 	var filters []whereFilter
@@ -181,6 +198,11 @@ func parseWhereFilters(args []string) ([]whereFilter, error) {
 			whereArg := args[i+1]
 			if strings.TrimSpace(whereArg) == "" {
 				return nil, fmt.Errorf("--where argument cannot be empty")
+			}
+			if n := countWhereOperators(whereArg); n > 1 {
+				return nil, fmt.Errorf(
+					"--where takes one clause per flag; %q has %d operators — repeat --where to AND clauses instead of combining them in one string: --where 'field=value' --where 'field2!=value2'",
+					whereArg, n)
 			}
 			var op, fieldPart, valuePart string
 			if strings.Contains(whereArg, "!=") {
@@ -209,6 +231,65 @@ func parseWhereFilters(args []string) ([]whereFilter, error) {
 		i++
 	}
 	return filters, nil
+}
+
+// derivedWhereFields are the field names --where/--fields can reference that
+// are computed by a materialize* pass rather than read from frontmatter or the
+// entity schema: materializeGateEligibility and materializeSuppressedBy only
+// write these keys into e.fields when a filter or explicit field already names
+// them (discover.go's referenced guard, format.go's materializeSuppressedBy),
+// so collecting known field names off scanned entities after materialization
+// would silently drop a name whenever nothing else in the same invocation
+// referenced it first. Listed statically instead so validation never depends on
+// that ordering.
+var derivedWhereFields = []string{"gate-condition", "gate-eligible", "gate-readiness", suppressedByField}
+
+// knownWhereFields returns the field names a --where clause may reference: the
+// union of every scanned entity's frontmatter keys (covers workflow-specific
+// fields like sprint/sprint-readiness, which the schema's permissive_additions
+// intentionally leaves uncanonicalized), the canonical entity schema's declared
+// field names (covers verdict/completed/archived/mod-block/pr/issue — canonical
+// but absent from an active-only corpus where every archived member carrying
+// them has been filtered out), and the derived names above.
+func knownWhereFields(entities []*entity) map[string]bool {
+	known := map[string]bool{}
+	for _, e := range entities {
+		for k := range e.fields {
+			known[k] = true
+		}
+	}
+	for k := range loadEntitySchema().fields {
+		known[k] = true
+	}
+	for _, k := range derivedWhereFields {
+		known[k] = true
+	}
+	return known
+}
+
+// validateWhereFields rejects a --where clause naming a field absent from
+// knownWhereFields — Check B of the #314 fix. A misspelled or unknown field
+// (e.g. "spint") reads as the empty string in applyFilters rather than erroring,
+// which silently returns the wrong row set; this makes it a loud exit-1 instead.
+// Skipped on a zero-entity scan: the result is empty either way, and every
+// --where would otherwise error on a fresh workflow before any entity exists to
+// populate the corpus half of the union.
+func validateWhereFields(entities []*entity, filters []whereFilter) error {
+	if len(entities) == 0 || len(filters) == 0 {
+		return nil
+	}
+	known := knownWhereFields(entities)
+	for _, f := range filters {
+		if !known[f.field] {
+			names := make([]string, 0, len(known))
+			for name := range known {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			return fmt.Errorf("--where: unknown field %q — known fields: %s", f.field, strings.Join(names, ", "))
+		}
+	}
+	return nil
 }
 
 // applyFilters keeps entities matching all --where clauses. Matches

--- a/internal/status/where_archived_test.go
+++ b/internal/status/where_archived_test.go
@@ -1,0 +1,51 @@
+// ABOUTME: AC-2 regression pin — --archived composes with --where as
+// ABOUTME: active-plus-archived, not an archived-only scope swap.
+package status
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWhereArchivedComposesAsActivePlusArchived pins AC-2: --archived is
+// already inclusive (activeAndArchivedEntities = scanEntitiesActive +
+// archiveEntities), so a --where clause matching one active and one archived
+// entity returns only the active member without --archived, and both members
+// with it. enum-scope-workflow carries exactly this shape: top-placed (active)
+// and arch-placed (archived) share status=backlog, differing only by
+// placement — this must fail if --archived ever becomes archived-only or stops
+// composing with --where.
+func TestWhereArchivedComposesAsActivePlusArchived(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("testdata", "enum-scope-workflow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := pinnedEnv(t)
+
+	t.Run("active-only", func(t *testing.T) {
+		out, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--where", "status=backlog")
+		if code != 0 {
+			t.Fatalf("exit=%d, want 0 (err=%q)", code, errOut)
+		}
+		if !strings.Contains(out, "top-placed") {
+			t.Fatalf("active-only --where status=backlog must include top-placed:\n%s", out)
+		}
+		if strings.Contains(out, "arch-placed") {
+			t.Fatalf("active-only --where status=backlog must NOT include arch-placed:\n%s", out)
+		}
+	})
+
+	t.Run("active-plus-archived", func(t *testing.T) {
+		out, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--where", "status=backlog", "--archived")
+		if code != 0 {
+			t.Fatalf("exit=%d, want 0 (err=%q)", code, errOut)
+		}
+		if !strings.Contains(out, "top-placed") {
+			t.Fatalf("--where status=backlog --archived must include top-placed:\n%s", out)
+		}
+		if !strings.Contains(out, "arch-placed") {
+			t.Fatalf("--where status=backlog --archived must include arch-placed:\n%s", out)
+		}
+	})
+}

--- a/internal/status/where_validate_test.go
+++ b/internal/status/where_validate_test.go
@@ -1,0 +1,143 @@
+// ABOUTME: AC-1 (#314) --where robustness — Check A (compound-in-one-string
+// ABOUTME: operator-count syntax guard) and Check B (unknown-field-name guard).
+package status
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// compoundWhereShapes are the four ways a single --where argument can carry two
+// clauses instead of one. All four must be rejected: today all four return
+// 156-of-156 rows at exit 0 on a live corpus (silent match-all for three of
+// them, silent empty-result for the "sprint=A sprint-readiness=ready" case).
+// Only a multi-operator syntax check catches all four — a shape like
+// "a!=1 b!=2" cuts to the legitimate field name "a" with a garbage value, so
+// field-name validation alone (Check B) does not see anything wrong with it.
+var compoundWhereShapes = []struct {
+	name string
+	arg  string
+}{
+	{"eq-then-neq", "a=1 b!=2"},
+	{"neq-then-neq", "a!=1 b!=2"},
+	{"eq-then-eq", "a=1 b=2"},
+	{"neq-then-eq", "a!=1 b=2"},
+}
+
+// TestWhereCompoundShapesRejected locks Check A: every compound-in-one-string
+// shape exits 1 with a message naming the repeated-flag fix (repeat --where),
+// not a silent match-all/match-none at exit 0.
+func TestWhereCompoundShapesRejected(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("testdata", "seq-workflow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := pinnedEnv(t)
+
+	for _, tc := range compoundWhereShapes {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			out, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--where", tc.arg)
+			if code != 1 {
+				t.Fatalf("--where %q exit=%d (out=%q err=%q), want 1", tc.arg, code, out, errOut)
+			}
+			if out != "" {
+				t.Fatalf("--where %q: stdout must be empty on rejection, got %q", tc.arg, out)
+			}
+			if !strings.Contains(errOut, "repeat --where") {
+				t.Fatalf("--where %q: stderr = %q, want it to name the repeated-flag fix", tc.arg, errOut)
+			}
+		})
+	}
+}
+
+// TestWhereUnknownFieldRejected locks Check B: a field name absent from both the
+// scanned corpus and the canonical schema is a loud error listing the known
+// fields, not a silent match-all (!=) or match-none (=).
+func TestWhereUnknownFieldRejected(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("testdata", "seq-workflow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := pinnedEnv(t)
+
+	cases := []string{"nosuchfield!=x", "spint=v"}
+	for _, arg := range cases {
+		arg := arg
+		t.Run(arg, func(t *testing.T) {
+			out, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--where", arg)
+			if code != 1 {
+				t.Fatalf("--where %q exit=%d (out=%q err=%q), want 1", arg, code, out, errOut)
+			}
+			if out != "" {
+				t.Fatalf("--where %q: stdout must be empty on rejection, got %q", arg, out)
+			}
+			if !strings.Contains(errOut, "unknown field") {
+				t.Fatalf("--where %q: stderr = %q, want it to say unknown field", arg, errOut)
+			}
+			// The schema half of the union must be listed even though this
+			// active-only corpus has no entity carrying these canonical keys.
+			for _, want := range []string{"verdict", "archived", "id", "status", "title"} {
+				if !strings.Contains(errOut, want) {
+					t.Fatalf("--where %q: stderr = %q, want known-fields list to include %q", arg, errOut, want)
+				}
+			}
+		})
+	}
+}
+
+// TestWhereNoOverRejection locks the counter-baseline: a known-but-unpopulated
+// canonical field (verdict is schema-declared but absent from every active
+// entity in this fixture) must not error. Losing the schema half of the union
+// would make this exit 1, breaking a legitimate query on a fresh active read.
+func TestWhereNoOverRejection(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("testdata", "seq-workflow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := pinnedEnv(t)
+
+	_, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--where", "verdict!=")
+	if code != 0 {
+		t.Fatalf("--where 'verdict!=' exit=%d (err=%q), want 0 (no over-rejection)", code, errOut)
+	}
+}
+
+// TestWhereDerivedNamesAccepted locks that the four computed field names
+// (gate-condition, gate-eligible, gate-readiness, next-suppressed-by) are
+// accepted even though materializeGateEligibility/materializeSuppressedBy only
+// populate them in e.fields when something in the same invocation already
+// references them — the static derived list must not depend on that ordering.
+func TestWhereDerivedNamesAccepted(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("testdata", "suppress-workflow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := pinnedEnv(t)
+
+	cases := []string{"next-suppressed-by = concurrency-full", "gate-eligible=true"}
+	for _, arg := range cases {
+		arg := arg
+		t.Run(arg, func(t *testing.T) {
+			_, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--where", arg)
+			if code != 0 {
+				t.Fatalf("--where %q exit=%d (err=%q), want 0", arg, code, errOut)
+			}
+		})
+	}
+}
+
+// TestWhereEmptyWorkflowSkipsFieldValidation locks the zero-entity guard: with
+// nothing scanned, Check B must not fire (every result is empty either way), so
+// a fresh workflow's first --where does not error before any entity exists to
+// populate the corpus half of the known-field union.
+func TestWhereEmptyWorkflowSkipsFieldValidation(t *testing.T) {
+	root := t.TempDir()
+	env := pinnedEnv(t)
+
+	_, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--where", "sprint=X")
+	if code != 0 {
+		t.Fatalf("--where on empty workflow exit=%d (err=%q), want 0", code, errOut)
+	}
+}

--- a/skills/fo-status-viewer/SKILL.md
+++ b/skills/fo-status-viewer/SKILL.md
@@ -19,7 +19,14 @@ ${SPACEDOCK_BIN:-spacedock} status --workflow-dir {workflow_dir} [--page N|--lim
 - `--validate` — run before trusting manually edited workflow state.
 - `--resolve REF` — deterministic lookup by slug, exact stored ID, or sd-b32 address prefix; `--root` rejects unqualified cross-workflow ambiguity rather than guessing.
 - `--next-id` — preview the next-id candidate for `sequential` and `sd-b32` (n/a for `slug`). For `sd-b32`, pass `--id-seed "{slug-or-title}"` and optionally `--id-actor "{actor-or-agent}"` so creation context enters the candidate. To file a new entity, do NOT pair `--next-id` with a hand-written file — use `spacedock new` under the eagerly loaded `«write.classify»` contract, which mints the id and atomically writes the stamped entity in one call. `--next-id` is candidate-preview only.
-- `--next` / `--where "pr !="` — targeted event-loop queries.
+- `--where <field>=<value>` — **THE entity query.** One clause per flag; repeat
+  the flag to AND clauses (`--where sprint=X --where 'sprint-readiness!=defer'`).
+  Two clauses in one string is an error, not an AND. `field!=` means non-empty,
+  `field=` means empty. Unknown field names are a loud error listing the known
+  fields. Known fields are this workflow's frontmatter keys plus the canonical
+  set: `id slug status title score source worktree pr started completed verdict
+  mod-block archived issue`. Never `find`/`grep` the state dir — query it.
+- `--next` — dispatchable entities.
 
 The `--set` flag updates entity frontmatter fields:
 - `--set {slug} field=value` sets a field
@@ -38,7 +45,9 @@ The commissioned README directs the captain to dispatch the FO to inspect workfl
 **Canonical invocations** (all start with `${SPACEDOCK_BIN:-spacedock} status --workflow-dir {workflow_dir}`):
 - Overview: no extra flags shows the first 25 rows, sorted by later stage first then score descending; use `--page N` for more or `--limit 0` for the full table.
 - Dispatchables: `--next`.
-- Archive view: `--archived`.
+- Archived-inclusive view: `--archived` returns active **plus** archived, not
+  archived-only. A full-sprint answer incl. done is one query:
+  `--where sprint=X --archived --fields slug,status,verdict,archived`.
 - Single-entity: `--resolve {ref}` then `--where slug={resolved-slug}`.
 
 **Output rendering guidance.** Forward `status` stdout verbatim inside a fenced code block, with a one-line preface naming the request ("Workflow overview:", "Dispatchable entities:", "Archived entities:"). On empty results, render a literal note ("No dispatchable entities right now.") instead of an empty fence. Do not paraphrase rows, omit columns, invent fields, summarize counts, or editorialize.


### PR DESCRIPTION
Closes GitHub #314: `status --where` silently returned the wrong, unfiltered result on a bad field or a compound-in-one-string clause instead of erroring.

## What changed
- Reject compound-in-one-string `--where` shapes with a named-fix error.
- Reject unknown/misspelled `--where` field names, listing the known set.
- Document `--archived` as active-plus-archived, not a scope swap.
- Add a real `status --help` synopsis naming `--where` as the entity query.

## Evidence
- Validator built both the pre-fix and post-fix binaries and byte-diffed real output against the live `docs/dev` corpus (not just re-ran unit tests): all 4 ACs reproduced.
- `go test ./...` and `go test ./... -race`: full suite green, including the pinned parity goldens.

---
[3t](/spacedock-dev/spacedock/blob/73430c7f4a761c6d61a26d34dbe4bc8b0757fb4e/status-where-robust-and-discoverable.md)