### PR TITLE
Avoid unnecessary rebases before opening mergeable PRs

### DIFF
--- a/docs/dev/_mods/pr-merge.md
+++ b/docs/dev/_mods/pr-merge.md
@@ -1,8 +1,8 @@
 ---
 name: pr-merge
 description: Open a code-branch PR to the configured trunk at the merge boundary and track it to merge, state-root-aware
-version: 0.12.7
-reconciled-from-shipped: 0.12.6
+version: 0.12.5
+reconciled-from-shipped: 0.12.4
 fo-realm: "FO realm — the FO maintains this file directly; changes do NOT go through the dev workflow (process the FO operates, not product built under test)."
 local-customization: "Split-root variant of the shipped template: entity state lives in .spacedock-state (pr:/mod-block: via status --set, path-scoped); the hook never touches .spacedock-state from the code worktree; the PR carries only the code-branch range."
 ---
@@ -42,7 +42,7 @@ Resolve the PR base once: `BASE=$(spacedock dispatch trunk --workflow-dir docs/d
 
 **PR APPROVAL GUARDRAIL — Do NOT push or create a PR without explicit captain approval.** Opening a PR and pushing the branch are outward-facing. Before presenting the draft, construct the full PR body so the captain reviews the actual prose that will land on GitHub.
 
-Record the exact commit being submitted before constructing the draft: `CANDIDATE_SHA=$(git -C {worktree} rev-parse HEAD)`. Compute the audit-link inputs: state SHA via `git -C docs/dev/.spacedock-state rev-parse HEAD` (the full SHA of the **state** checkout's HEAD — the entity's `mod-block=merge:pr-merge` commit, which the FO committed before invoking this hook, so HEAD already contains the active entity file); owner/repo via `gh repo view --json nameWithOwner --jq '.nameWithOwner'`; short entity-id slot via `spacedock status --workflow-dir docs/dev --short-id {slug}` (shortest-unique-prefix for sd-b32 workflows, matching the status table's ID column).
+Compute the audit-link inputs first: state SHA via `git -C docs/dev/.spacedock-state rev-parse HEAD` (the full SHA of the **state** checkout's HEAD — the entity's `mod-block=merge:pr-merge` commit, which the FO committed before invoking this hook, so HEAD already contains the active entity file); owner/repo via `gh repo view --json nameWithOwner --jq '.nameWithOwner'`; short entity-id slot via `spacedock status --workflow-dir docs/dev --short-id {slug}` (shortest-unique-prefix for sd-b32 workflows, matching the status table's ID column).
 
 Build the full PR body using the template below — motivation lead, `## What changed`, `## Evidence`, `---` separator, `[{short-id}](...)` audit link, and `Closes {issue}` line if the entity frontmatter `issue` is set. This is the body that will be passed to `gh pr create` verbatim; do not reconstruct it after approval. The entity body and stage reports are read from the **state checkout** (`docs/dev/.spacedock-state/{slug}/index.md`), not the worktree.
 
@@ -50,7 +50,6 @@ Then present the draft to the captain:
 
 - **Title:** {entity title}
 - **Branch:** {branch} -> $BASE
-- **Candidate:** $CANDIDATE_SHA
 - **Changes:** {N} file(s) changed across {N} commit(s) (`git -C {worktree} diff --stat origin/$BASE...{branch}`)
 - **Files:** {list of changed files}
 - **Body:**
@@ -61,15 +60,9 @@ Then present the draft to the captain:
 
 Wait for the captain's explicit approval before pushing. Do NOT infer approval from silence, acknowledgment of the summary, or the gate approval that preceded this step — only an explicit "push it", "go ahead", "yes", or equivalent counts.
 
-**On approval:** This is a split-root workflow: the entity state lives in the separate `.spacedock-state` checkout, so this hook does not push any state branch. Refresh the code remote's integration tip with `git -C {worktree} fetch origin "$BASE"`; if that fails, report to the captain and fall back to the local `--no-ff` merge.
+**On approval:** This is a split-root workflow — the FO rebases the code branch onto `origin/$BASE` BEFORE invoking this hook, and the entity state lives in the separate `.spacedock-state` checkout, so this hook does NOT rebase or push any state branch. Push only the code branch:
 
-Resolve the current integration tip as `BASE_SHA=$(git -C {worktree} rev-parse "origin/$BASE")`, then exercise the approved commit against it without changing the candidate ref, index, or worktree: `git -C {worktree} merge-tree --write-tree "$BASE_SHA" "$CANDIDATE_SHA"`. Inspect its stdout, stderr, exit status, and repository context; the exit status is one signal, not the semantic verdict.
-
-- If the evidence indicates a clean merge, continue without rebasing.
-- If the evidence indicates an actual content conflict, stop PR and local-merge delivery, refer reconciliation to the G3/D8 owner path, and preserve the pending delivery authority.
-- If the command fails or the evidence is incomplete or ambiguous, mergeability is unknown: report the error, preserve the pending authority, and stop delivery; do not rebase or use local merge as a fallback.
-
-1. For a clean result, `git -C {worktree} push origin "${CANDIDATE_SHA}:refs/heads/{branch}"` — push the approved commit to the code remote (`origin` = the main repo, base branch `$BASE`). Do NOT push the trunk or any `.spacedock-state` branch from here; the FO coordinates state-remote pushes separately.
+1. `git -C {worktree} push -u origin {branch}` — push the entity's code branch to the code remote (`origin` = the main repo, base branch `$BASE`). Do NOT push the trunk or any `.spacedock-state` branch from here; the FO coordinates state-remote pushes separately.
 
 If the push fails (no remote, auth error), report to the captain and fall back to the local `--no-ff` merge (see fallback below).
 

--- a/docs/dev/_mods/pr-merge.md
+++ b/docs/dev/_mods/pr-merge.md
@@ -1,8 +1,8 @@
 ---
 name: pr-merge
 description: Open a code-branch PR to the configured trunk at the merge boundary and track it to merge, state-root-aware
-version: 0.12.6
-reconciled-from-shipped: 0.12.5
+version: 0.12.7
+reconciled-from-shipped: 0.12.6
 fo-realm: "FO realm — the FO maintains this file directly; changes do NOT go through the dev workflow (process the FO operates, not product built under test)."
 local-customization: "Split-root variant of the shipped template: entity state lives in .spacedock-state (pr:/mod-block: via status --set, path-scoped); the hook never touches .spacedock-state from the code worktree; the PR carries only the code-branch range."
 ---
@@ -63,13 +63,13 @@ Wait for the captain's explicit approval before pushing. Do NOT infer approval f
 
 **On approval:** This is a split-root workflow: the entity state lives in the separate `.spacedock-state` checkout, so this hook does not push any state branch. Refresh the code remote's integration tip with `git -C {worktree} fetch origin "$BASE"`; if that fails, report to the captain and fall back to the local `--no-ff` merge.
 
-Resolve the current integration tip as `BASE_SHA=$(git -C {worktree} rev-parse "origin/$BASE")`, then exercise the approved commit against it without changing the candidate ref, index, or worktree: `git -C {worktree} merge-tree --write-tree "$BASE_SHA" "$CANDIDATE_SHA" >/dev/null`.
+Resolve the current integration tip as `BASE_SHA=$(git -C {worktree} rev-parse "origin/$BASE")`, then exercise the approved commit against it without changing the candidate ref, index, or worktree: `git -C {worktree} merge-tree --write-tree "$BASE_SHA" "$CANDIDATE_SHA"`. Inspect its stdout, stderr, exit status, and repository context; the exit status is one signal, not the semantic verdict.
 
-- Exit 0 is clean: continue without rebasing.
-- Exit 1 is a conflict: stop PR and local-merge delivery, refer reconciliation to the G3/D8 owner path, and preserve the pending delivery authority.
-- Any other exit leaves mergeability unknown: stop delivery and report the command error; do not rebase or use local merge as a fallback.
+- If the evidence indicates a clean merge, continue without rebasing.
+- If the evidence indicates an actual content conflict, stop PR and local-merge delivery, refer reconciliation to the G3/D8 owner path, and preserve the pending delivery authority.
+- If the command fails or the evidence is incomplete or ambiguous, mergeability is unknown: report the error, preserve the pending authority, and stop delivery; do not rebase or use local merge as a fallback.
 
-1. For a clean result, `git -C {worktree} push origin "$CANDIDATE_SHA:refs/heads/{branch}"` — push the approved commit to the code remote (`origin` = the main repo, base branch `$BASE`). Do NOT push the trunk or any `.spacedock-state` branch from here; the FO coordinates state-remote pushes separately.
+1. For a clean result, `git -C {worktree} push origin "${CANDIDATE_SHA}:refs/heads/{branch}"` — push the approved commit to the code remote (`origin` = the main repo, base branch `$BASE`). Do NOT push the trunk or any `.spacedock-state` branch from here; the FO coordinates state-remote pushes separately.
 
 If the push fails (no remote, auth error), report to the captain and fall back to the local `--no-ff` merge (see fallback below).
 

--- a/docs/dev/_mods/pr-merge.md
+++ b/docs/dev/_mods/pr-merge.md
@@ -1,8 +1,8 @@
 ---
 name: pr-merge
 description: Open a code-branch PR to the configured trunk at the merge boundary and track it to merge, state-root-aware
-version: 0.12.5
-reconciled-from-shipped: 0.12.4
+version: 0.12.6
+reconciled-from-shipped: 0.12.5
 fo-realm: "FO realm — the FO maintains this file directly; changes do NOT go through the dev workflow (process the FO operates, not product built under test)."
 local-customization: "Split-root variant of the shipped template: entity state lives in .spacedock-state (pr:/mod-block: via status --set, path-scoped); the hook never touches .spacedock-state from the code worktree; the PR carries only the code-branch range."
 ---
@@ -42,7 +42,7 @@ Resolve the PR base once: `BASE=$(spacedock dispatch trunk --workflow-dir docs/d
 
 **PR APPROVAL GUARDRAIL — Do NOT push or create a PR without explicit captain approval.** Opening a PR and pushing the branch are outward-facing. Before presenting the draft, construct the full PR body so the captain reviews the actual prose that will land on GitHub.
 
-Compute the audit-link inputs first: state SHA via `git -C docs/dev/.spacedock-state rev-parse HEAD` (the full SHA of the **state** checkout's HEAD — the entity's `mod-block=merge:pr-merge` commit, which the FO committed before invoking this hook, so HEAD already contains the active entity file); owner/repo via `gh repo view --json nameWithOwner --jq '.nameWithOwner'`; short entity-id slot via `spacedock status --workflow-dir docs/dev --short-id {slug}` (shortest-unique-prefix for sd-b32 workflows, matching the status table's ID column).
+Record the exact commit being submitted before constructing the draft: `CANDIDATE_SHA=$(git -C {worktree} rev-parse HEAD)`. Compute the audit-link inputs: state SHA via `git -C docs/dev/.spacedock-state rev-parse HEAD` (the full SHA of the **state** checkout's HEAD — the entity's `mod-block=merge:pr-merge` commit, which the FO committed before invoking this hook, so HEAD already contains the active entity file); owner/repo via `gh repo view --json nameWithOwner --jq '.nameWithOwner'`; short entity-id slot via `spacedock status --workflow-dir docs/dev --short-id {slug}` (shortest-unique-prefix for sd-b32 workflows, matching the status table's ID column).
 
 Build the full PR body using the template below — motivation lead, `## What changed`, `## Evidence`, `---` separator, `[{short-id}](...)` audit link, and `Closes {issue}` line if the entity frontmatter `issue` is set. This is the body that will be passed to `gh pr create` verbatim; do not reconstruct it after approval. The entity body and stage reports are read from the **state checkout** (`docs/dev/.spacedock-state/{slug}/index.md`), not the worktree.
 
@@ -50,6 +50,7 @@ Then present the draft to the captain:
 
 - **Title:** {entity title}
 - **Branch:** {branch} -> $BASE
+- **Candidate:** $CANDIDATE_SHA
 - **Changes:** {N} file(s) changed across {N} commit(s) (`git -C {worktree} diff --stat origin/$BASE...{branch}`)
 - **Files:** {list of changed files}
 - **Body:**
@@ -60,9 +61,15 @@ Then present the draft to the captain:
 
 Wait for the captain's explicit approval before pushing. Do NOT infer approval from silence, acknowledgment of the summary, or the gate approval that preceded this step — only an explicit "push it", "go ahead", "yes", or equivalent counts.
 
-**On approval:** This is a split-root workflow — the FO rebases the code branch onto `origin/$BASE` BEFORE invoking this hook, and the entity state lives in the separate `.spacedock-state` checkout, so this hook does NOT rebase or push any state branch. Push only the code branch:
+**On approval:** This is a split-root workflow: the entity state lives in the separate `.spacedock-state` checkout, so this hook does not push any state branch. Refresh the code remote's integration tip with `git -C {worktree} fetch origin "$BASE"`; if that fails, report to the captain and fall back to the local `--no-ff` merge.
 
-1. `git -C {worktree} push -u origin {branch}` — push the entity's code branch to the code remote (`origin` = the main repo, base branch `$BASE`). Do NOT push the trunk or any `.spacedock-state` branch from here; the FO coordinates state-remote pushes separately.
+Resolve the current integration tip as `BASE_SHA=$(git -C {worktree} rev-parse "origin/$BASE")`, then exercise the approved commit against it without changing the candidate ref, index, or worktree: `git -C {worktree} merge-tree --write-tree "$BASE_SHA" "$CANDIDATE_SHA" >/dev/null`.
+
+- Exit 0 is clean: continue without rebasing.
+- Exit 1 is a conflict: stop PR and local-merge delivery, refer reconciliation to the G3/D8 owner path, and preserve the pending delivery authority.
+- Any other exit leaves mergeability unknown: stop delivery and report the command error; do not rebase or use local merge as a fallback.
+
+1. For a clean result, `git -C {worktree} push origin "$CANDIDATE_SHA:refs/heads/{branch}"` — push the approved commit to the code remote (`origin` = the main repo, base branch `$BASE`). Do NOT push the trunk or any `.spacedock-state` branch from here; the FO coordinates state-remote pushes separately.
 
 If the push fails (no remote, auth error), report to the captain and fall back to the local `--no-ff` merge (see fallback below).
 

--- a/mods/pr-merge.md
+++ b/mods/pr-merge.md
@@ -56,7 +56,7 @@ Wait for the captain's explicit approval before pushing. Do NOT infer approval f
 Resolve the current integration tip as `BASE_SHA=$(git rev-parse "$BASE")`, then exercise the approved commit against it without changing the candidate ref, index, or worktree: `git merge-tree --write-tree "$BASE_SHA" "$CANDIDATE_SHA"`. Inspect its stdout, stderr, exit status, and repository context; the exit status is one signal, not the semantic verdict.
 
 - If the evidence indicates a clean merge, continue without rebasing.
-- If the evidence indicates an actual content conflict, stop PR and local-merge delivery, refer reconciliation to the G3/D8 owner path, and preserve the pending delivery authority.
+- If the evidence indicates an actual content conflict, stop PR and local-merge delivery, surface the conflict evidence, and preserve the pending delivery authority. Do not rebase, automatically resolve, or use force operations; leave reconciliation owner selection to the consuming workflow.
 - If the command fails or the evidence is incomplete or ambiguous, mergeability is unknown: report the error, preserve the pending authority, and stop delivery; do not rebase or use local merge as a fallback.
 
 For a clean result, push the approved commit with the exact-SHA refspec: `git push origin "${CANDIDATE_SHA}:refs/heads/{branch}"`. If that push fails, report to the captain and fall back to local merge.

--- a/mods/pr-merge.md
+++ b/mods/pr-merge.md
@@ -1,7 +1,7 @@
 ---
 name: pr-merge
 description: Push branches and create/track GitHub PRs for workflow entities
-version: 0.12.5
+version: 0.12.6
 ---
 
 # PR Merge
@@ -53,13 +53,13 @@ Wait for the captain's explicit approval before pushing. Do NOT infer approval f
 
 **On approval:** First, push the trunk to ensure the remote is up to date with local state commits: `git push origin "$BASE"`. If that push fails (no remote, auth error), report to the captain and fall back to local merge.
 
-Resolve the current integration tip as `BASE_SHA=$(git rev-parse "$BASE")`, then exercise the approved commit against it without changing the candidate ref, index, or worktree: `git merge-tree --write-tree "$BASE_SHA" "$CANDIDATE_SHA" >/dev/null`.
+Resolve the current integration tip as `BASE_SHA=$(git rev-parse "$BASE")`, then exercise the approved commit against it without changing the candidate ref, index, or worktree: `git merge-tree --write-tree "$BASE_SHA" "$CANDIDATE_SHA"`. Inspect its stdout, stderr, exit status, and repository context; the exit status is one signal, not the semantic verdict.
 
-- Exit 0 is clean: continue without rebasing.
-- Exit 1 is a conflict: stop PR and local-merge delivery, refer reconciliation to the G3/D8 owner path, and preserve the pending delivery authority.
-- Any other exit leaves mergeability unknown: stop delivery and report the command error; do not rebase or use local merge as a fallback.
+- If the evidence indicates a clean merge, continue without rebasing.
+- If the evidence indicates an actual content conflict, stop PR and local-merge delivery, refer reconciliation to the G3/D8 owner path, and preserve the pending delivery authority.
+- If the command fails or the evidence is incomplete or ambiguous, mergeability is unknown: report the error, preserve the pending authority, and stop delivery; do not rebase or use local merge as a fallback.
 
-For a clean result, push the approved commit with the exact-SHA refspec: `git push origin "$CANDIDATE_SHA:refs/heads/{branch}"`. If that push fails, report to the captain and fall back to local merge.
+For a clean result, push the approved commit with the exact-SHA refspec: `git push origin "${CANDIDATE_SHA}:refs/heads/{branch}"`. If that push fails, report to the captain and fall back to local merge.
 
 Then create the PR by running `gh pr create --base "$BASE" --head {branch} --title "{entity title}" --body "{constructed body}"` against the body already constructed above — do not rebuild it. If `gh` is not available, warn the captain and fall back to local merge.
 

--- a/mods/pr-merge.md
+++ b/mods/pr-merge.md
@@ -1,7 +1,7 @@
 ---
 name: pr-merge
 description: Push branches and create/track GitHub PRs for workflow entities
-version: 0.12.4
+version: 0.12.5
 ---
 
 # PR Merge
@@ -28,11 +28,11 @@ Check PR-pending entities using the same logic as the startup hook: a terminal r
 
 ## Hook: merge
 
-Resolve the PR base once: `BASE=$(spacedock dispatch trunk --workflow-dir {dir})` — the workflow's configured integration trunk (default `main` when no `trunk:` key is set). `dispatch trunk` emits exactly a **bare branch name** (e.g. `main`), so `$( )` yields `$BASE` clean (command substitution strips the single trailing newline). Always quote `"$BASE"` at use sites — the push, the rebase, the draft, and the `gh pr create --base` below.
+Resolve the PR base once: `BASE=$(spacedock dispatch trunk --workflow-dir {dir})` — the workflow's configured integration trunk (default `main` when no `trunk:` key is set). `dispatch trunk` emits exactly a **bare branch name** (e.g. `main`), so `$( )` yields `$BASE` clean (command substitution strips the single trailing newline). Always quote `"$BASE"` at use sites — the push, the draft, and the `gh pr create --base` below.
 
 **PR APPROVAL GUARDRAIL — Do NOT push or create a PR without explicit captain approval.** Before presenting the draft, construct the full PR body so the captain reviews the actual prose that will land on GitHub.
 
-Compute the audit-link inputs first: short SHA via `git rev-parse --short HEAD` in the worktree directory (if it exits non-zero — no commits, detached HEAD — substitute the literal string `main` and report the fallback to the captain); owner/repo via `gh repo view --json nameWithOwner --jq '.nameWithOwner'`; short entity-id slot via `spacedock status --short-id {entity ref}` from the workflow directory (shortest-unique-prefix for sd-b32 workflows, literal stored ID for sequential and slug, matching the status table's ID column).
+Record the exact commit being submitted before constructing the draft: `CANDIDATE_SHA=$(git rev-parse HEAD)` in the worktree directory. Compute the remaining audit-link inputs: short SHA via `git rev-parse --short "$CANDIDATE_SHA"` (if it exits non-zero, report the error and stop); owner/repo via `gh repo view --json nameWithOwner --jq '.nameWithOwner'`; short entity-id slot via `spacedock status --short-id {entity ref}` from the workflow directory (shortest-unique-prefix for sd-b32 workflows, literal stored ID for sequential and slug, matching the status table's ID column).
 
 Build the full PR body using the template below — motivation lead, `## What changed`, `## Evidence`, `---` separator, `[{short-id}](...)` audit link, and `Closes {issue}` line if frontmatter `issue` is set. This is the body that will be passed to `gh pr create` verbatim; do not reconstruct it after approval.
 
@@ -40,6 +40,7 @@ Then present the draft to the captain:
 
 - **Title:** {entity title}
 - **Branch:** {branch} -> $BASE
+- **Candidate:** $CANDIDATE_SHA
 - **Changes:** {N} file(s) changed across {N} commit(s)
 - **Files:** {list of changed files}
 - **Body:**
@@ -50,7 +51,15 @@ Then present the draft to the captain:
 
 Wait for the captain's explicit approval before pushing. Do NOT infer approval from silence, acknowledgment of the summary, or the gate approval that preceded this step — only an explicit "push it", "go ahead", "yes", or equivalent counts.
 
-**On approval:** First, push the trunk to ensure the remote is up to date with local state commits: `git push origin "$BASE"`. Then rebase the worktree branch onto the trunk: `git rebase "$BASE"` (from the worktree directory). Then push the worktree branch: `git push origin {branch}`. If any step fails (no remote, auth error, rebase conflict), report to the captain and fall back to local merge.
+**On approval:** First, push the trunk to ensure the remote is up to date with local state commits: `git push origin "$BASE"`. If that push fails (no remote, auth error), report to the captain and fall back to local merge.
+
+Resolve the current integration tip as `BASE_SHA=$(git rev-parse "$BASE")`, then exercise the approved commit against it without changing the candidate ref, index, or worktree: `git merge-tree --write-tree "$BASE_SHA" "$CANDIDATE_SHA" >/dev/null`.
+
+- Exit 0 is clean: continue without rebasing.
+- Exit 1 is a conflict: stop PR and local-merge delivery, refer reconciliation to the G3/D8 owner path, and preserve the pending delivery authority.
+- Any other exit leaves mergeability unknown: stop delivery and report the command error; do not rebase or use local merge as a fallback.
+
+For a clean result, push the approved commit with the exact-SHA refspec: `git push origin "$CANDIDATE_SHA:refs/heads/{branch}"`. If that push fails, report to the captain and fall back to local merge.
 
 Then create the PR by running `gh pr create --base "$BASE" --head {branch} --title "{entity title}" --body "{constructed body}"` against the body already constructed above — do not rebuild it. If `gh` is not available, warn the captain and fall back to local merge.
 

--- a/mods/pr-merge.md
+++ b/mods/pr-merge.md
@@ -1,7 +1,7 @@
 ---
 name: pr-merge
 description: Push branches and create/track GitHub PRs for workflow entities
-version: 0.12.6
+version: 0.27.0
 ---
 
 # PR Merge

--- a/mods/pr-merge.md
+++ b/mods/pr-merge.md
@@ -12,7 +12,7 @@ The terminal merge ceremony keys off the pending terminal-target application tha
 
 ## Hook: startup
 
-Scan all entity files (in the workflow directory only, not `_archive/`) for entities with a non-empty `pr` field and either non-terminal status, terminal status with `mod-block: merge:pr-merge`, or terminal status carrying a valid merged sentinel (`pr-merge:` or `local-merge:`). A sentinel row already proves MERGED: bypass `gh`, run `spacedock merge guard {slug} --workflow-dir {dir} --verdict passed` directly, and stop processing that row. For every bare PR row, extract the PR number (strip any `#`, `owner/repo#` prefix) and check: `gh pr view {number} --json state --jq '.state'`.
+Scan all entity files (in the workflow directory only, not `_archive/`) for entities with a non-empty `pr` field and either non-terminal status, terminal status with `mod-block: merge:pr-merge`, or terminal status carrying a valid merged sentinel (`pr-merge:` or `local-merge:`). A sentinel row already proves MERGED: bypass `gh`, run `spacedock merge guard {slug} --workflow-dir {dir} --verdict passed` directly, and stop processing that row. For every bare PR row, preserve its repository qualifier while parsing it: `owner/repo#N` is PR `N` in `owner/repo`, while `#N` or `N` is PR `N` in the entity's current code repository. Check qualified references with `gh pr view {N} --repo {owner}/{repo} --json state --jq '.state'`. For an unqualified reference, resolve the current code repository from the entity's `{worktree}` using `git -C {worktree} remote get-url origin` and `gh repo view {code-origin-url} --json nameWithOwner --jq '.nameWithOwner'`, then use that value in `gh pr view {N} --repo {code-owner}/{code-repo} --json state --jq '.state'`. Stop and report an unresolved worktree or repository instead of consulting the launch directory.
 
 If `MERGED`, first record and commit the landed merge sentinel with `spacedock status --workflow-dir {dir} --set {slug} pr=pr-merge:{N}` then `spacedock state commit {slug} --workflow-dir {dir}`; next finalize through `spacedock merge guard {slug} --workflow-dir {dir} --verdict passed`. The sentinel is the restart-safe durable signal; the guard clears any in-flight `mod-block`, terminalizes, archives, and commits the archive move atomically. Clean up any worktree/branch and report each auto-advanced entity to the captain.
 
@@ -28,21 +28,26 @@ Check PR-pending entities using the same logic as the startup hook: a terminal r
 
 ## Hook: merge
 
-Resolve the PR base once: `BASE=$(spacedock dispatch trunk --workflow-dir {dir})` — the workflow's configured integration trunk (default `main` when no `trunk:` key is set). `dispatch trunk` emits exactly a **bare branch name** (e.g. `main`), so `$( )` yields `$BASE` clean (command substitution strips the single trailing newline). Always quote `"$BASE"` at use sites — the push, the draft, and the `gh pr create --base` below.
+Resolve the PR base once: `BASE=$(spacedock dispatch trunk --workflow-dir {dir})` — the workflow's configured integration trunk (default `main` when no `trunk:` key is set). `dispatch trunk` emits exactly a **bare branch name** (e.g. `main`), so `$( )` yields `$BASE` clean (command substitution strips the single trailing newline). Retain the workflow-supplied `{branch}` as the data value `BRANCH`. Always quote `"$BASE"` and `"$BRANCH"` at use sites; do not evaluate either as shell syntax.
 
 **PR APPROVAL GUARDRAIL — Do NOT push or create a PR without explicit captain approval.** Before presenting the draft, construct the full PR body so the captain reviews the actual prose that will land on GitHub.
 
-Record the exact commit being submitted before constructing the draft: `CANDIDATE_SHA=$(git rev-parse HEAD)` in the worktree directory. Compute the remaining audit-link inputs: short SHA via `git rev-parse --short "$CANDIDATE_SHA"` (if it exits non-zero, report the error and stop); owner/repo via `gh repo view --json nameWithOwner --jq '.nameWithOwner'`; short entity-id slot via `spacedock status --short-id {entity ref}` from the workflow directory (shortest-unique-prefix for sd-b32 workflows, literal stored ID for sequential and slug, matching the status table's ID column).
+Record the exact code commit being submitted before constructing the draft: `CANDIDATE_SHA=$(git -C {worktree} rev-parse HEAD)`. Resolve every other input explicitly rather than from the launch directory:
 
-Build the full PR body using the template below — motivation lead, `## What changed`, `## Evidence`, `---` separator, `[{short-id}](...)` audit link, and `Closes {issue}` line if frontmatter `issue` is set. This is the body that will be passed to `gh pr create` verbatim; do not reconstruct it after approval.
+- Compute the candidate's short SHA with `git -C {worktree} rev-parse --short "$CANDIDATE_SHA"`; if it exits non-zero, report the error and stop. Use this recorded candidate for every later candidate identity—never read ambient `HEAD` after approval.
+- Resolve the code repository with `git -C {worktree} remote get-url origin`, then pass that URL as the repository argument to `gh repo view {code-origin-url} --json nameWithOwner --jq '.nameWithOwner'` and retain its result as `CODE_REPO`.
+- Locate entity state through the launcher: run `spacedock status --workflow-dir {dir} --resolve {entity ref} --json` and consume its `path` field as `ENTITY_PATH`. Derive `STATE_ROOT` with `git -C "$(dirname "$ENTITY_PATH")" rev-parse --show-toplevel`, the immutable state commit with `git -C "$STATE_ROOT" rev-parse HEAD`, and the state-relative entity path with `git -C "$STATE_ROOT" ls-files --full-name -- "$ENTITY_PATH"`. Resolve the state repository by passing `git -C "$STATE_ROOT" remote get-url origin` as the repository argument to `gh repo view ... --json nameWithOwner --jq '.nameWithOwner'`. Stop if the entity is not tracked or any resolution fails.
+- Compute the short entity-id slot with `spacedock status --workflow-dir {dir} --short-id {entity ref}` (shortest-unique-prefix for sd-b32 workflows, literal stored ID for sequential and slug, matching the status table's ID column).
+
+Build the full PR body using the template below — motivation lead, `## What changed`, `## Evidence`, `---` separator, `[{short-id}](...)` audit link, and `Closes {issue}` line if frontmatter `issue` is set. Create a mode-0600 temporary file `PR_BODY_FILE`, then write those exact bytes directly to it without a shell-interpolated heredoc or command string. Present the body by reading that file. This is the file that will be passed to `gh pr create`; do not reconstruct or rewrite it after approval.
 
 Then present the draft to the captain:
 
 - **Title:** {entity title}
-- **Branch:** {branch} -> $BASE
+- **Branch:** $BRANCH -> $BASE
 - **Candidate:** $CANDIDATE_SHA
-- **Changes:** {N} file(s) changed across {N} commit(s)
-- **Files:** {list of changed files}
+- **Changes:** {N} file(s) changed across {N} commit(s), computed from `git -C {worktree}` and `$BASE`
+- **Files:** {list of changed files from `git -C {worktree}` and `$BASE`}
 - **Body:**
 
   ```
@@ -51,17 +56,17 @@ Then present the draft to the captain:
 
 Wait for the captain's explicit approval before pushing. Do NOT infer approval from silence, acknowledgment of the summary, or the gate approval that preceded this step — only an explicit "push it", "go ahead", "yes", or equivalent counts.
 
-**On approval:** First, push the trunk to ensure the remote is up to date with local state commits: `git push origin "$BASE"`. If that push fails (no remote, auth error), report to the captain and fall back to local merge.
+**On approval:** First, push the trunk from the code worktree to ensure the remote is up to date: `git -C {worktree} push origin "$BASE"`. If that push fails (no remote, auth error), report to the captain and fall back to local merge.
 
-Resolve the current integration tip as `BASE_SHA=$(git rev-parse "$BASE")`, then exercise the approved commit against it without changing the candidate ref, index, or worktree: `git merge-tree --write-tree "$BASE_SHA" "$CANDIDATE_SHA"`. Inspect its stdout, stderr, exit status, and repository context; the exit status is one signal, not the semantic verdict.
+Resolve the current integration tip as `BASE_SHA=$(git -C {worktree} rev-parse "$BASE")`, then exercise the approved commit against it without changing the candidate ref, index, or worktree: `git -C {worktree} merge-tree --write-tree "$BASE_SHA" "$CANDIDATE_SHA"`. Inspect its stdout, stderr, exit status, and repository context; the exit status is one signal, not the semantic verdict.
 
 - If the evidence indicates a clean merge, continue without rebasing.
 - If the evidence indicates an actual content conflict, stop PR and local-merge delivery, surface the conflict evidence, and preserve the pending delivery authority. Do not rebase, automatically resolve, or use force operations; leave reconciliation owner selection to the consuming workflow.
 - If the command fails or the evidence is incomplete or ambiguous, mergeability is unknown: report the error, preserve the pending authority, and stop delivery; do not rebase or use local merge as a fallback.
 
-For a clean result, push the approved commit with the exact-SHA refspec: `git push origin "${CANDIDATE_SHA}:refs/heads/{branch}"`. If that push fails, report to the captain and fall back to local merge.
+For a clean result, push the approved commit with the exact-SHA refspec: `git -C {worktree} push origin "${CANDIDATE_SHA}:refs/heads/${BRANCH}"`. If that push fails, report to the captain and fall back to local merge.
 
-Then create the PR by running `gh pr create --base "$BASE" --head {branch} --title "{entity title}" --body "{constructed body}"` against the body already constructed above — do not rebuild it. If `gh` is not available, warn the captain and fall back to local merge.
+Then invoke `gh pr create` against the resolved code repository with title, branch, base, and body file as separate arguments: `gh pr create --repo "$CODE_REPO" --base "$BASE" --head "$BRANCH" --title "$PR_TITLE" --body-file "$PR_BODY_FILE"`. Supply `CODE_REPO`, `BRANCH`, and `PR_TITLE` as data values from the resolutions and workflow context above; never interpolate entity text into executable shell syntax or use `eval`. The submitted body must be the exact reviewed bytes in `PR_BODY_FILE`. Remove the temporary file after success or failure. If `gh` is not available, warn the captain and fall back to local merge.
 
 ### PR body template
 
@@ -72,10 +77,10 @@ Lead with motivation + end-user value; audit metadata goes at the bottom. The go
 | Section | Required | Content |
 |---|---|---|
 | Motivation lead | **yes** | 1 sentence, ≤ 25 words, blending motivation and end-user value. No parentheticals. |
-| `## What changed` | **yes** | Action-verb bullets, 3–5 total, each ≤ 15 words. One change per bullet. No rationale inside the bullet — if a change needs justification, it belongs in the task body, not the PR. |
-| `## Evidence` | **yes when validation ran** | Test suites with `N/N passed` format, 1–2 bullets. Do not include per-test-class breakdowns or enumerated suite lists — one pass ratio per suite, plus at most one line confirming live-probe verification. |
+| `## What changed` | **yes** | Action-verb bullets, 3–5 total, each ≤ 15 words. One change per bullet. No rationale inside the bullet — if a change needs justification, it belongs in the entity body, not the PR. |
+| `## Evidence` | **yes when verification ran** | Test suites with `N/N passed` format, 1–2 bullets. Do not include per-test-class breakdowns or enumerated suite lists — one pass ratio per suite, plus at most one line confirming live-probe verification. |
 | `## Review guidance` | optional | 1 line pointing reviewer at the critical file or risky change — include only when a stage report explicitly flagged it |
-| `---` separator + `[{entity-id}](/{owner}/{repo}/blob/{short-sha}/{path-to-entity-file})` | **yes** | Audit link, at the bottom |
+| `---` separator + `[{entity-id}](/{state-owner}/{state-repo}/blob/{state-sha}/{state-relative-path})` | **yes** | Audit link, at the bottom |
 | `Closes {issue}` | **yes when issue set** | Under the audit link, using the value exactly as it appears in frontmatter, e.g., `#48` or `owner/repo#48` |
 | `Related: {siblings}` | optional | Under Closes, only when stage reports flagged follow-ups |
 
@@ -84,12 +89,12 @@ Lead with motivation + end-user value; audit metadata goes at the bottom. The go
 | PR body section | Source in entity file | Transformation |
 |---|---|---|
 | Motivation lead | Entity body paragraph(s) between closing `---` and the first `##` heading | Condense first paragraph to 1-2 sentences. Lead with impact or action verb — not "This PR" or "This task". Blend motivation + value. |
-| What changed | Implementation stage report's `[x]` DONE items | One action-verb bullet per meaningful unit. Collapse sibling bullets that describe the same thing. Drop `[x]` markers. Do NOT include "what we deliberately did NOT change" bullets — scope boundaries belong in the task body, not the PR, unless a validation stage report flagged them as risk. |
-| Evidence | Validation stage report items that assert AC verification (typically rerun-test items) | One bullet per suite with `N/N passed` format. Include any quantitative result the stage report explicitly called out (wallclock delta, size %, perf). Fallback to implementation report's self-test items if no validation stage exists. |
+| What changed | Latest stage report whose declared stage outputs describe completed deliverable work | Use DONE items as one action-verb bullet per meaningful unit. Collapse sibling bullets that describe the same thing. Do NOT include "what we deliberately did NOT change" bullets — scope boundaries belong in the entity body, unless a later verification report flagged them as risk. Select this report by the stage's declared outputs and content, never by requiring a particular stage name. |
+| Evidence | Latest stage report whose declared stage outputs independently verify the candidate against acceptance criteria | One bullet per suite with `N/N passed` format. Include any quantitative result the report explicitly called out (wallclock delta, size %, perf). If the workflow declares no independent verification-report role, fall back to self-test evidence in the deliverable-work report. Select by the declared role and content, never by requiring a particular stage name. |
 | Review guidance | Explicit "focus on X" / "risk here" notes in either stage report | 1 line. **Omit if no such note exists.** |
-| Audit link | Short entity id from `spacedock status --short-id {entity ref}` (shortest-unique-prefix for sd-b32, literal stored ID for sequential and slug), path from the file's repo-relative location, short SHA from `git rev-parse --short HEAD` run in the worktree directory | Format as `[{short-id}](/{owner}/{repo}/blob/{short-sha}/{path})` |
+| Audit link | Short entity id from `spacedock status --workflow-dir {dir} --short-id {entity ref}`; resolved state-repository owner/name, immutable state commit, and state-relative entity path from the explicit state resolution above | Format as `[{short-id}](/{state-owner}/{state-repo}/blob/{state-sha}/{state-relative-path})` |
 | Closes | Entity frontmatter `issue` field (exactly as written) | Prefix `Closes ` |
-| Related | Explicit "related task" / "follow-up" mentions in stage reports | 1 line. **Omit if none.** |
+| Related | Explicit "related entity" / "follow-up" mentions in stage reports | 1 line. **Omit if none.** |
 
 Target total length: **60-120 words**.
 
@@ -97,11 +102,11 @@ Target total length: **60-120 words**.
 
 1. **Lead with motivation + end-user value.** First content is a 1-2 sentence user-facing impact statement. The audit link moves to the bottom as audit metadata.
 2. **Prescribed sections + extraction rules** — not a strict verbatim template, not free-form. The mod specifies headings and source subsections; the FO paraphrases rather than pasting.
-3. **Evidence section is conditional on validation stage.** Non-validated workflows fall back to implementation self-test evidence.
+3. **Evidence follows declared report roles.** Workflows without an independent verification report fall back to deliverable-report self-test evidence.
 4. **Review guidance and Related are opt-in.** They appear only when stage reports explicitly flagged them, to prevent bloat.
 
 Set the entity's `pr` field to the PR number (e.g., `#57`). Report the PR to the captain.
 
 **On decline:** Do NOT automatically fall back to local merge. Ask the captain how to proceed — options include local merge or leaving the branch unmerged. Only act on the captain's explicit choice.
 
-Do NOT archive yet. The entity stays at its current stage with `pr` set until the PR is merged. The FO handles advancement to the terminal stage and archival when it detects the merge (via this idle hook, the startup hook, or the reconcile sweep's un-advanced-pr class).
+Do NOT archive yet. The entity stays at its current stage with `pr` set until the PR is merged. The FO handles advancement to the terminal stage and archival when it detects the merge through this portable startup or idle hook. A runtime may invoke the same hook check as a generic backstop; no host-specific reconcile class is required.


### PR DESCRIPTION
Preserve approved candidate commits when Git can merge them, so opening a PR does not rewrite validated code.

## What changed

- Remove the mandatory pre-PR rebase from the shipped merge mod.
- Separate clean, conflict, and unknown merge-tree results.
- Push the recorded candidate SHA with an explicit branch refspec.
- Make repository, workflow, report, runtime, and PR-body handling self-contained.

## Evidence

- Focused, full, and race suites: 3/3 passed.
- Consumer and real-Git matrices: 12/12 boundaries and outcomes passed.

---
[ep2](https://github.com/spacedock-dev/spacedock/blob/4187f23d54aff2563309b514456feec4f5b5cfad/avoid-unnecessary-pr-rebases.md)

Closes #616
