### PR TITLE
Make FO dispatch of moving-target conflict owners explicit

### DIFF
--- a/internal/ensigncycle/conflict_owner_handoff_live_test.go
+++ b/internal/ensigncycle/conflict_owner_handoff_live_test.go
@@ -1,0 +1,151 @@
+//go:build live
+
+package ensigncycle
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLiveCodexOwnedConflictReturnsToRegisteredWorker(t *testing.T) {
+	runner := newCodexLiveRunner(t)
+	root := t.TempDir()
+	worktreeRel := filepath.Join(".worktrees", "spacedock-ensign-conflict-owner")
+	worktree := filepath.Join(root, worktreeRel)
+	entity := filepath.Join(root, "conflict-owner.md")
+	marker := filepath.Join(worktree, "owner-handoff.marker")
+
+	writeFile(t, filepath.Join(root, "README.md"), conflictOwnerWorkflow())
+	writeFile(t, filepath.Join(root, "conflict.txt"), "base\n")
+	writeFile(t, entity, conflictOwnerEntity(worktreeRel))
+	gitInit(t, root)
+	git(t, root, "worktree", "add", "-q", "-b", "spacedock-ensign/conflict-owner", worktree)
+	writeFile(t, filepath.Join(worktree, "conflict.txt"), "worker branch\n")
+	gitAsCaptain(t, worktree, "add", "conflict.txt")
+	gitAsCaptain(t, worktree, "commit", "-q", "-m", "worker: change conflict target")
+	writeFile(t, filepath.Join(root, "conflict.txt"), "moved main\n")
+	gitAsCaptain(t, root, "add", "conflict.txt")
+	gitAsCaptain(t, root, "commit", "-q", "-m", "captain: move target")
+
+	cmd := exec.Command("git", "-C", worktree, "rebase", "main")
+	if out, err := cmd.CombinedOutput(); err == nil {
+		t.Fatalf("fixture rebase unexpectedly succeeded: %s", out)
+	}
+	before := readFile(t, entity)
+
+	scenario := sharedRuntimeScenario{name: "owned-conflict-owner-handoff"}
+	prompt := "Use $spacedock:first-officer for this whole run. The fixture is paused at the runtime boundary of an owned code-worktree rebase conflict for conflict-owner in implementation. " +
+		"Reconstitute the recorded live owner by spawning exactly one implementation ensign with identity conflict-owner/implementation/spacedock-ensign/conflict-owner/" + worktreeRel + "; its first assignment only acknowledges readiness and it must remain addressable. " +
+		"Then handle the existing conflict exactly through the first-officer conflict-owner contract. The owner handoff's next action is to write owner-handoff.marker containing runtime-worker-owner, commit it on the registered branch using the shared Git identity user.name=Captain and user.email=captain@example.test, and leave conflict.txt unresolved beyond the required rebase abort. " +
+		"Do not edit the entity. Stop after the owner completes the follow-up."
+	result, err := runner.run(t, scenario, root, prompt)
+	if err != nil {
+		t.Fatalf("%v\nArtifacts: %s", err, result.artifactDir)
+	}
+
+	if after := readFile(t, entity); after != before {
+		t.Fatalf("owner handoff changed authority bytes\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+	if got := strings.TrimSpace(readFile(t, marker)); got != "runtime-worker-owner" {
+		t.Fatalf("worker marker = %q, want runtime-worker-owner", got)
+	}
+	if got := strings.TrimSpace(git(t, worktree, "branch", "--show-current")); got != "spacedock-ensign/conflict-owner" {
+		t.Fatalf("marker branch = %q, want registered branch", got)
+	}
+	if got := strings.TrimSpace(git(t, worktree, "log", "-1", "--format=%an <%ae>")); got != "Captain <captain@example.test>" {
+		t.Fatalf("marker Git author = %q, want shared Captain credential", got)
+	}
+	rebaseDir := strings.TrimSpace(git(t, worktree, "rev-parse", "--git-path", "rebase-merge"))
+	if _, err := os.Stat(rebaseDir); !os.IsNotExist(err) {
+		t.Fatalf("rebase was not cleanly aborted: %v", err)
+	}
+	for _, event := range []string{"spawn_agent", "followup_task"} {
+		if !strings.Contains(result.jsonl, event) {
+			t.Errorf("Codex stream lacks actual %s runtime call; artifacts: %s", event, result.artifactDir)
+		}
+	}
+	assertConflictOwnerFreshEnvelope(t, runner.binary, root, entity, worktreeRel)
+}
+
+func assertConflictOwnerFreshEnvelope(t *testing.T, binary, root, entity, worktree string) {
+	t.Helper()
+	checklist := filepath.Join(root, "fresh-owner.checklist")
+	scope := filepath.Join(root, "fresh-owner.scope.md")
+	writeFile(t, checklist, "Write the owner marker on the registered branch.\n")
+	writeFile(t, scope, "entity: conflict-owner\nstage: implementation\npr: 632\nbranch: spacedock-ensign/conflict-owner\nworktree: "+worktree+"\nold base/head: base / worker\nmoved base: main\nconflict paths: conflict.txt\nnext owner action: reconcile and write marker\n")
+	cmd := exec.Command(binary, "dispatch", "build", "--host", "codex", "--workflow-dir", root, "--entity-path", entity, "--stage", "implementation", "--checklist-file", checklist, "--scope-notes-file", scope)
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fresh owner build: %v\n%s", err, out)
+	}
+	var envelope struct {
+		Name         string `json:"name"`
+		DispatchFile string `json:"dispatch_file_path"`
+	}
+	if err := json.Unmarshal(out, &envelope); err != nil {
+		t.Fatalf("decode fresh owner envelope: %v\n%s", err, out)
+	}
+	if envelope.Name == "" || envelope.DispatchFile == "" {
+		t.Fatalf("fresh owner envelope lacks spawn identity: %s", out)
+	}
+	body := readFile(t, envelope.DispatchFile)
+	for _, want := range []string{"implementation", "spacedock-ensign/conflict-owner", worktree, "conflict paths: conflict.txt"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("fresh owner dispatch body missing %q\n%s", want, body)
+		}
+	}
+}
+
+func gitAsCaptain(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{"-C", dir, "-c", "user.name=Captain", "-c", "user.email=captain@example.test"}, args...)
+	out, err := exec.Command("git", full...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+func conflictOwnerWorkflow() string {
+	return "---\n" +
+		"commissioned-by: spacedock@1\n" +
+		"entity-type: task\n" +
+		"id-style: slug\n" +
+		"stages:\n" +
+		"  defaults:\n" +
+		"    worktree: true\n" +
+		"    concurrency: 1\n" +
+		"  states:\n" +
+		"    - name: backlog\n" +
+		"      initial: true\n" +
+		"    - name: implementation\n" +
+		"    - name: done\n" +
+		"      terminal: true\n" +
+		"---\n" +
+		"# Conflict owner fixture\n\n" +
+		"### implementation\n\nReconcile only through the registered owner.\n\n- **Outputs:** owner marker on the registered branch.\n"
+}
+
+func conflictOwnerEntity(worktree string) string {
+	return "---\n" +
+		"title: Conflict owner\n" +
+		"status: implementation\n" +
+		"started: 2026-08-07T00:00:00Z\n" +
+		"pr: 632\n" +
+		"mod-block: preserved\n" +
+		"worktree: " + worktree + "\n" +
+		"gates:\n" +
+		"  version: 1\n" +
+		"  records:\n" +
+		"    - id: gate:fixture:backlog\n" +
+		"      stage: backlog\n" +
+		"      application:\n" +
+		"        target-stage: implementation\n" +
+		"        state: consumed\n" +
+		"---\n\nOwned moving-target conflict fixture.\n"
+}

--- a/internal/ensigncycle/conflict_owner_handoff_live_test.go
+++ b/internal/ensigncycle/conflict_owner_handoff_live_test.go
@@ -4,26 +4,38 @@ package ensigncycle
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/dispatch"
+	"github.com/spacedock-dev/spacedock/internal/status"
 )
+
+type conflictOwnerTuple struct {
+	Entity       string
+	Stage        string
+	WorkerName   string
+	Branch       string
+	Worktree     string
+	DispatchFile string
+}
 
 func TestLiveCodexOwnedConflictReturnsToRegisteredWorker(t *testing.T) {
 	runner := newCodexLiveRunner(t)
 	root := t.TempDir()
-	worktreeRel := filepath.Join(".worktrees", "spacedock-ensign-conflict-owner")
-	worktree := filepath.Join(root, worktreeRel)
 	entity := filepath.Join(root, "conflict-owner.md")
-	marker := filepath.Join(worktree, "owner-handoff.marker")
 
 	writeFile(t, filepath.Join(root, "README.md"), conflictOwnerWorkflow())
 	writeFile(t, filepath.Join(root, "conflict.txt"), "base\n")
-	writeFile(t, entity, conflictOwnerEntity(worktreeRel))
+	writeFile(t, entity, conflictOwnerEntity())
 	gitInit(t, root)
-	git(t, root, "worktree", "add", "-q", "-b", "spacedock-ensign/conflict-owner", worktree)
+	owner := stampConflictOwner(t, runner.binary, root, entity)
+	worktree := filepath.Join(root, owner.Worktree)
+	marker := filepath.Join(worktree, "owner-handoff.marker")
 	writeFile(t, filepath.Join(worktree, "conflict.txt"), "worker branch\n")
 	gitAsCaptain(t, worktree, "add", "conflict.txt")
 	gitAsCaptain(t, worktree, "commit", "-q", "-m", "worker: change conflict target")
@@ -38,8 +50,8 @@ func TestLiveCodexOwnedConflictReturnsToRegisteredWorker(t *testing.T) {
 	before := readFile(t, entity)
 
 	scenario := sharedRuntimeScenario{name: "owned-conflict-owner-handoff"}
-	prompt := "Use $spacedock:first-officer for this whole run. The fixture is paused at the runtime boundary of an owned code-worktree rebase conflict for conflict-owner in implementation. " +
-		"Reconstitute the recorded live owner by spawning exactly one implementation ensign with identity conflict-owner/implementation/spacedock-ensign/conflict-owner/" + worktreeRel + "; its first assignment only acknowledges readiness and it must remain addressable. " +
+	prompt := fmt.Sprintf("Use $spacedock:first-officer for this whole run. The fixture is paused at the runtime boundary of an owned code-worktree rebase conflict for %s in %s. ", owner.Entity, owner.Stage) +
+		fmt.Sprintf("Reconstitute the owner recorded by the initial stamped dispatch %s by spawning exactly one worker named %s with identity %s/%s/%s/%s; its first assignment only acknowledges readiness and it must remain addressable. ", owner.DispatchFile, owner.WorkerName, owner.Entity, owner.Stage, owner.Branch, owner.Worktree) +
 		"Then handle the existing conflict exactly through the first-officer conflict-owner contract. The owner handoff's next action is to write owner-handoff.marker containing runtime-worker-owner, commit it on the registered branch using the shared Git identity user.name=Captain and user.email=captain@example.test, and leave conflict.txt unresolved beyond the required rebase abort. " +
 		"Do not edit the entity. Stop after the owner completes the follow-up."
 	result, err := runner.run(t, scenario, root, prompt)
@@ -53,8 +65,8 @@ func TestLiveCodexOwnedConflictReturnsToRegisteredWorker(t *testing.T) {
 	if got := strings.TrimSpace(readFile(t, marker)); got != "runtime-worker-owner" {
 		t.Fatalf("worker marker = %q, want runtime-worker-owner", got)
 	}
-	if got := strings.TrimSpace(git(t, worktree, "branch", "--show-current")); got != "spacedock-ensign/conflict-owner" {
-		t.Fatalf("marker branch = %q, want registered branch", got)
+	if got := strings.TrimSpace(git(t, worktree, "branch", "--show-current")); got != owner.Branch {
+		t.Fatalf("marker branch = %q, want stamped owner branch %q", got, owner.Branch)
 	}
 	if got := strings.TrimSpace(git(t, worktree, "log", "-1", "--format=%an <%ae>")); got != "Captain <captain@example.test>" {
 		t.Fatalf("marker Git author = %q, want shared Captain credential", got)
@@ -68,16 +80,68 @@ func TestLiveCodexOwnedConflictReturnsToRegisteredWorker(t *testing.T) {
 			t.Errorf("Codex stream lacks actual %s runtime call; artifacts: %s", event, result.artifactDir)
 		}
 	}
-	assertConflictOwnerFreshEnvelope(t, runner.binary, root, entity, worktreeRel)
+	assertConflictOwnerFreshEnvelope(t, runner.binary, root, entity, owner)
 }
 
-func assertConflictOwnerFreshEnvelope(t *testing.T, binary, root, entity, worktree string) {
+func stampConflictOwner(t *testing.T, binary, root, entity string) conflictOwnerTuple {
+	t.Helper()
+	checklist := filepath.Join(root, "initial-owner.checklist")
+	writeFile(t, checklist, "Acknowledge readiness and remain addressable; do not change entity or code before the same-stage follow-up.\n")
+	cmd := exec.Command(binary, "dispatch", "build", "--stamp", "--host", "codex", "--workflow-dir", root, "--entity-path", entity, "--stage", "implementation", "--checklist-file", checklist)
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("initial stamped owner build: %v\n%s", err, out)
+	}
+	spawn, err := dispatch.CodexMultiAgentV2SpawnInput(out)
+	if err != nil {
+		t.Fatalf("record initial stamped owner: %v\n%s", err, out)
+	}
+	fields := status.ParseFrontmatter(entity)
+	worktree := fields["worktree"]
+	if fields["started"] == "" || worktree == "" {
+		t.Fatalf("initial dispatch did not stamp owner checkout: %#v", fields)
+	}
+	if subject := strings.TrimSpace(git(t, root, "log", "-1", "--format=%s")); subject != "dispatch: conflict-owner entering implementation" {
+		t.Fatalf("initial stamped dispatch commit = %q, want owner-entry commit", subject)
+	}
+	worktreePath := filepath.Join(root, worktree)
+	branch := strings.TrimSpace(git(t, worktreePath, "branch", "--show-current"))
+	owner := conflictOwnerTuple{
+		Entity:       spawn.Identity.Slug,
+		Stage:        spawn.Identity.Stage,
+		WorkerName:   spawn.Identity.Name,
+		Branch:       branch,
+		Worktree:     worktree,
+		DispatchFile: readInitialDispatchPath(t, out),
+	}
+	if owner.Entity == "" || owner.Stage == "" || owner.WorkerName == "" || owner.Branch == "" {
+		t.Fatalf("initial stamped dispatch produced incomplete owner tuple: %#v", owner)
+	}
+	return owner
+}
+
+func readInitialDispatchPath(t *testing.T, raw []byte) string {
+	t.Helper()
+	var envelope struct {
+		DispatchFile string `json:"dispatch_file_path"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode initial stamped owner envelope: %v\n%s", err, raw)
+	}
+	if envelope.DispatchFile == "" {
+		t.Fatalf("initial stamped owner envelope lacks dispatch file: %s", raw)
+	}
+	return envelope.DispatchFile
+}
+
+func assertConflictOwnerFreshEnvelope(t *testing.T, binary, root, entity string, owner conflictOwnerTuple) {
 	t.Helper()
 	checklist := filepath.Join(root, "fresh-owner.checklist")
 	scope := filepath.Join(root, "fresh-owner.scope.md")
 	writeFile(t, checklist, "Write the owner marker on the registered branch.\n")
-	writeFile(t, scope, "entity: conflict-owner\nstage: implementation\npr: 632\nbranch: spacedock-ensign/conflict-owner\nworktree: "+worktree+"\nold base/head: base / worker\nmoved base: main\nconflict paths: conflict.txt\nnext owner action: reconcile and write marker\n")
-	cmd := exec.Command(binary, "dispatch", "build", "--host", "codex", "--workflow-dir", root, "--entity-path", entity, "--stage", "implementation", "--checklist-file", checklist, "--scope-notes-file", scope)
+	writeFile(t, scope, "entity: "+owner.Entity+"\nstage: "+owner.Stage+"\npr: 632\nbranch: "+owner.Branch+"\nworktree: "+owner.Worktree+"\nold base/head: base / worker\nmoved base: main\nconflict paths: conflict.txt\nnext owner action: reconcile and write marker\n")
+	cmd := exec.Command(binary, "dispatch", "build", "--host", "codex", "--workflow-dir", root, "--entity-path", entity, "--stage", owner.Stage, "--checklist-file", checklist, "--scope-notes-file", scope)
 	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -90,11 +154,11 @@ func assertConflictOwnerFreshEnvelope(t *testing.T, binary, root, entity, worktr
 	if err := json.Unmarshal(out, &envelope); err != nil {
 		t.Fatalf("decode fresh owner envelope: %v\n%s", err, out)
 	}
-	if envelope.Name == "" || envelope.DispatchFile == "" {
-		t.Fatalf("fresh owner envelope lacks spawn identity: %s", out)
+	if envelope.Name != owner.WorkerName || envelope.DispatchFile == "" {
+		t.Fatalf("fresh owner envelope identity = %q, want stamped owner %q: %s", envelope.Name, owner.WorkerName, out)
 	}
 	body := readFile(t, envelope.DispatchFile)
-	for _, want := range []string{"implementation", "spacedock-ensign/conflict-owner", worktree, "conflict paths: conflict.txt"} {
+	for _, want := range []string{owner.Entity, owner.Stage, owner.Branch, owner.Worktree, "conflict paths: conflict.txt"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("fresh owner dispatch body missing %q\n%s", want, body)
 		}
@@ -131,14 +195,14 @@ func conflictOwnerWorkflow() string {
 		"### implementation\n\nReconcile only through the registered owner.\n\n- **Outputs:** owner marker on the registered branch.\n"
 }
 
-func conflictOwnerEntity(worktree string) string {
+func conflictOwnerEntity() string {
 	return "---\n" +
 		"title: Conflict owner\n" +
 		"status: implementation\n" +
-		"started: 2026-08-07T00:00:00Z\n" +
+		"started:\n" +
 		"pr: 632\n" +
 		"mod-block: preserved\n" +
-		"worktree: " + worktree + "\n" +
+		"worktree:\n" +
 		"gates:\n" +
 		"  version: 1\n" +
 		"  records:\n" +

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -128,10 +128,12 @@ The FO declares state intent by invoking the prose-functions below. Each is idem
 
 - → **shipped**: `` `spacedock state commit <slug>` `` — on exit 3 → `«halt.rebase-conflict»(paths)`.
 
-## «halt.rebase-conflict»(paths): abort, surface, stop
+## «halt.rebase-conflict»(paths): halt state; route owned code
 
-- **block:** an «engage» `state ready` / `«state.commit»` exit 3 already carries the remediation in its stderr — HALT per that output. A manual FO-held `pull --rebase` CONFLICT (code worktree, the reconcile sweep's `stale-branch` remedy): run `git rebase --abort`, surface `paths` + peer commit to the captain, stop. Never `--force`/`--force-with-lease`, never `-X ours`/`-X theirs`, never discard either side — do not force-push or auto-resolve.
-- → **prose** — no binary resolves a two-writer conflict; the FO halts and the captain reconciles.
+- **block:** an «engage» `state ready` / `«state.commit»` exit 3 carries remediation in stderr — HALT; a state-sync conflict remains workflow-wide.
+- **effect:** for a manual FO-held `pull --rebase` CONFLICT in an owned code worktree, run `git rebase --abort`, surface exact paths + peer commit, then invoke dispatch-core's same-stage owner handoff; unrelated entities may continue. Cold or unowned checkouts are report-only.
+- **block:** never force-push, auto-resolve, or discard either side.
+- → **prose** — the recorded owner, not the FO, reconciles code.
 
 ## Mod Hook Convention
 

--- a/skills/first-officer/references/fo-dispatch-core.md
+++ b/skills/first-officer/references/fo-dispatch-core.md
@@ -50,6 +50,14 @@ Advancing a completed worker. The gate-presentation spine is in the boot-residen
 
 **Supersede-shutdown.** On fresh dispatch from a `-cycleN` increment or a feedback-rework re-entering the prior stage, invoke `«worker.shutdown»` for the prior cohort BEFORE the new dispatch in a SEPARATE message. The prior cohort is every roster member whose handle decomposes to the same `(slug, stage)` pair as the new dispatch. Issue the adapter's cooperative-shutdown call and drop them from session memory. **Mandatory at the boundary; backstops, if any, are the adapter's.**
 
+## Same-Stage Conflict Owner Handoff
+
+After `«halt.rebase-conflict»` aborts an owned code-worktree rebase, keep the entity in its current stage and route one opaque reconciliation assignment to the recorded owner. Write a scope-notes file that names the entity, current stage, PR, registered branch/worktree, old base/head, moved base, exact conflict paths, and next owner action. The package is transport only: do not parse, classify, or resolve the conflict, and do not mutate entity frontmatter or Git refs while routing it.
+
+If `«addressable-worker»` exposes a matching live worker, require its entity, stage, branch, and worktree to equal the tuple proven by the original stamped dispatch, then run ordinary `«dispatch.build» --advance` for that same stage with the scope-notes file and forward its emitted prompt through the existing reuse-advance handle. Otherwise run an ordinary fresh dispatch for the same recorded stage with the same scope-notes file and send its emitted spawn envelope through `«worker.spawn»`; do not add `--stamp`, because the registered branch/worktree already exists.
+
+The worker identity, stage agent, branch, and worktree are the only routing inputs. The PR author, Git author, and shared Git credential are never owner signals. A missing proven tuple, a cold or unowned checkout, or a split-root state-sync conflict is report-only and does not enter this route. This is a per-entity hold, so unrelated entities may continue after the dispatch.
+
 ## «reuse.model-match»: stamped model matches the next stage's declared model
 
 - **guard:** skip when `next_stage.effective_model` is null; `«worker-identity»` stamps the null case and null-declared stages accept any reused worker.


### PR DESCRIPTION
Moving-target conflicts now return to the workflow owner of the existing checkout without relying on Git credentials or new ownership state.

## What changed

- Route owned code-worktree conflicts through existing live or fresh dispatch.
- Carry the owner tuple produced by the initial stamped dispatch.
- Preserve authority bytes, registered checkout, and conflict-abort behavior.
- Add no command grammar, parser, resolver, or stored field.

## Evidence

- 3/3 validation outcomes passed at exact head `7057ad6f7`.
- 1/1 completed Codex handoff wrote on the stamped owner branch.

---
[d8](/spacedock-dev/spacedock/blob/d2696b32bb36cd3506b7bf8167078806be53bd7d/codify-conflict-owner-dispatch-handoff.md)
