### PR TITLE
Canonicalise conventional frontmatter values at the shared write path

### DIFF
--- a/internal/cli/terminal_consume_test.go
+++ b/internal/cli/terminal_consume_test.go
@@ -228,7 +228,11 @@ func TestTerminalDeliveryFailureReworkRoundTrip(t *testing.T) {
 	}
 	archived := filepath.Join(root, "_archive", "task.md")
 	fields = entityFields(t, archived)
-	if strings.TrimSpace(fields["status"]) != "done" || strings.TrimSpace(fields["verdict"]) != "passed" ||
+	// The stored verdict carries the schema's case (PASSED) while the signal line
+	// asserted above stays lowercase — the CLI surface and the stored surface
+	// differ by design, and the gates-owned locked write normalises like the
+	// legacy path does.
+	if strings.TrimSpace(fields["status"]) != "done" || strings.TrimSpace(fields["verdict"]) != "PASSED" ||
 		strings.TrimSpace(fields["completed"]) == "" {
 		t.Fatalf("finalized fields = status:%q verdict:%q completed:%q", fields["status"], fields["verdict"], fields["completed"])
 	}

--- a/internal/status/field_conformance.go
+++ b/internal/status/field_conformance.go
@@ -145,8 +145,13 @@ func fieldViolation(name string, spec schemaField, value string) string {
 		return ""
 	}
 	if len(spec.Conventional) > 0 {
+		// Case-insensitive: a conventional enum fixes which token was chosen, not
+		// its casing. Entities written before the verdict writer normalised case
+		// (`verdict: passed`) are semantically conformant, and warning on them
+		// would demand hand-editing already-archived terminal entities to silence
+		// a diagnostic about a value the tool itself wrote.
 		for _, allowed := range spec.Conventional {
-			if value == allowed {
+			if strings.EqualFold(value, allowed) {
 				return ""
 			}
 		}

--- a/internal/status/finalize_status_guard_test.go
+++ b/internal/status/finalize_status_guard_test.go
@@ -69,7 +69,10 @@ func TestFinalizeStatusGateSetWithTerminalStatusAllowed(t *testing.T) {
 		t.Fatalf("finalize WITH status={terminal} in the same call must succeed (exit 0), got %d (stderr=%q)", code, errOut)
 	}
 	fm := readWhole(t, filepath.Join(root, "002-vendor-script.md"))
-	if !strings.Contains(fm, "status: done") || !strings.Contains(fm, "verdict: passed") {
+	// `verdict=passed` on the CLI stores as the schema's PASSED: updateFrontmatter
+	// canonicalises conventional values on every write, so --set and merge guard
+	// cannot disagree on stored case.
+	if !strings.Contains(fm, "status: done") || !strings.Contains(fm, "verdict: PASSED") {
 		t.Fatalf("entity should have terminalized:\n%s", fm)
 	}
 }
@@ -90,7 +93,7 @@ func TestFinalizeStatusGateAlreadyTerminalAllowed(t *testing.T) {
 		t.Fatalf("finalize on an already-terminal entity must succeed (exit 0), got %d (stderr=%q)", code, errOut)
 	}
 	fm := readWhole(t, filepath.Join(root, "already-done.md"))
-	if !strings.Contains(fm, "verdict: passed") {
+	if !strings.Contains(fm, "verdict: PASSED") {
 		t.Fatalf("entity should have gained a verdict:\n%s", fm)
 	}
 }

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -286,7 +286,10 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 			slug, postUpdateStatus, terminalStageName(roots.definitionDir), slug))
 	}
 
-	if !force && policy != mergeLocal && isTerminalUpdate() && modBlock == "" && postUpdatePR == "" && postUpdateVerdict != "rejected" {
+	// The rejected carve-out is case-insensitive (isRejectedVerdict): the verdict
+	// under test comes from frontmatter or from a --set value, so it may arrive as
+	// the `REJECTED` merge guard writes or the `rejected` an older binary wrote.
+	if !force && policy != mergeLocal && isTerminalUpdate() && modBlock == "" && postUpdatePR == "" && !isRejectedVerdict(postUpdateVerdict) {
 		mergeHooks := scanMods(roots.definitionDir)["merge"]
 		if len(mergeHooks) > 0 {
 			return errExit(stderr, fmt.Sprintf(

--- a/internal/status/merge.go
+++ b/internal/status/merge.go
@@ -419,6 +419,17 @@ func finalize(roots roots, slug, modBlock, pr, verdict, worktree string, hookReg
 	if terminal == "" {
 		return errExit(stderr, fmt.Sprintf("workflow %s declares no terminal stage — cannot finalize", roots.definitionDir))
 	}
+	// The CLI surface and the stored surface differ on case, and this is the one
+	// boundary between them: `--verdict passed|rejected` is lowercase (what the
+	// help text documents and every caller and doc passes), while the entity
+	// schema declares the frontmatter value's conventional set as
+	// [PASSED REJECTED]. Writing the flag verbatim made `status --validate` warn
+	// on the entity this verb had just finalized — permanently, since it is
+	// terminal and archived by then. Normalise here, not in either writer: both
+	// the gates delivery write and the legacy --set read `stored`, so neither
+	// path can drift. Everything downstream that reads a verdict back compares
+	// case-insensitively (runArchive's guards, runSet's, the validator).
+	stored := storedVerdict(verdict)
 	// Fail-closed writer selection: only a genuinely gate-less entity takes the
 	// legacy finalization path. A REAL pending terminal application with a
 	// disturbed briefing room or an unreadable gates record is a refusal, never
@@ -436,13 +447,13 @@ func finalize(roots roots, slug, modBlock, pr, verdict, worktree string, hookReg
 	if pendingApproval {
 		// Sole-consumer write: gates owns the locked candidate carrying the
 		// spend, terminal status, verdict, and completed together.
-		if _, err := gates.FinalizeTerminalApproval(entityPath, roots.definitionDir, verdict, nowTimestamp()); err != nil {
+		if _, err := gates.FinalizeTerminalApproval(entityPath, roots.definitionDir, stored, nowTimestamp()); err != nil {
 			return errExit(stderr, fmt.Sprintf("merge guard: terminal delivery write refused for %s: %v", slug, err))
 		}
 	} else {
 		terminalize := []fieldUpdate{
 			{field: "status", value: terminal, hasValue: true},
-			{field: "verdict", value: verdict, hasValue: true},
+			{field: "verdict", value: stored, hasValue: true},
 			{field: "completed", hasValue: false},
 		}
 		if rc := emitSet(roots, slug, terminalize, stderr); rc != 0 {

--- a/internal/status/merge_guard_foreign_cwd_test.go
+++ b/internal/status/merge_guard_foreign_cwd_test.go
@@ -110,8 +110,8 @@ func TestMergeGuardForeignCwdRefusalNamesWorkingFix(t *testing.T) {
 	if got := frontmatterField(t, archived, "status"); got != "done" {
 		t.Fatalf("archived entity status = %q, want done", got)
 	}
-	if got := frontmatterField(t, archived, "verdict"); got != "passed" {
-		t.Fatalf("archived entity verdict = %q, want passed", got)
+	if got := frontmatterField(t, archived, "verdict"); got != "PASSED" {
+		t.Fatalf("archived entity verdict = %q, want PASSED (the schema-cased stored value)", got)
 	}
 }
 

--- a/internal/status/merge_guard_test.go
+++ b/internal/status/merge_guard_test.go
@@ -152,8 +152,8 @@ func TestMergeGuardFinalizesFromMergedSentinelNonArmed(t *testing.T) {
 	if got := frontmatterField(t, archived, "status"); got != "done" {
 		t.Fatalf("archived status=%q, want done", got)
 	}
-	if got := frontmatterField(t, archived, "verdict"); got != "passed" {
-		t.Fatalf("archived verdict=%q, want passed", got)
+	if got := frontmatterField(t, archived, "verdict"); got != "PASSED" {
+		t.Fatalf("archived verdict=%q, want PASSED (the schema-cased stored value)", got)
 	}
 }
 
@@ -288,8 +288,8 @@ func TestMergeGuardArmThenFinalizeLocal(t *testing.T) {
 	if got := frontmatterField(t, archived, "status"); got != "done" {
 		t.Fatalf("archived status=%q, want done", got)
 	}
-	if got := frontmatterField(t, archived, "verdict"); got != "passed" {
-		t.Fatalf("archived verdict=%q, want passed", got)
+	if got := frontmatterField(t, archived, "verdict"); got != "PASSED" {
+		t.Fatalf("archived verdict=%q, want PASSED (the schema-cased stored value)", got)
 	}
 	if got := frontmatterField(t, archived, "mod-block"); got != "" {
 		t.Fatalf("archived mod-block should be cleared, got %q", got)
@@ -409,8 +409,8 @@ func TestMergeGuardRejectedFinalizesNoPR(t *testing.T) {
 	if got := frontmatterField(t, archived, "status"); got != "done" {
 		t.Fatalf("archived status=%q, want done", got)
 	}
-	if got := frontmatterField(t, archived, "verdict"); got != "rejected" {
-		t.Fatalf("archived verdict=%q, want rejected", got)
+	if got := frontmatterField(t, archived, "verdict"); got != "REJECTED" {
+		t.Fatalf("archived verdict=%q, want REJECTED (the schema-cased stored value)", got)
 	}
 }
 
@@ -433,8 +433,8 @@ func TestMergeGuardRejectedClearsModBlockFirst(t *testing.T) {
 	if got := frontmatterField(t, archived, "status"); got != "done" {
 		t.Fatalf("archived status=%q, want done", got)
 	}
-	if got := frontmatterField(t, archived, "verdict"); got != "rejected" {
-		t.Fatalf("archived verdict=%q, want rejected", got)
+	if got := frontmatterField(t, archived, "verdict"); got != "REJECTED" {
+		t.Fatalf("archived verdict=%q, want REJECTED (the schema-cased stored value)", got)
 	}
 	if got := frontmatterField(t, archived, "mod-block"); got != "" {
 		t.Fatalf("archived mod-block should be cleared, got %q", got)
@@ -548,8 +548,8 @@ func TestMergeGuardFinalizesMissingMergeModRejected(t *testing.T) {
 		t.Fatalf("stdout should signal finalized, got %q", out)
 	}
 	archived := filepath.Join(root, "_archive", "140-missing-mod-rejected.md")
-	if got := frontmatterField(t, archived, "verdict"); got != "rejected" {
-		t.Fatalf("archived verdict=%q, want rejected", got)
+	if got := frontmatterField(t, archived, "verdict"); got != "REJECTED" {
+		t.Fatalf("archived verdict=%q, want REJECTED (the schema-cased stored value)", got)
 	}
 }
 
@@ -951,8 +951,8 @@ func TestMergeGuardFinalizesFolderFormEntity(t *testing.T) {
 	if got := frontmatterField(t, archived, "status"); got != "done" {
 		t.Fatalf("archived status=%q, want done", got)
 	}
-	if got := frontmatterField(t, archived, "verdict"); got != "passed" {
-		t.Fatalf("archived verdict=%q, want passed", got)
+	if got := frontmatterField(t, archived, "verdict"); got != "PASSED" {
+		t.Fatalf("archived verdict=%q, want PASSED (the schema-cased stored value)", got)
 	}
 	// The source folder is gone from the live root.
 	if fileExists(filepath.Join(root, "110-pr-merged-folder", "index.md")) {

--- a/internal/status/mutate.go
+++ b/internal/status/mutate.go
@@ -145,7 +145,13 @@ func updateFrontmatter(path string, updates []fieldUpdate) (*resolvedFields, err
 			}
 			resolved.set(u.field, now)
 		} else {
-			resolved.set(u.field, u.value)
+			// Single normalisation point for every frontmatter write that goes
+			// through this engine — the user-facing `--set`, finalize's
+			// gate-less terminalize, archive. A field with a schema-declared
+			// conventional set is stored in the schema's spelling whatever case
+			// the caller used, so stored state cannot depend on which verb wrote
+			// it. Values outside the set pass through untouched.
+			resolved.set(u.field, canonicalConventional(u.field, u.value))
 		}
 	}
 
@@ -338,13 +344,16 @@ func runArchive(definitionDir, entityDir, spellingDir, slug string, force, quiet
 	// `verdict: rejected` entity is also exempted: it never ran the merge ceremony
 	// (no PR to require, no merge to gate on), so the requirement is vacuous — this
 	// matches the --set finalize path (runSet), keeping reject-then-archive on the
-	// happy path without --force.
+	// happy path without --force. The exemption reads the verdict case-insensitively
+	// (isRejectedVerdict): merge guard finalizes by writing REJECTED and archiving in
+	// the same run, so a case-sensitive test would refuse the archive step of the
+	// very ceremony that wrote the value.
 	policy, perr := resolveMergePolicy(definitionDir)
 	if perr != nil {
 		fmt.Fprintf(stderr, "Error: %s\n", perr)
 		return 1
 	}
-	if !force && policy != mergeLocal && verdict != "rejected" && modBlock == "" && pr == "" {
+	if !force && policy != mergeLocal && !isRejectedVerdict(verdict) && modBlock == "" && pr == "" {
 		mergeHooks := scanMods(definitionDir)["merge"]
 		if len(mergeHooks) > 0 {
 			fmt.Fprintf(stderr,
@@ -366,7 +375,7 @@ func runArchive(definitionDir, entityDir, spellingDir, slug string, force, quiet
 	// `--set` gate's carve-out for `verdict: rejected`. Layered after the
 	// merge-hook invariant so an entity that ALSO skipped the merge ceremony keeps
 	// reporting that cause first (unchanged from today). --force bypasses.
-	if verdict != "" && verdict != "rejected" && !force {
+	if verdict != "" && !isRejectedVerdict(verdict) && !force {
 		readme := filepath.Join(definitionDir, "README.md")
 		if fileExists(readme) {
 			status := strings.TrimSpace(fields["status"])

--- a/internal/status/testdata/golden/eof-newline-no-trailing-newline.txt
+++ b/internal/status/testdata/golden/eof-newline-no-trailing-newline.txt
@@ -4,7 +4,7 @@ title: No EOF newline
 status: done
 score: "0.5"
 source: x
-verdict: passed
+verdict: PASSED
 ---
 # No EOF newline
 

--- a/internal/status/testdata/golden/eof-newline-with-trailing-newline.txt
+++ b/internal/status/testdata/golden/eof-newline-with-trailing-newline.txt
@@ -4,7 +4,7 @@ title: EOF newline
 status: done
 score: "0.5"
 source: x
-verdict: passed
+verdict: PASSED
 ---
 # EOF newline
 

--- a/internal/status/testdata/golden/merge-local-nosentinel-set.txt
+++ b/internal/status/testdata/golden/merge-local-nosentinel-set.txt
@@ -2,6 +2,6 @@
 0
 ===== stdout =====
 status: implementation -> done
-verdict:  -> passed
+verdict:  -> PASSED
 
 ===== stderr =====

--- a/internal/status/testdata/golden/merge-sentinel-set.txt
+++ b/internal/status/testdata/golden/merge-sentinel-set.txt
@@ -2,6 +2,6 @@
 0
 ===== stdout =====
 status: implementation -> done
-verdict:  -> passed
+verdict:  -> PASSED
 
 ===== stderr =====

--- a/internal/status/testdata/golden/native-conflict-warning.txt
+++ b/internal/status/testdata/golden/native-conflict-warning.txt
@@ -2,7 +2,7 @@
 0
 ===== stdout =====
 status: backlog -> done
-verdict:  -> passed
+verdict:  -> PASSED
 
 ===== stderr =====
 Warning: entity 'conflict' has both <ROOT>/conflict.md and <ROOT>/conflict/index.md; preferring folder form. Remove the flat file to silence this warning.

--- a/internal/status/verdict.go
+++ b/internal/status/verdict.go
@@ -1,0 +1,60 @@
+// ABOUTME: conventional-value case boundary — lowercase on the CLI, the schema's
+// ABOUTME: spelling in frontmatter, and case-insensitive on every read back.
+package status
+
+import "strings"
+
+// canonicalConventional maps value to the conventional spelling it matches
+// case-insensitively, and returns it UNCHANGED otherwise. The allowed set is
+// read from the embedded entity mdschema — never a Go literal — so editing the
+// schema changes what is canonicalised on write exactly as it changes what
+// fieldViolation accepts on read.
+//
+// Unmatched values pass through untouched, deliberately. A conventional list is
+// advisory (`invalid_severity: warn`), so a field may legitimately carry a value
+// outside it; case-folding such a value would be an unasked-for edit to state
+// the caller wrote on purpose. `verdict` is the only conventional enum in the
+// entity schema today, but nothing here is verdict-specific.
+func canonicalConventional(field, value string) string {
+	spec, ok := loadEntitySchema().fields[field]
+	if !ok || len(spec.Conventional) == 0 {
+		return value
+	}
+	trimmed := strings.TrimSpace(value)
+	for _, allowed := range spec.Conventional {
+		if strings.EqualFold(trimmed, allowed) {
+			return allowed
+		}
+	}
+	return value
+}
+
+// storedVerdict maps a CLI verdict (`--verdict passed|rejected`, lowercase, as
+// the help text documents) to the value written into frontmatter, where the
+// entity schema declares the conventional set as [PASSED REJECTED]. The CLI
+// surface deliberately does NOT change, since every caller, skill and doc passes
+// lowercase.
+//
+// This is the guard for the ONE writer that does not go through
+// updateFrontmatter: gates.FinalizeTerminalApproval owns its own locked write,
+// so finalize() must hand it the stored spelling. Every other write — the
+// user-facing `--set`, finalize's gate-less path, archive — is canonicalised
+// inside updateFrontmatter and needs no caller-side normalisation.
+//
+// An empty verdict stays empty: it matches no conventional value, so it passes
+// through, and a verdict-less transition writes nothing rather than an
+// empty-string uppercase.
+func storedVerdict(verdict string) string {
+	return canonicalConventional("verdict", verdict)
+}
+
+// isRejectedVerdict reports whether a verdict READ back from frontmatter is the
+// rejected one, ignoring case. Several guards carve out rejected entities (a
+// rejected entity never ran the merge ceremony, so the merge-hook and
+// terminal-status requirements are vacuous for it). Those carve-outs must hold
+// for the `REJECTED` this binary writes, for the `rejected` older binaries wrote,
+// and for whatever case a hand-edit left behind — a guard that refused on case
+// alone would strand exactly the entities it is meant to exempt.
+func isRejectedVerdict(verdict string) bool {
+	return strings.EqualFold(strings.TrimSpace(verdict), "rejected")
+}

--- a/internal/status/verdict_case_test.go
+++ b/internal/status/verdict_case_test.go
@@ -1,0 +1,108 @@
+// ABOUTME: verdict case boundary — the CLI takes lowercase `--verdict passed|rejected`,
+// ABOUTME: frontmatter carries the schema's PASSED/REJECTED, and reads accept either case.
+package status
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMergeGuardWritesSchemaCasedVerdict pins the write-boundary normalisation.
+// `merge guard --verdict` documents (and every caller uses) the lowercase
+// `passed|rejected`, but entity.mdschema.yml declares the frontmatter value's
+// conventional set as [PASSED REJECTED] — so writing the flag verbatim made
+// `status --validate` warn on the entity the verb itself had just finalized, a
+// permanent warning because the entity is terminal and archived. The verb
+// upper-cases at the write boundary: the flag surface stays lowercase, the
+// stored state matches the schema.
+//
+// The `rejected` leg is not a mirror of `passed`: it also covers the guards that
+// read the verdict straight back out of frontmatter. finalize archives through
+// runArchive without --force, and the archive-side merge-hook invariant exempts
+// a rejected entity — an exemption that must survive the case change.
+func TestMergeGuardWritesSchemaCasedVerdict(t *testing.T) {
+	for _, tc := range []struct{ name, slug, flag, want string }{
+		{"passed", "080-pr-merged", "passed", "PASSED"},
+		{"rejected", "040-rejected", "rejected", "REJECTED"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root, out, errOut, code := driveMergeGuard(t, "merge-pr-workflow", tc.slug, "--verdict", tc.flag)
+			if code != 0 {
+				t.Fatalf("finalize should exit 0, got %d (stdout=%q stderr=%q)", code, out, errOut)
+			}
+			archived := filepath.Join(root, "_archive", tc.slug+".md")
+			if got := frontmatterField(t, archived, "verdict"); got != tc.want {
+				t.Fatalf("archived verdict=%q, want %q (the schema's conventional value)", got, tc.want)
+			}
+			vOut, vErr, _ := runNative(t, root, pinnedEnv(t), "--workflow-dir", root, "--validate")
+			if strings.Contains(vOut+vErr, "field 'verdict'") {
+				t.Fatalf("--validate must not warn on the verdict the verb just wrote:\nstdout=%s\nstderr=%s", vOut, vErr)
+			}
+		})
+	}
+}
+
+// TestValidateAcceptsEitherVerdictCase pins the read side: an entity carrying a
+// lowercase verdict — everything a pre-fix binary wrote — validates clean. The
+// conventional-enum comparison is case-insensitive, so already-archived entities
+// need no migration and no hand-editing.
+func TestValidateAcceptsEitherVerdictCase(t *testing.T) {
+	for _, verdict := range []string{"passed", "PASSED", "rejected", "REJECTED"} {
+		t.Run(verdict, func(t *testing.T) {
+			root := stageFixtureWith(t, "merge-pr-workflow", map[string]string{
+				"_archive/200-legacy-verdict.md": "---\nid: \"200\"\ntitle: Legacy verdict casing\n" +
+					"status: done\nverdict: " + verdict + "\nscore: \"0.5\"\nsource: roadmap\n---\n" +
+					"# Legacy verdict casing\n",
+			})
+			out, errOut, _ := runNative(t, root, pinnedEnv(t), "--workflow-dir", root, "--validate")
+			if strings.Contains(out+errOut, "field 'verdict'") {
+				t.Fatalf("verdict %q must validate clean in either case:\nstdout=%s\nstderr=%s", verdict, out, errOut)
+			}
+		})
+	}
+}
+
+// TestSetStoresSchemaCasedVerdict pins the OTHER terminal writer. `merge guard`
+// is not the only way a verdict reaches frontmatter: the user-facing
+// `status --set <slug> verdict=passed` writes one too, and normalising only the
+// merge-guard verb would leave stored case depending on which verb finalized the
+// entity. updateFrontmatter canonicalises on every write, so both agree.
+func TestSetStoresSchemaCasedVerdict(t *testing.T) {
+	for _, tc := range []struct{ flag, want string }{
+		{"passed", "PASSED"},
+		{"PASSED", "PASSED"},
+		{"rejected", "REJECTED"},
+		{"Rejected", "REJECTED"},
+	} {
+		t.Run(tc.flag, func(t *testing.T) {
+			root := stageFixture(t, "seq-workflow")
+			_, errOut, code := runNative(t, root, pinnedEnv(t), "--workflow-dir", root,
+				"--set", "002-vendor-script", "status=done", "completed", "verdict="+tc.flag, "worktree=")
+			if code != 0 {
+				t.Fatalf("--set finalize should exit 0, got %d (stderr=%q)", code, errOut)
+			}
+			if got := frontmatterField(t, filepath.Join(root, "002-vendor-script.md"), "verdict"); got != tc.want {
+				t.Fatalf("--set verdict=%s stored %q, want %q", tc.flag, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNonConventionalValuePassesThroughUnchanged pins the deliberate limit on
+// canonicalisation. A conventional list is advisory (`invalid_severity: warn`),
+// so a field may legitimately carry a value outside it — canonicalisation
+// snaps values ONTO the schema's spellings, it does not case-fold everything.
+// A blanket strings.ToUpper would silently rewrite `needs-work` to `NEEDS-WORK`,
+// editing state the caller wrote on purpose.
+func TestNonConventionalValuePassesThroughUnchanged(t *testing.T) {
+	root := stageFixture(t, "seq-workflow")
+	_, errOut, code := runNative(t, root, pinnedEnv(t), "--workflow-dir", root,
+		"--set", "002-vendor-script", "verdict=needs-work", "--force")
+	if code != 0 {
+		t.Fatalf("--set with a non-conventional verdict should exit 0, got %d (stderr=%q)", code, errOut)
+	}
+	if got := frontmatterField(t, filepath.Join(root, "002-vendor-script.md"), "verdict"); got != "needs-work" {
+		t.Fatalf("non-conventional verdict stored %q, want it unchanged as %q", got, "needs-work")
+	}
+}

--- a/internal/status/verdict_guard_test.go
+++ b/internal/status/verdict_guard_test.go
@@ -74,7 +74,7 @@ func TestVerdictGateFinalizeWithVerdictAllowed(t *testing.T) {
 		t.Fatalf("finalize WITH a verdict must succeed (exit 0), got %d (stderr=%q)", code, errOut)
 	}
 	fm := readWhole(t, filepath.Join(root, "002-vendor-script.md"))
-	if !strings.Contains(fm, "status: done") || !strings.Contains(fm, "verdict: passed") {
+	if !strings.Contains(fm, "status: done") || !strings.Contains(fm, "verdict: PASSED") {
 		t.Fatalf("entity should have terminalized with a verdict:\n%s", fm)
 	}
 }


### PR DESCRIPTION
Adopts the exact validated candidate from contributor PR #634 for protected CI execution. Fixes #497. Original contribution and authorship remain credited in commit 6c45fd59c.