### PR TITLE
Keep journey-delta reporting green across failed-job reruns

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -585,18 +585,55 @@ jobs:
         with:
           go-version: "1.22"
 
-      - name: Download this run's Claude journey metrics
-        uses: actions/download-artifact@v5
-        with:
-          pattern: runtime-live-e2e-claude-live-*
-          path: ${{ runner.temp }}/current-run-artifacts
-          merge-multiple: true
+      - name: Recover this run's journey metrics
+        id: recover_current_metrics
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
 
-      - name: Download this run's Codex journey metrics
-        uses: actions/download-artifact@v5
-        with:
-          name: runtime-live-e2e-codex-live
-          path: ${{ runner.temp }}/current-run-artifacts
+          warn_and_skip() {
+            artifact_name="$1"
+            rm -rf "$RUNNER_TEMP/current-run-artifacts" "$RUNNER_TEMP/current-run-metrics"
+            echo "::warning::journey metrics artifact $artifact_name is unavailable; skipping journey-cost delta comment" >&2
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          mkdir -p "$RUNNER_TEMP/current-run-artifacts"
+          for artifact_name in \
+            runtime-live-e2e-claude-live-claude-sonnet-5 \
+            runtime-live-e2e-codex-live
+          do
+            if ! artifact_id="$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" \
+              --paginate \
+              --jq ".artifacts[] | select(.name == \"$artifact_name\" and .expired == false) | [.created_at, .id] | @tsv" \
+              | sort -k1,1 -k2,2n | tail -1 | cut -f2)"
+            then
+              warn_and_skip "$artifact_name"
+            fi
+            if [ -z "$artifact_id" ]; then
+              warn_and_skip "$artifact_name"
+            fi
+
+            artifact_zip="$RUNNER_TEMP/current-run-artifact-$artifact_id.zip"
+            artifact_dir="$RUNNER_TEMP/current-run-artifacts/$artifact_id"
+            if ! gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" > "$artifact_zip"; then
+              warn_and_skip "$artifact_name"
+            fi
+            if ! unzip -tq "$artifact_zip" >/dev/null; then
+              warn_and_skip "$artifact_name"
+            fi
+            mkdir -p "$artifact_dir"
+            if ! unzip -q "$artifact_zip" -d "$artifact_dir"; then
+              warn_and_skip "$artifact_name"
+            fi
+            if ! find "$artifact_dir" -path '*/journey-metrics/*.json' -type f -print -quit | grep -q .; then
+              warn_and_skip "$artifact_name"
+            fi
+          done
+          echo "found=true" >> "$GITHUB_OUTPUT"
 
       # Best-effort: no previously published release (or one with no
       # journey-costs asset) means no baseline to diff against. `|| true` /
@@ -604,6 +641,7 @@ jobs:
       # missing baseline never REDs the PR.
       - name: Download the latest published release's journey-cost ledger
         id: download_previous_ledger
+        if: steps.recover_current_metrics.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -630,14 +668,14 @@ jobs:
       # same class of problem) is layout-agnostic — it locates the metrics
       # files wherever they actually landed.
       - name: Locate this run's journey metrics
-        if: steps.download_previous_ledger.outputs.found == 'true'
+        if: steps.recover_current_metrics.outputs.found == 'true' && steps.download_previous_ledger.outputs.found == 'true'
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/current-run-metrics"
           find "$RUNNER_TEMP/current-run-artifacts" -path '*/journey-metrics/*.json' -type f -exec cp {} "$RUNNER_TEMP/current-run-metrics/" \;
 
       - name: Post the journey-cost delta PR comment
-        if: steps.download_previous_ledger.outputs.found == 'true'
+        if: steps.recover_current_metrics.outputs.found == 'true' && steps.download_previous_ledger.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -101,6 +101,9 @@ Without auth, the respective live suite skips locally (Claude/Codex/Pi), except 
 
 The deletion removes 17 seconds of tmux setup and avoids a 172.5-second duplicate Pi smoke per run.
 
+The optional journey-delta job uses the newest metrics artifact for each live producer in the run.
+If one artifact is unavailable or incomplete, the job warns and skips the comment. The required test result does not change.
+
 Workflow: `.github/workflows/runtime-live-e2e.yml`. The offline gate job (`go test ./...`, no secrets) must pass before a live lane uses an environment approval.
 
 - Pull requests run `claude-sonnet-5` at maximum effort and `gpt-5.6-luna` at maximum effort.


### PR DESCRIPTION
Failed-job reruns no longer stay red when optional journey metrics are unavailable, so required live-test results remain authoritative.

## What changed

- Recover the newest exact artifact from each live producer.
- Skip the optional delta comment when either artifact is unavailable or incomplete.
- Document that metrics failures do not change required test results.

## Evidence

- Required Go suites: 2/2 passed, including the race suite.
- Focused release and registry checks: 2/2 passed; detached recovery audit passed.

---
[qz](/spacedock-dev/spacedock/blob/d77719f6959b1998553a4fa55b6762a63944bdd4/keep-journey-delta-green-on-rerun.md)
