### PR TITLE
Run Claude common live journeys two at a time

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -262,9 +262,9 @@ jobs:
         run: echo "CLAUDE_CONFIG_DIR=$RUNNER_TEMP/spacedock-claude-config/${{ matrix.model }}" >> "$GITHUB_ENV"
 
       # Run all 16 exported common journeys through the Claude transport. The exact
-      # prefix selector is shared with Codex and Pi; -failfast stops at the first
-      # non-TODO regression. Go runs at most two Claude journeys concurrently; the
-      # loose 90-minute timeout is a suite-wide runaway backstop.
+      # prefix selector is shared with Codex and Pi. Go runs at most two Claude
+      # journeys concurrently; queued work can start after a failure despite
+      # -failfast. The loose 90-minute timeout is a suite-wide runaway backstop.
       # Output discipline: gotestsum runs the suite ONCE, prints a CLEAN step log
       # (per-package progress + an `=== Failed` recap listing each failing test
       # with file:line — no per-test === RUN / --- PASS firehose) and writes the

--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -263,8 +263,8 @@ jobs:
 
       # Run all 16 exported common journeys through the Claude transport. The exact
       # prefix selector is shared with Codex and Pi; -failfast stops at the first
-      # non-TODO regression. The loose 90-minute timeout is a suite-wide runaway
-      # backstop for these sequential journeys, not an individual-journey budget.
+      # non-TODO regression. Go runs at most two Claude journeys concurrently; the
+      # loose 90-minute timeout is a suite-wide runaway backstop.
       # Output discipline: gotestsum runs the suite ONCE, prints a CLEAN step log
       # (per-package progress + an `=== Failed` recap listing each failing test
       # with file:line — no per-test === RUN / --- PASS firehose) and writes the
@@ -277,7 +277,7 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p "$SPACEDOCK_LIVE_ARTIFACT_DIR"
-          SPACEDOCK_LIVE_RUNTIME=claude gotestsum --jsonfile live-e2e-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast ./internal/ensigncycle/
+          SPACEDOCK_LIVE_RUNTIME=claude gotestsum --jsonfile live-e2e-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast -parallel 2 ./internal/ensigncycle/
 
       # Current Claude substrate proofs. Each exact test name owns one claim:
       # merged named-Agent dispatch, explicit bare dispatch, or break-glass recovery

--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -40,9 +40,11 @@ export SPACEDOCK_REPO_ROOT="$PWD"
 
 Run the common journeys by selecting one transport. The Claude command runs at
 most two common journeys at one time. The Codex and Pi commands run the same
-journeys in sequence. Each command stops at the first non-TODO failure. Claude's
-90-minute timeout is a loose suite-wide runaway backstop; Codex and Pi retain the
-40-minute backstop:
+journeys in sequence. The Claude command keeps `-failfast`, but Go can start
+queued parallel journeys after a failure. At most two Claude journeys run at one
+time. The sequential Codex and Pi commands stop at the first non-TODO failure.
+Claude's 90-minute timeout is a loose suite-wide runaway backstop; Codex and Pi
+retain the 40-minute backstop:
 
 ```bash
 SPACEDOCK_LIVE_RUNTIME=claude go test -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast -parallel 2 ./internal/ensigncycle -v

--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -38,13 +38,14 @@ export SPACEDOCK_BIN="$PWD/spacedock"
 export SPACEDOCK_REPO_ROOT="$PWD"
 ```
 
-Run the common journeys by selecting one transport. Each command uses the same
-16 exported sequential tests and stops at the first non-TODO failure. Claude's
-90-minute timeout is a loose suite-wide runaway backstop; Codex and Pi retain
-the 40-minute backstop:
+Run the common journeys by selecting one transport. The Claude command runs at
+most two common journeys at one time. The Codex and Pi commands run the same
+journeys in sequence. Each command stops at the first non-TODO failure. Claude's
+90-minute timeout is a loose suite-wide runaway backstop; Codex and Pi retain the
+40-minute backstop:
 
 ```bash
-SPACEDOCK_LIVE_RUNTIME=claude go test -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast ./internal/ensigncycle -v
+SPACEDOCK_LIVE_RUNTIME=claude go test -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast -parallel 2 ./internal/ensigncycle -v
 ```
 
 Run all three current Claude substrate proofs with one 20-minute backstop:

--- a/internal/contractlint/live_registry_reconciliation_test.go
+++ b/internal/contractlint/live_registry_reconciliation_test.go
@@ -113,9 +113,9 @@ func TestRuntimeLiveCommonSuiteTimeouts(t *testing.T) {
 	for _, command := range []struct {
 		name, text, want string
 	}{
-		{"workflow Claude", live, `SPACEDOCK_LIVE_RUNTIME=claude gotestsum --jsonfile live-e2e-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast ./internal/ensigncycle/`},
+		{"workflow Claude", live, `SPACEDOCK_LIVE_RUNTIME=claude gotestsum --jsonfile live-e2e-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast -parallel 2 ./internal/ensigncycle/`},
 		{"workflow Codex", live, `SPACEDOCK_LIVE_RUNTIME=codex gotestsum --jsonfile codex-shared-scenarios-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle`},
-		{"docs Claude", docs, `SPACEDOCK_LIVE_RUNTIME=claude go test -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast ./internal/ensigncycle -v`},
+		{"docs Claude", docs, `SPACEDOCK_LIVE_RUNTIME=claude go test -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast -parallel 2 ./internal/ensigncycle -v`},
 		{"docs Codex", docs, `SPACEDOCK_LIVE_RUNTIME=codex go test -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle -v`},
 		{"docs Pi", docs, `SPACEDOCK_LIVE_RUNTIME=pi go test -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle -v`},
 	} {

--- a/internal/ensigncycle/shared_live_runner_test.go
+++ b/internal/ensigncycle/shared_live_runner_test.go
@@ -23,12 +23,16 @@ func liveJourney[Builder, Assertion any](t *testing.T, id, fixtureID string, bui
 	}
 	build, buildCalls := countedLiveFunction(t, builder)
 	assert, assertionCalls := countedLiveFunction(t, assertion)
-	driver, target := liveDriverForRuntime(t)
+	newDriver, target := liveDriverForRuntime(t)
 	for _, todo := range todos {
 		if todo.target == target {
 			t.Skipf("TODO(%s): %s/%s lacks passing live evidence", todo.owner, target, id)
 		}
 	}
+	if os.Getenv("SPACEDOCK_LIVE_RUNTIME") == "claude" {
+		t.Parallel()
+	}
+	driver := newDriver()
 	exercise(t, driver, sharedRuntimeScenario{name: id}, build, assert)
 	if *buildCalls == 0 || *assertionCalls == 0 {
 		t.Fatalf("live journey %s executed builder/assertion %d/%d times", id, *buildCalls, *assertionCalls)
@@ -48,7 +52,7 @@ func countedLiveFunction[Function any](t *testing.T, function Function) (Functio
 
 func noLiveGrade(liveResult) {}
 
-func liveDriverForRuntime(t *testing.T) (liveDriver, string) {
+func liveDriverForRuntime(t *testing.T) (func() liveDriver, string) {
 	t.Helper()
 	switch runtime := os.Getenv("SPACEDOCK_LIVE_RUNTIME"); runtime {
 	case "claude":
@@ -57,11 +61,11 @@ func liveDriverForRuntime(t *testing.T) (liveDriver, string) {
 			t.Fatal(err)
 			return nil, ""
 		}
-		return newClaudeLiveRunner(t), role
+		return func() liveDriver { return newClaudeLiveRunner(t) }, role
 	case "codex":
-		return codexAsLiveDriver{t: t, runner: newCodexLiveRunner(t)}, "codex"
+		return func() liveDriver { return codexAsLiveDriver{t: t, runner: newCodexLiveRunner(t)} }, "codex"
 	case "pi":
-		return newPiSharedLiveDriver(t), "pi"
+		return func() liveDriver { return newPiSharedLiveDriver(t) }, "pi"
 	default:
 		t.Fatalf("SPACEDOCK_LIVE_RUNTIME=%q, want claude, codex, or pi", runtime)
 		return nil, ""

--- a/internal/release/journey_workflow_test.go
+++ b/internal/release/journey_workflow_test.go
@@ -54,8 +54,8 @@ func TestRuntimeLiveWorkflowGuardRejectsMissingCodexJourneyMetricUpload(t *testi
 func TestRuntimeLiveWorkflowGuardRejectsMissingSharedScenarioRun(t *testing.T) {
 	live := readWorkflow(t, "runtime-live-e2e.yml")
 	adversarial := strings.Replace(live,
-		`SPACEDOCK_LIVE_RUNTIME=claude gotestsum --jsonfile live-e2e-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast ./internal/ensigncycle/`,
-		`# SPACEDOCK_LIVE_RUNTIME=claude gotestsum --jsonfile live-e2e-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast ./internal/ensigncycle/`,
+		`SPACEDOCK_LIVE_RUNTIME=claude gotestsum --jsonfile live-e2e-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast -parallel 2 ./internal/ensigncycle/`,
+		`# SPACEDOCK_LIVE_RUNTIME=claude gotestsum --jsonfile live-e2e-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast -parallel 2 ./internal/ensigncycle/`,
 		1)
 	if adversarial == live {
 		t.Fatal("fixture workflow missing Claude shared scenario run command")


### PR DESCRIPTION
Runs only Claude common journeys with Go parallelism capped at two. Codex, Pi, and substrate proofs remain sequential. The documentation explicitly records that queued Claude work can start after a failure despite -failfast. Focused contract, release, and ensigncycle checks pass; the earlier candidate also passed full and race validation.