### PR TITLE
Reject a stale same-minor launcher before First Officer work

### DIFF
--- a/docs/site/get-started/install.md
+++ b/docs/site/get-started/install.md
@@ -106,6 +106,10 @@ See [supported sandboxes](../reference/sandbox.md).
 
 Run `spacedock doctor`.
 
+If startup says the installed launcher is missing a required command, upgrade
+Spacedock and relaunch. On macOS, run `brew upgrade spacedock`. On Linux, rerun
+the checksum-verified binary installer shown above.
+
 ## Next
 
 Read about the [survey report](survey.md) to understand your usage pattern

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -4,14 +4,13 @@ Shared first-officer semantics — the boot-resident core. The active runtime ad
 
 ## Startup
 
-**Launcher command invariant:** Resolve ONE launcher at the version gate — `SPACEDOCK_BIN` when set/executable, else `spacedock` on `$PATH` — and use THAT launcher (written `${SPACEDOCK_BIN:-spacedock}`) for every later helper call. A gate failing binary-absent that then succeeds via the approved install performs its ONE launcher resolution at that point. Never drift to a bare `spacedock` mid-session; bare `spacedock` is fine only for naming a command, the fallback probe, and install hints.
+**Launcher invariant:** Resolve executable `SPACEDOCK_BIN`, else `$PATH`'s `spacedock`; use `${SPACEDOCK_BIN:-spacedock}` always. Binary-absent success after approved install performs its ONE launcher resolution at that point. Never drift to a bare `spacedock` mid-session.
 
-1. **Binary version gate.** Sandbox check (every class): Bash `[ "${APP_SANDBOX_CONTAINER_ID:-}" = "agent-safehouse" ]` (registry name+VALUE: `internal/safehouse/state.go`). Inside a sandbox: never offer/run an install; tell the human to run that exact command outside the sandbox. Run `${SPACEDOCK_BIN:-spacedock} --version`, parse line 1: `spacedock <version>`. These skills require binary minor 0.27.
-   - **Binary absent** (retry once with bare `spacedock` if `SPACEDOCK_BIN` is unusable; no `doctor` — no binary): OS from `uname -s` (load-bearing: no binary, no `OS:` line). Hint: Linux `curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/main/install.sh | sh`; macOS `brew tap spacedock-dev/homebrew-tap && brew install spacedock` or `brew install spacedock-dev/homebrew-tap/spacedock`; fallback `go build -o spacedock ./cmd/spacedock`; other OS: unsupported OS — hint-and-abort with the source build. Outside a sandbox, read `references/fo-install-gate.md` for the install offer.
-   - **Wrong version**: major.minor below/above/absent (bare `dev`, not `+dev`). ABORT with the mismatch; run `${SPACEDOCK_BIN:-spacedock} doctor`.
-
-   In every class, do NOT proceed to discovery or `--boot`.
-
+1. **Binary gate.** Check `[ "${APP_SANDBOX_CONTAINER_ID:-}" = "agent-safehouse" ]`; inside, never offer/run installation; say to run it outside the sandbox. `${SPACEDOCK_BIN:-spacedock} --version` line 1 must be `spacedock <version>`. These skills require binary minor 0.27.
+   - **Binary absent:** retry bare `spacedock` once if `SPACEDOCK_BIN` is unusable. Use `uname -s`, not `doctor`/`OS:`. Linux: `curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/main/install.sh | sh`; macOS: `brew tap spacedock-dev/homebrew-tap`, then `brew install spacedock-dev/homebrew-tap/spacedock`; other OS: unsupported OS, hint `go build -o spacedock ./cmd/spacedock`, ABORT. Outside sandbox read `references/fo-install-gate.md`.
+   - **Wrong version:** major.minor below/above/absent (bare `dev`) → ABORT; `${SPACEDOCK_BIN:-spacedock} doctor`.
+   - **Compatible minor:** `${SPACEDOCK_BIN:-spacedock} gate --help` once; stdout must contain `spacedock gate withdraw <entity> --reason TEXT`. Read-only; no workflow state.
+   - **Missing capability** (nonzero/absent line): ABORT before boot. Name executable, line-1 version, missing `gate withdraw … --reason`. Give only macOS `brew upgrade spacedock` or Linux `curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/main/install.sh | sh`; say relaunch. No in-session install/repoint, source/repository advice, plugin refresh, network lookup, or alternate launcher.
 2. **Boot — local identify.** Invoke `«state.boot»()` once and retain its boot record.
 3. **Interaction boundary.** Invoke `«interaction.boundary»()` with that boot record and the launch context.
 

--- a/skills/integration/testdata/version_gate_flow.sh
+++ b/skills/integration/testdata/version_gate_flow.sh
@@ -10,6 +10,7 @@
 set -u
 
 REQUIRED_MINOR="${REQUIRED_MINOR:-0.27}"
+REQUIRED_CAPABILITY="${REQUIRED_CAPABILITY:-spacedock gate withdraw <entity> --reason TEXT}"
 LINUX_CMD='curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/main/install.sh | sh'
 DARWIN_CMD='brew tap spacedock-dev/homebrew-tap && brew install spacedock'
 key="${CLAUDE_CODE_SESSION_ID:-${CODEX_THREAD_ID:-fixture}}"
@@ -49,8 +50,24 @@ fi
 if [ "$present" = 1 ]; then
 	ver="$(printf '%s\n' "$vout" | sed -n '1s/^spacedock //p')"
 	if [ "$(major_minor "$ver")" = "$REQUIRED_MINOR" ]; then
+		helpout=""
+		if ! helpout="$("$launcher" gate --help 2>/dev/null)" || ! printf '%s\n' "$helpout" | awk -v required="$REQUIRED_CAPABILITY" 'index($0, required) { found=1 } END { exit !found }'; then
+			os="${FIXTURE_OS:-$(uname -s)}"
+			case "$os" in
+			Darwin) REMEDY='brew upgrade spacedock' ;;
+			Linux) REMEDY="$LINUX_CMD" ;;
+			*) REMEDY='install the current Spacedock binary for this OS' ;;
+			esac
+			say "selected launcher: $launcher"
+			say "observed version: spacedock $ver"
+			say "missing capability: $REQUIRED_CAPABILITY"
+			say "upgrade the installed launcher: $REMEDY"
+			say "then relaunch"
+			exit 3
+		fi
 		say "gate passed: spacedock $ver"
-		exit 0
+		"$launcher" status --boot --identify --json
+		exit $?
 	fi
 	# Wrong-version class: unchanged by this task — abort + doctor pointer.
 	say "version mismatch: binary $ver, skills require $REQUIRED_MINOR — run \${SPACEDOCK_BIN:-spacedock} doctor for the per-class remedy"

--- a/skills/integration/version_gate_fixture_test.go
+++ b/skills/integration/version_gate_fixture_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 const curlInstallToken = "curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/main/install.sh | sh"
+const withdrawCapability = "spacedock gate withdraw <entity> --reason TEXT"
 
 // gateFixtureDir builds the captive-command fixture tree:
 //
@@ -54,10 +55,18 @@ func writeExe(t *testing.T, path, body string) {
 // $COUNT_FILE, and honors the real install.sh's stderr contract
 // (`install.sh: installed spacedock <version> to <dir>/spacedock`).
 func captiveInstall(version string, extraVersionLines ...string) string {
-	captiveBinary := "#!/bin/sh\necho \"spacedock " + version + "\"\n"
+	captiveBinary := "#!/bin/sh\n" +
+		"[ -n \"${INVOCATION_LOG:-}\" ] && printf '%s|%s\\n' \"$0\" \"$*\" >> \"$INVOCATION_LOG\"\n" +
+		"case \"$*\" in\n" +
+		"--version) echo \"spacedock " + version + "\"\n"
 	for _, l := range extraVersionLines {
 		captiveBinary += "echo \"" + l + "\"\n"
 	}
+	captiveBinary += "  ;;\n" +
+		"'gate --help') echo '" + withdrawCapability + "' ;;\n" +
+		"'status --boot --identify --json') echo '{\"command\":\"status\",\"boot\":true}' ;;\n" +
+		"*) exit 9 ;;\n" +
+		"esac\n"
 	return "#!/bin/sh\n" +
 		"mkdir -p \"$HOME/.local/bin\"\n" +
 		"cat > \"$HOME/.local/bin/spacedock\" <<'EOS'\n" + captiveBinary + "EOS\n" +
@@ -84,6 +93,7 @@ func runGateFlow(t *testing.T, dir string, extraEnv []string) (string, int) {
 		"HOME=" + filepath.Join(dir, "home"),
 		"COUNT_FILE=" + filepath.Join(dir, "install-count"),
 		"CAPTIVE_INSTALL=" + os.Getenv("CAPTIVE_INSTALL"),
+		"INVOCATION_LOG=" + filepath.Join(dir, "invocations"),
 		"FIXTURE_OS=Linux",
 		"REQUIRED_MINOR=0.27",
 	}
@@ -114,6 +124,94 @@ const fixtureSessionID = "fixture-session-0001"
 
 func sentinelPath(dir string) string {
 	return filepath.Join(dir, "spacedock-install-attempted-"+fixtureSessionID)
+}
+
+func writeGateLauncher(t *testing.T, dir, version, help string) string {
+	t.Helper()
+	path := filepath.Join(dir, "selected", "spacedock")
+	body := `#!/bin/sh
+printf '%s|%s\n' "$0" "$*" >> "$INVOCATION_LOG"
+case "$*" in
+--version)
+	printf '%s\n' 'spacedock ` + version + `'
+	;;
+'gate --help')
+	printf '%s\n' '` + help + `'
+	;;
+'status --boot --identify --json')
+	printf '%s\n' '{"command":"status","boot":true}'
+	;;
+*)
+	printf '%s\n' "unexpected invocation: $*" >&2
+	exit 9
+	;;
+esac
+`
+	writeExe(t, path, body)
+	return path
+}
+
+func invocationLog(t *testing.T, dir string) []string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, "invocations"))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Split(strings.TrimSpace(string(b)), "\n")
+}
+
+func TestGateFlowRejectsStaleSameMinorBeforeBoot(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		os     string
+		remedy string
+	}{
+		{name: "Darwin", os: "Darwin", remedy: "brew upgrade spacedock"},
+		{name: "Linux", os: "Linux", remedy: curlInstallToken},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := gateFixtureDir(t, captiveInstall("0.27.0"))
+			launcher := writeGateLauncher(t, dir, "0.27.0-pre2+dev", "stale gate help")
+			out, code := runGateFlow(t, dir, []string{"SPACEDOCK_BIN=" + launcher, "FIXTURE_OS=" + tc.os})
+			if code != 3 {
+				t.Fatalf("exit = %d, want 3 for stale same-minor launcher:\n%s", code, out)
+			}
+			wantCalls := []string{launcher + "|--version", launcher + "|gate --help"}
+			if got := invocationLog(t, dir); strings.Join(got, "\n") != strings.Join(wantCalls, "\n") {
+				t.Fatalf("invocations = %#v, want %#v", got, wantCalls)
+			}
+			for _, want := range []string{launcher, "spacedock 0.27.0-pre2+dev", withdrawCapability, tc.remedy, "relaunch"} {
+				if !strings.Contains(out, want) {
+					t.Fatalf("stale failure missing %q:\n%s", want, out)
+				}
+			}
+			for _, forbidden := range []string{"go build", "source", "checkout", "repository", "plugin refresh", "SPACEDOCK_BIN repointed"} {
+				if strings.Contains(out, forbidden) {
+					t.Fatalf("stale failure contains forbidden development/repoint advice %q:\n%s", forbidden, out)
+				}
+			}
+		})
+	}
+}
+
+func TestGateFlowCompatibleSameMinorProbesThenBootsOnce(t *testing.T) {
+	dir := gateFixtureDir(t, captiveInstall("0.27.0"))
+	launcher := writeGateLauncher(t, dir, "0.27.0-pre2+dev", "Usage:\n       "+withdrawCapability+" [--workflow-dir DIR]")
+	out, code := runGateFlow(t, dir, []string{"SPACEDOCK_BIN=" + launcher})
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 for compatible same-minor launcher:\n%s", code, out)
+	}
+	wantCalls := []string{
+		launcher + "|--version",
+		launcher + "|gate --help",
+		launcher + "|status --boot --identify --json",
+	}
+	if got := invocationLog(t, dir); strings.Join(got, "\n") != strings.Join(wantCalls, "\n") {
+		t.Fatalf("invocations = %#v, want %#v", got, wantCalls)
+	}
 }
 
 // TestGateFlowInstallAndResumeConvergence is AC-2 fixture 1: a captive install


### PR DESCRIPTION
First Officers now reject stale same-minor launchers before workflow work, preventing obsolete command surfaces from changing project state.

## What changed

- Probe the selected launcher after its version check and before boot.
- Stop stale launchers with OS-specific upgrade and relaunch guidance.
- Preserve one executable and one boot for compatible installations.
- Add command-ledger fixtures and public troubleshooting guidance.

## Evidence

- 2/2 focused stale and compatible launcher fixtures passed.
- 3/3 live host boots and 2/2 full and race suites passed.

---
[5f6](/spacedock-dev/spacedock/blob/9fd586c692c039e35f02767f4650baecf3755903/reject-stale-same-minor-launcher-before-fo-work.md)
