### PR TITLE
Restore optional manual Pi common-live CI

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -11,8 +11,8 @@
 # and runs unconditionally on every PR. Only live jobs declare an `environment:`
 # (a required-reviewer approval gate, reviewer = clkao) and read only the
 # host-specific secret they need: ANTHROPIC_API_KEY for Claude and
-# OPENAI_API_KEY for Codex. Pull requests queue Sonnet 5 and Codex Luna. A
-# manual pre-release dispatch replaces Sonnet with Opus and waits for approval.
+# OPENAI_API_KEY for Codex or Pi. Pull requests queue Sonnet 5 and Codex Luna.
+# Manual Opus and Pi cadences run only their selected runtime.
 
 name: Runtime Live E2E
 
@@ -20,13 +20,14 @@ on:
   workflow_dispatch:
     inputs:
       live_cadence:
-        description: "Select the routine Sonnet lane or the Opus pre-release lane."
+        description: "Select routine Sonnet, Opus pre-release, or optional Pi evidence."
         required: true
         type: choice
         default: sonnet
         options:
           - sonnet
           - opus-pre-release
+          - pi
       claude_version:
         description: "Pin Claude Code to a specific version (e.g. 2.1.107, stable, latest). Empty = installer default."
         required: false
@@ -79,6 +80,7 @@ jobs:
   # Pull requests normalize to one Sonnet 5 leg. Manual dispatches choose the
   # routine Sonnet cadence or the separately approved Opus pre-release cadence.
   claude-live:
+    if: ${{ github.event_name == 'pull_request' || inputs.live_cadence == 'sonnet' || inputs.live_cadence == 'opus-pre-release' }}
     needs: offline
     # The offline gate runs first without secrets. The selected live leg then
     # waits for its CI-E2E or CI-E2E-OPUS approval.
@@ -307,6 +309,7 @@ jobs:
           if-no-files-found: warn
 
   codex-live:
+    if: ${{ github.event_name == 'pull_request' || inputs.live_cadence == 'sonnet' }}
     needs: offline
     runs-on: ubuntu-latest
     environment:
@@ -556,6 +559,224 @@ jobs:
             ./spacedock
             ./codex-shared-scenarios-detail.jsonl
             live-artifacts/codex/**
+            live-artifacts/journey-metrics/**
+          if-no-files-found: warn
+
+  pi-live:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.live_cadence == 'pi' }}
+    needs: offline
+    runs-on: ubuntu-latest
+    environment:
+      name: CI-E2E-PI
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      SPACEDOCK_PI_LIVE_REQUIRED: "1"
+      SPACEDOCK_PI_LIVE_CHILD_MODEL: openai/gpt-5.6-luna:max
+      SPACEDOCK_LIVE_ARTIFACT_DIR: ${{ github.workspace }}/live-artifacts/pi
+      SPACEDOCK_JOURNEY_METRICS_DIR: ${{ github.workspace }}/live-artifacts/journey-metrics/pi
+      PI_OFFLINE: "1"
+    steps:
+      - name: Check required secret
+        run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "OPENAI_API_KEY is required for pi-live after CI-E2E-PI approval." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.22"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install Pi CLI and substrates
+        run: |
+          set -euo pipefail
+
+          npm --version
+          node --version
+
+          # Compatibility pins: pi-coding-agent 0.80.x requires Node >=22.19 and
+          # provides @earendil-works/pi-ai/compat, which pi-subagents 0.35.x loads.
+          # Keep these exact pins together; do not let npm's engine-aware resolver
+          # fall back to legacy-node20 pi-coding-agent while pi-subagents floats new.
+          PI_CODING_AGENT_VERSION="0.80.10"
+          PI_CODING_AGENT_INTEGRITY="sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg=="
+          PI_SUBAGENTS_VERSION="0.35.1"
+          PI_SUBAGENTS_INTEGRITY="sha512-nIH6liO541FZ1RoeEu58Ligd59tiNw0/ODPgHh7uvx9Dk4UpWH08F84/l1+hXCzUgC85OCmyVtngWkZjcK94Cg=="
+          PI_INTERCOM_VERSION="0.6.0"
+          PI_INTERCOM_INTEGRITY="sha512-OFPh/DXfPhUUSDLTRJiFPEvw00fOA/spjsxUcXiuCHvb2ZkRL02G8Q91mTd+3d42A9AK8BSmbD0+8imFPuHGoQ=="
+
+          pack_dir="$RUNNER_TEMP/pi-live-npm-packs"
+          mkdir -p "$pack_dir"
+          verified_pack() {
+            local spec="$1"
+            local expected_integrity="$2"
+            local pack_json actual_integrity filename
+            pack_json="$(npm pack "$spec" --pack-destination "$pack_dir" --ignore-scripts --json)"
+            actual_integrity="$(printf '%s' "$pack_json" | node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync(0,'utf8'))[0]; process.stdout.write(p.integrity)")"
+            filename="$(printf '%s' "$pack_json" | node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync(0,'utf8'))[0]; process.stdout.write(p.filename)")"
+            if [ "$actual_integrity" != "$expected_integrity" ]; then
+              echo "integrity mismatch for $spec: expected $expected_integrity got $actual_integrity" >&2
+              exit 1
+            fi
+            printf '%s/%s\n' "$pack_dir" "$filename"
+          }
+
+          pi_coding_agent_tgz="$(verified_pack "@earendil-works/pi-coding-agent@$PI_CODING_AGENT_VERSION" "$PI_CODING_AGENT_INTEGRITY")"
+          pi_subagents_tgz="$(verified_pack "pi-subagents@$PI_SUBAGENTS_VERSION" "$PI_SUBAGENTS_INTEGRITY")"
+          pi_intercom_tgz="$(verified_pack "pi-intercom@$PI_INTERCOM_VERSION" "$PI_INTERCOM_INTEGRITY")"
+
+          npm install -g "$pi_coding_agent_tgz" --ignore-scripts --no-audit --no-fund --omit=dev
+          command -v pi
+          test -x "$(command -v pi)"
+          pi --version
+          global_npm_root="$(npm root -g)"
+          node -e "const p=require('$global_npm_root/@earendil-works/pi-coding-agent/package.json'); if (p.name !== '@earendil-works/pi-coding-agent') throw new Error('unexpected Pi package name '+p.name); if (p.version !== '$PI_CODING_AGENT_VERSION') throw new Error('unexpected Pi version '+p.version); if (!p.bin || p.bin.pi !== 'dist/cli.js') throw new Error('unexpected Pi bin '+JSON.stringify(p.bin)); console.log('verified '+p.name+'@'+p.version+' bin pi='+p.bin.pi)"
+
+          pi_npm_root="$HOME/.pi/agent/npm"
+          mkdir -p "$pi_npm_root"
+          npm install --prefix "$pi_npm_root" \
+            "$pi_subagents_tgz" \
+            "$pi_intercom_tgz" \
+            --ignore-scripts --no-audit --no-fund --omit=dev
+          node -e "const p=require('$pi_npm_root/node_modules/pi-subagents/package.json'); if (p.name !== 'pi-subagents') throw new Error('unexpected pi-subagents package name '+p.name); if (p.version !== '$PI_SUBAGENTS_VERSION') throw new Error('unexpected pi-subagents version '+p.version); console.log('verified '+p.name+'@'+p.version)"
+          node -e "const p=require('$pi_npm_root/node_modules/pi-intercom/package.json'); if (p.name !== 'pi-intercom') throw new Error('unexpected pi-intercom package name '+p.name); if (p.version !== '$PI_INTERCOM_VERSION') throw new Error('unexpected pi-intercom version '+p.version); console.log('verified '+p.name+'@'+p.version)"
+          test -f "$pi_npm_root/node_modules/pi-subagents/src/extension/index.ts"
+          test -f "$pi_npm_root/node_modules/pi-subagents/skills/pi-subagents/SKILL.md"
+          test -f "$pi_npm_root/node_modules/pi-subagents/src/intercom/intercom-bridge.ts"
+          test -f "$pi_npm_root/node_modules/pi-intercom/skills/pi-intercom/SKILL.md"
+          echo "PI_SUBAGENTS_PACKAGE_ROOT=$pi_npm_root/node_modules/pi-subagents" >> "$GITHUB_ENV"
+          echo "PI_INTERCOM_PACKAGE_ROOT=$pi_npm_root/node_modules/pi-intercom" >> "$GITHUB_ENV"
+
+      - name: Guard Pi substrate compatibility
+        run: |
+          set -euo pipefail
+
+          global_npm_root="$(npm root -g)"
+          pi_npm_root="$HOME/.pi/agent/npm"
+          GLOBAL_NPM_ROOT="$global_npm_root" \
+          PI_AGENT_ROOT="$global_npm_root/@earendil-works/pi-coding-agent" \
+          PI_SUBAGENTS_ROOT="$pi_npm_root/node_modules/pi-subagents" \
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const { pathToFileURL } = require('url');
+
+          function readPackage(root) {
+            return JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+          }
+          function fail(message) {
+            console.error(`Pi substrate compatibility guard failed: ${message}`);
+            process.exit(1);
+          }
+
+          const nodeVersion = process.versions.node.split('.').map(Number);
+          if (nodeVersion[0] < 22 || (nodeVersion[0] === 22 && nodeVersion[1] < 19)) {
+            fail(`Node ${process.versions.node} does not satisfy pi-coding-agent's >=22.19.0 engine requirement`);
+          }
+
+          const agentRoot = process.env.PI_AGENT_ROOT;
+          const subagentsRoot = process.env.PI_SUBAGENTS_ROOT;
+          const agentPackage = readPackage(agentRoot);
+          const subagentsPackage = readPackage(subagentsRoot);
+          if (agentPackage.version !== '0.80.10') {
+            fail(`expected @earendil-works/pi-coding-agent 0.80.10, got ${agentPackage.version}`);
+          }
+          if (subagentsPackage.version !== '0.35.1') {
+            fail(`expected pi-subagents 0.35.1, got ${subagentsPackage.version}`);
+          }
+
+          // pi-ai is usually vendored nested under pi-coding-agent (npm does not hoist it
+          // to the global root); check the nested copy pi actually loads first, then the
+          // top-level global root. The /compat export is ESM-only (import condition), so
+          // probe it with a dynamic import, never require.resolve.
+          const piAICandidates = [
+            path.join(agentRoot, 'node_modules', '@earendil-works', 'pi-ai'),
+            path.join(process.env.GLOBAL_NPM_ROOT, '@earendil-works/pi-ai'),
+          ];
+          const piAIRoot = piAICandidates.find((candidate) => fs.existsSync(path.join(candidate, 'package.json')));
+          if (!piAIRoot) {
+            fail(`cannot locate @earendil-works/pi-ai under pi-coding-agent ${agentPackage.version} (checked ${piAICandidates.join(', ')})`);
+          }
+          const piAIPackage = readPackage(piAIRoot);
+          const compatExport = piAIPackage.exports && piAIPackage.exports['./compat'] && piAIPackage.exports['./compat'].import;
+          if (!compatExport) {
+            fail(`pi-subagents ${subagentsPackage.version} requires @earendil-works/pi-ai/compat, but @earendil-works/pi-ai ${piAIPackage.version} from pi-coding-agent ${agentPackage.version} does not declare that export`);
+          }
+          const compatPath = path.join(piAIRoot, compatExport);
+          if (!fs.existsSync(compatPath)) {
+            fail(`@earendil-works/pi-ai/compat resolves to missing file ${compatPath}`);
+          }
+          import(pathToFileURL(compatPath).href).then(() => {
+            console.log(`verified pi-subagents ${subagentsPackage.version} is paired with @earendil-works/pi-ai ${piAIPackage.version}: ${compatPath}`);
+          }).catch((error) => {
+            fail(`@earendil-works/pi-ai/compat exists but failed to load: ${error.message}`);
+          });
+          NODE
+
+      - name: Build spacedock binary
+        run: |
+          go build -o ./spacedock ./cmd/spacedock
+          echo "SPACEDOCK_BIN=$(pwd)/spacedock" >> "$GITHUB_ENV"
+          echo "SPACEDOCK_REPO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+          echo "$(pwd)" >> "$GITHUB_PATH"
+
+      - name: Install gotestsum
+        run: bash .github/scripts/install-gotestsum.sh
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global init.defaultBranch main
+
+      - name: Verify Pi current-checkout setup
+        run: |
+          mkdir -p "$SPACEDOCK_LIVE_ARTIFACT_DIR"
+          spacedock doctor --host pi --plugin-dir "$GITHUB_WORKSPACE" | tee "$SPACEDOCK_LIVE_ARTIFACT_DIR/pi-doctor.txt"
+          test -f "$GITHUB_WORKSPACE/skills/first-officer/references/pi-first-officer-runtime.md"
+          test -f "$GITHUB_WORKSPACE/skills/ensign/references/pi-ensign-runtime.md"
+          test -f "$PI_SUBAGENTS_PACKAGE_ROOT/src/extension/index.ts"
+          test -f "$PI_SUBAGENTS_PACKAGE_ROOT/skills/pi-subagents/SKILL.md"
+          test -f "$PI_SUBAGENTS_PACKAGE_ROOT/src/intercom/intercom-bridge.ts"
+          test -f "$PI_INTERCOM_PACKAGE_ROOT/skills/pi-intercom/SKILL.md"
+
+      - name: Show tool versions
+        run: |
+          pi --version
+          go version
+          echo "### Pi live tool versions" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`pi --version\`: \`$(pi --version)\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Model: \`openai/gpt-5.6-luna\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Thinking: \`max\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`go version\`: \`$(go version)\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run live Pi common journeys
+        run: |
+          set -o pipefail
+          SPACEDOCK_LIVE_RUNTIME=pi gotestsum --jsonfile pi-coverage-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle
+
+      - name: Run live Pi front-door smoke
+        if: ${{ !cancelled() }}
+        run: |
+          set -o pipefail
+          gotestsum --jsonfile pi-front-door-smoke-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 15m -run TestLivePiFrontDoorSmoke ./internal/ensigncycle
+
+      - name: Upload live artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: runtime-live-e2e-pi-live
+          path: |
+            ./spacedock
+            ./pi-coverage-detail.jsonl
+            ./pi-front-door-smoke-detail.jsonl
+            live-artifacts/pi/**
             live-artifacts/journey-metrics/**
           if-no-files-found: warn
 

--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -113,7 +113,7 @@ Without auth, the respective live suite skips locally (Claude/Codex/Pi), except 
 | Codex resolver and `TestLiveCommon...` | Current-checkout resolution and common journeys | Both PR and release jobs consume Codex metrics. |
 | Pi `TestLiveCommon...` and `TestLivePiFrontDoorSmoke` | Common journeys plus one four-part substrate proof | The detail artifacts preserve each run. |
 
-The deletion removes 17 seconds of tmux setup and avoids a 172.5-second duplicate Pi smoke per run.
+The manual Pi lane keeps the lean surface: it does not install tmux and runs one front-door substrate smoke.
 
 The optional journey-delta job uses the newest metrics artifact for each live producer in the run.
 If one artifact is unavailable or incomplete, the job warns and skips the comment. The required test result does not change.
@@ -121,8 +121,8 @@ If one artifact is unavailable or incomplete, the job warns and skips the commen
 Workflow: `.github/workflows/runtime-live-e2e.yml`. The offline gate job (`go test ./...`, no secrets) must pass before a live lane uses an environment approval.
 
 - Pull requests run `claude-sonnet-5` at maximum effort and `gpt-5.6-luna` at maximum effort.
-- An explicit `live_cadence=opus-pre-release` dispatch runs `claude-opus-4-8` at maximum effort.
-- Pi live evidence runs locally with `pi login`. The offline job keeps the registry reconciliation. An explicit local API key is also supported.
+- An explicit `live_cadence=opus-pre-release` dispatch runs offline plus `claude-opus-4-8` at maximum effort. It allocates no Codex or Pi runner and requests only `CI-E2E-OPUS` approval.
+- An explicit `live_cadence=pi` dispatch runs the 17 common Pi journeys and the Pi front-door proof with `openai/gpt-5.6-luna` at maximum thinking. It waits only for `CI-E2E-PI` approval and retains Pi logs, diagnostics, journey metrics, and session artifacts. Pull requests still run only Sonnet and Codex; Pi is optional and is not a merge requirement. Local Pi execution remains supported with `pi login` or an API key.
 
 All live lanes must test the current checkout, not a remote `--ref next` install. The Codex lane generates a local marketplace under `$RUNNER_TEMP`:
 

--- a/docs/site/contributing/architecture-notes.md
+++ b/docs/site/contributing/architecture-notes.md
@@ -31,9 +31,8 @@ Each common test binds its stable ID, fixture builder, target-scoped TODO owner,
 
 CI runs these in `.github/workflows/runtime-live-e2e.yml`. The offline gate job (`go test ./...`, no secrets) must pass before a live lane spends its environment approval:
 
-- **Pull requests** run Claude Sonnet 5 at maximum effort and Codex Luna at maximum effort.
-- **Pre-release dispatches** run Opus at maximum effort when `live_cadence=opus-pre-release`.
-- **Pi evidence** uses the local subscription path with `pi login`. Pull requests keep only the free registry reconciliation.
+- **Pull requests** run Claude Sonnet 5 at maximum effort and Codex Luna at maximum effort; they do not run Pi.
+- **Manual release evidence** is runtime-exclusive: `opus-pre-release` runs only Opus/max behind `CI-E2E-OPUS`, and `pi` runs only Pi Luna/max behind `CI-E2E-PI` while retaining the common-journey and front-door artifacts.
 
 Every live lane tests the current checkout, never a remote `--ref next` install. For the local invocation commands and the full layer-by-layer breakdown of the scenario surface, see [the development workflow](development-workflow.md).
 

--- a/internal/contractlint/live_registry_reconciliation_test.go
+++ b/internal/contractlint/live_registry_reconciliation_test.go
@@ -90,16 +90,16 @@ func TestRuntimeLiveRegistryReconciliation(t *testing.T) {
 
 	workflow := string(mustRead(t, filepath.Join(repo, ".github", "workflows", "runtime-live-e2e.yml")))
 	docs := string(mustRead(t, filepath.Join(repo, "docs", "runtime-live-ci.md")))
-	if strings.Count(workflow, "-run '^TestLiveCommon' -failfast") != 2 || strings.Count(workflow, "-run '^TestLiveCommon'") != 2 {
-		t.Errorf("workflow must contain exactly two common selectors with -failfast")
+	if strings.Count(workflow, "-run '^TestLiveCommon' -failfast") != 3 || strings.Count(workflow, "-run '^TestLiveCommon'") != 3 {
+		t.Errorf("workflow must contain exactly three common selectors with -failfast")
 	}
-	for _, runtime := range []string{"claude", "codex"} {
+	for _, runtime := range []string{"claude", "codex", "pi"} {
 		if strings.Count(workflow, "SPACEDOCK_LIVE_RUNTIME="+runtime) != 1 {
 			t.Errorf("workflow runtime selector %q is not unique", runtime)
 		}
 	}
-	if strings.Contains(workflow, "SPACEDOCK_LIVE_RUNTIME=pi") || strings.Count(docs, "SPACEDOCK_LIVE_RUNTIME=pi go test") != 1 {
-		t.Error("Pi common selector must exist once in the local guide and never in the workflow")
+	if strings.Count(docs, "SPACEDOCK_LIVE_RUNTIME=pi go test") != 1 {
+		t.Error("Pi common selector must exist once in the local guide")
 	}
 }
 
@@ -210,6 +210,7 @@ func TestRuntimeLiveCommonSuiteTimeouts(t *testing.T) {
 	}{
 		{"workflow Claude", live, `SPACEDOCK_LIVE_RUNTIME=claude gotestsum --jsonfile live-e2e-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast -parallel 2 ./internal/ensigncycle/`},
 		{"workflow Codex", live, `SPACEDOCK_LIVE_RUNTIME=codex gotestsum --jsonfile codex-shared-scenarios-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle`},
+		{"workflow Pi", live, `SPACEDOCK_LIVE_RUNTIME=pi gotestsum --jsonfile pi-coverage-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle`},
 		{"docs Claude", docs, `SPACEDOCK_LIVE_RUNTIME=claude go test -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast -parallel 2 ./internal/ensigncycle -v`},
 		{"docs Codex", docs, `SPACEDOCK_LIVE_RUNTIME=codex go test -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle -v`},
 		{"docs Pi", docs, `SPACEDOCK_LIVE_RUNTIME=pi go test -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle -v`},

--- a/internal/ensigncycle/journey_metrics_live_test.go
+++ b/internal/ensigncycle/journey_metrics_live_test.go
@@ -3,13 +3,34 @@
 package ensigncycle
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spacedock-dev/spacedock/internal/journeymetrics"
 )
+
+func Example_emitPiScenarioMetrics() {
+	dir, _ := os.MkdirTemp("", "pi-metrics-proof")
+	defer os.RemoveAll(dir)
+	model := "openai/gpt-5.6-luna:max"
+	_ = writePiScenarioMetrics(dir, sharedRuntimeScenario{name: "pi-metrics-proof"}, liveResult{duration: 2 * time.Second}, model)
+	paths, err := filepath.Glob(filepath.Join(dir, "shared-scenarios", "*.json"))
+	if err != nil || len(paths) != 1 {
+		fmt.Printf("files=%d error=%v\n", len(paths), err)
+		return
+	}
+	data, _ := os.ReadFile(paths[0])
+	var record journeymetrics.Record
+	err = json.Unmarshal(data, &record)
+	fmt.Printf("files=%d bytes=%t error=%v scenario=%s runtime=%s model=%s duration=%d\n",
+		len(paths), len(data) > 0, err, record.ScenarioID, record.Runtime, record.Model, record.DurationMS)
+	// Output: files=1 bytes=true error=<nil> scenario=pi-metrics-proof runtime=pi model=openai/gpt-5.6-luna:max duration=2000
+}
 
 func emitClaudeScenarioMetrics(t *testing.T, scenario sharedRuntimeScenario, result liveResult, model string) {
 	t.Helper()
@@ -123,4 +144,30 @@ func emitCodexScenarioMetrics(t *testing.T, scenario sharedRuntimeScenario, resu
 	if err := journeymetrics.EmitRecord(filepath.Join(dir, "shared-scenarios"), record); err != nil {
 		t.Fatalf("emit Codex journey metrics for %s: %v", scenario.name, err)
 	}
+}
+
+func emitPiScenarioMetrics(t *testing.T, scenario sharedRuntimeScenario, result liveResult, model string) {
+	t.Helper()
+	dir := os.Getenv("SPACEDOCK_JOURNEY_METRICS_DIR")
+	if dir == "" {
+		return
+	}
+	if err := writePiScenarioMetrics(dir, scenario, result, model); err != nil {
+		t.Fatalf("emit Pi journey metrics for %s: %v", scenario.name, err)
+	}
+}
+
+func writePiScenarioMetrics(dir string, scenario sharedRuntimeScenario, result liveResult, model string) error {
+	record := journeymetrics.BuildRecord(journeymetrics.JourneySpec{
+		ScenarioID: scenario.name,
+		Source:     "live-harness",
+		Mode:       journeymetrics.ModeLLMLive,
+		Runtime:    "pi",
+		Executor:   "llm",
+		Host:       "pi",
+		Model:      model,
+	}, journeymetrics.BehaviorResult{Passed: true}, journeymetrics.Observation{
+		Duration: result.duration,
+	})
+	return journeymetrics.EmitRecord(filepath.Join(dir, "shared-scenarios"), record)
 }

--- a/internal/ensigncycle/journey_metrics_live_test.go
+++ b/internal/ensigncycle/journey_metrics_live_test.go
@@ -4,7 +4,6 @@ package ensigncycle
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,22 +13,33 @@ import (
 	"github.com/spacedock-dev/spacedock/internal/journeymetrics"
 )
 
-func Example_emitPiScenarioMetrics() {
-	dir, _ := os.MkdirTemp("", "pi-metrics-proof")
-	defer os.RemoveAll(dir)
-	model := "openai/gpt-5.6-luna:max"
-	_ = writePiScenarioMetrics(dir, sharedRuntimeScenario{name: "pi-metrics-proof"}, liveResult{duration: 2 * time.Second}, model)
-	paths, err := filepath.Glob(filepath.Join(dir, "shared-scenarios", "*.json"))
-	if err != nil || len(paths) != 1 {
-		fmt.Printf("files=%d error=%v\n", len(paths), err)
-		return
-	}
-	data, _ := os.ReadFile(paths[0])
-	var record journeymetrics.Record
-	err = json.Unmarshal(data, &record)
-	fmt.Printf("files=%d bytes=%t error=%v scenario=%s runtime=%s model=%s duration=%d\n",
-		len(paths), len(data) > 0, err, record.ScenarioID, record.Runtime, record.Model, record.DurationMS)
-	// Output: files=1 bytes=true error=<nil> scenario=pi-metrics-proof runtime=pi model=openai/gpt-5.6-luna:max duration=2000
+func FuzzPiSharedLiveDriverEmitsJourneyMetric(f *testing.F) {
+	f.Add("pi-metrics-proof")
+	f.Fuzz(func(t *testing.T, scenarioName string) {
+		dir := t.TempDir()
+		t.Setenv("SPACEDOCK_JOURNEY_METRICS_DIR", dir)
+		driver := piSharedLiveDriver{modelName: "openai/gpt-5.6-luna:max"}
+		driver.emitMetrics(t, sharedRuntimeScenario{name: scenarioName}, liveResult{duration: 2 * time.Second})
+
+		paths, err := filepath.Glob(filepath.Join(dir, "shared-scenarios", "*.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(paths) != 1 {
+			t.Fatalf("Pi journey metric files = %d, want 1", len(paths))
+		}
+		data, err := os.ReadFile(paths[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		var record journeymetrics.Record
+		if len(data) == 0 || json.Unmarshal(data, &record) != nil {
+			t.Fatalf("Pi journey metric is empty or invalid: %q", data)
+		}
+		if record.ScenarioID != scenarioName || record.Runtime != "pi" || record.Model != driver.modelName || record.DurationMS != 2000 {
+			t.Fatalf("Pi journey metric = %#v", record)
+		}
+	})
 }
 
 func emitClaudeScenarioMetrics(t *testing.T, scenario sharedRuntimeScenario, result liveResult, model string) {
@@ -152,12 +162,6 @@ func emitPiScenarioMetrics(t *testing.T, scenario sharedRuntimeScenario, result 
 	if dir == "" {
 		return
 	}
-	if err := writePiScenarioMetrics(dir, scenario, result, model); err != nil {
-		t.Fatalf("emit Pi journey metrics for %s: %v", scenario.name, err)
-	}
-}
-
-func writePiScenarioMetrics(dir string, scenario sharedRuntimeScenario, result liveResult, model string) error {
 	record := journeymetrics.BuildRecord(journeymetrics.JourneySpec{
 		ScenarioID: scenario.name,
 		Source:     "live-harness",
@@ -169,5 +173,7 @@ func writePiScenarioMetrics(dir string, scenario sharedRuntimeScenario, result l
 	}, journeymetrics.BehaviorResult{Passed: true}, journeymetrics.Observation{
 		Duration: result.duration,
 	})
-	return journeymetrics.EmitRecord(filepath.Join(dir, "shared-scenarios"), record)
+	if err := journeymetrics.EmitRecord(filepath.Join(dir, "shared-scenarios"), record); err != nil {
+		t.Fatalf("emit Pi journey metrics for %s: %v", scenario.name, err)
+	}
 }

--- a/internal/ensigncycle/pi_shared_live_runner_test.go
+++ b/internal/ensigncycle/pi_shared_live_runner_test.go
@@ -41,8 +41,10 @@ func (d piSharedLiveDriver) withStubPATH(dir string) liveDriver {
 	d.env = withSpacedockShimShellEnv(d.t, d.env, dir)
 	return d
 }
-func (d piSharedLiveDriver) emitMetrics(*testing.T, sharedRuntimeScenario, liveResult) {}
-func (d piSharedLiveDriver) gradeShallowBootObservation(*testing.T, liveResult)        {}
+func (d piSharedLiveDriver) emitMetrics(t *testing.T, scenario sharedRuntimeScenario, result liveResult) {
+	emitPiScenarioMetrics(t, scenario, result, d.modelName)
+}
+func (d piSharedLiveDriver) gradeShallowBootObservation(*testing.T, liveResult) {}
 func (d piSharedLiveDriver) prepareRecordedGate(*testing.T) (liveDriver, func(liveResult)) {
 	return d, noLiveGrade
 }

--- a/internal/release/cilog_clean_output_workflow_test.go
+++ b/internal/release/cilog_clean_output_workflow_test.go
@@ -16,6 +16,8 @@ import (
 var transformedLiveSteps = []string{
 	"Run live Claude E2E",
 	"Run live Codex shared scenarios",
+	"Run live Pi common journeys",
+	"Run live Pi front-door smoke",
 }
 
 // TestLiveWorkflowStepsUseGotestsumOneRunShape pins each transformed live step to
@@ -67,9 +69,9 @@ func TestLiveWorkflowInstallsPinnedGotestsum(t *testing.T) {
 			installs++
 		}
 	}
-	// The offline gate and the two live jobs each install gotestsum.
-	if installs != 3 {
-		t.Errorf("expected gotestsum in the offline gate and both live jobs, found %d installs", installs)
+	// The offline gate and the three live jobs each install gotestsum.
+	if installs != 4 {
+		t.Errorf("expected gotestsum in the offline gate and all three live jobs, found %d installs", installs)
 	}
 
 	// Read the EXECUTABLE commands, not the raw text: commenting out every

--- a/internal/release/journey_workflow_test.go
+++ b/internal/release/journey_workflow_test.go
@@ -66,16 +66,16 @@ func TestRuntimeLiveWorkflowGuardRejectsMissingSharedScenarioRun(t *testing.T) {
 	}
 }
 
-func TestRuntimeLiveWorkflowGuardRejectsPaidPiJob(t *testing.T) {
+func TestRuntimeLiveWorkflowGuardRejectsMissingPiJourneyMetricUpload(t *testing.T) {
 	live := readWorkflow(t, "runtime-live-e2e.yml")
-	adversarial := live + `
-  pi-live:
-    environment:
-      name: CI-E2E-PI
-`
+	last := strings.LastIndex(live, `live-artifacts/journey-metrics/**`)
+	if last < 0 {
+		t.Fatal("fixture workflow missing Pi journey metrics upload path")
+	}
+	adversarial := live[:last] + `live-artifacts/pi/**` + live[last+len(`live-artifacts/journey-metrics/**`):]
 
 	if err := assertRuntimeLiveWorkflowUploadsRawJourneyMetrics(adversarial); err == nil {
-		t.Fatal("runtime live workflow guard accepted a paid Pi live job")
+		t.Fatal("runtime live workflow guard accepted a Pi producer without retained journey metrics")
 	}
 }
 

--- a/internal/release/runtime_live_evidence_workflow_test.go
+++ b/internal/release/runtime_live_evidence_workflow_test.go
@@ -27,6 +27,8 @@ type liveCadenceWorkflow struct {
 		} `yaml:"workflow_dispatch"`
 	} `yaml:"on"`
 	Jobs map[string]struct {
+		If          string            `yaml:"if"`
+		Env         map[string]string `yaml:"env"`
 		Environment struct {
 			Name string `yaml:"name"`
 		} `yaml:"environment"`
@@ -40,6 +42,9 @@ const (
 	pullRequestCadence = `${{ github.event_name == 'pull_request' && 'pull-request' || inputs.live_cadence }}`
 	claudeCadenceModel = `${{ (github.event_name == 'pull_request' || inputs.live_cadence == 'sonnet') && 'claude-sonnet-5' || 'claude-opus-4-8' }}`
 	claudeCadenceEnv   = `${{ (github.event_name == 'pull_request' || inputs.live_cadence == 'sonnet') && 'CI-E2E' || 'CI-E2E-OPUS' }}`
+	claudeCadenceIf    = `${{ github.event_name == 'pull_request' || inputs.live_cadence == 'sonnet' || inputs.live_cadence == 'opus-pre-release' }}`
+	codexCadenceIf     = `${{ github.event_name == 'pull_request' || inputs.live_cadence == 'sonnet' }}`
+	piCadenceIf        = `${{ github.event_name == 'workflow_dispatch' && inputs.live_cadence == 'pi' }}`
 )
 
 func TestRuntimeLiveWorkflowHasOneExplicitClaudeCadence(t *testing.T) {
@@ -70,8 +75,8 @@ func assertOneClaudeCadence(workflow string) error {
 		return err
 	}
 	input, ok := parsed.On.WorkflowDispatch.Inputs["live_cadence"]
-	if !ok || input.Default != "sonnet" || fmt.Sprint(input.Options) != fmt.Sprint([]string{"sonnet", "opus-pre-release"}) {
-		return fmt.Errorf("workflow_dispatch live_cadence choice is not the approved two-value surface")
+	if !ok || input.Default != "sonnet" || fmt.Sprint(input.Options) != fmt.Sprint([]string{"sonnet", "opus-pre-release", "pi"}) {
+		return fmt.Errorf("workflow_dispatch live_cadence choice is not the approved three-value surface")
 	}
 	job, ok := parsed.Jobs["claude-live"]
 	if !ok {
@@ -90,11 +95,19 @@ func assertOneClaudeCadence(workflow string) error {
 	if len(rows) != 1 || rows[0] != want {
 		return fmt.Errorf("Claude matrix include = %#v, want one explicit row %#v", rows, want)
 	}
-	if codex, ok := parsed.Jobs["codex-live"]; !ok || codex.Environment.Name != "CI-E2E-CODEX" {
-		return fmt.Errorf("workflow lacks the Codex approval lane")
+	if job.If != claudeCadenceIf {
+		return fmt.Errorf("Claude job if = %q, want exclusive cadence condition %q", job.If, claudeCadenceIf)
 	}
-	if _, ok := parsed.Jobs["pi-live"]; ok {
-		return fmt.Errorf("workflow retains a Pi approval lane")
+	codex, ok := parsed.Jobs["codex-live"]
+	if !ok || codex.Environment.Name != "CI-E2E-CODEX" || codex.If != codexCadenceIf {
+		return fmt.Errorf("Codex lane environment/if = %q/%q, want CI-E2E-CODEX/%q", codex.Environment.Name, codex.If, codexCadenceIf)
+	}
+	pi, ok := parsed.Jobs["pi-live"]
+	if !ok || pi.Environment.Name != "CI-E2E-PI" || pi.If != piCadenceIf {
+		return fmt.Errorf("Pi lane environment/if = %q/%q, want CI-E2E-PI/%q", pi.Environment.Name, pi.If, piCadenceIf)
+	}
+	if pi.Env["OPENAI_API_KEY"] != `${{ secrets.OPENAI_API_KEY }}` || pi.Env["SPACEDOCK_PI_LIVE_CHILD_MODEL"] != "openai/gpt-5.6-luna:max" {
+		return fmt.Errorf("Pi lane key/model = %q/%q, want stored OpenAI key and Luna/max", pi.Env["OPENAI_API_KEY"], pi.Env["SPACEDOCK_PI_LIVE_CHILD_MODEL"])
 	}
 	return nil
 }
@@ -117,6 +130,8 @@ var liveClaims = []liveClaim{
 	{"Run live Claude substrate proofs", "TestLiveBreakGlassShimRecovery", "claude-break-glass-recovery"},
 	{"Verify Codex resolver against installed plugin", "TestCodexResolveManifestAgainstInstalledHost", "codex-current-checkout-manifest-resolution"},
 	{"Run live Codex shared scenarios", "TestLiveCommon", "codex-common-journeys"},
+	{"Run live Pi common journeys", "TestLiveCommon", "pi-common-journeys"},
+	{"Run live Pi front-door smoke", "TestLivePiFrontDoorSmoke", "pi-front-door-substrate"},
 }
 
 var offlineControls = []string{
@@ -145,8 +160,14 @@ func TestRuntimeLiveWorkflowNamedEvidenceMutationControls(t *testing.T) {
 		"removed claim selector": func(s string) string {
 			return strings.Replace(s, "TestLiveBreakGlassShimRecovery", "TestLiveMergedTeamModeDispatch", 1)
 		},
-		"paid Pi job": func(s string) string {
-			return s + "\n  pi-live:\n    environment:\n      name: CI-E2E-PI\n"
+		"Pi cadence loses exclusivity": func(s string) string {
+			return strings.Replace(s, piCadenceIf, `${{ github.event_name == 'workflow_dispatch' }}`, 1)
+		},
+		"Opus cadence starts Codex": func(s string) string {
+			return strings.Replace(s, codexCadenceIf, `${{ github.event_name == 'pull_request' || inputs.live_cadence != 'pi' }}`, 1)
+		},
+		"Pi cadence starts Claude": func(s string) string {
+			return strings.Replace(s, claudeCadenceIf, `${{ github.event_name == 'pull_request' || inputs.live_cadence != 'none' }}`, 1)
 		},
 		"legacy PTY flag": func(s string) string {
 			return strings.Replace(s, "DISABLE_AUTOUPDATER: \"1\"", "DISABLE_AUTOUPDATER: \"1\"\n      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: \"1\"", 1)
@@ -159,7 +180,7 @@ func TestRuntimeLiveWorkflowNamedEvidenceMutationControls(t *testing.T) {
 	for name, mutate := range mutations {
 		t.Run(name, func(t *testing.T) {
 			adversarial := mutate(live)
-			if assertNamedLiveEvidence(adversarial) == nil && assertOfflineControls(adversarial) == nil {
+			if assertOneClaudeCadence(adversarial) == nil && assertNamedLiveEvidence(adversarial) == nil && assertOfflineControls(adversarial) == nil {
 				t.Fatal("mutation escaped the workflow guards")
 			}
 		})
@@ -191,7 +212,7 @@ func assertNamedLiveEvidence(workflow string) error {
 	if len(expected) != 0 {
 		return fmt.Errorf("workflow lacks owned selector steps %v", expected)
 	}
-	for _, dead := range []string{"TestLivePty", "TestLivePiRecordedGateLifecycle", "TestLivePiSubagentEnsignSmoke", "TestLivePiFrontDoorSmoke", "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "pty-team-mode", "Install tmux", "journey-metrics/pi", "inputs.effort", "CI-E2E-PI"} {
+	for _, dead := range []string{"TestLivePty", "TestLivePiRecordedGateLifecycle", "TestLivePiSubagentEnsignSmoke", "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "pty-team-mode", "Install tmux", "inputs.effort"} {
 		if activeYAMLText(workflow, dead) {
 			return fmt.Errorf("workflow retains dead surface %q", dead)
 		}

--- a/internal/release/workflow_exec_guard_test.go
+++ b/internal/release/workflow_exec_guard_test.go
@@ -31,6 +31,7 @@ func assertRuntimeLiveWorkflowUploadsRawJourneyMetrics(workflow string) error {
 	for _, want := range []string{
 		`SPACEDOCK_JOURNEY_METRICS_DIR: ${{ github.workspace }}/live-artifacts/journey-metrics/claude/${{ matrix.model }}`,
 		`SPACEDOCK_JOURNEY_METRICS_DIR: ${{ github.workspace }}/live-artifacts/journey-metrics/codex`,
+		`SPACEDOCK_JOURNEY_METRICS_DIR: ${{ github.workspace }}/live-artifacts/journey-metrics/pi`,
 	} {
 		if !hasExecutableYAMLLine(workflow, want) {
 			return fmt.Errorf("runtime-live-e2e.yml missing active metrics env line %q", want)
@@ -46,19 +47,18 @@ func assertRuntimeLiveWorkflowUploadsRawJourneyMetrics(workflow string) error {
 	if codexRun < 0 {
 		return fmt.Errorf("runtime-live-e2e.yml has no executable Codex shared scenario run")
 	}
-	for _, job := range parseWorkflowJobs(workflow) {
-		if job.name == "pi-live" {
-			return fmt.Errorf("runtime-live-e2e.yml retains a paid Pi live job")
-		}
+	piRun := findExecutableStep(steps, "Run live Pi common journeys", "TestLiveCommon")
+	if piRun < 0 {
+		return fmt.Errorf("runtime-live-e2e.yml has no executable Pi shared scenario run")
 	}
 	if !hasJourneyMetricsUploadAfter(steps, claudeRun, codexRun) {
 		return fmt.Errorf("runtime-live-e2e.yml Claude shared scenario job does not upload raw journey metrics")
 	}
-	if !hasJourneyMetricsUploadAfter(steps, codexRun, len(steps)) {
+	if !hasJourneyMetricsUploadAfter(steps, codexRun, piRun) {
 		return fmt.Errorf("runtime-live-e2e.yml Codex shared scenario job does not upload raw journey metrics")
 	}
-	if hasExecutableYAMLLine(workflow, `SPACEDOCK_JOURNEY_METRICS_DIR: ${{ github.workspace }}/live-artifacts/journey-metrics/pi`) {
-		return fmt.Errorf("runtime-live-e2e.yml retains a Pi journey-metrics path without a producer")
+	if !hasJourneyMetricsUploadAfter(steps, piRun, len(steps)) {
+		return fmt.Errorf("runtime-live-e2e.yml Pi shared scenario job does not upload raw journey metrics")
 	}
 	return nil
 }


### PR DESCRIPTION
Maintainers can run optional Pi CI and retain common-journey and substrate evidence without making Pi a pull-request requirement.

## What changed

- Restore a manual Pi-only cadence with retained artifacts.
- Make manual Opus and Pi routing runtime-exclusive.
- Emit Pi common-journey metrics in the existing schema.
- Add executable guards for routing, artifacts, and metrics emission.
- Update runtime CI documentation for the restored cadence.

## Evidence

- Offline, race, registry, owner, and focused suites: 5/5 passed.
- Exact cadence checks: Pi 11/11 common tests passed; Pi and Opus exclusivity verified.

## Review guidance

Require exact PR Sonnet and Codex lanes to pass and Pi to skip before merge.

---
[0a](/spacedock-dev/spacedock/blob/e51ea35102409933794becc83576f579ead98912/restore-optional-manual-pi-common-live-ci.md)
