### PR TITLE
Make local Codex live auth failure self-correcting

### DIFF
--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -73,6 +73,8 @@ For Codex, install and authenticate the CLI (or set `OPENAI_API_KEY`), then run:
 SPACEDOCK_LIVE_RUNTIME=codex go test -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle -v
 ```
 
+Leave `SPACEDOCK_CODEX_LIVE_REQUIRED` unset for this local path. When no `OPENAI_API_KEY` is set, the harness copies `~/.codex/auth.json` into an isolated `CODEX_HOME`; if the variable is already set, run `unset SPACEDOCK_CODEX_LIVE_REQUIRED` first.
+
 Run the Pi live proofs locally with the same package versions pinned in CI:
 
 ```bash

--- a/internal/ensigncycle/codex_liveenv.go
+++ b/internal/ensigncycle/codex_liveenv.go
@@ -34,7 +34,7 @@ func decideCodexLiveAuth(openAIAPIKey string, localAuthAvailable bool, required 
 	if required != "" {
 		return codexLiveAuthDecision{
 			mode:    codexAuthFatal,
-			message: "OPENAI_API_KEY is required for the approval-gated codex-live lane",
+			message: "OPENAI_API_KEY is required when SPACEDOCK_CODEX_LIVE_REQUIRED is set; unset SPACEDOCK_CODEX_LIVE_REQUIRED for a local run that uses isolated Codex OAuth",
 		}
 	}
 	if localAuthAvailable {


### PR DESCRIPTION
Local Codex live tests now explain recovery from CI-only auth settings, avoiding unnecessary GitHub runs without weakening isolation.

## What changed

- Name the CI-only flag in the fatal diagnostic.
- Direct local operators to unset it for isolated OAuth.
- Document isolated auth copying beside the local test command.

## Evidence

- Auth and isolation checks: 3/3 passed.
- Full and race suites: 2/2 passed.

---
[pm](/spacedock-dev/spacedock/blob/2ee4b97005885fe6f87e30356ed49bb08bbe2afd/make-local-codex-live-auth-failure-self-correcting.md)
