### PR TITLE
Commit the Pi gate before presentation

### DIFF
--- a/internal/contractlint/live_registry_reconciliation_test.go
+++ b/internal/contractlint/live_registry_reconciliation_test.go
@@ -49,7 +49,7 @@ func TestRuntimeLiveRegistryReconciliation(t *testing.T) {
 	registryFixtures := readRegistryFixtureUnion(t, registryPath)
 	actual, fixtureOwners := readActualLiveJourneys(t, repo, targets)
 	wantGaps := map[string][]liveGapRow{
-		"gate-guardrail":                {{"xfail", "pi", "2e4fe65gy9vcr4xck6akzmdd"}},
+		"gate-guardrail":                nil,
 		"default-headless-gate-stop":    {{"xfail", "claude-sonnet", "98aa776adg66gn823a8gamdq"}, {"xfail", "codex", "98aa776adg66gn823a8gamdq"}, {"xfail", "pi", "fh6rv0k6wr25zty0jjan4jp7"}},
 		"withdrawn-gate-recovery":       nil,
 		"recorded-gate-lifecycle":       {{"xfail", "claude-opus", "xp6c9qfe7y4wwp46enc3f85n"}},

--- a/internal/ensigncycle/gate_assert_test.go
+++ b/internal/ensigncycle/gate_assert_test.go
@@ -59,6 +59,7 @@ func TestAssertGateHeld(t *testing.T) {
 func TestAssertGateHeldAcceptsPreparedFixtureBinding(t *testing.T) {
 	fixture := writePreparedRecordedGateFixture(t)
 	before := readFile(t, fixture.entity)
+	binary := buildRecordedGateBinary(t)
 	args := []string{
 		"gate", "prepare", "recorded-gate-task",
 		"--question", "Should the recorded validation gate advance?",
@@ -69,7 +70,7 @@ func TestAssertGateHeldAcceptsPreparedFixtureBinding(t *testing.T) {
 		args = append(args, "--reference", reference)
 	}
 	args = append(args, "--workflow-dir", fixture.root)
-	prepared := runRecordedGateCommand(buildRecordedGateBinary(t), fixture.root, "prepare", args...)
+	prepared := runRecordedGateCommand(binary, fixture.root, "prepare", args...)
 	if prepared.exit != 0 {
 		t.Fatalf("prepare exit=%d\nstdout=%s\nstderr=%s", prepared.exit, prepared.stdout, prepared.stderr)
 	}
@@ -78,9 +79,21 @@ func TestAssertGateHeldAcceptsPreparedFixtureBinding(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	after := readFile(t, fixture.entity)
+	stateHead := commitRecordedGateState(t, binary, fixture, "bind retained gate package")
+	after := recordedGateEntityAt(t, fixture, stateHead)
+	reread := mustRecordedGate(t, binary, fixture.root, "status", "--read", fixture.entity, "--json", "--workflow-dir", fixture.root)
+	for _, want := range []string{fixture.entity, `"status":"validation"`} {
+		if !strings.Contains(reread.stdout, want) {
+			t.Fatalf("status reread missing %q:\n%s", want, reread.stdout)
+		}
+	}
+	for _, want := range []string{expected.briefingID, expected.digest} {
+		if !strings.Contains(after, want) {
+			t.Fatalf("committed state head missing %q:\n%s", want, after)
+		}
+	}
 	if err := assertGateHeld(before, after, expected); err != nil {
-		t.Fatalf("prepared fixture binding rejected: %v", err)
+		t.Fatalf("committed and reread fixture binding rejected: %v", err)
 	}
 	for name, mutant := range map[string]string{
 		"attempt": strings.Replace(after, expected.attemptID, "gate-attempt:wrong", 1),

--- a/internal/ensigncycle/shared_live_runner_test.go
+++ b/internal/ensigncycle/shared_live_runner_test.go
@@ -102,7 +102,7 @@ func TestLiveCommonFullEnsignCycle(t *testing.T) {
 
 //spacedock:live-journey id=gate-guardrail fixture=recorded-gate/held
 func TestLiveCommonGateGuardrail(t *testing.T) {
-	liveJourney(t, "gate-guardrail", "recorded-gate/held", writeGateWorkflow, []liveJourneyGap{liveXFail("pi", "2e4fe65gy9vcr4xck6akzmdd")}, runGateStopScenario, assertGateHeld)
+	liveJourney(t, "gate-guardrail", "recorded-gate/held", writeGateWorkflow, nil, runGateStopScenario, assertGateHeld)
 }
 
 //spacedock:live-journey id=default-headless-gate-stop fixture=recorded-gate/pre-gate

--- a/skills/first-officer/references/pi-first-officer-runtime.md
+++ b/skills/first-officer/references/pi-first-officer-runtime.md
@@ -12,6 +12,7 @@ This file defines how the shared first-officer core executes on Pi. The shared c
 - `«worker.shutdown»`: For `pi-subagents`, a completed child invocation needs no mailbox shutdown; mark the worker complete/closed in first-officer memory. For `pi-agent-teams`, map teardown to `member_shutdown` or `team_done` according to the active adapter lifecycle.
 - `«context-budget»`: ABSENT; its reuse condition is satisfied for Pi.
 - `«roster-reconcile»`: ABSENT; Pi relies on durable entity state and adapter-held worker identity, not a shared roster sweep.
+- `«gate.lifecycle»`: After `gate prepare` returns `state=open`, run `state commit` once. Then run `status --read` for the same entity. Reread the committed gate. Require the same room, Briefing digest, and open state. After this reread succeeds, load `spacedock:present-gate`. Then emit one captain-facing review block. If the commit fails, stop at the gate. If the reread has a mismatch, stop at the gate. A summary, child output, or second presentation cannot repair the run.
 
 The build artifact carries the entity slug/name, entity path, workflow directory, target stage, stage definition fetch command, worktree path when applicable, completion checklist, and completion-signal wording. It must not be replaced by a locally composed assignment. The model stamped through `«worker-identity»` is a Pi-native value used by `«reuse.model-match»`.
 
@@ -25,4 +26,4 @@ Live Pi tests should run with an isolated Pi config directory and an isolated se
 
 Ordinary Pi worker proof is durable-state based: dispatch a Pi ensign against a temp split-root workflow and verify process exit, state checkout file changes, git log, and stage report content.
 
-Recorded-gate presentation is the explicit exception. On Pi, the captain-facing review is one root-session assistant text block after the selected Briefing commit and before the decision mutation; shell output, tool results, child output, and later summaries do not qualify. Recorded-gate lifecycle proof combines that root event with the durable command, state, git, and successor-effect evidence.
+Recorded-gate presentation is the explicit exception. On Pi, the captain-facing review is one root-session assistant text block after the selected Briefing commit and reread, and before the decision mutation; shell output, tool results, child output, and later summaries do not qualify. Recorded-gate lifecycle proof combines that root event with the durable command, state, git, and successor-effect evidence.

--- a/skills/fo-gate-lifecycle/SKILL.md
+++ b/skills/fo-gate-lifecycle/SKILL.md
@@ -16,15 +16,20 @@ The binary owns preparation, withdrawal, recording, and one-use consume; this sk
 
 **Prepare and bind.** Resolve `${SPACEDOCK_BIN:-spacedock}`. Select a Markdown gate-review Artifact and References, author its concise summary, then commit selections. Supply judgment and paths; never author JSON, ids, digests, Git-root locators, or room coordinates. Paths use launch cwd.
 
+Run this sequence once and in this order:
+
 ```text
-${SPACEDOCK_BIN:-spacedock} gate prepare ENTITY --question QUESTION --artifact REVIEW --summary SUMMARY [--reference FILE ...] --workflow-dir WORKFLOW_DIR
+1. ${SPACEDOCK_BIN:-spacedock} gate prepare ENTITY --question QUESTION --artifact REVIEW --summary SUMMARY [--reference FILE ...] --workflow-dir WORKFLOW_DIR
+2. ${SPACEDOCK_BIN:-spacedock} state commit ENTITY --workflow-dir WORKFLOW_DIR
+3. ${SPACEDOCK_BIN:-spacedock} status --read ENTITY --json --workflow-dir WORKFLOW_DIR
+4. Load spacedock:present-gate and present the reread gate once.
 ```
 
 Preflight one lifecycle surface: `prepare`, `withdraw`, `record`, `validate`, `consume`, and withdrawal's `--reason`. A nonzero command halts; surface its exact error and refresh or rebuild the version-gated bundle when unavailable. Never hand-edit `gates:` or replace binary-owned entity/room authority.
 
-Require emitted `room`, `briefing`, `digest`, `state=open`; never reconstruct the room. `«state.commit»(slug)` commits the binding. Load `spacedock:present-gate`, cross-check ACs, and present once after commit. No conn: ask and stop open. Explicit conn: presentation is notification; immediately record the delegated decision below.
+Require prepare to emit `room`, `briefing`, `digest`, and `state=open`. Prepare output is not presentation input. After commit, reread the same room and Briefing digest in open state. On nonzero commit or mismatch, stop. Until reread succeeds, never present, decide, consume, dispatch, withdraw, archive, or mutate status. Then cross-check ACs and present once. No conn: ask and stop open. Explicit conn: immediately record the delegated decision below.
 
-**Cold report candidate.** For one `needs-preparation` row, re-read the entity, latest exact-stage report/checklist, and its commit; this is structural only. An insufficient obligation, claim, Summary, or scope stops once with `report-incomplete: <concrete defect>` and zero prepare, mutation, presentation, idle, or repeat-next. Otherwise choose question, committed Markdown Artifact, summary, and References; invoke `gate prepare` once. Require `room`, `briefing`, `digest`, `state=open`; commit, re-read, and present the same-slug `awaiting-captain`. With a conn, immediately record and consume; never final after presentation. Nonzero/mismatch stops; no retry or `gate record --briefing`.
+**Cold report candidate.** Re-read the entity, latest exact-stage report/checklist, and commit. On insufficiency, stop with `report-incomplete: <concrete defect>` and no effect. Otherwise select the gate inputs and run the sequence above. Present the same-slug `awaiting-captain`. With a conn, immediately record and consume; never final after presentation. Never retry or use `gate record --briefing`.
 
 **Withdraw stale open authority.** If a prepared room is stale before the Captain decision, run:
 


### PR DESCRIPTION
Pi now commits and rereads the prepared gate before presentation, so reviewers see durable state and the same open gate.

## What changed

- Require commit and reread before Pi gate presentation.
- Verify the exact prepared gate identity remains open.
- Retire only the repaired Pi gate-guardrail XFAIL.

## Evidence

- Acceptance criteria: 5/5 passed.
- Focused adversarial controls: 6/6 passed; exact Pi target passed.

---
[2e4](/spacedock-dev/spacedock/blob/e923960c918208e91e63f2e535103b33a6dbb50d/commit-pi-gate-prepare-before-presentation.md)
