### PR TITLE
Make headless Sonnet and Codex spawn implementation before validation

### DIFF
--- a/docs/runtime-live-ci-registry.md
+++ b/docs/runtime-live-ci-registry.md
@@ -112,8 +112,9 @@ deterministic coverage to the default suite, or delete it.
 ### `default-headless-gate-stop`
 
 - **Entry point:** `TestLiveCommonDefaultHeadlessGateStop`
-- **Required outcome:** A headless launch without decision authority advances
-  from the preceding stage to the first human gate, presents it, and stops open.
+- **Required outcome:** A headless launch without decision authority dispatches
+  and completes the preceding-stage worker, then presents the first human gate
+  and stops open.
 - **Fixtures:**
   - `recorded-gate/pre-gate` — the held-gate workflow with the member starting in
     the preceding implementation stage.

--- a/internal/contractlint/initial_worker_spawn_guard_test.go
+++ b/internal/contractlint/initial_worker_spawn_guard_test.go
@@ -23,7 +23,7 @@ const initialWorkerChecklistFallback = "When neither source supplies an item, us
 
 const initialWorkerStartedTransition = "status={next_stage} started"
 
-const initialWorkerGateSuccessorGuard = "If the next stage has `gate: true`, update it with `status={next_stage} started`, then enter `«gate.lifecycle»`; do not run `«dispatch.build» --advance` or route work to the completed worker."
+const initialWorkerGateSuccessorGuard = "If the next stage has `gate: true`, update it with `status={next_stage} started`. Dispatch it under the normal reuse and freshness rules. Enter `«gate.lifecycle»` only after `«completion-signal»` arrives and the stage report passes the completion gate."
 
 func TestInitialWorkerSpawnGuardPrecedesCompletionAndValidation(t *testing.T) {
 	body := readRepoFile(t, "skills/first-officer/references/fo-dispatch-core.md")

--- a/internal/contractlint/initial_worker_spawn_guard_test.go
+++ b/internal/contractlint/initial_worker_spawn_guard_test.go
@@ -23,6 +23,8 @@ const initialWorkerChecklistFallback = "When neither source supplies an item, us
 
 const initialWorkerStartedTransition = "status={next_stage} started"
 
+const initialWorkerGateSuccessorGuard = "If the next stage has `gate: true`, update it with `status={next_stage} started`, then enter `«gate.lifecycle»`; do not run `«dispatch.build» --advance` or route work to the completed worker."
+
 func TestInitialWorkerSpawnGuardPrecedesCompletionAndValidation(t *testing.T) {
 	body := readRepoFile(t, "skills/first-officer/references/fo-dispatch-core.md")
 
@@ -62,7 +64,10 @@ func TestInitialWorkerDispatchAlwaysBuildsANonemptyChecklist(t *testing.T) {
 
 func TestInitialWorkerDispatchStampsBothStageTransitionsStarted(t *testing.T) {
 	body := readRepoFile(t, "skills/first-officer/references/fo-dispatch-core.md")
-	if got := strings.Count(body, initialWorkerStartedTransition); got != 2 {
-		t.Fatalf("initial dispatch contract has %d started stage transitions, want 2", got)
+	if got := strings.Count(body, initialWorkerStartedTransition); got != 3 {
+		t.Fatalf("initial dispatch contract has %d started stage transitions, want 3", got)
+	}
+	if !strings.Contains(body, initialWorkerGateSuccessorGuard) {
+		t.Fatalf("initial dispatch contract missing gate-successor guard %q", initialWorkerGateSuccessorGuard)
 	}
 }

--- a/internal/contractlint/initial_worker_spawn_guard_test.go
+++ b/internal/contractlint/initial_worker_spawn_guard_test.go
@@ -21,6 +21,8 @@ const initialWorkerChecklistGuard = "Build a numbered checklist of one to three 
 
 const initialWorkerChecklistFallback = "When neither source supplies an item, use the target stage's declared requirement as one linchpin; do not pad."
 
+const initialWorkerStartedTransition = "status={next_stage} started"
+
 func TestInitialWorkerSpawnGuardPrecedesCompletionAndValidation(t *testing.T) {
 	body := readRepoFile(t, "skills/first-officer/references/fo-dispatch-core.md")
 
@@ -55,5 +57,12 @@ func TestInitialWorkerDispatchAlwaysBuildsANonemptyChecklist(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("initial dispatch contract missing nonempty-checklist rule %q", want)
 		}
+	}
+}
+
+func TestInitialWorkerDispatchStampsBothStageTransitionsStarted(t *testing.T) {
+	body := readRepoFile(t, "skills/first-officer/references/fo-dispatch-core.md")
+	if got := strings.Count(body, initialWorkerStartedTransition); got != 2 {
+		t.Fatalf("initial dispatch contract has %d started stage transitions, want 2", got)
 	}
 }

--- a/internal/contractlint/initial_worker_spawn_guard_test.go
+++ b/internal/contractlint/initial_worker_spawn_guard_test.go
@@ -1,0 +1,46 @@
+// ABOUTME: Pins the initial First Officer worker-spawn and completion boundary.
+// ABOUTME: Rejects ceremonial substitutes that previously let validation start.
+package contractlint
+
+import (
+	"strings"
+	"testing"
+)
+
+const initialWorkerSpawnGuard = "After a successful initial `«dispatch.build»`, call `«worker.spawn»` in the same turn."
+
+const initialWorkerHandleGuard = "Record its returned handle before any later status change, report read, gate preparation, narration, or wait."
+
+const initialWorkerCompletionGuard = "Do not advance to validation until `«completion-signal»` arrives and the entity-file stage report passes the completion gate."
+
+const initialWorkerFalseEvidenceGuard = "A successful dispatch build, narration, direct status change, or self-authored report is not worker evidence."
+
+const initialWorkerEmptyWaitGuard = "An empty wait without a completion signal is not worker evidence."
+
+func TestInitialWorkerSpawnGuardPrecedesCompletionAndValidation(t *testing.T) {
+	body := readRepoFile(t, "skills/first-officer/references/fo-dispatch-core.md")
+
+	spawn := strings.Index(body, initialWorkerSpawnGuard)
+	handle := strings.Index(body, initialWorkerHandleGuard)
+	completion := strings.Index(body, initialWorkerCompletionGuard)
+	falseEvidence := strings.Index(body, initialWorkerFalseEvidenceGuard)
+	emptyWait := strings.Index(body, initialWorkerEmptyWaitGuard)
+	if spawn < 0 {
+		t.Fatalf("initial dispatch contract missing real spawn guard %q", initialWorkerSpawnGuard)
+	}
+	if handle < 0 {
+		t.Fatalf("initial dispatch contract missing returned-handle guard %q", initialWorkerHandleGuard)
+	}
+	if completion < 0 {
+		t.Fatalf("initial dispatch contract missing completion-before-validation guard %q", initialWorkerCompletionGuard)
+	}
+	if falseEvidence < 0 {
+		t.Fatalf("initial dispatch contract missing false-evidence guard %q", initialWorkerFalseEvidenceGuard)
+	}
+	if emptyWait < 0 {
+		t.Fatalf("initial dispatch contract missing empty-wait guard %q", initialWorkerEmptyWaitGuard)
+	}
+	if !(spawn < handle && handle < completion && completion < falseEvidence && falseEvidence < emptyWait) {
+		t.Fatalf("initial dispatch guard order = spawn:%d handle:%d completion:%d false-evidence:%d empty-wait:%d", spawn, handle, completion, falseEvidence, emptyWait)
+	}
+}

--- a/internal/contractlint/initial_worker_spawn_guard_test.go
+++ b/internal/contractlint/initial_worker_spawn_guard_test.go
@@ -17,6 +17,10 @@ const initialWorkerFalseEvidenceGuard = "A successful dispatch build, narration,
 
 const initialWorkerEmptyWaitGuard = "An empty wait without a completion signal is not worker evidence."
 
+const initialWorkerChecklistGuard = "Build a numbered checklist of one to three dispatch-specific linchpin signals"
+
+const initialWorkerChecklistFallback = "When neither source supplies an item, use the target stage's declared requirement as one linchpin; do not pad."
+
 func TestInitialWorkerSpawnGuardPrecedesCompletionAndValidation(t *testing.T) {
 	body := readRepoFile(t, "skills/first-officer/references/fo-dispatch-core.md")
 
@@ -42,5 +46,14 @@ func TestInitialWorkerSpawnGuardPrecedesCompletionAndValidation(t *testing.T) {
 	}
 	if !(spawn < handle && handle < completion && completion < falseEvidence && falseEvidence < emptyWait) {
 		t.Fatalf("initial dispatch guard order = spawn:%d handle:%d completion:%d false-evidence:%d empty-wait:%d", spawn, handle, completion, falseEvidence, emptyWait)
+	}
+}
+
+func TestInitialWorkerDispatchAlwaysBuildsANonemptyChecklist(t *testing.T) {
+	body := readRepoFile(t, "skills/first-officer/references/fo-dispatch-core.md")
+	for _, want := range []string{initialWorkerChecklistGuard, initialWorkerChecklistFallback} {
+		if !strings.Contains(body, want) {
+			t.Errorf("initial dispatch contract missing nonempty-checklist rule %q", want)
+		}
 	}
 }

--- a/internal/contractlint/initial_worker_spawn_guard_test.go
+++ b/internal/contractlint/initial_worker_spawn_guard_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 )
 
-const initialWorkerSpawnGuard = "After a successful initial `«dispatch.build»`, call `«worker.spawn»` in the same turn."
+const initialWorkerSpawnGuard = "On exit 0, the next host action MUST be `«worker.spawn»` with every helper-emitted field unchanged."
 
-const initialWorkerHandleGuard = "Record its returned handle before any later status change, report read, gate preparation, narration, or wait."
+const initialWorkerHandleGuard = "Record the returned handle before narration, a file edit, status change, report read, gate action, or wait."
 
 const initialWorkerCompletionGuard = "Do not advance to validation until `«completion-signal»` arrives and the entity-file stage report passes the completion gate."
 

--- a/internal/contractlint/live_registry_reconciliation_test.go
+++ b/internal/contractlint/live_registry_reconciliation_test.go
@@ -50,7 +50,7 @@ func TestRuntimeLiveRegistryReconciliation(t *testing.T) {
 	actual, fixtureOwners := readActualLiveJourneys(t, repo, targets)
 	wantGaps := map[string][]liveGapRow{
 		"gate-guardrail":                nil,
-		"default-headless-gate-stop":    {{"xfail", "pi", "fh6rv0k6wr25zty0jjan4jp7"}},
+		"default-headless-gate-stop":    {{"xfail", "claude-sonnet", "n28423efmj358m5av61z2fxx"}, {"xfail", "codex", "n28423efmj358m5av61z2fxx"}, {"xfail", "pi", "fh6rv0k6wr25zty0jjan4jp7"}},
 		"withdrawn-gate-recovery":       nil,
 		"recorded-gate-lifecycle":       {{"xfail", "claude-opus", "xp6c9qfe7y4wwp46enc3f85n"}},
 		"rejection-flow":                {{"xfail", "claude-sonnet", "zhcb4bcz1qgcn7ajx2ctxpxk"}, {"xfail", "claude-opus", "zhcb4bcz1qgcn7ajx2ctxpxk"}, {"xfail", "codex", "dvddbpsf4tdt3yjw1yjyp14k"}, {"xfail", "pi", "zhcb4bcz1qgcn7ajx2ctxpxk"}},

--- a/internal/contractlint/live_registry_reconciliation_test.go
+++ b/internal/contractlint/live_registry_reconciliation_test.go
@@ -50,7 +50,7 @@ func TestRuntimeLiveRegistryReconciliation(t *testing.T) {
 	actual, fixtureOwners := readActualLiveJourneys(t, repo, targets)
 	wantGaps := map[string][]liveGapRow{
 		"gate-guardrail":                nil,
-		"default-headless-gate-stop":    {{"xfail", "claude-sonnet", "98aa776adg66gn823a8gamdq"}, {"xfail", "codex", "98aa776adg66gn823a8gamdq"}, {"xfail", "pi", "fh6rv0k6wr25zty0jjan4jp7"}},
+		"default-headless-gate-stop":    {{"xfail", "pi", "fh6rv0k6wr25zty0jjan4jp7"}},
 		"withdrawn-gate-recovery":       nil,
 		"recorded-gate-lifecycle":       {{"xfail", "claude-opus", "xp6c9qfe7y4wwp46enc3f85n"}},
 		"rejection-flow":                {{"xfail", "claude-sonnet", "zhcb4bcz1qgcn7ajx2ctxpxk"}, {"xfail", "claude-opus", "zhcb4bcz1qgcn7ajx2ctxpxk"}, {"xfail", "codex", "dvddbpsf4tdt3yjw1yjyp14k"}, {"xfail", "pi", "zhcb4bcz1qgcn7ajx2ctxpxk"}},

--- a/internal/ensigncycle/claude_live_runner_test.go
+++ b/internal/ensigncycle/claude_live_runner_test.go
@@ -230,11 +230,19 @@ func runGateStopScenario(t *testing.T, runner liveDriver, scenario sharedRuntime
 	workflowRoot := t.TempDir()
 	fixture := build(t, workflowRoot)
 	before := readFile(t, fixture.entity)
-	commandLog := filepath.Join(fixture.root, "evidence", "command.log")
+	observerRoot := t.TempDir()
+	if err := os.Symlink(fixture.stateRoot, filepath.Join(observerRoot, ".spacedock-state")); err != nil {
+		t.Fatal(err)
+	}
+	commandLog := filepath.Join(observerRoot, "command.log")
+	if err := assertObserverOutsideWorkflow(workflowRoot, commandLog); err != nil {
+		t.Fatal(err)
+	}
 	shimDir := writeRecordedGateLoggingShim(t, buildRecordedGateBinary(t), commandLog)
 	runner = runner.withStubPATH(shimDir)
 
 	result := runner.run(t, scenario, workflowRoot, gatePrompt(workflowRoot))
+	writeFile(t, filepath.Join(result.artifactDir, "command.log"), readFile(t, commandLog))
 	if _, err := os.Stat(filepath.Join(fixture.stateRoot, "_archive", "recorded-gate-task", "index.md")); !os.IsNotExist(err) {
 		t.Fatalf("recorded-gate-task was archived while waiting at the gate; stat err=%v", err)
 	}
@@ -248,7 +256,28 @@ func runGateStopScenario(t *testing.T, runner liveDriver, scenario sharedRuntime
 		semantic = append(semantic, &gradedErr{code: "gate-not-held", msg: err.Error()})
 	}
 	semantic = append(semantic, assertRecordedGateHoldLog(readFile(t, commandLog), scenario.name == "default-headless-gate-stop"))
+	if scenario.name == "default-headless-gate-stop" {
+		semantic = append(semantic, assertImplementationWorkerLifecycle(nativeLifecycleStream(t, runner, result), after))
+	}
 	finishLiveScenario(t, runner, scenario, result, semantic...)
+}
+
+func nativeLifecycleStream(t *testing.T, runner liveDriver, result liveResult) string {
+	t.Helper()
+	var started struct {
+		Type     string `json:"type"`
+		ThreadID string `json:"thread_id"`
+	}
+	for _, line := range strings.Split(result.stream, "\n") {
+		if json.Unmarshal([]byte(line), &started) == nil && started.Type == "thread.started" {
+			paths, _ := filepath.Glob(filepath.Join(runner.home(), "sessions", "*", "*", "*", "rollout-*"+started.ThreadID+".jsonl"))
+			if len(paths) != 1 {
+				t.Fatalf("Codex parent rollout for %q = %v, want one", started.ThreadID, paths)
+			}
+			return result.stream + "\n" + readFile(t, paths[0])
+		}
+	}
+	return result.stream
 }
 
 func runClaudeWithdrawnGateRecoveryScenario(t *testing.T, runner liveDriver, scenario sharedRuntimeScenario, build func(*testing.T, string) recordedGateFixture, assert func(*gates.Document) error) {

--- a/internal/ensigncycle/claude_runtime_helpers_test.go
+++ b/internal/ensigncycle/claude_runtime_helpers_test.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	statuspkg "github.com/spacedock-dev/spacedock/internal/status"
 )
 
 func encodeProjectDir(cwd string) string {
@@ -117,6 +119,91 @@ func assertRecordedGateHoldLog(log string, requireImplementation ...bool) error 
 	return nil
 }
 
+func assertImplementationWorkerLifecycle(stream, entity string) error {
+	type block struct {
+		Type  string `json:"type"`
+		Name  string `json:"name"`
+		ID    string `json:"id"`
+		Input struct{ Description, Command string }
+	}
+	type row struct {
+		Type      string `json:"type"`
+		Subtype   string `json:"subtype"`
+		Status    string `json:"status"`
+		ToolUseID string `json:"tool_use_id"`
+		Message   *struct{ Content []block }
+		Payload   struct {
+			Type, Name, Arguments, Author string
+			Content                       json.RawMessage
+		}
+	}
+	spawnID, codexWorker, spawns, completed, validation := "", "", 0, -1, -1
+	for i, line := range strings.Split(stream, "\n") {
+		var event row
+		if json.Unmarshal([]byte(line), &event) != nil {
+			continue
+		}
+		if event.Payload.Type == "function_call" && event.Payload.Name == "spawn_agent" && strings.Contains(event.Payload.Arguments, "implementation") {
+			spawns++
+			var args struct {
+				TaskName string `json:"task_name"`
+			}
+			_ = json.Unmarshal([]byte(event.Payload.Arguments), &args)
+			codexWorker = "/root/" + args.TaskName
+		}
+		if event.Payload.Type == "agent_message" && event.Payload.Author == codexWorker && strings.Contains(string(event.Payload.Content), "Done:") {
+			completed = i
+		}
+		if event.Payload.Type == "custom_tool_call" && strings.Contains(line, "status=validation") {
+			validation = i
+		}
+		if event.Message != nil {
+			for _, item := range event.Message.Content {
+				if item.Type == "tool_use" && item.Name == "Agent" && strings.Contains(strings.ToLower(item.Input.Description), "implementation") {
+					spawns++
+					spawnID = item.ID
+				}
+				if item.Type == "tool_use" && item.Name == "Bash" && strings.Contains(item.Input.Command, "status=validation") {
+					validation = i
+				}
+			}
+		}
+		if event.Type == "system" && event.Subtype == "task_notification" && event.Status == "completed" && event.ToolUseID == spawnID {
+			completed = i
+		}
+	}
+	spans, reportErr := statuspkg.FindSectionSpans([]byte(entity), []string{"Stage Report: implementation"})
+	if spawns != 1 || completed < 0 || validation < 0 || completed >= validation || reportErr != nil || len(spans) != 1 || !strings.Contains(entity[spans[0].Start:spans[0].End], "- DONE:") {
+		return &gradedErr{code: "implementation-worker-not-dispatched", msg: fmt.Sprintf("implementation lifecycle incomplete: spawns=%d completed=%d validation=%d report=%v", spawns, completed, validation, reportErr)}
+	}
+	return nil
+}
+
+func assertObserverOutsideWorkflow(workflowRoot, observer string) error {
+	rel, err := filepath.Rel(workflowRoot, observer)
+	if err != nil || rel == "." || rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("observer log is inside the workflow: %s", observer)
+	}
+	return nil
+}
+
+func TestImplementationLifecycleAndObserverNegativeControls(t *testing.T) {
+	entity := "---\nstatus: validation\n---\n# Task\n\n## Stage Report: implementation\n\n- DONE: work\n"
+	claude := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Agent","id":"worker-1","input":{"description":"Task: implementation"}}]}}` + "\n" +
+		`{"type":"system","subtype":"task_notification","status":"completed","tool_use_id":"worker-1"}` + "\n" +
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"spacedock status --set task status=validation"}}]}}`
+	if err := assertImplementationWorkerLifecycle(claude, entity); err != nil {
+		t.Fatalf("complete native lifecycle rejected: %v", err)
+	}
+	root := t.TempDir()
+	if assertObserverOutsideWorkflow(root, filepath.Join(root, "evidence", "command.log")) == nil {
+		t.Fatal("in-workflow observer path passed")
+	}
+	if err := assertObserverOutsideWorkflow(root, filepath.Join(t.TempDir(), "command.log")); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func successfulStatusSet(log string, allowed ...string) (found bool) {
 	for _, line := range strings.Split(log, "\n") {
 		if strings.HasPrefix(line, "exit=0\tstatus ") && strings.Contains(line, " --set ") && (len(allowed) == 0 || found || !strings.HasSuffix(line, " "+allowed[0])) {
@@ -141,6 +228,9 @@ func TestAssertRecordedGateHoldLogAcceptsPrepareFirstLifecycle(t *testing.T) {
 		"state-head\tabc123\n"
 	if err := assertRecordedGateHoldLog(prepared, true); err != nil {
 		t.Fatalf("prepare-first hold log rejected: %v", err)
+	}
+	if err := assertImplementationWorkerLifecycle(prepared, "---\nstatus: validation\n---\n# Task\n"); err == nil {
+		t.Fatal("command-only baseline passed the native lifecycle oracle")
 	}
 	for name, tc := range map[string]struct {
 		mutation string

--- a/internal/ensigncycle/claude_runtime_helpers_test.go
+++ b/internal/ensigncycle/claude_runtime_helpers_test.go
@@ -113,7 +113,8 @@ func assertRecordedGateHoldLog(log string, requireImplementation ...bool) error 
 		return errGraded(boundary + "the gate was withdrawn after prepare")
 	case successfulStatusSet(log[prepare:]):
 		return errGraded(boundary + "status changed after prepare")
-	case len(requireImplementation) > 0 && requireImplementation[0] && strings.Count(log[:prepare], " --stage implementation") == 1 && strings.Count(log[:prepare], " --stage validation") != 1: return &gradedErr{code: "dispatch-envelope-not-acknowledged", msg: boundary + "validation dispatch envelope count was not one"}
+	case len(requireImplementation) > 0 && requireImplementation[0] && strings.Count(log[:prepare], " --stage implementation") == 1 && strings.Count(log[:prepare], " --stage validation") != 1:
+		return &gradedErr{code: "dispatch-envelope-not-acknowledged", msg: boundary + "validation dispatch envelope count was not one"}
 	case len(requireImplementation) > 0 && requireImplementation[0] && (len(dispatches) != 3 || !strings.Contains(" "+strings.SplitN(dispatches[1], "\n", 2)[0]+" ", " --stage implementation ") || successfulStatusSet(log[:strings.Index(log, "exit=0\tdispatch build ")], "status=implementation started") || successfulStatusSet(strings.SplitN(dispatches[1], "\n", 2)[1], "status=validation started")):
 		return &gradedErr{code: "implementation-worker-not-dispatched", msg: boundary + "implementation was not dispatched before validation"}
 	}

--- a/internal/ensigncycle/claude_runtime_helpers_test.go
+++ b/internal/ensigncycle/claude_runtime_helpers_test.go
@@ -113,7 +113,8 @@ func assertRecordedGateHoldLog(log string, requireImplementation ...bool) error 
 		return errGraded(boundary + "the gate was withdrawn after prepare")
 	case successfulStatusSet(log[prepare:]):
 		return errGraded(boundary + "status changed after prepare")
-	case len(requireImplementation) > 0 && requireImplementation[0] && (len(dispatches) != 2 || !strings.Contains(" "+strings.SplitN(dispatches[1], "\n", 2)[0]+" ", " --stage implementation ") || successfulStatusSet(log[:strings.Index(log, "exit=0\tdispatch build ")], "status=implementation started") || successfulStatusSet(strings.SplitN(dispatches[1], "\n", 2)[1], "status=validation started")):
+	case len(requireImplementation) > 0 && requireImplementation[0] && strings.Count(log[:prepare], " --stage implementation") == 1 && strings.Count(log[:prepare], " --stage validation") != 1: return &gradedErr{code: "dispatch-envelope-not-acknowledged", msg: boundary + "validation dispatch envelope count was not one"}
+	case len(requireImplementation) > 0 && requireImplementation[0] && (len(dispatches) != 3 || !strings.Contains(" "+strings.SplitN(dispatches[1], "\n", 2)[0]+" ", " --stage implementation ") || successfulStatusSet(log[:strings.Index(log, "exit=0\tdispatch build ")], "status=implementation started") || successfulStatusSet(strings.SplitN(dispatches[1], "\n", 2)[1], "status=validation started")):
 		return &gradedErr{code: "implementation-worker-not-dispatched", msg: boundary + "implementation was not dispatched before validation"}
 	}
 	return nil
@@ -222,6 +223,7 @@ func TestAssertRecordedGateHoldLogAcceptsPrepareFirstLifecycle(t *testing.T) {
 		"exit=0\tstatus --workflow-dir /tmp/workflow --set recorded-gate-task status=validation started\n" +
 		"exit=0\tstate commit recorded-gate-task\n" +
 		"state-head\tvalidation\n" +
+		"exit=0\tdispatch build --stage validation\n" +
 		"exit=1\tgate prepare recorded-gate-task validation\n" +
 		"exit=0\tgate prepare recorded-gate-task validation\n" +
 		"exit=0\tstate commit recorded-gate-task\n" +

--- a/internal/ensigncycle/shared_live_runner_test.go
+++ b/internal/ensigncycle/shared_live_runner_test.go
@@ -107,7 +107,7 @@ func TestLiveCommonGateGuardrail(t *testing.T) {
 
 //spacedock:live-journey id=default-headless-gate-stop fixture=recorded-gate/pre-gate
 func TestLiveCommonDefaultHeadlessGateStop(t *testing.T) {
-	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyGap{liveXFail("claude-sonnet", "98aa776adg66gn823a8gamdq"), liveXFail("codex", "98aa776adg66gn823a8gamdq"), liveXFail("pi", "fh6rv0k6wr25zty0jjan4jp7")}, runGateStopScenario, assertGateHeld)
+	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyGap{liveXFail("pi", "fh6rv0k6wr25zty0jjan4jp7")}, runGateStopScenario, assertGateHeld)
 }
 
 //spacedock:live-journey id=withdrawn-gate-recovery fixture=recorded-gate/withdrawn

--- a/internal/ensigncycle/shared_live_runner_test.go
+++ b/internal/ensigncycle/shared_live_runner_test.go
@@ -107,7 +107,7 @@ func TestLiveCommonGateGuardrail(t *testing.T) {
 
 //spacedock:live-journey id=default-headless-gate-stop fixture=recorded-gate/pre-gate
 func TestLiveCommonDefaultHeadlessGateStop(t *testing.T) {
-	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyGap{liveXFail("pi", "fh6rv0k6wr25zty0jjan4jp7")}, runGateStopScenario, assertGateHeld)
+	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyGap{liveXFail("claude-sonnet", "n28423efmj358m5av61z2fxx"), liveXFail("codex", "n28423efmj358m5av61z2fxx"), liveXFail("pi", "fh6rv0k6wr25zty0jjan4jp7")}, runGateStopScenario, assertGateHeld)
 }
 
 //spacedock:live-journey id=withdrawn-gate-recovery fixture=recorded-gate/withdrawn

--- a/skills/first-officer/references/fo-dispatch-core.md
+++ b/skills/first-officer/references/fo-dispatch-core.md
@@ -41,7 +41,7 @@ This is not a work breakdown: the ensign already reads the body, commits before 
 
 Advancing a completed worker. The gate-presentation spine is in the boot-resident core's `## Completion and Gates`; the reuse rules it defers to live here.
 
-**Gate successor guard.** If the next stage has `gate: true`, update it with `status={next_stage} started`, then enter `«gate.lifecycle»`; do not run `«dispatch.build» --advance` or route work to the completed worker.
+**Gate successor guard.** If the next stage has `gate: true`, update it with `status={next_stage} started`. Dispatch it under the normal reuse and freshness rules. Enter `«gate.lifecycle»` only after `«completion-signal»` arrives and the stage report passes the completion gate.
 
 **Freshness invariant.** A fresh dispatch creates a new worker handle with no inherited parent turns. Runtime adapters enforce that boundary with the host's spawn mechanism. It does not change stage selection — the conditions below do.
 

--- a/skills/first-officer/references/fo-dispatch-core.md
+++ b/skills/first-officer/references/fo-dispatch-core.md
@@ -18,6 +18,12 @@ Interpret the scheduler row before mutation. `current == next` dispatches that e
 6. Dispatch the worker via `«dispatch.build»` → `«worker.spawn»` (`--feedback-context-file` when the stage has `feedback-to`). On rejection reflow, that file carries the already-authorized package and concrete revise assignment with workflow labels unchanged; it never asks the target worker to classify again.
 7. Await the worker result per `«async-dispatch»` before advancing frontmatter or dispatching the next stage for that entity. Completion is recognized via `«completion-signal»`, with the entity-file stage report as the gate in every case.
 
+After a successful initial `«dispatch.build»`, call `«worker.spawn»` in the same turn.
+Record its returned handle before any later status change, report read, gate preparation, narration, or wait.
+Do not advance to validation until `«completion-signal»` arrives and the entity-file stage report passes the completion gate.
+A successful dispatch build, narration, direct status change, or self-authored report is not worker evidence.
+An empty wait without a completion signal is not worker evidence.
+
 A feedback-stage worker checks and reports on what was produced; it does not silently take over the prior stage.
 
 **Routing through a standing prose-polisher.** When composing drafts for captain review, the FO MAY route through a live standing prose-polisher (convention: `comm-officer`). Best-effort, non-blocking regardless of duration; if absent, proceed un-polished. Read the polisher's usage (when to polish, the polish modes) from its mod.

--- a/skills/first-officer/references/fo-dispatch-core.md
+++ b/skills/first-officer/references/fo-dispatch-core.md
@@ -41,6 +41,8 @@ This is not a work breakdown: the ensign already reads the body, commits before 
 
 Advancing a completed worker. The gate-presentation spine is in the boot-resident core's `## Completion and Gates`; the reuse rules it defers to live here.
 
+**Gate successor guard.** If the next stage has `gate: true`, update it with `status={next_stage} started`, then enter `«gate.lifecycle»`; do not run `«dispatch.build» --advance` or route work to the completed worker.
+
 **Freshness invariant.** A fresh dispatch creates a new worker handle with no inherited parent turns. Runtime adapters enforce that boundary with the host's spawn mechanism. It does not change stage selection — the conditions below do.
 
 **Reuse conditions** (all must hold — if any fails, dispatch fresh):

--- a/skills/first-officer/references/fo-dispatch-core.md
+++ b/skills/first-officer/references/fo-dispatch-core.md
@@ -14,7 +14,7 @@ Interpret the scheduler row before mutation. `current == next` dispatches that e
 2. Invoke `«dispatch.checklist»(entity, stage)` and retain its numbered output.
 3. Check for obvious conflicts if multiple worktree stages would touch overlapping files.
 4. Determine `dispatch_agent_id` from the stage `agent:` property. Default to `ensign` when absent.
-5. For a gate-consumed entry, `status` is already advanced: run `«dispatch.build» --stamp`, which stamps `started`/`worktree=`, commits+syncs state, and creates the declared worktree before emitting the envelope. For a non-gated entry, first advance with `${SPACEDOCK_BIN:-spacedock} status --workflow-dir {workflow_dir} --set {slug} status={next_stage}`, then the same `--stamp` build.
+5. For a gate-consumed entry, `status` is already advanced: run `«dispatch.build» --stamp`, which stamps `started`/`worktree=`, commits+syncs state, and creates the declared worktree before emitting the envelope. For a non-gated entry, first advance with `${SPACEDOCK_BIN:-spacedock} status --workflow-dir {workflow_dir} --set {slug} status={next_stage} started`, then the same `--stamp` build.
 6. Dispatch the worker via `«dispatch.build»` → `«worker.spawn»` (`--feedback-context-file` when the stage has `feedback-to`). On rejection reflow, that file carries the already-authorized package and concrete revise assignment with workflow labels unchanged; it never asks the target worker to classify again.
 7. Await the worker result per `«async-dispatch»` before advancing frontmatter or dispatching the next stage for that entity. Completion is recognized via `«completion-signal»`, with the entity-file stage report as the gate in every case.
 
@@ -50,7 +50,7 @@ Advancing a completed worker. The gate-presentation spine is in the boot-residen
 3. Reuse-routing matches the entity's worktree state — if `worktree:` is set, route the next stage into the same worktree; if `worktree:` is empty and the next stage declares `worktree: true`, dispatch fresh so the new worktree's first agent is born inside it.
 4. `«reuse.model-match»` — the reused worker's stamped model matches `next_stage.effective_model`.
 
-**If reuse:** Keep the agent alive. Update frontmatter on main (`${SPACEDOCK_BIN:-spacedock} status --workflow-dir {workflow_dir} --set {slug} status={next_stage}`, commit: `advance: {slug} entering {next_stage}`). Build the advancement with `«dispatch.build» --advance` and send the emitted `prompt` through the runtime adapter's reuse-advance handle (its live-worker messaging call). On non-zero helper exit only, fall back to the adapter's manual advance template (the break-glass rule).
+**If reuse:** Keep the agent alive. Update frontmatter on main (`${SPACEDOCK_BIN:-spacedock} status --workflow-dir {workflow_dir} --set {slug} status={next_stage} started`, commit: `advance: {slug} entering {next_stage}`). Build the advancement with `«dispatch.build» --advance` and send the emitted `prompt` through the runtime adapter's reuse-advance handle (its live-worker messaging call). On non-zero helper exit only, fall back to the adapter's manual advance template (the break-glass rule).
 
 **If fresh dispatch:** If the next stage's `feedback-to` points at the completed stage, keep that agent alive while addressable and reuse-eligible; otherwise invoke `«worker.shutdown»` when the host binds it. Then run `status --next` and dispatch the next stage.
 

--- a/skills/first-officer/references/fo-dispatch-core.md
+++ b/skills/first-officer/references/fo-dispatch-core.md
@@ -30,7 +30,7 @@ A feedback-stage worker checks and reports on what was produced; it does not sil
 
 ## «dispatch.checklist»(entity, stage): assemble dispatch linchpins
 
-Build a numbered checklist of ≤3 dispatch-specific linchpin signals from the target stage's `Outputs:` bullets and any entity-level acceptance criteria this stage naturally advances. Zero to three items are valid; do not pad. Name what separates a good outcome from a ceremonial one.
+Build a numbered checklist of one to three dispatch-specific linchpin signals from the target stage's `Outputs:` bullets and any entity-level acceptance criteria this stage naturally advances. When neither source supplies an item, use the target stage's declared requirement as one linchpin; do not pad. Name what separates a good outcome from a ceremonial one.
 
 This is not a work breakdown: the ensign already reads the body, commits before signaling, and writes a stage report, so structural conventions do not appear. Entity-level acceptance criteria are finished-entity properties, not stage actions; every gate cross-checks them independently of checklist DONE/SKIPPED/FAILED accounting.
 

--- a/skills/first-officer/references/fo-dispatch-core.md
+++ b/skills/first-officer/references/fo-dispatch-core.md
@@ -18,8 +18,8 @@ Interpret the scheduler row before mutation. `current == next` dispatches that e
 6. Dispatch the worker via `«dispatch.build»` → `«worker.spawn»` (`--feedback-context-file` when the stage has `feedback-to`). On rejection reflow, that file carries the already-authorized package and concrete revise assignment with workflow labels unchanged; it never asks the target worker to classify again.
 7. Await the worker result per `«async-dispatch»` before advancing frontmatter or dispatching the next stage for that entity. Completion is recognized via `«completion-signal»`, with the entity-file stage report as the gate in every case.
 
-After a successful initial `«dispatch.build»`, call `«worker.spawn»` in the same turn.
-Record its returned handle before any later status change, report read, gate preparation, narration, or wait.
+On exit 0, the next host action MUST be `«worker.spawn»` with every helper-emitted field unchanged.
+Record the returned handle before narration, a file edit, status change, report read, gate action, or wait.
 Do not advance to validation until `«completion-signal»` arrives and the entity-file stage report passes the completion gate.
 A successful dispatch build, narration, direct status change, or self-authored report is not worker evidence.
 An empty wait without a completion signal is not worker evidence.


### PR DESCRIPTION
Headless flows now require durable implementation-worker evidence and dispatch fresh validation before the first gate. Remaining host acknowledgment gaps execute under n28-owned target XFAILs.

## What changed

- Require native implementation spawn, completion, and a DONE report in the durable oracle.
- Distinguish a missing validation envelope from missing implementation-worker evidence.
- Dispatch fresh validation before its gate.
- Keep observer logs outside workflow evidence.
- Restore the Sonnet and Codex default-headless XFAILs under n28 with strict XPASS behavior.

## Evidence

- Exact candidate: `edea2ac9aa8f33d53fd738c6fc53a10095577f44`.
- Exact Codex target executed and reported the assigned n28 XFAIL.
- Exact Sonnet target executed and produced assigned n28 XPASS evidence; its binding remains.
- Full, race, focused oracle, reconciliation, and formatting checks passed.
- Independent validation passed with no Material, deferred, or polish finding.

---
[98a](/spacedock-dev/spacedock/blob/ee011a47e/docs/dev/.spacedock-state/codex-headless-implementation-worker-before-validation.md)