### PR TITLE
Remove stale Sonnet owner-handoff XFAIL evidence

### DIFF
--- a/internal/contractlint/live_registry_reconciliation_test.go
+++ b/internal/contractlint/live_registry_reconciliation_test.go
@@ -56,7 +56,7 @@ func TestRuntimeLiveRegistryReconciliation(t *testing.T) {
 		"rejection-flow":                {{"xfail", "codex", "dvddbpsf4tdt3yjw1yjyp14k"}, {"xfail", "pi", "p17swb3375rt525fn7f8xt7e"}},
 		"smallest-sufficient-mechanism": {{"xfail", "pi", "h30c9jrfcf21fdh2qs5z58sd"}},
 		"keep-moving-posture":           {{"xfail", "pi", "x02375wsg6q61xek7p0t36j2"}},
-		"owned-conflict-owner-handoff":  {{"xfail", "claude-sonnet", "xp6c9qfe7y4wwp46enc3f85n"}, {"xfail", "claude-opus", "xp6c9qfe7y4wwp46enc3f85n"}, {"xfail", "pi", "xp6c9qfe7y4wwp46enc3f85n"}},
+		"owned-conflict-owner-handoff":  {{"xfail", "claude-opus", "xp6c9qfe7y4wwp46enc3f85n"}, {"xfail", "pi", "xp6c9qfe7y4wwp46enc3f85n"}},
 	}
 	for id, want := range wantGaps {
 		if !reflect.DeepEqual(actual[id].gaps, want) {

--- a/internal/ensigncycle/shared_live_runner_test.go
+++ b/internal/ensigncycle/shared_live_runner_test.go
@@ -177,5 +177,5 @@ func TestLiveCommonACValueReanchor(t *testing.T) {
 
 //spacedock:live-journey id=owned-conflict-owner-handoff fixture=conflict-owner/stamped-checkout
 func TestLiveCommonOwnedConflictOwnerHandoff(t *testing.T) {
-	liveJourney(t, "owned-conflict-owner-handoff", "conflict-owner/stamped-checkout", writeConflictOwnerFixture, []liveJourneyGap{liveXFail("claude-sonnet", "xp6c9qfe7y4wwp46enc3f85n"), liveXFail("claude-opus", "xp6c9qfe7y4wwp46enc3f85n"), liveXFail("pi", "xp6c9qfe7y4wwp46enc3f85n")}, runConflictOwnerHandoffJourney, assertConflictOwnerHandoff)
+	liveJourney(t, "owned-conflict-owner-handoff", "conflict-owner/stamped-checkout", writeConflictOwnerFixture, []liveJourneyGap{liveXFail("claude-opus", "xp6c9qfe7y4wwp46enc3f85n"), liveXFail("pi", "xp6c9qfe7y4wwp46enc3f85n")}, runConflictOwnerHandoffJourney, assertConflictOwnerHandoff)
 }


### PR DESCRIPTION
Live evidence now reports the repaired Sonnet owner-handoff journey without a stale expected-failure binding.

## What changed

- Remove the Sonnet owner-handoff XFAIL binding.
- Update registry reconciliation to match current evidence.
- Preserve Opus and Pi evidence ownership.

## Evidence

- Focused validation: 7/7 passed.
- Exact Sonnet XPASS and Codex normal PASS evidence verified.

---

[xp6](/spacedock-dev/spacedock-state/blob/5f0c2177c87aa97200142d4b122cd10d67b21a51/restore-live-evidence-after-completed-repairs.md)
