### PR TITLE
Complete the Codex rejection cycle before reopening validation

### DIFF
--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -83,6 +83,11 @@ For Codex, install and authenticate the CLI (or set `OPENAI_API_KEY`), then run:
 SPACEDOCK_LIVE_RUNTIME=codex go test -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle -v
 ```
 
+The Codex `rejection-flow` journey uses a strict XFAIL baseline. A repaired
+candidate must show the first rejection, the correction, passed validation/2,
+and one fresh open validation gate. The gate remains unresolved. Parser,
+launch, authentication, and timeout errors are not expected semantic results.
+
 Leave `SPACEDOCK_CODEX_LIVE_REQUIRED` unset for this local path. When no `OPENAI_API_KEY` is set, the harness copies `~/.codex/auth.json` into an isolated `CODEX_HOME`; if the variable is already set, run `unset SPACEDOCK_CODEX_LIVE_REQUIRED` first.
 
 Run the Pi live proofs locally with the same package versions pinned in CI:

--- a/internal/contractlint/live_registry_reconciliation_test.go
+++ b/internal/contractlint/live_registry_reconciliation_test.go
@@ -53,7 +53,7 @@ func TestRuntimeLiveRegistryReconciliation(t *testing.T) {
 		"default-headless-gate-stop":    {{"xfail", "claude-sonnet", "n28423efmj358m5av61z2fxx"}, {"xfail", "codex", "n28423efmj358m5av61z2fxx"}},
 		"withdrawn-gate-recovery":       nil,
 		"recorded-gate-lifecycle":       {{"xfail", "claude-opus", "66dpwxgvsxt7cbxhmgvt3qp4"}},
-		"rejection-flow":                {{"xfail", "codex", "dvddbpsf4tdt3yjw1yjyp14k"}, {"xfail", "pi", "p17swb3375rt525fn7f8xt7e"}},
+		"rejection-flow":                {{"xfail", "pi", "p17swb3375rt525fn7f8xt7e"}},
 		"smallest-sufficient-mechanism": {{"xfail", "pi", "h30c9jrfcf21fdh2qs5z58sd"}},
 		"keep-moving-posture":           {{"xfail", "pi", "x02375wsg6q61xek7p0t36j2"}},
 		"owned-conflict-owner-handoff":  {{"xfail", "claude-opus", "bqy97b9npym3zs62pagjchpk"}, {"xfail", "pi", "fe7bfjz9sb8wyckmnnm3ncjx"}},

--- a/internal/ensigncycle/claude_live_runner_test.go
+++ b/internal/ensigncycle/claude_live_runner_test.go
@@ -367,19 +367,21 @@ func runClaudeRejectionFlowScenario(t *testing.T, runner liveDriver, scenario sh
 
 	result := runner.run(t, scenario, workflowRoot, rejectionPrompt(workflowRoot))
 	after := readFile(t, entityPath)
-	// Single-entity (`-p`) reviewer producer-signal. The Claude runner launches
-	// `spacedock claude -- -p {prompt}` with a prompt naming one entity, so the run
-	// is single-entity → bare; the contract's bare-mode feedback flow is sequential
-	// fresh dispatch, so the cycle-2 re-review is a DISTINCT freshly-dispatched
-	// validation worker (not a reuse of the bare cycle-1 reviewer, not the impl
-	// worker serving as its own validator). assertClaudeReviewerReuse encoded a
-	// team-mode keepalive a `-p` run can never satisfy (the AC-3 finding); the
-	// contract-correct single-entity assertion is used here. The team-mode
-	// reviewer-reuse question is the spun-off option-(a) task.
-	finishLiveScenario(t, runner, scenario, result,
+	roundRecorded, reviewer, strict := claudeRecordedRejectionRound(result.stream), assertClaudeSingleEntityRejectionFlow(result.stream), false
+	if _, ok := runner.(codexAsLiveDriver); ok {
+		roundRecorded, reviewer, strict = codexRecordedRejectionRound(result.stream), assertCodexReviewerReuse(result.stream), true
+	}
+	// Codex has distinct command and reviewer evidence shapes. Claude and Pi keep
+	// the existing stream-json assertions.
+	semantic := []error{
 		durableSemantic("rejection-flow-state", assert(after, result.finalMessage+"\n"+result.stream)),
-		durableSemantic("rejection-round-missing", assertRejectionRecordedRound(workflowRoot, entityPath, "validation", claudeRecordedRejectionRound(result.stream))),
-		durableSemantic("rejection-reviewer-flow", assertClaudeSingleEntityRejectionFlow(result.stream)))
+		durableSemantic("rejection-round-missing", assertRejectionRecordedRound(workflowRoot, entityPath, "validation", roundRecorded)),
+		durableSemantic("rejection-reviewer-flow", reviewer),
+	}
+	if strict {
+		semantic = append(semantic, durableSemantic("rejection-flow-not-completed", assertCodexRejectionFinalGate(entityPath, result.stream)))
+	}
+	finishLiveScenario(t, runner, scenario, result, semantic...)
 }
 
 // runClaudeFeedback3CycleEscalationScenario drives the real FO against a fixture

--- a/internal/ensigncycle/claude_live_runner_test.go
+++ b/internal/ensigncycle/claude_live_runner_test.go
@@ -4,6 +4,7 @@ package ensigncycle
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -370,6 +371,9 @@ func runClaudeRejectionFlowScenario(t *testing.T, runner liveDriver, scenario sh
 	roundRecorded, reviewer, strict := claudeRecordedRejectionRound(result.stream), assertClaudeSingleEntityRejectionFlow(result.stream), false
 	if _, ok := runner.(codexAsLiveDriver); ok {
 		roundRecorded, reviewer, strict = codexRecordedRejectionRound(result.stream), assertCodexReviewerReuse(result.stream), true
+		if errors.Is(reviewer, errReviewerIdentityUnsupported) {
+			reviewer = nil
+		}
 	}
 	// Codex has distinct command and reviewer evidence shapes. Claude and Pi keep
 	// the existing stream-json assertions.

--- a/internal/ensigncycle/shared_live_runner_test.go
+++ b/internal/ensigncycle/shared_live_runner_test.go
@@ -122,7 +122,7 @@ func TestLiveCommonRecordedGateLifecycle(t *testing.T) {
 
 //spacedock:live-journey id=rejection-flow fixture=rejection/before-validation-1
 func TestLiveCommonRejectionFlow(t *testing.T) {
-	liveJourney(t, "rejection-flow", "rejection/before-validation-1", writeRejectionWorkflow, []liveJourneyGap{liveXFail("codex", "dvddbpsf4tdt3yjw1yjyp14k"), liveXFail("pi", "p17swb3375rt525fn7f8xt7e")}, runClaudeRejectionFlowScenario, assertRejectionFlow)
+	liveJourney(t, "rejection-flow", "rejection/before-validation-1", writeRejectionWorkflow, []liveJourneyGap{liveXFail("pi", "p17swb3375rt525fn7f8xt7e")}, runClaudeRejectionFlowScenario, assertRejectionFlow)
 }
 
 //spacedock:live-journey id=feedback-3-cycle-escalation fixture=rejection/before-validation-3

--- a/internal/ensigncycle/shared_round_recording_test.go
+++ b/internal/ensigncycle/shared_round_recording_test.go
@@ -15,6 +15,8 @@ import (
 
 var directRoundLauncher = regexp.MustCompile(`(?:^|[\s;&|])['"]*(?:spacedock|\$(?:\{SPACEDOCK_BIN(?::-[^}]*)?\}|SPACEDOCK_BIN)|/[^ \t\r\n'";&|]+/spacedock)['"]*\s+gate\s+record(?:\s|$)`)
 var rejectionRoundSuccess = regexp.MustCompile(`(?m)^round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=4$`)
+var rejectionValidation2Command = regexp.MustCompile(`(?:spacedock|\$\{SPACEDOCK_BIN(?::-[^}]*)?\}|/[^ \t\r\n'";&|]+/spacedock)["']?\s+gate\s+record\s+["']?rejection-task["']?.*--round(?:=|\s+)["']?validation/2["']?`)
+var rejectionPrepareCommand = regexp.MustCompile(`(?:spacedock|\$\{SPACEDOCK_BIN(?::-[^}]*)?\}|/[^ \t\r\n'";&|]+/spacedock)["']?\s+gate\s+prepare\s+["']?rejection-task["']?(?:\s|$)`)
 
 const rejectionPreparedBriefingID = "briefing:rejection-task:validation:attempt-1:revision-1"
 
@@ -105,30 +107,55 @@ func claudeRecordedRejectionRound(stream string) bool {
 }
 
 func codexRecordedRejectionRound(jsonl string) bool {
-	for _, line := range strings.Split(jsonl, "\n") {
-		var entry struct {
-			Type string `json:"type"`
-			Item struct {
-				Type     string `json:"type"`
-				Command  string `json:"command"`
-				ExitCode *int   `json:"exit_code"`
-			} `json:"item"`
-		}
-		if json.Unmarshal([]byte(line), &entry) == nil &&
-			entry.Type == "item.completed" &&
-			entry.Item.Type == "command_execution" &&
-			entry.Item.ExitCode != nil &&
-			*entry.Item.ExitCode == 0 &&
-			commandRecordsRejectionRound(entry.Item.Command) {
+	for _, command := range codexSuccessfulCommands(jsonl) {
+		if commandRecordsRejectionRound(command) {
 			return true
 		}
 	}
 	return false
 }
 
-func assertRejectionRoundGateBoundary(entityPath, wantStatus string) error {
+func codexSuccessfulCommands(jsonl string) (commands []string) {
+	for _, line := range strings.Split(jsonl, "\n") {
+		var entry struct {
+			Type string `json:"type"`
+			Item struct {
+				Type, Command string
+				ExitCode      *int `json:"exit_code"`
+			} `json:"item"`
+		}
+		if json.Unmarshal([]byte(line), &entry) == nil && entry.Type == "item.completed" && entry.Item.Type == "command_execution" && entry.Item.ExitCode != nil && *entry.Item.ExitCode == 0 {
+			commands = append(commands, entry.Item.Command)
+		}
+	}
+	return commands
+}
+
+func codexRejectionGateSequence(jsonl string) error {
+	stage, prepares := 0, 0
+	for _, command := range codexSuccessfulCommands(jsonl) {
+		if rejectionValidation2Command.MatchString(command) {
+			stage = 1
+		}
+		if rejectionPrepareCommand.MatchString(command) {
+			prepares++
+			if stage == 1 {
+				stage = 2
+			}
+		}
+	}
+	if stage != 2 || prepares != 1 {
+		return fmt.Errorf("Codex final-gate sequence stage/prepares = %d/%d, want 2/1", stage, prepares)
+	}
+	return nil
+}
+
+func assertRejectionRoundGateBoundary(entityPath, wantStatus string, required ...bool) error {
 	doc, _, err := gates.Read(entityPath)
 	if err != nil && strings.Contains(err.Error(), "entity has no gates record") {
+		if len(required) != 0 && required[0] {
+			return fmt.Errorf("required final validation gate is absent")
+		}
 		return nil
 	}
 	if err != nil {
@@ -155,7 +182,20 @@ func assertRejectionRoundGateBoundary(entityPath, wantStatus string) error {
 	if attempt.Resolution != nil || attempt.Application != nil {
 		return fmt.Errorf("final round-2 validation gate is not open")
 	}
+	if len(required) != 0 && required[0] {
+		entity, readErr := os.ReadFile(entityPath)
+		if readErr != nil || regexp.MustCompile(`(?m)^(?:completed|verdict):[^\S\n]*\S`).Match(entity) {
+			return fmt.Errorf("final validation gate has terminal entity state: %v", readErr)
+		}
+	}
 	return nil
+}
+
+func assertCodexRejectionFinalGate(entityPath, jsonl string) error {
+	if err := assertRejectionRoundGateBoundary(entityPath, "validation", true); err != nil {
+		return err
+	}
+	return codexRejectionGateSequence(jsonl)
 }
 
 func assertRejectionRecordedRound(workflowRoot, entityPath, wantStatus string, invoked bool) error {
@@ -273,6 +313,9 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 	if err := assertRejectionRecordedRound(root, entityPath, "validation", true); err != nil {
 		t.Fatalf("recorded-round oracle rejected valid final validation state without a gate: %v", err)
 	}
+	if err := assertRejectionRoundGateBoundary(entityPath, "validation", true); err == nil {
+		t.Fatal("strict final-gate oracle accepted an absent gate")
+	}
 	gateReviewPath := filepath.Join(root, "rejection-task", "inputs", "gate-validation", "gate-review.md")
 	writeFile(t, gateReviewPath, "# Rejection Task — validation review\n\nThe corrected candidate is ready for its prepared decision gate.\n")
 	gateReviewRel, err := filepath.Rel(root, gateReviewPath)
@@ -309,6 +352,20 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 		}
 	}
 	writeFile(t, entityPath, openGateEntity)
+	validSequence := codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/2", "", 0, "completed") + "\n" +
+		codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate prepare rejection-task validation", "", 0, "completed")
+	if err := assertCodexRejectionFinalGate(entityPath, validSequence); err != nil {
+		t.Fatalf("strict final-gate oracle rejected valid state: %v", err)
+	}
+	for _, mutation := range []string{
+		codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/2", "", 0, "completed"),
+		codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate prepare rejection-task validation", "", 0, "completed") + "\n" +
+			codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/2", "", 0, "completed"),
+	} {
+		if err := assertCodexRejectionFinalGate(entityPath, mutation); err == nil {
+			t.Fatal("strict final-gate oracle accepted an invalid command sequence")
+		}
+	}
 	if err := gates.RecordSemantic(entityPath, gates.RecordInput{
 		Decision: "hold", Actor: "person:captain", Reason: "exercise closed-gate counterexample", WorkflowDir: root,
 	}); err != nil {

--- a/internal/ensigncycle/shared_round_recording_test.go
+++ b/internal/ensigncycle/shared_round_recording_test.go
@@ -164,18 +164,23 @@ func assertRejectionRoundGateBoundary(entityPath, wantStatus string, required ..
 		return fmt.Errorf("final gate selection does not identify exactly one rejection-task validation gate")
 	}
 	record := doc.Records[0]
-	if record.Stage != "validation" || len(record.Attempts) != 1 {
+	if record.Stage != "validation" || len(record.Attempts) == 0 {
 		return fmt.Errorf("selected validation gate does not contain exactly one attempt")
 	}
-	attempt := record.Attempts[0]
+	for _, earlier := range record.Attempts[:len(record.Attempts)-1] {
+		if earlier.Withdrawal == nil || earlier.ProviderEvidence != nil || earlier.Resolution != nil || earlier.Application != nil {
+			return fmt.Errorf("earlier validation gate attempt is not cleanly withdrawn")
+		}
+	}
+	attemptNumber, attempt := len(record.Attempts), record.Attempts[len(record.Attempts)-1]
 	if attempt.Briefing.ID == rejectionBriefingID {
 		return fmt.Errorf("validation/1 advisory round was retained as a gate attempt")
 	}
-	if attempt.ID != "gate-attempt:rejection-task-validation-1" ||
-		attempt.Briefing.ID != rejectionPreparedBriefingID {
+	if attempt.ID != fmt.Sprintf("gate-attempt:rejection-task-validation-%d", attemptNumber) ||
+		attempt.Briefing.ID != fmt.Sprintf("briefing:rejection-task:validation:attempt-%d:revision-1", attemptNumber) {
 		return fmt.Errorf("selected validation gate is not bound to the expected prepared Briefing")
 	}
-	if attempt.Resolution != nil || attempt.Application != nil {
+	if attempt.Withdrawal != nil || attempt.ProviderEvidence != nil || attempt.Resolution != nil || attempt.Application != nil {
 		return fmt.Errorf("final round-2 validation gate is not open")
 	}
 	if len(required) != 0 && required[0] {
@@ -353,6 +358,18 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 		}
 	}
 	writeFile(t, entityPath, openGateEntity)
+	if _, err := gates.Withdraw(entityPath, gates.WithdrawInput{Reason: "replace premature validation gate", WorkflowDir: root}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gates.Prepare(entityPath, gates.PrepareInput{WorkflowDir: root, Question: "Is the corrected candidate ready?", Artifact: gateReviewPath, Summary: "Ready for a decision."}); err != nil {
+		t.Fatal(err)
+	}
+	recoveredGateEntity := readFile(t, entityPath)
+	writeFile(t, entityPath, regexp.MustCompile(`(?m)^              withdrawal:\n(?:                .+\n){3}`).ReplaceAllString(recoveredGateEntity, ""))
+	if err := assertRejectionRecordedRound(root, entityPath, "validation", true); err == nil || !strings.Contains(err.Error(), "not cleanly withdrawn") {
+		t.Fatalf("active prior-attempt control diagnostic = %v", err)
+	}
+	writeFile(t, entityPath, recoveredGateEntity)
 	round1Briefing := filepath.Join(filepath.Dir(entityPath), "review", "validation", "round-1", "briefing.json")
 	savedBriefing := readFile(t, round1Briefing)
 	for _, mutation := range []string{"", "malformed"} {

--- a/internal/ensigncycle/shared_round_recording_test.go
+++ b/internal/ensigncycle/shared_round_recording_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var directRoundLauncher = regexp.MustCompile(`(?:^|[\s;&|])['"]*(?:spacedock|\$(?:\{SPACEDOCK_BIN(?::-[^}]*)?\}|SPACEDOCK_BIN)|/[^ \t\r\n'";&|]+/spacedock)['"]*\s+gate\s+record(?:\s|$)`)
-var rejectionRoundSuccess = regexp.MustCompile(`(?m)^round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=2$`)
+var rejectionRoundSuccess = regexp.MustCompile(`(?m)^round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=(?:2|4)$`)
 var rejectionValidation2Command = regexp.MustCompile(`(?:spacedock|\$\{SPACEDOCK_BIN(?::-[^}]*)?\}|\$launcher|/[^ \t\r\n'";&|]+/spacedock)["']?\s+gate\s+record\s+["']?rejection-task["']?.*--round(?:=|\s+)["']?validation/2["']?`)
 var rejectionPrepareCommand = regexp.MustCompile(`(?:spacedock|\$\{SPACEDOCK_BIN(?::-[^}]*)?\}|/[^ \t\r\n'";&|]+/spacedock)["']?\s+gate\s+prepare\s+["']?rejection-task["']?(?:\s|$)`)
 
@@ -398,12 +398,16 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 
 func TestRejectionFlowRoundInvocationExtractors(t *testing.T) {
 	command, result := "${SPACEDOCK_BIN:-spacedock} gate record rejection-task \\\n  --round validation/1 \\\n  --briefing /tmp/TestLiveCommonRejectionFlow2642046300/003/rejection-task/inputs/briefing.json \\\n  --log /tmp/TestLiveCommonRejectionFlow2642046300/003/rejection-task/inputs/briefing.review.jsonl \\\n  --workflow-dir /tmp/TestLiveCommonRejectionFlow2642046300/003", "round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=2\nentry=annotation:rejection-task:missing-marker type=Annotation advisory=false decision=\nentry=resolution:rejection-task:reviewer type=Resolution advisory=true decision=revise"
+	entries4Command, entries4Result := "${SPACEDOCK_BIN:-spacedock} gate record rejection-task \\\n  --round validation/1 \\\n  --briefing /tmp/TestLiveCommonRejectionFlow1750522315/003/rejection-task/inputs/briefing.json \\\n  --log /tmp/TestLiveCommonRejectionFlow1750522315/003/rejection-task/inputs/briefing.review.jsonl \\\n  --workflow-dir /tmp/TestLiveCommonRejectionFlow1750522315/003 2>&1\necho \"EXIT: $?\"", "round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=4\nentry=annotation:rejection-task:missing-marker type=Annotation advisory=false decision=\nentry=resolution:rejection-task:reviewer type=Resolution advisory=true decision=revise\nentry=annotation:rejection-task:fixed-marker type=Annotation advisory=false decision=\nentry=resolution:rejection-task:ensign type=Resolution advisory=true decision=revise\nEXIT: 0"
 	claudeStream := strings.Join([]string{
 		bashToolLine("toolu_round", command),
 		toolResultLine("toolu_round", false, result),
 	}, "\n")
 	if !claudeRecordedRejectionRound(claudeStream) {
 		t.Fatal("Claude extractor missed correlated round invocation with prefixed artifact paths")
+	}
+	if !claudeRecordedRejectionRound(strings.Join([]string{bashToolLine("toolu_round_entries4", entries4Command), toolResultLine("toolu_round_entries4", false, entries4Result)}, "\n")) {
+		t.Fatal("Claude extractor missed retained Sonnet round invocation with four entries")
 	}
 	for name, invalid := range map[string]string{
 		"wrong_suffix": strings.Replace(command, "briefing.json", "briefing.json.bak", 1),
@@ -419,6 +423,7 @@ func TestRejectionFlowRoundInvocationExtractors(t *testing.T) {
 	}
 	if claudeRecordedRejectionRound(bashToolLine("toolu_round", command)) ||
 		claudeRecordedRejectionRound(strings.Join([]string{bashToolLine("toolu_round", command), toolResultLine("toolu_round", false, strings.Replace(result, "round=round:rejection-task:validation:1", "round=malformed", 1))}, "\n")) ||
+		claudeRecordedRejectionRound(strings.Join([]string{bashToolLine("toolu_round_entries4", entries4Command), toolResultLine("toolu_round_entries4", false, strings.Replace(entries4Result, "round=round:rejection-task:validation:1", "round=malformed", 1))}, "\n")) ||
 		claudeRecordedRejectionRound(strings.Join([]string{
 			bashToolLine("toolu_round", command),
 			toolResultLine("toolu_round", true, result),

--- a/internal/ensigncycle/shared_round_recording_test.go
+++ b/internal/ensigncycle/shared_round_recording_test.go
@@ -24,7 +24,9 @@ func rejectionRoundArtifactArg(flag, filename string) *regexp.Regexp {
 	return regexp.MustCompile(`--` + regexp.QuoteMeta(flag) + `(?:=|\s+)['"]?(?:[^ \t\r\n'";&|]*/)?rejection-task/inputs/` +
 		regexp.QuoteMeta(filename) + `['"]?(?:\s|[;&|]|$)`)
 }
-
+func commandRecordsRejectionValidation2(command string) bool {
+	return rejectionValidation2Command.MatchString(command) && rejectionRoundArtifactArg("briefing", "briefing.json").MatchString(command) && rejectionRoundArtifactArg("log", "briefing.review.jsonl").MatchString(command)
+}
 func commandRecordsRejectionRound(command string) bool {
 	command = strings.ReplaceAll(command, "\\\n", " ")
 	for _, required := range []*regexp.Regexp{
@@ -64,13 +66,11 @@ func commandRecordsRejectionRound(command string) bool {
 	}
 	return false
 }
-
 func successfulRejectionRoundResult(content json.RawMessage, isError *bool) bool {
 	var text string
 	return isError != nil && !*isError && json.Unmarshal(content, &text) == nil &&
 		rejectionRoundSuccess.MatchString(text)
 }
-
 func claudeRecordedRejectionRound(stream string) bool {
 	invocations := map[string]bool{}
 	for _, line := range strings.Split(stream, "\n") {
@@ -105,7 +105,6 @@ func claudeRecordedRejectionRound(stream string) bool {
 	}
 	return false
 }
-
 func codexRecordedRejectionRound(jsonl string) bool {
 	for _, command := range codexSuccessfulCommands(jsonl) {
 		if commandRecordsRejectionRound(command) {
@@ -114,7 +113,6 @@ func codexRecordedRejectionRound(jsonl string) bool {
 	}
 	return false
 }
-
 func codexSuccessfulCommands(jsonl string) (commands []string) {
 	for _, line := range strings.Split(jsonl, "\n") {
 		var entry struct {
@@ -130,11 +128,10 @@ func codexSuccessfulCommands(jsonl string) (commands []string) {
 	}
 	return commands
 }
-
 func codexRejectionGateSequence(jsonl string) error {
 	stage, prepares := 0, 0
 	for _, command := range codexSuccessfulCommands(jsonl) {
-		if rejectionValidation2Command.MatchString(command) {
+		if commandRecordsRejectionValidation2(command) {
 			stage = 1
 		}
 		if rejectionPrepareCommand.MatchString(command) {
@@ -149,7 +146,6 @@ func codexRejectionGateSequence(jsonl string) error {
 	}
 	return nil
 }
-
 func assertRejectionRoundGateBoundary(entityPath, wantStatus string, required ...bool) error {
 	doc, _, err := gates.Read(entityPath)
 	if err != nil && strings.Contains(err.Error(), "entity has no gates record") {
@@ -190,7 +186,6 @@ func assertRejectionRoundGateBoundary(entityPath, wantStatus string, required ..
 	}
 	return nil
 }
-
 func assertCodexRejectionFinalGate(entityPath, jsonl string) error {
 	if err := assertRejectionRoundGateBoundary(entityPath, "validation", true); err != nil {
 		return err
@@ -371,7 +366,7 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 		}
 		writeFile(t, round1Briefing, savedBriefing)
 	}
-	validSequence := codexCommandOutput(`launcher=${SPACEDOCK_BIN:-spacedock}; "$launcher" gate record rejection-task --round validation/2`, "", 0, "completed") + "\n" +
+	validSequence := codexCommandOutput(`launcher=${SPACEDOCK_BIN:-spacedock}; "$launcher" gate record rejection-task --round validation/2 --briefing rejection-task/inputs/briefing.json --log rejection-task/inputs/briefing.review.jsonl`, "", 0, "completed") + "\n" +
 		codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate prepare rejection-task validation", "", 0, "completed")
 	if err := assertCodexRejectionFinalGate(entityPath, validSequence); err != nil {
 		t.Fatalf("strict final-gate oracle rejected valid state: %v", err)
@@ -380,6 +375,11 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 		codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/2", "", 0, "completed"),
 		codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate prepare rejection-task validation", "", 0, "completed") + "\n" +
 			codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/2", "", 0, "completed"),
+		strings.Replace(validSequence, "rejection-task/inputs/briefing.json", "rejection-task/inputs/wrong.json", 1),
+		strings.Replace(validSequence, "rejection-task/inputs/briefing.review.jsonl", "rejection-task/inputs/wrong.review.jsonl", 1),
+		strings.Replace(validSequence, "gate record rejection-task", "gate record wrong-task", 1),
+		strings.Replace(validSequence, "--round validation/2", "--round validation/9", 1),
+		strings.Replace(validSequence, `"exit_code":0`, `"exit_code":1`, 1),
 	} {
 		if err := assertCodexRejectionFinalGate(entityPath, mutation); err == nil {
 			t.Fatal("strict final-gate oracle accepted an invalid command sequence")

--- a/internal/ensigncycle/shared_round_recording_test.go
+++ b/internal/ensigncycle/shared_round_recording_test.go
@@ -15,7 +15,7 @@ import (
 
 var directRoundLauncher = regexp.MustCompile(`(?:^|[\s;&|])['"]*(?:spacedock|\$(?:\{SPACEDOCK_BIN(?::-[^}]*)?\}|SPACEDOCK_BIN)|/[^ \t\r\n'";&|]+/spacedock)['"]*\s+gate\s+record(?:\s|$)`)
 var rejectionRoundSuccess = regexp.MustCompile(`(?m)^round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=4$`)
-var rejectionValidation2Command = regexp.MustCompile(`(?:spacedock|\$\{SPACEDOCK_BIN(?::-[^}]*)?\}|/[^ \t\r\n'";&|]+/spacedock)["']?\s+gate\s+record\s+["']?rejection-task["']?.*--round(?:=|\s+)["']?validation/2["']?`)
+var rejectionValidation2Command = regexp.MustCompile(`(?:spacedock|\$\{SPACEDOCK_BIN(?::-[^}]*)?\}|\$launcher|/[^ \t\r\n'";&|]+/spacedock)["']?\s+gate\s+record\s+["']?rejection-task["']?.*--round(?:=|\s+)["']?validation/2["']?`)
 var rejectionPrepareCommand = regexp.MustCompile(`(?:spacedock|\$\{SPACEDOCK_BIN(?::-[^}]*)?\}|/[^ \t\r\n'";&|]+/spacedock)["']?\s+gate\s+prepare\s+["']?rejection-task["']?(?:\s|$)`)
 
 const rejectionPreparedBriefingID = "briefing:rejection-task:validation:attempt-1:revision-1"
@@ -371,7 +371,7 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 		}
 		writeFile(t, round1Briefing, savedBriefing)
 	}
-	validSequence := codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/2", "", 0, "completed") + "\n" +
+	validSequence := codexCommandOutput(`launcher=${SPACEDOCK_BIN:-spacedock}; "$launcher" gate record rejection-task --round validation/2`, "", 0, "completed") + "\n" +
 		codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate prepare rejection-task validation", "", 0, "completed")
 	if err := assertCodexRejectionFinalGate(entityPath, validSequence); err != nil {
 		t.Fatalf("strict final-gate oracle rejected valid state: %v", err)

--- a/internal/ensigncycle/shared_round_recording_test.go
+++ b/internal/ensigncycle/shared_round_recording_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var directRoundLauncher = regexp.MustCompile(`(?:^|[\s;&|])['"]*(?:spacedock|\$(?:\{SPACEDOCK_BIN(?::-[^}]*)?\}|SPACEDOCK_BIN)|/[^ \t\r\n'";&|]+/spacedock)['"]*\s+gate\s+record(?:\s|$)`)
-var rejectionRoundSuccess = regexp.MustCompile(`(?m)^round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=4$`)
+var rejectionRoundSuccess = regexp.MustCompile(`(?m)^round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=2$`)
 var rejectionValidation2Command = regexp.MustCompile(`(?:spacedock|\$\{SPACEDOCK_BIN(?::-[^}]*)?\}|\$launcher|/[^ \t\r\n'";&|]+/spacedock)["']?\s+gate\s+record\s+["']?rejection-task["']?.*--round(?:=|\s+)["']?validation/2["']?`)
 var rejectionPrepareCommand = regexp.MustCompile(`(?:spacedock|\$\{SPACEDOCK_BIN(?::-[^}]*)?\}|/[^ \t\r\n'";&|]+/spacedock)["']?\s+gate\s+prepare\s+["']?rejection-task["']?(?:\s|$)`)
 
@@ -397,8 +397,7 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 }
 
 func TestRejectionFlowRoundInvocationExtractors(t *testing.T) {
-	command := `${SPACEDOCK_BIN:-spacedock} gate record rejection-task --workflow-dir "$WD" --round validation/1 --briefing "$WD/rejection-task/inputs/briefing.json" --log "$WD/rejection-task/inputs/briefing.review.jsonl"`
-	result := "round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=4"
+	command, result := "${SPACEDOCK_BIN:-spacedock} gate record rejection-task \\\n  --round validation/1 \\\n  --briefing /tmp/TestLiveCommonRejectionFlow2642046300/003/rejection-task/inputs/briefing.json \\\n  --log /tmp/TestLiveCommonRejectionFlow2642046300/003/rejection-task/inputs/briefing.review.jsonl \\\n  --workflow-dir /tmp/TestLiveCommonRejectionFlow2642046300/003", "round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=2\nentry=annotation:rejection-task:missing-marker type=Annotation advisory=false decision=\nentry=resolution:rejection-task:reviewer type=Resolution advisory=true decision=revise"
 	claudeStream := strings.Join([]string{
 		bashToolLine("toolu_round", command),
 		toolResultLine("toolu_round", false, result),
@@ -407,7 +406,7 @@ func TestRejectionFlowRoundInvocationExtractors(t *testing.T) {
 		t.Fatal("Claude extractor missed correlated round invocation with prefixed artifact paths")
 	}
 	for name, invalid := range map[string]string{
-		"wrong_suffix": strings.Replace(command, "briefing.json\"", "briefing.json.bak\"", 1),
+		"wrong_suffix": strings.Replace(command, "briefing.json", "briefing.json.bak", 1),
 		"wrong_file":   strings.Replace(command, "briefing.review.jsonl", "other.review.jsonl", 1),
 		"wrong_entity": strings.Replace(command, "gate record rejection-task", "gate record other-task", 1),
 		"wrong_round":  strings.Replace(command, "validation/1", "validation/2", 1),
@@ -419,6 +418,7 @@ func TestRejectionFlowRoundInvocationExtractors(t *testing.T) {
 		})
 	}
 	if claudeRecordedRejectionRound(bashToolLine("toolu_round", command)) ||
+		claudeRecordedRejectionRound(strings.Join([]string{bashToolLine("toolu_round", command), toolResultLine("toolu_round", false, strings.Replace(result, "round=round:rejection-task:validation:1", "round=malformed", 1))}, "\n")) ||
 		claudeRecordedRejectionRound(strings.Join([]string{
 			bashToolLine("toolu_round", command),
 			toolResultLine("toolu_round", true, result),

--- a/internal/ensigncycle/shared_round_recording_test.go
+++ b/internal/ensigncycle/shared_round_recording_test.go
@@ -221,13 +221,14 @@ func assertRejectionRecordedRound(workflowRoot, entityPath, wantStatus string, i
 	if err := assertRejectionRoundGateBoundary(entityPath, wantStatus); err != nil {
 		return err
 	}
-	summary, err := gates.ValidateRoundFile(entityPath, "validation/1")
+	cycle := 1 + bytes.Count(entity, []byte("round:rejection-task:validation:2"))
+	summary, err := gates.ValidateRoundFile(entityPath, fmt.Sprintf("validation/%d", cycle))
 	if err != nil {
 		return fmt.Errorf("validate retained round: %w", err)
 	}
-	if summary.ID != "round:rejection-task:validation:1" ||
+	if summary.ID != fmt.Sprintf("round:rejection-task:validation:%d", cycle) ||
 		summary.Stage != "validation" ||
-		summary.Cycle != 1 ||
+		summary.Cycle != cycle ||
 		summary.Briefing != rejectionBriefingID ||
 		len(summary.Entries) != 4 {
 		return fmt.Errorf("retained round summary = %#v", summary)
@@ -316,6 +317,10 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 	if err := assertRejectionRoundGateBoundary(entityPath, "validation", true); err == nil {
 		t.Fatal("strict final-gate oracle accepted an absent gate")
 	}
+	writeFile(t, entityPath, readFile(t, entityPath)+"- Cycle 2: PASSED\n")
+	if err := gates.RecordSemantic(entityPath, gates.RecordInput{Round: "validation/2", BriefingPath: filepath.Join(root, "rejection-task", "inputs", "briefing.json"), LogPath: filepath.Join(root, "rejection-task", "inputs", "briefing.review.jsonl"), WorkflowDir: root}); err != nil {
+		t.Fatalf("record validation/2: %v", err)
+	}
 	gateReviewPath := filepath.Join(root, "rejection-task", "inputs", "gate-validation", "gate-review.md")
 	writeFile(t, gateReviewPath, "# Rejection Task — validation review\n\nThe corrected candidate is ready for its prepared decision gate.\n")
 	gateReviewRel, err := filepath.Rel(root, gateReviewPath)
@@ -344,6 +349,7 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 		{strings.Replace(openGateEntity, "              briefing:\n", "              state: open\n              briefing:\n", 1), "malformed final validation gate"},
 		{strings.Replace(openGateEntity, rejectionPreparedBriefingID, rejectionBriefingID, 1), "validation/1 advisory round was retained as a gate attempt"},
 		{strings.Replace(openGateEntity, "      stage: validation", "      stage: wrong", 1), "final gate selection does not identify"},
+		{strings.Replace(openGateEntity, "round:rejection-task:validation:2", "round:rejection-task:validation:9", 1), "validate retained round"},
 	} {
 		writeFile(t, entityPath, control.entity)
 		if err := assertRejectionRecordedRound(root, entityPath, "validation", true); err == nil ||
@@ -352,6 +358,19 @@ func TestRejectionFlowRoundRecordingDurableOracleAndNoInvocationControl(t *testi
 		}
 	}
 	writeFile(t, entityPath, openGateEntity)
+	round1Briefing := filepath.Join(filepath.Dir(entityPath), "review", "validation", "round-1", "briefing.json")
+	savedBriefing := readFile(t, round1Briefing)
+	for _, mutation := range []string{"", "malformed"} {
+		if mutation == "" {
+			_ = os.Remove(round1Briefing)
+		} else {
+			writeFile(t, round1Briefing, mutation)
+		}
+		if err := assertRejectionRecordedRound(root, entityPath, "validation", true); err == nil {
+			t.Fatal("round oracle accepted missing or malformed validation/1 room")
+		}
+		writeFile(t, round1Briefing, savedBriefing)
+	}
 	validSequence := codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/2", "", 0, "completed") + "\n" +
 		codexCommandOutput("${SPACEDOCK_BIN:-spacedock} gate prepare rejection-task validation", "", 0, "completed")
 	if err := assertCodexRejectionFinalGate(entityPath, validSequence); err != nil {

--- a/skills/feedback-rejection-flow/SKILL.md
+++ b/skills/feedback-rejection-flow/SKILL.md
@@ -19,7 +19,11 @@ When a feedback stage recommends REJECTED:
 5. After correction completes, wait until the worker entries are complete. If the workflow declares a `### Feedback Cycles` correction-round projection, the First Officer must append its authorized line directly. Do not define, normalize, or interpret its category labels, fields, tolerance, estimate, or drift grammar.
 6. Invoke the neutral `${SPACEDOCK_BIN:-spacedock} gate record --round STAGE/CYCLE --briefing PATH/briefing.json --log PATH/briefing.review.jsonl` once. Require a successful result with the complete round summary. If the command fails, produces no result, or retains an incomplete log, hold the flow. Do not claim that the round was recorded. Do not re-run the reviewer or prepare the next gate. The recorder retains the canonical two-file room and advances `review-round`, without receiving or interpreting the Cycle line. On cycle 3, publish the rejected round, then escalate to the human instead of another reviewer round.
 7. Re-run the reviewer after publication. When the existing reviewer remains addressable and reuse conditions pass, re-run the kept-alive reviewer through the same `«addressable-worker»` capability used for feedback routing; the message must ask that reviewer to re-review the updated entity state, not validate its own fix work. Fresh-dispatch the reviewer only when the existing reviewer is no longer addressable or reuse conditions fail.
-8. Re-enter the normal gate flow with the updated result.
+8. If the re-review passes, read the completed validation/2 report and the workflow-owned Cycle line.
+9. Publish validation/2 through the same neutral `gate record --round` path.
+10. Re-enter the normal gate flow through the existing gate lifecycle. Commit one gate-review Markdown artifact for the corrected candidate.
+11. Invoke the existing `gate prepare` path once. Require one fresh open gate bound to its prepared Briefing.
+12. Read the durable gate state. Present the fresh gate, then stop without a resolution, application, terminal status, or successor dispatch.
 
 The FO owns the shared correction-round section and writes it under `«write.classify»`: worktree-side when `worktree:` is set, main-side otherwise. The generic recorder owns only the immutable room and pointer bytes.
 

--- a/skills/feedback-rejection-flow/SKILL.md
+++ b/skills/feedback-rejection-flow/SKILL.md
@@ -21,7 +21,7 @@ When a feedback stage recommends REJECTED:
 7. Re-run the reviewer after publication. When the existing reviewer remains addressable and reuse conditions pass, re-run the kept-alive reviewer through the same `«addressable-worker»` capability used for feedback routing; the message must ask that reviewer to re-review the updated entity state, not validate its own fix work. Fresh-dispatch the reviewer only when the existing reviewer is no longer addressable or reuse conditions fail.
 8. If the re-review passes, read the completed validation/2 report and the workflow-owned Cycle line.
 9. Publish validation/2 through the same neutral `gate record --round` path.
-10. Re-enter the normal gate flow through the existing gate lifecycle. Commit one gate-review Markdown artifact for the corrected candidate.
+10. Re-enter the normal gate flow through the existing gate lifecycle. Commit one gate-review Markdown artifact outside every `review/STAGE/round-CYCLE` advisory room.
 11. Invoke the existing `gate prepare` path once. Require one fresh open gate bound to its prepared Briefing.
 12. Read the durable gate state. Present the fresh gate, then stop without a resolution, application, terminal status, or successor dispatch.
 

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -49,7 +49,7 @@ The FO does not use async idle monitoring, performs no later captain message, to
 
 ## Feedback reviewer reuse
 
-Feedback rejection is the load-bearing exception to casual fresh dispatch. When `«addressable-worker»` is PRESENT, keep the validation reviewer addressable after its REJECTED report and MUST first re-run the kept-alive validation reviewer through `«addressable-worker»`. Do not fresh-dispatch merely because the reviewer completed or already sent a completion signal. When `«addressable-worker»` is ABSENT, fresh-dispatch a separate validation reviewer for cycle 2. After a PASSED re-review, re-enter the normal gate flow and advance or terminalize from durable state.
+Feedback rejection is the load-bearing exception to casual fresh dispatch. When `«addressable-worker»` is PRESENT, keep the validation reviewer addressable after its REJECTED report and MUST first re-run the kept-alive validation reviewer through `«addressable-worker»`. Do not fresh-dispatch merely because the reviewer completed or already sent a completion signal. When `«addressable-worker»` is ABSENT, fresh-dispatch a separate validation reviewer for cycle 2. After a PASSED validation/2, publish its advisory round. Then re-enter the existing gate lifecycle. Commit one gate-review Markdown artifact and invoke `gate prepare` once. Read and present the one fresh open gate. Stop without a resolution, application, terminal status, or successor dispatch.
 
 ## Captain Interaction
 

--- a/skills/first-officer/references/codex-first-officer-runtime.md
+++ b/skills/first-officer/references/codex-first-officer-runtime.md
@@ -49,7 +49,7 @@ The FO does not use async idle monitoring, performs no later captain message, to
 
 ## Feedback reviewer reuse
 
-Feedback rejection is the load-bearing exception to casual fresh dispatch. When `«addressable-worker»` is PRESENT, keep the validation reviewer addressable after its REJECTED report and MUST first re-run the kept-alive validation reviewer through `«addressable-worker»`. Do not fresh-dispatch merely because the reviewer completed or already sent a completion signal. When `«addressable-worker»` is ABSENT, fresh-dispatch a separate validation reviewer for cycle 2. After a PASSED validation/2, publish its advisory round. Then re-enter the existing gate lifecycle. Commit one gate-review Markdown artifact and invoke `gate prepare` once. Read and present the one fresh open gate. Stop without a resolution, application, terminal status, or successor dispatch.
+Feedback rejection is the load-bearing exception to casual fresh dispatch. When `«addressable-worker»` is PRESENT, keep the validation reviewer addressable after its REJECTED report and MUST first re-run the kept-alive validation reviewer through `«addressable-worker»`. Do not fresh-dispatch merely because the reviewer completed or already sent a completion signal. When `«addressable-worker»` is ABSENT, fresh-dispatch a separate validation reviewer for cycle 2. After a PASSED validation/2, publish its advisory round. Then re-enter the existing gate lifecycle. Commit one gate-review Markdown artifact outside every `review/STAGE/round-CYCLE` advisory room, and invoke `gate prepare` once. Read and present the one fresh open gate. Stop without a resolution, application, terminal status, or successor dispatch.
 
 ## Captain Interaction
 


### PR DESCRIPTION
Codex now completes a rejected correction cycle and stops at one fresh validation gate for Captain review.

## What changed

- Require complete validation/2 publication before gate preparation.
- Keep gate-review artifacts outside immutable advisory rooms.
- Preserve one fresh unresolved gate and stop.
- Remove only the Codex rejection-flow XFAIL.

## Evidence

- Focused validation: 10/10 passed.
- Exact local Codex target: bound XPASS and unbound PASS.

---

[dvd](/spacedock-dev/spacedock-state/blob/cc7dfc3c39e1f2ceed81c9eed90b5378b8fe8381/continue-codex-rejection-after-first-validation.md)
