### PR TITLE
Stop Sonnet zero-discovery filesystem search

### DIFF
--- a/internal/ensigncycle/broad_search_detect_test.go
+++ b/internal/ensigncycle/broad_search_detect_test.go
@@ -114,6 +114,14 @@ func TestDetectBroadSearchAtBoot(t *testing.T) {
 			wantNames: "find",
 		},
 		{
+			name: "artifact_9074747236_adapter_find_reds",
+			lines: []string{
+				streamLine(`find /tmp/spacedock-live-plugin-3439009114/skills/first-officer/references -iname "*claude*"`),
+			},
+			wantRed:   true,
+			wantNames: "find",
+		},
+		{
 			name: "find_scoped_under_resolved_workflow_passes",
 			lines: []string{
 				streamLine(`spacedock status --discover`),

--- a/skills/first-officer/SKILL.md
+++ b/skills/first-officer/SKILL.md
@@ -31,7 +31,7 @@ The skill loader supplies the absolute base directory for this `first-officer` s
 ## Runtime adapter
 
 Load the runtime adapter for your platform:
-- Claude Code (`CLAUDECODE` env var is set): read `references/claude-first-officer-runtime.md`
+- Claude Code (`CLAUDECODE` env var is set): read exactly `{first_officer_base}/references/claude-first-officer-runtime.md`; do not list or search the references directory.
 - Codex (`CODEX_THREAD_ID` env var is set): read `references/codex-first-officer-runtime.md`
 - Pi (`PI_CODING_AGENT_DIR` is set, or this session is running under Pi without the Claude/Codex markers above): read `references/pi-first-officer-runtime.md`
 


### PR DESCRIPTION
Sonnet now reads the Claude adapter from the exact loader-supplied path and stops without filesystem discovery.

## What changed

- Use the exact First Officer base for the Claude adapter path.
- Retain the exact prohibited `find` command as a focused detector control.
- Preserve all other runtimes, bindings, formats, and authority.

## Evidence

- Local Sonnet zero-discovery target: normal PASS in 26.87 seconds.
- Full, race, focused, registry, owner, format, and diff checks passed.

---

[3rns](/spacedock-dev/spacedock-state/blob/7d3279bcb437efc983a85accdc0048052344062d/stop-sonnet-zero-discovery-broad-search.md)
