### PR TITLE
Acknowledge stamped CLI worker dispatches

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,6 +16,7 @@
     "automation"
   ],
   "skills": "./skills/",
+  "hooks": "./hooks.json",
   "interface": {
     "displayName": "Spacedock",
     "shortDescription": "Plain text workflows for AI agents",

--- a/hooks.json
+++ b/hooks.json
@@ -10,6 +10,27 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Agent|Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${SPACEDOCK_BIN:-spacedock}\" dispatch ack-hook"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${SPACEDOCK_BIN:-spacedock}\" dispatch ack-hook"
+          }
+        ]
+      }
     ]
   }
 }

--- a/internal/contractlint/live_registry_reconciliation_test.go
+++ b/internal/contractlint/live_registry_reconciliation_test.go
@@ -50,7 +50,7 @@ func TestRuntimeLiveRegistryReconciliation(t *testing.T) {
 	actual, fixtureOwners := readActualLiveJourneys(t, repo, targets)
 	wantGaps := map[string][]liveGapRow{
 		"gate-guardrail":                nil,
-		"default-headless-gate-stop":    {{"xfail", "claude-sonnet", "kky8pg7wc8xgb985epwss092"}},
+		"default-headless-gate-stop":    {{"xfail", "claude-sonnet", "kky8pg7wc8xgb985epwss092"}, {"xfail", "codex", "kky8pg7wc8xgb985epwss092"}},
 		"withdrawn-gate-recovery":       nil,
 		"recorded-gate-lifecycle":       {{"xfail", "claude-opus", "66dpwxgvsxt7cbxhmgvt3qp4"}},
 		"rejection-flow":                {{"xfail", "codex", "dvddbpsf4tdt3yjw1yjyp14k"}, {"xfail", "pi", "p17swb3375rt525fn7f8xt7e"}},

--- a/internal/contractlint/live_registry_reconciliation_test.go
+++ b/internal/contractlint/live_registry_reconciliation_test.go
@@ -50,7 +50,7 @@ func TestRuntimeLiveRegistryReconciliation(t *testing.T) {
 	actual, fixtureOwners := readActualLiveJourneys(t, repo, targets)
 	wantGaps := map[string][]liveGapRow{
 		"gate-guardrail":                nil,
-		"default-headless-gate-stop":    {{"xfail", "claude-sonnet", "n28423efmj358m5av61z2fxx"}, {"xfail", "codex", "n28423efmj358m5av61z2fxx"}},
+		"default-headless-gate-stop":    {{"xfail", "claude-sonnet", "kky8pg7wc8xgb985epwss092"}},
 		"withdrawn-gate-recovery":       nil,
 		"recorded-gate-lifecycle":       {{"xfail", "claude-opus", "66dpwxgvsxt7cbxhmgvt3qp4"}},
 		"rejection-flow":                {{"xfail", "codex", "dvddbpsf4tdt3yjw1yjyp14k"}, {"xfail", "pi", "p17swb3375rt525fn7f8xt7e"}},

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spacedock-dev/spacedock/internal/claudeteam"
+	"github.com/spacedock-dev/spacedock/internal/dispatchack"
 	"github.com/spacedock-dev/spacedock/internal/runtimehost"
 	"github.com/spacedock-dev/spacedock/internal/status"
 )
@@ -99,6 +100,8 @@ type buildOutput struct {
 	RunInBackground *bool    `json:"run_in_background,omitempty"`
 	Agent           *string  `json:"agent,omitempty"`
 	Skill           *string  `json:"skill,omitempty"`
+	AckEpoch        string   `json:"dispatch_ack_epoch,omitempty"`
+	AckRef          string   `json:"dispatch_ack_ref,omitempty"`
 }
 
 // buildAdvanceOutput is the stdout JSON envelope for `--advance` mode: a pointer
@@ -560,6 +563,10 @@ func runBuildFields(probe claudeteam.TeamStateProbe, workflowLauncher string, op
 	// still decomposes; short names pass through byte-identical.
 	workerKey := strings.ReplaceAll(subagentType, ":", "-")
 	slug := status.EntitySlug(entityPath)
+	entityID := entityFields["id"]
+	if entityID == "" {
+		entityID = slug
+	}
 	idStyle := readmeFields["id-style"]
 	derivedName := capWorkerName(workerKey, slug, stage, entityFields["id"], idStyle)
 
@@ -767,6 +774,23 @@ func runBuildFields(probe claudeteam.TeamStateProbe, workflowLauncher string, op
 		return buildError(stderr, 1,
 			"dispatch filename '%s' exceeds %d characters", dispatchFileName, dispatchFileNameMaxLen)
 	}
+	var acknowledgment dispatchack.Record
+	if opts.Stamp && (host == "claude" && os.Getenv("CLAUDE_CODE_SESSION_ID") != "" || host == "codex" && os.Getenv("CODEX_THREAD_ID") != "") {
+		if advance {
+			state, err := dispatchack.State(entityPath, entityID, stage)
+			if err != nil {
+				return buildError(stderr, 1, "cannot read dispatch acknowledgment: %s", err)
+			}
+			if state == dispatchack.Pending || state == dispatchack.Armed {
+				return buildError(stderr, 1, "dispatch acknowledgment for entity %s stage %s is %s", slug, stage, state)
+			}
+		} else {
+			acknowledgment, err = dispatchack.Create(entityPath, entityID, stage, host)
+			if err != nil {
+				return buildError(stderr, 1, "%s", err)
+			}
+		}
+	}
 	dispatchFilePath := filepath.Join(dispatchFileDir, dispatchFileName+".md")
 	if err := os.MkdirAll(dispatchFileDir, 0o755); err != nil {
 		fmt.Fprintf(stderr, "dispatch_file_write_failed: %s: %s\n", dispatchFilePath, err)
@@ -814,17 +838,33 @@ func runBuildFields(probe claudeteam.TeamStateProbe, workflowLauncher string, op
 		return emitBuildJSON(stdout, outAdvance)
 	}
 
+	description := fmt.Sprintf("%s: %s", entityTitle, stage)
+	if acknowledgment.Epoch != "" {
+		token := " [sda-" + acknowledgment.Epoch + "]"
+		prompt += token
+		if host == "claude" {
+			description += token
+		}
+	}
 	out := buildOutput{
 		SchemaVersion: schemaVersion,
 		SubagentType:  subagentType,
-		Description:   fmt.Sprintf("%s: %s", entityTitle, stage),
+		Description:   description,
 		FetchCommands: fetchCommands,
 		DispatchFile:  dispatchFilePath,
 		Prompt:        prompt,
 		Model:         effectiveModel,
+		AckEpoch:      acknowledgment.Epoch,
+	}
+	if acknowledgment.Epoch != "" {
+		out.AckRef = acknowledgment.Ref()
 	}
 	if !bareMode {
-		out.Name = &derivedName
+		name := derivedName
+		if host == "codex" && acknowledgment.Epoch != "" {
+			name = acknowledgment.Name(name)
+		}
+		out.Name = &name
 		if teamName != "" {
 			out.TeamName = &teamName
 		}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/spacedock-dev/spacedock/internal/claudeteam"
+	"github.com/spacedock-dev/spacedock/internal/dispatchack"
 )
 
 // Run routes launcher-independent dispatch subcommands. Artifact builds must use
@@ -30,6 +31,8 @@ func RunWithLauncher(probe claudeteam.TeamStateProbe, workflowLauncher string, a
 	}
 
 	switch args[0] {
+	case "ack-hook":
+		return dispatchack.HandleHook(stdin, stdout, stderr)
 	case "build":
 		if wantsHelp(args[1:]) {
 			printBuildUsage(stdout)

--- a/internal/dispatchack/ack.go
+++ b/internal/dispatchack/ack.go
@@ -1,0 +1,232 @@
+// Package dispatchack binds one fresh CLI dispatch to one native worker start.
+package dispatchack
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const Pending, Armed, Consumed = "pending", "armed", "consumed"
+
+type Record struct {
+	State          string `json:"state"`
+	EntityID       string `json:"entity_id"`
+	EntityPath     string `json:"entity_path"`
+	Stage          string `json:"stage"`
+	Host           string `json:"host"`
+	Epoch          string `json:"epoch"`
+	HostSessionID  string `json:"host_session_id,omitempty"`
+	ToolUseID      string `json:"tool_use_id,omitempty"`
+	NativeWorkerID string `json:"native_worker_id,omitempty"`
+}
+type lookup struct {
+	Repo string `json:"repo"`
+	Record
+}
+
+func (r Record) Ref() string { return activeRef(r.EntityID, r.Stage) }
+func (r Record) Name(base string) string {
+	suffix := "-sda-" + r.Epoch
+	if len(base)+len(suffix) > 64 {
+		base = strings.TrimRight(base[:64-len(suffix)], "-")
+	}
+	return base + suffix
+}
+
+var tokenRE = regexp.MustCompile(`sda-([0-9a-f]{32})`)
+
+func Create(entityPath, entityID, stage, host string) (Record, error) {
+	repo, rel, err := repository(entityPath)
+	if err != nil {
+		return Record{}, err
+	}
+	b := make([]byte, 16)
+	if _, err = rand.Read(b); err != nil {
+		return Record{}, err
+	}
+	r := Record{State: Pending, EntityID: entityID, EntityPath: rel, Stage: stage, Host: host, Epoch: hex.EncodeToString(b)}
+	if err = transition(repo, "", r); err != nil {
+		return Record{}, fmt.Errorf("dispatch acknowledgment already exists or cannot be created: %w", err)
+	}
+	if err = os.MkdirAll(lookupDir(), 0o700); err == nil {
+		var f *os.File
+		f, err = os.OpenFile(lookupPath(r.Epoch), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			err = json.NewEncoder(f).Encode(lookup{Repo: repo, Record: r})
+			if closeErr := f.Close(); err == nil {
+				err = closeErr
+			}
+		}
+	}
+	return r, err
+}
+func State(entityPath, entityID, stage string) (string, error) {
+	repo, _, err := repository(entityPath)
+	if err != nil {
+		return "", nil
+	}
+	if r, _, err := read(repo, activeRef(entityID, stage)); err == nil {
+		return r.State, nil
+	}
+	return "", nil
+}
+func Clear(entityPath, entityID, stage string) error {
+	repo, _, err := repository(entityPath)
+	if err != nil {
+		return err
+	}
+	r, oid, err := read(repo, activeRef(entityID, stage))
+	if err != nil || r.State != Consumed {
+		return fmt.Errorf("dispatch acknowledgment is not consumed")
+	}
+	if _, err = git(repo, "update-ref", "-d", activeRef(entityID, stage), oid); err == nil {
+		_ = os.Remove(lookupPath(r.Epoch))
+	}
+	return err
+}
+func HandleHook(stdin io.Reader, stdout, stderr io.Writer) int {
+	var e struct {
+		Event   string         `json:"hook_event_name"`
+		Session string         `json:"session_id"`
+		ToolID  string         `json:"tool_use_id"`
+		AgentID string         `json:"agent_id"`
+		Input   map[string]any `json:"tool_input"`
+	}
+	if err := json.NewDecoder(stdin).Decode(&e); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	switch e.Event {
+	case "PreToolUse":
+		epoch := eventEpoch(e.Input)
+		if epoch == "" {
+			return 0
+		}
+		if err := arm(epoch, e.Session, e.ToolID); err != nil {
+			deny(stdout, err.Error())
+		}
+	case "SubagentStart":
+		if err := consume(e.Session, e.AgentID); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+	}
+	return 0
+}
+func arm(epoch, session, toolID string) error {
+	l, err := loadLookup(epoch)
+	if err != nil || session == "" || toolID == "" {
+		return fmt.Errorf("dispatch acknowledgment does not match one pending envelope")
+	}
+	r, oid, err := read(l.Repo, activeRef(l.EntityID, l.Stage))
+	if err != nil || r.State != Pending || r.Epoch != epoch {
+		return fmt.Errorf("dispatch acknowledgment is stale or already armed")
+	}
+	r.State, r.HostSessionID, r.ToolUseID = Armed, session, toolID
+	return transition(l.Repo, oid, r)
+}
+func consume(session, worker string) error {
+	entries, _ := os.ReadDir(lookupDir())
+	var found *lookup
+	var oid string
+	for _, entry := range entries {
+		l, err := loadLookup(strings.TrimSuffix(entry.Name(), ".json"))
+		if err != nil {
+			continue
+		}
+		r, candidate, err := read(l.Repo, activeRef(l.EntityID, l.Stage))
+		if err == nil && r.State == Armed && r.HostSessionID == session {
+			if found != nil {
+				return fmt.Errorf("more than one armed dispatch acknowledgment matches this session")
+			}
+			l.Record, found, oid = r, &l, candidate
+		}
+	}
+	if found == nil {
+		return nil
+	}
+	if worker == "" {
+		return fmt.Errorf("SubagentStart did not supply a native worker ID")
+	}
+	found.State, found.NativeWorkerID = Consumed, worker
+	return transition(found.Repo, oid, found.Record)
+}
+func transition(repo, old string, r Record) error {
+	data, _ := json.Marshal(r)
+	oid, err := gitInput(repo, data, "hash-object", "-w", "--stdin")
+	if err != nil {
+		return err
+	}
+	if old == "" {
+		old = strings.Repeat("0", 40)
+	}
+	cmd := fmt.Sprintf("start\nupdate %s %s %s\ncreate %s %s\nprepare\ncommit\n", activeRef(r.EntityID, r.Stage), oid, old, auditRef(r.EntityID, r.Stage, r.Epoch, r.State), oid)
+	_, err = gitInput(repo, []byte(cmd), "update-ref", "--stdin")
+	return err
+}
+func read(repo, ref string) (Record, string, error) {
+	oid, err := git(repo, "rev-parse", "--verify", ref)
+	if err != nil {
+		return Record{}, "", err
+	}
+	raw, err := git(repo, "cat-file", "blob", oid)
+	var r Record
+	if err == nil {
+		err = json.Unmarshal([]byte(raw), &r)
+	}
+	return r, oid, err
+}
+func repository(entity string) (string, string, error) {
+	if resolved, err := filepath.EvalSymlinks(entity); err == nil {
+		entity = resolved
+	}
+	repo, err := git(filepath.Dir(entity), "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", "", err
+	}
+	rel, err := filepath.Rel(repo, entity)
+	return repo, filepath.ToSlash(rel), err
+}
+func eventEpoch(input map[string]any) string {
+	for _, key := range []string{"description", "task_name", "name", "prompt"} {
+		if value, ok := input[key].(string); ok {
+			if match := tokenRE.FindStringSubmatch(value); len(match) == 2 {
+				return match[1]
+			}
+		}
+	}
+	return ""
+}
+func deny(w io.Writer, reason string) {
+	fmt.Fprintf(w, `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%q}}`, reason)
+}
+func activeRef(id, stage string) string { return "refs/spacedock/dispatch-ack/" + id + "/" + stage }
+func auditRef(id, stage, epoch, state string) string {
+	return "refs/spacedock/dispatch-ack-audit/" + id + "/" + stage + "/" + epoch + "/" + state
+}
+func lookupDir() string              { return fmt.Sprint(os.TempDir(), "/spacedock-dispatch-ack-", os.Getuid()) }
+func lookupPath(epoch string) string { return filepath.Join(lookupDir(), epoch+".json") }
+func loadLookup(epoch string) (lookup, error) {
+	var l lookup
+	raw, err := os.ReadFile(lookupPath(epoch))
+	if err == nil {
+		err = json.Unmarshal(raw, &l)
+	}
+	return l, err
+}
+func git(repo string, args ...string) (string, error) { return gitInput(repo, nil, args...) }
+func gitInput(repo string, input []byte, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir, cmd.Stdin = repo, bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}

--- a/internal/dispatchack/ack_test.go
+++ b/internal/dispatchack/ack_test.go
@@ -1,0 +1,115 @@
+package dispatchack
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spacedock-dev/spacedock/internal/testgit"
+)
+
+func TestLifecycleAndReplay(t *testing.T) {
+	for _, host := range []string{"claude", "codex"} {
+		t.Run(host, func(t *testing.T) {
+			entity := repo(t)
+			rec, err := Create(entity, "n28423efmj358m5av61z2fxx", "implementation", host)
+			if err != nil || rec.State != Pending || rec.Epoch == "" {
+				t.Fatalf("Create() = %#v, %v", rec, err)
+			}
+			if _, err := Create(entity, rec.EntityID, rec.Stage, host); err == nil {
+				t.Fatal("second Create succeeded")
+			}
+			key := "description"
+			if host == "codex" {
+				key = "task_name"
+			}
+			pre := map[string]any{"hook_event_name": "PreToolUse", "session_id": "session-1", "tool_name": "Agent", "tool_use_id": "call-1", "tool_input": map[string]any{key: "worker-sda-" + rec.Epoch}}
+			hook(t, pre)
+			armed := active(t, entity, rec)
+			if armed.State != Armed || armed.ToolUseID != "call-1" || armed.NativeWorkerID != "" {
+				t.Fatalf("armed = %#v", armed)
+			}
+			if code, out := hook(t, pre); code != 0 || !strings.Contains(out, `"permissionDecision":"deny"`) {
+				t.Fatalf("replay hook = %d, %q", code, out)
+			}
+			start := map[string]any{"hook_event_name": "SubagentStart", "session_id": "session-1", "agent_id": "worker-1", "agent_type": "spacedock:ensign"}
+			hook(t, start)
+			consumed := active(t, entity, rec)
+			if consumed.State != Consumed || consumed.NativeWorkerID != "worker-1" {
+				t.Fatalf("consumed = %#v", consumed)
+			}
+			for _, state := range []string{Pending, Armed, Consumed} {
+				ref := auditRef(rec.EntityID, rec.Stage, rec.Epoch, state)
+				if out := gitTest(t, filepath.Dir(entity), "show", ref); !strings.Contains(out, `"state":"`+state+`"`) {
+					t.Fatalf("audit %s = %q", state, out)
+				}
+			}
+			if err := Clear(entity, rec.EntityID, rec.Stage); err != nil {
+				t.Fatal(err)
+			}
+			if state, _ := State(entity, rec.EntityID, rec.Stage); state != "" {
+				t.Fatalf("cleared state = %q", state)
+			}
+		})
+	}
+}
+func TestDisabledAndMalformedHooksFailClosed(t *testing.T) {
+	entity := repo(t)
+	rec, err := Create(entity, "n28423efmj358m5av61z2fxx", "implementation", "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range []map[string]any{
+		{"hook_event_name": "PreToolUse", "session_id": "s", "tool_name": "Agent", "tool_use_id": "c", "tool_input": map[string]any{"task_name": "worker-sda-00000000000000000000000000000000"}},
+		{"hook_event_name": "SubagentStart", "session_id": "s", "agent_id": "worker"},
+	} {
+		hook(t, event)
+	}
+	if state, _ := State(entity, rec.EntityID, rec.Stage); state != Pending {
+		t.Fatalf("malformed hooks changed pending state to %q", state)
+	}
+	if err := Clear(entity, rec.EntityID, rec.Stage); err == nil {
+		t.Fatal("pending receipt was cleared")
+	}
+}
+func hook(t *testing.T, event any) (int, string) {
+	t.Helper()
+	raw, _ := json.Marshal(event)
+	var out, stderr bytes.Buffer
+	code := HandleHook(bytes.NewReader(raw), &out, &stderr)
+	return code, strings.TrimSpace(out.String())
+}
+func active(t *testing.T, entity string, want Record) Record {
+	t.Helper()
+	var got Record
+	if err := json.Unmarshal([]byte(gitTest(t, filepath.Dir(entity), "show", activeRef(want.EntityID, want.Stage))), &got); err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+func repo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	testgit.InitRepo(t, root, "-q")
+	entity := filepath.Join(root, "task.md")
+	if err := os.WriteFile(entity, []byte("---\nid: n28423efmj358m5av61z2fxx\nstatus: implementation\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitTest(t, root, "add", "task.md")
+	gitTest(t, root, "commit", "-qm", "seed")
+	return entity
+}
+func gitTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return string(out)
+}

--- a/internal/ensigncycle/claude_live_runner_test.go
+++ b/internal/ensigncycle/claude_live_runner_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spacedock-dev/spacedock/internal/dispatchack"
 	"github.com/spacedock-dev/spacedock/internal/gates"
 )
 
@@ -140,6 +141,7 @@ func newClaudeLiveRunner(t *testing.T) claudeLiveRunner {
 	t.Helper()
 	binary := buildRecordedGateBinary(t)
 	pluginDir := livePluginDir(t)
+	writeFile(t, filepath.Join(pluginDir, "hooks.json"), readFile(t, filepath.Join(repoRoot(t), "hooks.json")))
 	model := envOr("SPACEDOCK_LIVE_MODEL", "sonnet")
 
 	// isolatedClaudeEnv resolves the credential (OAuth benchmark-token locally,
@@ -262,27 +264,43 @@ func runGateStopScenario(t *testing.T, runner liveDriver, scenario sharedRuntime
 	semantic = append(semantic, durableSemantic("gate-not-held", assert(before, after, expected)))
 	semantic = append(semantic, assertRecordedGateHoldLog(readFile(t, commandLog), scenario.name == "default-headless-gate-stop"))
 	if scenario.name == "default-headless-gate-stop" {
-		semantic = append(semantic, assertImplementationWorkerLifecycle(nativeLifecycleStream(t, runner, result), after))
+		semantic = append(semantic, assertDispatchAckLifecycle(t, fixture, after, readFile(t, commandLog)))
 	}
 	finishLiveScenario(t, runner, scenario, result, semantic...)
 }
 
-func nativeLifecycleStream(t *testing.T, runner liveDriver, result liveResult) string {
+func assertDispatchAckLifecycle(t *testing.T, fixture recordedGateFixture, entity, log string) error {
 	t.Helper()
-	var started struct {
-		Type     string `json:"type"`
-		ThreadID string `json:"thread_id"`
+	prefix := "refs/spacedock/dispatch-ack-audit/recorded-gate-task/implementation/"
+	refs := strings.Fields(git(t, fixture.stateRoot, "for-each-ref", "--format=%(refname)", prefix))
+	if len(refs) != 3 {
+		return fmt.Errorf("implementation acknowledgment refs = %v, want pending, armed, consumed", refs)
 	}
-	for _, line := range strings.Split(result.stream, "\n") {
-		if json.Unmarshal([]byte(line), &started) == nil && started.Type == "thread.started" {
-			paths, _ := filepath.Glob(filepath.Join(runner.home(), "sessions", "*", "*", "*", "rollout-*"+started.ThreadID+".jsonl"))
-			if len(paths) != 1 {
-				t.Fatalf("Codex parent rollout for %q = %v, want one", started.ThreadID, paths)
-			}
-			return result.stream + "\n" + readFile(t, paths[0])
+	type receipt = dispatchack.Record
+	chain := map[string]receipt{}
+	for _, ref := range refs {
+		var r receipt
+		if err := json.Unmarshal([]byte(git(t, fixture.stateRoot, "show", ref)), &r); err != nil {
+			return err
 		}
+		chain[r.State] = r
 	}
-	return result.stream
+	t.Logf("dispatch acknowledgment chain: %#v", chain)
+	pending, armed, consumed := chain["pending"], chain["armed"], chain["consumed"]
+	identity := func(r receipt) string {
+		return r.EntityID + "\x00" + r.EntityPath + "\x00" + r.Stage + "\x00" + r.Host + "\x00" + r.Epoch
+	}
+	if pending.State == "" || identity(pending) != identity(armed) || identity(armed) != identity(consumed) || armed.ToolUseID == "" || consumed.NativeWorkerID == "" {
+		return fmt.Errorf("invalid acknowledgment chain: %#v", chain)
+	}
+	rel, _ := filepath.Rel(fixture.stateRoot, fixture.entity)
+	report := strings.TrimSpace(git(t, fixture.stateRoot, "log", "-1", "--format=%H", "-S## Stage Report: implementation", "--", rel))
+	gate := strings.TrimSpace(git(t, fixture.stateRoot, "log", "-1", "--format=%H", "-Sgate:recorded-gate-task:validation", "--", rel))
+	ordered := report != "" && gate != "" && report != gate && exec.Command("git", "-C", fixture.stateRoot, "merge-base", "--is-ancestor", report, gate).Run() == nil
+	if !ordered || !strings.Contains(entity, "## Stage Report: implementation") || !successfulStatusSet(log, "status=validation started") {
+		return fmt.Errorf("acknowledgment did not precede the committed report, validation status, and open gate")
+	}
+	return nil
 }
 
 func runClaudeWithdrawnGateRecoveryScenario(t *testing.T, runner liveDriver, scenario sharedRuntimeScenario, build func(*testing.T, string) recordedGateFixture, assert func(*gates.Document) error) {

--- a/internal/ensigncycle/shared_live_runner_test.go
+++ b/internal/ensigncycle/shared_live_runner_test.go
@@ -107,7 +107,7 @@ func TestLiveCommonGateGuardrail(t *testing.T) {
 
 //spacedock:live-journey id=default-headless-gate-stop fixture=recorded-gate/pre-gate
 func TestLiveCommonDefaultHeadlessGateStop(t *testing.T) {
-	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyGap{liveXFail("claude-sonnet", "kky8pg7wc8xgb985epwss092")}, runGateStopScenario, assertGateHeld)
+	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyGap{liveXFail("claude-sonnet", "kky8pg7wc8xgb985epwss092"), liveXFail("codex", "kky8pg7wc8xgb985epwss092")}, runGateStopScenario, assertGateHeld)
 }
 
 //spacedock:live-journey id=withdrawn-gate-recovery fixture=recorded-gate/withdrawn

--- a/internal/ensigncycle/shared_live_runner_test.go
+++ b/internal/ensigncycle/shared_live_runner_test.go
@@ -107,7 +107,7 @@ func TestLiveCommonGateGuardrail(t *testing.T) {
 
 //spacedock:live-journey id=default-headless-gate-stop fixture=recorded-gate/pre-gate
 func TestLiveCommonDefaultHeadlessGateStop(t *testing.T) {
-	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyGap{liveXFail("claude-sonnet", "n28423efmj358m5av61z2fxx"), liveXFail("codex", "n28423efmj358m5av61z2fxx")}, runGateStopScenario, assertGateHeld)
+	liveJourney(t, "default-headless-gate-stop", "recorded-gate/pre-gate", writePreGateWorkflow, []liveJourneyGap{liveXFail("claude-sonnet", "kky8pg7wc8xgb985epwss092")}, runGateStopScenario, assertGateHeld)
 }
 
 //spacedock:live-journey id=withdrawn-gate-recovery fixture=recorded-gate/withdrawn

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/spacedock-dev/spacedock/internal/claudeteam"
+	"github.com/spacedock-dev/spacedock/internal/dispatchack"
 )
 
 // runSet handles the --set mutation flow with mod-block / merge-hook /
@@ -61,6 +62,11 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 	entityPath := mainEntityPath
 
 	currentFields := ParseFrontmatter(entityPath)
+	entityID := currentFields["id"]
+	if entityID == "" {
+		entityID = slug
+	}
+	currentStatus := strings.TrimSpace(currentFields["status"])
 	modBlock := strings.TrimSpace(currentFields["mod-block"])
 	currentPR := strings.TrimSpace(currentFields["pr"])
 	currentVerdict := strings.TrimSpace(currentFields["verdict"])
@@ -112,8 +118,21 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 	// Any away status token in a repeated/chained update refuses the whole
 	// command byte-clean; the same-stage dispatch mutation itself and unrelated
 	// non-status updates remain allowed.
+	stageChanging := false
+	for _, u := range set.updates {
+		stageChanging = stageChanging || u.field == "status" && u.hasValue && u.value != currentStatus
+	}
+	ackState, ackErr := dispatchack.State(entityPath, entityID, currentStatus)
+	if ackErr != nil {
+		return errExit(stderr, "cannot read dispatch acknowledgment: "+ackErr.Error())
+	}
+	if stageChanging && (ackState == dispatchack.Pending || ackState == dispatchack.Armed) {
+		return errExit(stderr, fmt.Sprintf("entity %s cannot change status while its dispatch acknowledgment is %s", slug, ackState))
+	}
+	if stageChanging && ackState == dispatchack.Consumed && !hasCompleteCommittedStageReport(entityPath, currentStatus) {
+		return errExit(stderr, fmt.Sprintf("entity %s cannot change status until a durable, complete ## Stage Report: %s is committed", slug, currentStatus))
+	}
 	if strings.TrimSpace(currentFields["worktree"]) != "" {
-		currentStatus := strings.TrimSpace(currentFields["status"])
 		for _, stage := range stages {
 			if stage.Name != currentStatus || !enteredStageAwaitingCompletion(&entity{path: entityPath}, stage) {
 				continue
@@ -371,6 +390,11 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 	resolvedFields, err := updateFrontmatter(entityPath, set.updates)
 	if err != nil {
 		return errExit(stderr, err.Error())
+	}
+	if stageChanging && ackState == dispatchack.Consumed {
+		if err := dispatchack.Clear(entityPath, entityID, currentStatus); err != nil {
+			return errExit(stderr, "cannot clear dispatch acknowledgment: "+err.Error())
+		}
 	}
 
 	switch {


### PR DESCRIPTION
Stamped Claude and Codex CLI dispatches now use one binary-owned acknowledgment chain before workflow progress.

## What changed

- Create one pending acknowledgment envelope for each fresh stamped dispatch.
- Arm and consume the envelope through supported host hooks.
- Block replay and stage progress until one native worker is acknowledged and its report is complete.
- Remove only the repaired Codex binding.
- Transfer the Sonnet binding to its active gate-commit repair owner.

## Evidence

- Exact local Codex target: bound XPASS-green, then normal PASS.
- Focused, full, race, registry, owner, format, and diff checks passed.
- The deferred no-stamp handoff path remains outside this change.

---

[n28](/spacedock-dev/spacedock-state/blob/78f99014afdabc0e9d8e224f5cb17aaa75811381/mechanically-acknowledge-codex-implementation-dispatch.md)
