### PR TITLE
Recognize Codex atomic task filing

### DIFF
--- a/internal/ensigncycle/codex_live_runner_test.go
+++ b/internal/ensigncycle/codex_live_runner_test.go
@@ -3,7 +3,6 @@
 package ensigncycle
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -42,14 +41,7 @@ func (d codexAsLiveDriver) run(t *testing.T, scenario sharedRuntimeScenario, roo
 }
 
 func codexObservedCommands(jsonl string) []string {
-	var commands []string
-	for _, line := range strings.Split(jsonl, "\n") {
-		var event codexCommandItem
-		if json.Unmarshal([]byte(line), &event) == nil && event.Item.Type == "command_execution" {
-			commands = append(commands, event.Item.Command)
-		}
-	}
-	return commands
+	return successfulCodexCommands(jsonl)
 }
 func (d codexAsLiveDriver) emitMetrics(t *testing.T, scenario sharedRuntimeScenario, result liveResult) {
 	emitCodexScenarioMetrics(t, scenario, codexScenarioResult{finalMessage: result.finalMessage, jsonl: result.stream, artifactDir: result.artifactDir, duration: result.duration})

--- a/internal/ensigncycle/shared_filing_negative_test.go
+++ b/internal/ensigncycle/shared_filing_negative_test.go
@@ -105,8 +105,6 @@ func TestAssertClaudeFilingViaNew(t *testing.T) {
 func TestAssertCodexFilingViaNew(t *testing.T) {
 	slug := filingSlug
 
-	// Positive regression: artifact 9078284956 used Codex's /bin/bash -lc
-	// display form for a captured launcher and created wire-the-thing atomically.
 	artifactCommand := `/bin/bash -lc 'set -eu
 sd_bin="${SPACEDOCK_BIN:-spacedock}"
 printf '"'%s\\n' '---' 'title: Wire The Thing' 'status: backlog' '---' '' 'Wire the thing so it is connected and ready for follow-up work.' | \""'$sd_bin" new wire-the-thing --workflow-dir /tmp/TestLiveCommonFiling1757938389/002
@@ -122,7 +120,7 @@ printf '"'%s\\n' '---' 'title: Wire The Thing' 'status: backlog' '---' '' 'Wire 
 	redControls := map[string]string{
 		"manual file creation": codexCommand("printf body > " + slug + ".md"),
 		"preview plus write":   codexCommand("spacedock status --next-id; printf body > " + slug + ".md"),
-		"wrong slug":           codexCommand("spacedock new other-slug"),
+		"wrong slug":           codexCommand("spacedock new other-slug --workflow-dir /tmp/wire-the-thing"),
 		"narration only":       `{"type":"item.completed","item":{"type":"agent_message","text":"spacedock new wire-the-thing"}}`,
 	}
 	for name, stream := range redControls {

--- a/internal/ensigncycle/shared_filing_negative_test.go
+++ b/internal/ensigncycle/shared_filing_negative_test.go
@@ -1,6 +1,10 @@
 package ensigncycle
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 // Offline positive + negative cases for the `filing` scenario assertions. They
 // build synthetic host streams — a stream that filed via `new` (passes) and the
@@ -16,7 +20,21 @@ func claudeToolUse(name, inputJSON string) string {
 
 // codexCommand builds a `codex exec --json` command_execution item line.
 func codexCommand(command string) string {
-	return `{"type":"item.completed","item":{"type":"command_execution","command":"` + command + `"}}`
+	if !strings.Contains(command, "\n") {
+		var decoded string
+		if json.Unmarshal([]byte(`"`+command+`"`), &decoded) == nil {
+			command = decoded
+		}
+	}
+	exitCode := 0
+	var event codexCommandItem
+	event.Type = "item.completed"
+	event.Item.Type = "command_execution"
+	event.Item.Command = command
+	event.Item.Status = "completed"
+	event.Item.ExitCode = &exitCode
+	encoded, _ := json.Marshal(event)
+	return string(encoded)
 }
 
 func TestAssertClaudeFilingViaNew(t *testing.T) {
@@ -87,6 +105,33 @@ func TestAssertClaudeFilingViaNew(t *testing.T) {
 func TestAssertCodexFilingViaNew(t *testing.T) {
 	slug := filingSlug
 
+	// Positive regression: artifact 9078284956 used Codex's /bin/bash -lc
+	// display form for a captured launcher and created wire-the-thing atomically.
+	artifactCommand := `/bin/bash -lc 'set -eu
+sd_bin="${SPACEDOCK_BIN:-spacedock}"
+printf '"'%s\\n' '---' 'title: Wire The Thing' 'status: backlog' '---' '' 'Wire the thing so it is connected and ready for follow-up work.' | \""'$sd_bin" new wire-the-thing --workflow-dir /tmp/TestLiveCommonFiling1757938389/002
+"$sd_bin" status --boot --identify --json
+"$sd_bin" status --read wire-the-thing --json'`
+	if err := assertCodexFilingViaNew(codexCommand(artifactCommand), slug); err != nil {
+		t.Fatalf("expected artifact 9078284956's successful atomic filing to count: %v", err)
+	}
+	failed := strings.Replace(codexCommand(artifactCommand), `"exit_code":0`, `"exit_code":1`, 1)
+	if err := assertCodexFilingViaNew(failed, slug); err == nil {
+		t.Fatal("expected a failed atomic filing command to fail")
+	}
+	redControls := map[string]string{
+		"manual file creation": codexCommand("printf body > " + slug + ".md"),
+		"preview plus write":   codexCommand("spacedock status --next-id; printf body > " + slug + ".md"),
+		"wrong slug":           codexCommand("spacedock new other-slug"),
+		"narration only":       `{"type":"item.completed","item":{"type":"agent_message","text":"spacedock new wire-the-thing"}}`,
+	}
+	for name, stream := range redControls {
+		t.Run(name, func(t *testing.T) {
+			if assertCodexFilingViaNew(stream, slug) == nil {
+				t.Fatalf("%s counted as atomic filing", name)
+			}
+		})
+	}
 	// Positive: the FO filed via a `spacedock new <slug>` command_execution.
 	filed := codexCommand("spacedock new " + slug + " --workflow-dir .")
 	if err := assertCodexFilingViaNew(filed, slug); err != nil {

--- a/internal/ensigncycle/shared_filing_test.go
+++ b/internal/ensigncycle/shared_filing_test.go
@@ -81,9 +81,14 @@ func capturedLauncherFilesViaNew(command, slug string) bool {
 	segments := regexp.MustCompile(`\r?\n|;|&&|\|\||\|`).Split(command[captureEnd:], -1)
 	executable := regexp.QuoteMeta(varName)
 	call := regexp.MustCompile(`^(?:\$` + executable + `|\$\{` + executable + `\}|"\$` + executable + `"|"\$\{` + executable + `\}")[ \t]+(?:new|--new)\b`)
+	displayCall := regexp.MustCompile(`^\\""'\$` + executable + `"[ \t]+(?:new|--new)\b`)
 	for _, segment := range segments {
 		segment = strings.TrimSpace(segment)
-		if call.MatchString(segment) && strings.Contains(segment, slug) {
+		matched := call.MatchString(segment)
+		if strings.HasPrefix(command, "/bin/bash -lc ") {
+			matched = matched || displayCall.MatchString(segment)
+		}
+		if matched && strings.Contains(segment, slug) {
 			return true
 		}
 	}
@@ -161,9 +166,27 @@ func assertClaudeFilingViaNew(stream, slug string) error {
 type codexCommandItem struct {
 	Type string `json:"type"`
 	Item struct {
-		Type    string `json:"type"`
-		Command string `json:"command"`
+		Type     string `json:"type"`
+		Command  string `json:"command"`
+		Status   string `json:"status"`
+		ExitCode *int   `json:"exit_code"`
 	} `json:"item"`
+}
+
+func successfulCodexCommands(jsonl string) []string {
+	var commands []string
+	for _, line := range strings.Split(jsonl, "\n") {
+		var event codexCommandItem
+		if json.Unmarshal([]byte(line), &event) != nil ||
+			event.Type != "item.completed" ||
+			event.Item.Type != "command_execution" ||
+			event.Item.Status != "completed" ||
+			event.Item.ExitCode == nil || *event.Item.ExitCode != 0 {
+			continue
+		}
+		commands = append(commands, event.Item.Command)
+	}
+	return commands
 }
 
 // assertCodexFilingViaNew scans the `codex exec --json` transcript for the FO
@@ -180,22 +203,11 @@ func assertCodexFilingViaNew(jsonl, slug string) error {
 	filedViaNew := false
 	sawNextID := false
 
-	for _, line := range strings.Split(jsonl, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		var ev codexCommandItem
-		if err := json.Unmarshal([]byte(line), &ev); err != nil {
-			continue
-		}
-		if ev.Item.Type != "command_execution" {
-			continue
-		}
-		if commandFilesViaNew(ev.Item.Command, slug) {
+	for _, command := range successfulCodexCommands(jsonl) {
+		if commandFilesViaNew(command, slug) {
 			filedViaNew = true
 		}
-		if nextIDInvocation.MatchString(ev.Item.Command) {
+		if nextIDInvocation.MatchString(command) {
 			sawNextID = true
 		}
 	}

--- a/internal/ensigncycle/shared_filing_test.go
+++ b/internal/ensigncycle/shared_filing_test.go
@@ -48,7 +48,7 @@ func commandFilesViaNew(command, slug string) bool {
 	if !strings.Contains(command, slug) {
 		return false
 	}
-	if newInvocation.MatchString(command) {
+	if regexp.MustCompile(newInvocation.String() + `[ \t]+` + regexp.QuoteMeta(slug) + `(?:[ \t]|$)`).MatchString(command) {
 		return true
 	}
 	return capturedLauncherFilesViaNew(command, slug)
@@ -80,15 +80,15 @@ func capturedLauncherFilesViaNew(command, slug string) bool {
 	captureEnd := strings.Index(command, m[0]) + len(m[0])
 	segments := regexp.MustCompile(`\r?\n|;|&&|\|\||\|`).Split(command[captureEnd:], -1)
 	executable := regexp.QuoteMeta(varName)
-	call := regexp.MustCompile(`^(?:\$` + executable + `|\$\{` + executable + `\}|"\$` + executable + `"|"\$\{` + executable + `\}")[ \t]+(?:new|--new)\b`)
-	displayCall := regexp.MustCompile(`^\\""'\$` + executable + `"[ \t]+(?:new|--new)\b`)
+	call := regexp.MustCompile(`^(?:\$` + executable + `|\$\{` + executable + `\}|"\$` + executable + `"|"\$\{` + executable + `\}")[ \t]+(?:new|--new)[ \t]+` + regexp.QuoteMeta(slug) + `(?:[ \t]|$)`)
+	displayCall := regexp.MustCompile(`^\\""'\$` + executable + `"[ \t]+(?:new|--new)[ \t]+` + regexp.QuoteMeta(slug) + `(?:[ \t]|$)`)
 	for _, segment := range segments {
 		segment = strings.TrimSpace(segment)
 		matched := call.MatchString(segment)
 		if strings.HasPrefix(command, "/bin/bash -lc ") {
 			matched = matched || displayCall.MatchString(segment)
 		}
-		if matched && strings.Contains(segment, slug) {
+		if matched {
 			return true
 		}
 	}
@@ -177,10 +177,8 @@ func successfulCodexCommands(jsonl string) []string {
 	var commands []string
 	for _, line := range strings.Split(jsonl, "\n") {
 		var event codexCommandItem
-		if json.Unmarshal([]byte(line), &event) != nil ||
-			event.Type != "item.completed" ||
-			event.Item.Type != "command_execution" ||
-			event.Item.Status != "completed" ||
+		if json.Unmarshal([]byte(line), &event) != nil || event.Type != "item.completed" ||
+			event.Item.Type != "command_execution" || event.Item.Status != "completed" ||
 			event.Item.ExitCode == nil || *event.Item.ExitCode != 0 {
 			continue
 		}


### PR DESCRIPTION
Codex filing evidence now recognizes successful atomic task creation without accepting manual or wrong-slug commands.

## What changed

- Recognize successful captured-launcher `spacedock new` commands.
- Bind the requested slug to the positional task argument.
- Reject manual, preview-only, failed, and narration-only evidence.

## Evidence

- Implementation verification: 3/3 required obligations passed.
- Independent validation: 10/10 checks passed, including retained local Codex evidence.

---

[n5](/spacedock-dev/spacedock/blob/39eb114c4f556b8847aa8733c7149f70f3ab820d/recognize-codex-atomic-task-filing.md)
