### PR TITLE
Select the actionable Codex default-headless task

### DIFF
--- a/internal/ensigncycle/claude_live_runner_test.go
+++ b/internal/ensigncycle/claude_live_runner_test.go
@@ -270,20 +270,11 @@ func runGateStopScenario(t *testing.T, runner liveDriver, scenario sharedRuntime
 
 func nativeLifecycleStream(t *testing.T, runner liveDriver, result liveResult) string {
 	t.Helper()
-	var started struct {
-		Type     string `json:"type"`
-		ThreadID string `json:"thread_id"`
+	stream, err := codexNativeLifecycleStream(runner.home(), result.stream)
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, line := range strings.Split(result.stream, "\n") {
-		if json.Unmarshal([]byte(line), &started) == nil && started.Type == "thread.started" {
-			paths, _ := filepath.Glob(filepath.Join(runner.home(), "sessions", "*", "*", "*", "rollout-*"+started.ThreadID+".jsonl"))
-			if len(paths) != 1 {
-				t.Fatalf("Codex parent rollout for %q = %v, want one", started.ThreadID, paths)
-			}
-			return result.stream + "\n" + readFile(t, paths[0])
-		}
-	}
-	return result.stream
+	return stream
 }
 
 func runClaudeWithdrawnGateRecoveryScenario(t *testing.T, runner liveDriver, scenario sharedRuntimeScenario, build func(*testing.T, string) recordedGateFixture, assert func(*gates.Document) error) {

--- a/internal/ensigncycle/claude_runtime_helpers_test.go
+++ b/internal/ensigncycle/claude_runtime_helpers_test.go
@@ -136,10 +136,12 @@ func assertImplementationWorkerLifecycle(stream, entity string) error {
 		Message   *struct{ Content []block }
 		Payload   struct {
 			Type, Name, Arguments, Author string
+			CallID                        string `json:"call_id"`
+			Output                        string `json:"output"`
 			Content                       json.RawMessage
 		}
 	}
-	spawnID, codexWorker, spawns, completed, validation := "", "", 0, -1, -1
+	spawnID, codexSpawnCall, codexWorker, spawns, completed, validation := "", "", "", 0, -1, -1
 	piRunID := ""
 	for i, line := range strings.Split(stream, "\n") {
 		var event row
@@ -159,11 +161,14 @@ func assertImplementationWorkerLifecycle(stream, entity string) error {
 		_ = json.Unmarshal([]byte(line), &pi)
 		if event.Payload.Type == "function_call" && event.Payload.Name == "spawn_agent" && strings.Contains(event.Payload.Arguments, "implementation") {
 			spawns++
-			var args struct {
+			codexSpawnCall = event.Payload.CallID
+		}
+		if event.Payload.Type == "function_call_output" && codexSpawnCall != "" && event.Payload.CallID == codexSpawnCall {
+			var output struct {
 				TaskName string `json:"task_name"`
 			}
-			_ = json.Unmarshal([]byte(event.Payload.Arguments), &args)
-			codexWorker = "/root/" + args.TaskName
+			_ = json.Unmarshal([]byte(event.Payload.Output), &output)
+			codexWorker = output.TaskName
 		}
 		if event.Payload.Type == "agent_message" && event.Payload.Author == codexWorker && strings.Contains(string(event.Payload.Content), "Done:") {
 			completed = i
@@ -208,6 +213,34 @@ func assertImplementationWorkerLifecycle(stream, entity string) error {
 	return nil
 }
 
+func codexNativeLifecycleStream(codexHome, publicStream string) (string, error) {
+	var threadIDs []string
+	for _, line := range strings.Split(publicStream, "\n") {
+		var started struct {
+			Type     string `json:"type"`
+			ThreadID string `json:"thread_id"`
+		}
+		if json.Unmarshal([]byte(line), &started) == nil && started.Type == "thread.started" && started.ThreadID != "" {
+			threadIDs = append(threadIDs, started.ThreadID)
+		}
+	}
+	if len(threadIDs) == 0 {
+		return publicStream, nil
+	}
+	if len(threadIDs) != 1 {
+		return "", fmt.Errorf("Codex public stream thread IDs = %v, want one", threadIDs)
+	}
+	paths, err := filepath.Glob(filepath.Join(codexHome, "sessions", "*", "*", "*", "rollout-*"+threadIDs[0]+".jsonl"))
+	if err != nil || len(paths) != 1 {
+		return "", fmt.Errorf("Codex parent rollout for %q = %v, want one (glob error: %v)", threadIDs[0], paths, err)
+	}
+	rollout, err := os.ReadFile(paths[0])
+	if err != nil {
+		return "", fmt.Errorf("read Codex parent rollout %s: %w", paths[0], err)
+	}
+	return publicStream + "\n" + string(rollout), nil
+}
+
 func assertObserverOutsideWorkflow(workflowRoot, observer string) error {
 	rel, err := filepath.Rel(workflowRoot, observer)
 	if err != nil || rel == "." || rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
@@ -236,6 +269,51 @@ func TestImplementationLifecycleAndObserverNegativeControls(t *testing.T) {
 	}
 	if err := assertObserverOutsideWorkflow(root, filepath.Join(t.TempDir(), "command.log")); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCodexNativeLifecycleUsesCorrelatedSessionHandle(t *testing.T) {
+	home := t.TempDir()
+	rolloutDir := filepath.Join(home, "sessions", "2026", "08", "11")
+	if err := os.MkdirAll(rolloutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rollout := readFile(t, filepath.Join("testdata", "codex_native_lifecycle", "parent-rollout.jsonl"))
+	writeFile(t, filepath.Join(rolloutDir, "rollout-2026-08-11-parent-thread.jsonl"), rollout)
+	public := readFile(t, filepath.Join("testdata", "codex_native_lifecycle", "public.jsonl"))
+	entity := "---\nstatus: validation\n---\n# Task\n\n## Stage Report: implementation\n\n- DONE: work\n"
+
+	if err := assertImplementationWorkerLifecycle(public, entity); err == nil {
+		t.Fatal("public Codex stdout without native spawn/completion evidence passed")
+	}
+	combined, err := codexNativeLifecycleStream(home, public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assertImplementationWorkerLifecycle(combined, entity); err != nil {
+		t.Fatalf("correlated parent rollout rejected: %v", err)
+	}
+	withoutHandle := strings.Replace(combined, `"output":"{\"task_name\":\"/root/spacedock_ensign_task_implementation\",\"nickname\":\"Mill\"}"`, `"output":"{}"`, 1)
+	if err := assertImplementationWorkerLifecycle(withoutHandle, entity); err == nil {
+		t.Fatal("child final message without the spawn call's returned handle passed")
+	}
+}
+
+func TestCodexNativeLifecycleParentRolloutLookupFailsClosed(t *testing.T) {
+	public := readFile(t, filepath.Join("testdata", "codex_native_lifecycle", "public.jsonl"))
+	if _, err := codexNativeLifecycleStream(t.TempDir(), public); err == nil {
+		t.Fatal("missing parent rollout passed")
+	}
+	home := t.TempDir()
+	for _, day := range []string{"11", "12"} {
+		path := filepath.Join(home, "sessions", "2026", "08", day, "rollout-parent-thread.jsonl")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, path, "{}\n")
+	}
+	if _, err := codexNativeLifecycleStream(home, public); err == nil {
+		t.Fatal("ambiguous parent rollouts passed")
 	}
 }
 

--- a/internal/ensigncycle/claude_runtime_helpers_test.go
+++ b/internal/ensigncycle/claude_runtime_helpers_test.go
@@ -173,7 +173,7 @@ func assertImplementationWorkerLifecycle(stream, entity string) error {
 		if completed < 0 && event.Payload.Type == "agent_message" && event.Payload.Author == codexWorker && strings.Contains(string(event.Payload.Content), "Done:") {
 			completed = i
 		}
-		if event.Payload.Type == "custom_tool_call" && strings.Contains(line, "status=validation") {
+		if validation < 0 && event.Payload.Type == "custom_tool_call" && strings.Contains(line, "status=validation") {
 			validation = i
 		}
 		if pi.Message.ToolName == "subagent" && pi.Message.ToolCallID == spawnID {
@@ -300,6 +300,10 @@ func TestCodexNativeLifecycleUsesCorrelatedSessionHandle(t *testing.T) {
 	afterValidationOnly := strings.Replace(combined, "Done:", "Result:", 1)
 	if err := assertImplementationWorkerLifecycle(afterValidationOnly, entity); err == nil {
 		t.Fatal("matching completion only after validation passed")
+	}
+	betweenValidations := strings.Replace(combined, `{"timestamp":"2026-08-11T14:01:31Z"`, `{"payload":{"type":"custom_tool_call","input":"status=validation"}}`+"\n"+`{"timestamp":"2026-08-11T14:01:31Z"`, 1)
+	if err := assertImplementationWorkerLifecycle(betweenValidations, entity); err == nil {
+		t.Fatal("matching completion between validation transitions passed")
 	}
 	withoutHandle := strings.Replace(combined, `"output":"{\"task_name\":\"/root/spacedock_ensign_task_implementation\",\"nickname\":\"Mill\"}"`, `"output":"{}"`, 1)
 	if err := assertImplementationWorkerLifecycle(withoutHandle, entity); err == nil {

--- a/internal/ensigncycle/claude_runtime_helpers_test.go
+++ b/internal/ensigncycle/claude_runtime_helpers_test.go
@@ -170,7 +170,7 @@ func assertImplementationWorkerLifecycle(stream, entity string) error {
 			_ = json.Unmarshal([]byte(event.Payload.Output), &output)
 			codexWorker = output.TaskName
 		}
-		if event.Payload.Type == "agent_message" && event.Payload.Author == codexWorker && strings.Contains(string(event.Payload.Content), "Done:") {
+		if completed < 0 && event.Payload.Type == "agent_message" && event.Payload.Author == codexWorker && strings.Contains(string(event.Payload.Content), "Done:") {
 			completed = i
 		}
 		if event.Payload.Type == "custom_tool_call" && strings.Contains(line, "status=validation") {
@@ -292,6 +292,14 @@ func TestCodexNativeLifecycleUsesCorrelatedSessionHandle(t *testing.T) {
 	}
 	if err := assertImplementationWorkerLifecycle(combined, entity); err != nil {
 		t.Fatalf("correlated parent rollout rejected: %v", err)
+	}
+	withoutCompletion := strings.ReplaceAll(combined, "Done:", "Result:")
+	if err := assertImplementationWorkerLifecycle(withoutCompletion, entity); err == nil {
+		t.Fatal("lifecycle without a matching completion passed")
+	}
+	afterValidationOnly := strings.Replace(combined, "Done:", "Result:", 1)
+	if err := assertImplementationWorkerLifecycle(afterValidationOnly, entity); err == nil {
+		t.Fatal("matching completion only after validation passed")
 	}
 	withoutHandle := strings.Replace(combined, `"output":"{\"task_name\":\"/root/spacedock_ensign_task_implementation\",\"nickname\":\"Mill\"}"`, `"output":"{}"`, 1)
 	if err := assertImplementationWorkerLifecycle(withoutHandle, entity); err == nil {

--- a/internal/ensigncycle/testdata/codex_native_lifecycle/parent-rollout.jsonl
+++ b/internal/ensigncycle/testdata/codex_native_lifecycle/parent-rollout.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-08-11T14:01:28Z","payload":{"type":"function_call","name":"spawn_agent","call_id":"call_spawn","arguments":"{\"task_name\":\"spacedock_ensign_task_implementation\",\"fork_turns\":\"none\",\"message\":\"assignment\"}"}}
+{"timestamp":"2026-08-11T14:01:28Z","payload":{"type":"function_call_output","call_id":"call_spawn","output":"{\"task_name\":\"/root/spacedock_ensign_task_implementation\",\"nickname\":\"Mill\"}"}}
+{"timestamp":"2026-08-11T14:01:31Z","payload":{"type":"agent_message","author":"/root/spacedock_ensign_task_implementation","content":[{"type":"input_text","text":"Message Type: FINAL_ANSWER\nPayload:\nDone: implementation completed."}]}}
+{"timestamp":"2026-08-11T14:01:32Z","payload":{"type":"custom_tool_call","name":"functions.exec","input":"spacedock status --set task status=validation started"}}

--- a/internal/ensigncycle/testdata/codex_native_lifecycle/parent-rollout.jsonl
+++ b/internal/ensigncycle/testdata/codex_native_lifecycle/parent-rollout.jsonl
@@ -2,3 +2,4 @@
 {"timestamp":"2026-08-11T14:01:28Z","payload":{"type":"function_call_output","call_id":"call_spawn","output":"{\"task_name\":\"/root/spacedock_ensign_task_implementation\",\"nickname\":\"Mill\"}"}}
 {"timestamp":"2026-08-11T14:01:31Z","payload":{"type":"agent_message","author":"/root/spacedock_ensign_task_implementation","content":[{"type":"input_text","text":"Message Type: FINAL_ANSWER\nPayload:\nDone: implementation completed."}]}}
 {"timestamp":"2026-08-11T14:01:32Z","payload":{"type":"custom_tool_call","name":"functions.exec","input":"spacedock status --set task status=validation started"}}
+{"timestamp":"2026-08-11T14:01:33Z","payload":{"type":"agent_message","author":"/root/spacedock_ensign_task_implementation","content":[{"type":"input_text","text":"Message Type: FINAL_ANSWER\nPayload:\nDone: validation completed."}]}}

--- a/internal/ensigncycle/testdata/codex_native_lifecycle/public.jsonl
+++ b/internal/ensigncycle/testdata/codex_native_lifecycle/public.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"parent-thread"}
+{"type":"item.started","item":{"type":"collab_tool_call","tool":"wait","receiver_thread_ids":[],"agents_states":{}}}
+{"type":"turn.completed"}


### PR DESCRIPTION
Codex headless validation now grades the actual native worker lifecycle instead of relying on incomplete public JSONL.

## What changed

- Resolve the unique parent session rollout from isolated Codex state.
- Correlate native spawn calls with returned worker handles.
- Freeze the first implementation completion and validation transition.
- Reject missing, ambiguous, handle-less, and reordered lifecycle evidence.

## Evidence

- Focused, full, and race suites: 3/3 passed.
- Exact local Codex transition: bound XPASS and unbound PASS, 2/2 passed.
- Required PR checks passed, including the exact Codex failed-job retry.

---

[272](/spacedock-dev/spacedock/blob/9117aa2e7af63694d7181fb5cad5ac98a79ce5ac/select-actionable-codex-default-headless-task.md)