### PR TITLE
Add win64 and win32 native build support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,9 +26,11 @@ builds:
     goos: &channel-goos
       - darwin
       - linux
+      - windows
     goarch: &channel-goarch
       - arm64
       - amd64
+      - 386
     # The version stamp the formula's `test do` asserts. Target is the
     # internal/cli.Version var (NOT main.Version — package main has no Version
     # symbol, so -X main.Version is a silent no-op). Version must be a var, not a

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# Makefile for spacedock build and test targets
+
+.PHONY: all build build-windows-amd64 test test-windows-amd64 clean
+
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+LDFLAGS := -s -w -X github.com/spacedock-dev/spacedock/internal/cli.Version=$(VERSION)
+
+all: build
+
+build:
+	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o dist/spacedock ./cmd/spacedock
+
+build-windows-amd64:
+	@mkdir -p dist
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o dist/spacedock_windows_amd64.exe ./cmd/spacedock
+
+test:
+	go test ./...
+
+test-windows-amd64:
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./...
+
+clean:
+	rm -rf dist/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for spacedock build and test targets
 
-.PHONY: all build build-windows-amd64 test test-windows-amd64 clean
+.PHONY: all build build-windows build-windows-amd64 build-windows-386 test test-windows test-windows-amd64 clean
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -s -w -X github.com/spacedock-dev/spacedock/internal/cli.Version=$(VERSION)
@@ -14,11 +14,20 @@ build-windows-amd64:
 	@mkdir -p dist
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o dist/spacedock_windows_amd64.exe ./cmd/spacedock
 
+build-windows-386:
+	@mkdir -p dist
+	GOOS=windows GOARCH=386 CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o dist/spacedock_windows_386.exe ./cmd/spacedock
+
+build-windows: build-windows-amd64 build-windows-386
+
 test:
 	go test ./...
 
 test-windows-amd64:
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./...
+
+test-windows: test-windows-amd64
+	GOOS=windows GOARCH=386 CGO_ENABLED=0 go build ./...
 
 clean:
 	rm -rf dist/


### PR DESCRIPTION
This pull request supports windows native build.

These 2 commits help to build win64 and win32 spacedock.exe, I've tested correctness with executing --help.

    :: Build 64-bit Windows binary
    make build-windows-amd64
    dist\spacedock_windows_amd64.exe 

    :: Build 32-bit Windows binary
    make build-windows-386
    dist\spacedock_windows_386.exe 

    :: Or run compile checks
    make test-windows
 