### PR TITLE
Use Codex subscription auth in live CI

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -11,7 +11,7 @@
 # and runs unconditionally on every PR. Only live jobs declare an `environment:`
 # (a required-reviewer approval gate, reviewer = clkao) and read only the
 # host-specific secret they need: ANTHROPIC_API_KEY for Claude and
-# CODEX_AUTH_JSON/OPENAI_API_KEY for Codex and PI_OPENAI_CODEX_AUTH_JSON/OPENAI_API_KEY for Pi. Pull requests queue Sonnet 5 and Codex Luna.
+# CODEX_AUTH_JSON/OPENAI_API_KEY for Codex and Pi. Pull requests queue Sonnet 5 and Codex Luna.
 # Manual Opus and Pi cadences run only their selected runtime.
 
 name: Runtime Live E2E
@@ -316,7 +316,6 @@ jobs:
       name: CI-E2E-CODEX
     env:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
-      CODEX_HOME: ${{ runner.temp }}/spacedock-codex-auth
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SPACEDOCK_CODEX_LIVE_REQUIRED: "1"
       SPACEDOCK_LIVE_ARTIFACT_DIR: ${{ github.workspace }}/live-artifacts/codex
@@ -389,6 +388,10 @@ jobs:
 
       - name: Authenticate Codex
         run: |
+          set -euo pipefail
+          codex_home="$RUNNER_TEMP/spacedock-codex-auth"
+          export CODEX_HOME="$codex_home"
+          printf 'CODEX_HOME=%s\n' "$codex_home" >> "$GITHUB_ENV"
           if [ -n "$CODEX_AUTH_JSON" ]; then
             mkdir -p "$CODEX_HOME"
             printf '%s' "$CODEX_AUTH_JSON" > "$CODEX_HOME/auth.json"
@@ -577,18 +580,17 @@ jobs:
     environment:
       name: CI-E2E-PI
     env:
-      PI_OPENAI_CODEX_AUTH_JSON: ${{ secrets.PI_OPENAI_CODEX_AUTH_JSON }}
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SPACEDOCK_PI_LIVE_REQUIRED: "1"
-      SPACEDOCK_PI_LIVE_CHILD_MODEL: openai/gpt-5.6-luna:max
       SPACEDOCK_LIVE_ARTIFACT_DIR: ${{ github.workspace }}/live-artifacts/pi
       SPACEDOCK_JOURNEY_METRICS_DIR: ${{ github.workspace }}/live-artifacts/journey-metrics/pi
       PI_OFFLINE: "1"
     steps:
       - name: Check required secret
         run: |
-          if [ -z "${PI_OPENAI_CODEX_AUTH_JSON}" ] && [ -z "${OPENAI_API_KEY}" ]; then
-            echo "PI_OPENAI_CODEX_AUTH_JSON or OPENAI_API_KEY is required for pi-live after CI-E2E-PI approval." >&2
+          if [ -z "${CODEX_AUTH_JSON}" ] && [ -z "${OPENAI_API_KEY}" ]; then
+            echo "CODEX_AUTH_JSON or OPENAI_API_KEY is required for pi-live after CI-E2E-PI approval." >&2
             exit 1
           fi
 
@@ -761,7 +763,11 @@ jobs:
           go version
           echo "### Pi live tool versions" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`pi --version\`: \`$(pi --version)\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Model: \`openai/gpt-5.6-luna\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$CODEX_AUTH_JSON" ]; then
+            echo "- Model: \`openai-codex/gpt-5.6-luna\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Model: \`openai/gpt-5.6-luna\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "- Thinking: \`max\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`go version\`: \`$(go version)\`" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -11,7 +11,7 @@
 # and runs unconditionally on every PR. Only live jobs declare an `environment:`
 # (a required-reviewer approval gate, reviewer = clkao) and read only the
 # host-specific secret they need: ANTHROPIC_API_KEY for Claude and
-# OPENAI_API_KEY for Codex or Pi. Pull requests queue Sonnet 5 and Codex Luna.
+# CODEX_AUTH_JSON/OPENAI_API_KEY for Codex and PI_OPENAI_CODEX_AUTH_JSON/OPENAI_API_KEY for Pi. Pull requests queue Sonnet 5 and Codex Luna.
 # Manual Opus and Pi cadences run only their selected runtime.
 
 name: Runtime Live E2E
@@ -315,6 +315,8 @@ jobs:
     environment:
       name: CI-E2E-CODEX
     env:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      CODEX_HOME: ${{ runner.temp }}/spacedock-codex-auth
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SPACEDOCK_CODEX_LIVE_REQUIRED: "1"
       SPACEDOCK_LIVE_ARTIFACT_DIR: ${{ github.workspace }}/live-artifacts/codex
@@ -322,8 +324,8 @@ jobs:
     steps:
       - name: Check required secret
         run: |
-          if [ -z "${OPENAI_API_KEY}" ]; then
-            echo "OPENAI_API_KEY is required for codex-live after CI-E2E-CODEX approval." >&2
+          if [ -z "${CODEX_AUTH_JSON}" ] && [ -z "${OPENAI_API_KEY}" ]; then
+            echo "CODEX_AUTH_JSON or OPENAI_API_KEY is required for codex-live after CI-E2E-CODEX approval." >&2
             exit 1
           fi
 
@@ -385,9 +387,15 @@ jobs:
           printf 'SPACEDOCK_CODEX_REAL_BIN=%s\n' "$real_codex" >> "$GITHUB_ENV"
           printf '%s\n' "$shim_dir" >> "$GITHUB_PATH"
 
-      - name: Login to Codex
+      - name: Authenticate Codex
         run: |
-          printf '%s\n' "$OPENAI_API_KEY" | codex login --with-api-key
+          if [ -n "$CODEX_AUTH_JSON" ]; then
+            mkdir -p "$CODEX_HOME"
+            printf '%s' "$CODEX_AUTH_JSON" > "$CODEX_HOME/auth.json"
+            chmod 600 "$CODEX_HOME/auth.json"
+          else
+            printf '%s\n' "$OPENAI_API_KEY" | codex login --with-api-key
+          fi
           codex login status
 
       - name: Build spacedock binary
@@ -569,6 +577,7 @@ jobs:
     environment:
       name: CI-E2E-PI
     env:
+      PI_OPENAI_CODEX_AUTH_JSON: ${{ secrets.PI_OPENAI_CODEX_AUTH_JSON }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SPACEDOCK_PI_LIVE_REQUIRED: "1"
       SPACEDOCK_PI_LIVE_CHILD_MODEL: openai/gpt-5.6-luna:max
@@ -578,8 +587,8 @@ jobs:
     steps:
       - name: Check required secret
         run: |
-          if [ -z "${OPENAI_API_KEY}" ]; then
-            echo "OPENAI_API_KEY is required for pi-live after CI-E2E-PI approval." >&2
+          if [ -z "${PI_OPENAI_CODEX_AUTH_JSON}" ] && [ -z "${OPENAI_API_KEY}" ]; then
+            echo "PI_OPENAI_CODEX_AUTH_JSON or OPENAI_API_KEY is required for pi-live after CI-E2E-PI approval." >&2
             exit 1
           fi
 

--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -118,6 +118,29 @@ Without auth, the respective live suite skips locally (Claude/Codex/Pi), except 
 
 ### GitHub setup
 
+#### Subscription OAuth secrets
+
+The `CI-E2E-CODEX` Environment accepts `CODEX_AUTH_JSON`, the complete
+`~/.codex/auth.json` payload. The `CI-E2E-PI` Environment accepts
+`PI_OPENAI_CODEX_AUTH_JSON`, only the `openai-codex` object from Pi's
+`~/.pi/agent/auth.json`. Keep `OPENAI_API_KEY` in each Environment during the
+migration; the lane uses it only when its OAuth secret is absent.
+
+Create or rotate the secrets from a trusted workstation without printing them:
+
+    gh secret set CODEX_AUTH_JSON --env CI-E2E-CODEX < "$HOME/.codex/auth.json"
+    jq -c '."openai-codex"' "$HOME/.pi/agent/auth.json" \
+      | gh secret set PI_OPENAI_CODEX_AUTH_JSON --env CI-E2E-PI
+
+The Codex value remains the full file object; the Pi value remains one OAuth
+record and the runner supplies the outer provider key. Refreshes stay in the
+isolated run home and are never written back to GitHub. Replace a revoked or
+expired secret from a trusted workstation. If OAuth is absent, `OPENAI_API_KEY`
+is used; a lane fails before launch only when both credentials are absent.
+
+For OAuth Pi uses `openai-codex/gpt-5.6-luna:max`; the API-key fallback uses
+`openai/gpt-5.6-luna:max`. The model ID and `max` thinking level are unchanged.
+
 | Selected command | Unique evidence | Measured sample or cost |
 |---|---|---|
 | Claude `TestLiveCommon...` | The 17 registered common journeys | Journey metrics record duration, tokens, model, and available cost. |

--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -120,23 +120,26 @@ Without auth, the respective live suite skips locally (Claude/Codex/Pi), except 
 
 #### Subscription OAuth secrets
 
-The `CI-E2E-CODEX` Environment accepts `CODEX_AUTH_JSON`, the complete
-`~/.codex/auth.json` payload. The `CI-E2E-PI` Environment accepts
-`PI_OPENAI_CODEX_AUTH_JSON`, only the `openai-codex` object from Pi's
-`~/.pi/agent/auth.json`. Keep `OPENAI_API_KEY` in each Environment during the
-migration; the lane uses it only when its OAuth secret is absent.
+Both the `CI-E2E-CODEX` and `CI-E2E-PI` Environments accept `CODEX_AUTH_JSON`,
+the complete `~/.codex/auth.json` payload. Keep `OPENAI_API_KEY` in each
+Environment during the migration; the lane uses it only when its OAuth secret
+is absent.
 
-Create or rotate the secrets from a trusted workstation without printing them:
+Create or rotate the shared secret from a trusted workstation without printing
+it:
 
     gh secret set CODEX_AUTH_JSON --env CI-E2E-CODEX < "$HOME/.codex/auth.json"
-    jq -c '."openai-codex"' "$HOME/.pi/agent/auth.json" \
-      | gh secret set PI_OPENAI_CODEX_AUTH_JSON --env CI-E2E-PI
+    gh secret set CODEX_AUTH_JSON --env CI-E2E-PI < "$HOME/.codex/auth.json"
 
-The Codex value remains the full file object; the Pi value remains one OAuth
-record and the runner supplies the outer provider key. Refreshes stay in the
-isolated run home and are never written back to GitHub. Replace a revoked or
-expired secret from a trusted workstation. If OAuth is absent, `OPENAI_API_KEY`
-is used; a lane fails before launch only when both credentials are absent.
+For Codex the runner writes this object directly to the isolated
+`CODEX_HOME/auth.json`. For Pi it safely transforms `tokens.access_token`,
+`tokens.refresh_token`, `tokens.account_id`, and the access-token JWT `exp`
+into Pi's `openai-codex` record (`access`, `refresh`, `accountId`, and
+`expires`); the complete source payload is never passed to the Pi child.
+Refreshes stay in the isolated run home and are never written back to GitHub.
+Replace a revoked or expired secret from a trusted workstation. If OAuth is
+absent, `OPENAI_API_KEY` is used; a lane fails before launch only when both
+credentials are absent.
 
 For OAuth Pi uses `openai-codex/gpt-5.6-luna:max`; the API-key fallback uses
 `openai/gpt-5.6-luna:max`. The model ID and `max` thinking level are unchanged.
@@ -157,7 +160,7 @@ Workflow: `.github/workflows/runtime-live-e2e.yml`. The offline gate job (`go te
 
 - Pull requests run `claude-sonnet-5` at maximum effort and `gpt-5.6-luna` at maximum effort.
 - An explicit `live_cadence=opus-pre-release` dispatch runs offline plus `claude-opus-4-8` at maximum effort. It allocates no Codex or Pi runner and requests only `CI-E2E-OPUS` approval.
-- An explicit `live_cadence=pi` dispatch runs the 17 common Pi journeys and the Pi front-door proof with `openai/gpt-5.6-luna` at maximum thinking. It waits only for `CI-E2E-PI` approval and retains Pi logs, diagnostics, journey metrics, and session artifacts. Pull requests still run only Sonnet and Codex; Pi is optional and is not a merge requirement. Local Pi execution remains supported with `pi login` or an API key.
+- An explicit `live_cadence=pi` dispatch runs the 17 common Pi journeys and the Pi front-door proof with `openai-codex/gpt-5.6-luna` for OAuth or `openai/gpt-5.6-luna` for the API-key fallback, at maximum thinking. It waits only for `CI-E2E-PI` approval and retains Pi logs, diagnostics, journey metrics, and session artifacts. Pull requests still run only Sonnet and Codex; Pi is optional and is not a merge requirement. Local Pi execution remains supported with `pi login` or an API key.
 
 All live lanes must test the current checkout, not a remote `--ref next` install. The Codex lane generates a local marketplace under `$RUNNER_TEMP`:
 

--- a/internal/ensigncycle/codex_live_runner_test.go
+++ b/internal/ensigncycle/codex_live_runner_test.go
@@ -80,8 +80,9 @@ func (r codexLiveRunner) withStubPATH(t *testing.T, dir string) codexLiveRunner 
 func newCodexLiveRunner(t *testing.T) codexLiveRunner {
 	t.Helper()
 	openAIAPIKey := os.Getenv("OPENAI_API_KEY")
+	oauthJSON := os.Getenv("CODEX_AUTH_JSON")
 	realHome := os.Getenv("HOME")
-	decision := decideCodexLiveAuth(openAIAPIKey, codexLocalAuthAvailable(realHome), os.Getenv("SPACEDOCK_CODEX_LIVE_REQUIRED"))
+	decision := decideCodexLiveAuthForCI(oauthJSON, openAIAPIKey, codexLocalAuthAvailable(realHome), os.Getenv("SPACEDOCK_CODEX_LIVE_REQUIRED"))
 	switch decision.mode {
 	case codexAuthSkip:
 		t.Skip(decision.message)
@@ -101,12 +102,17 @@ func newCodexLiveRunner(t *testing.T) codexLiveRunner {
 	if err := seedCodexLiveConfig(codexHome); err != nil {
 		t.Fatalf("seed live Codex config: %v", err)
 	}
-	if decision.mode == codexAuthLocal {
+	switch decision.mode {
+	case codexAuthOAuth:
+		if err := seedCodexOAuthAuth(codexHome, oauthJSON); err != nil {
+			t.Fatalf("seed Codex OAuth auth: %v", err)
+		}
+	case codexAuthLocal:
 		if err := seedCodexLocalAuth(codexHome, realHome); err != nil {
 			t.Fatalf("seed local Codex auth: %v", err)
 		}
 	}
-	env := codexLiveEnv(codexHome, cleanHome, filepath.Dir(binary), openAIAPIKey)
+	env := codexLiveEnv(codexHome, cleanHome, filepath.Dir(binary), openAIAPIKey, decision.mode)
 
 	setupDir := filepath.Join(artifactRoot, "_setup")
 	if err := os.MkdirAll(setupDir, 0o755); err != nil {
@@ -115,7 +121,7 @@ func newCodexLiveRunner(t *testing.T) codexLiveRunner {
 	switch decision.mode {
 	case codexAuthAPIKey:
 		runCodexLiveCommand(t, setupDir, "codex-login.txt", openAIAPIKey+"\n", env, codexBin, "login", "--with-api-key")
-	case codexAuthLocal:
+	case codexAuthOAuth, codexAuthLocal:
 		runCodexLiveCommand(t, setupDir, "codex-login-status.txt", "", env, codexBin, "login", "status")
 	}
 

--- a/internal/ensigncycle/codex_liveenv.go
+++ b/internal/ensigncycle/codex_liveenv.go
@@ -1,6 +1,7 @@
 package ensigncycle
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ type codexAuthMode int
 const (
 	codexAuthSkip codexAuthMode = iota
 	codexAuthAPIKey
+	codexAuthOAuth
 	codexAuthLocal
 	codexAuthFatal
 )
@@ -27,14 +29,21 @@ tool_namespace = "agents"
 hide_spawn_agent_metadata = false
 `
 
-func decideCodexLiveAuth(openAIAPIKey string, localAuthAvailable bool, required string) codexLiveAuthDecision {
-	if openAIAPIKey != "" {
+func decideCodexLiveAuth(openAIKey string, localAuthAvailable bool, required string) codexLiveAuthDecision {
+	return decideCodexLiveAuthForCI("", openAIKey, localAuthAvailable, required)
+}
+
+func decideCodexLiveAuthForCI(oauthJSON, openAIKey string, localAuthAvailable bool, required string) codexLiveAuthDecision {
+	if strings.TrimSpace(oauthJSON) != "" {
+		return codexLiveAuthDecision{mode: codexAuthOAuth}
+	}
+	if openAIKey != "" {
 		return codexLiveAuthDecision{mode: codexAuthAPIKey}
 	}
 	if required != "" {
 		return codexLiveAuthDecision{
 			mode:    codexAuthFatal,
-			message: "OPENAI_API_KEY is required when SPACEDOCK_CODEX_LIVE_REQUIRED is set; unset SPACEDOCK_CODEX_LIVE_REQUIRED for a local run that uses isolated Codex OAuth",
+			message: "Codex OAuth or OPENAI_API_KEY is required when SPACEDOCK_CODEX_LIVE_REQUIRED is set",
 		}
 	}
 	if localAuthAvailable {
@@ -42,7 +51,7 @@ func decideCodexLiveAuth(openAIAPIKey string, localAuthAvailable bool, required 
 	}
 	return codexLiveAuthDecision{
 		mode:    codexAuthSkip,
-		message: "no live Codex auth available: set OPENAI_API_KEY or log in with codex to run the live Codex shared suite",
+		message: "no live Codex auth available: set CODEX_AUTH_JSON, OPENAI_API_KEY, or log in with codex to run the live Codex shared suite",
 	}
 }
 
@@ -64,6 +73,23 @@ func seedCodexLiveConfig(codexHome string) error {
 	}
 	if err := os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(codexLiveMultiAgentConfig), 0o600); err != nil {
 		return fmt.Errorf("write isolated Codex config: %w", err)
+	}
+	return nil
+}
+
+func seedCodexOAuthAuth(codexHome, authJSON string) error {
+	if strings.TrimSpace(authJSON) == "" {
+		return fmt.Errorf("Codex OAuth auth is empty")
+	}
+	var object map[string]any
+	if err := json.Unmarshal([]byte(authJSON), &object); err != nil || object == nil {
+		return fmt.Errorf("Codex OAuth auth is not a JSON object")
+	}
+	if err := os.MkdirAll(codexHome, 0o700); err != nil {
+		return fmt.Errorf("create isolated CODEX_HOME: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexHome, "auth.json"), []byte(authJSON), 0o600); err != nil {
+		return fmt.Errorf("write isolated Codex OAuth auth: %w", err)
 	}
 	return nil
 }

--- a/internal/ensigncycle/codex_liveenv_test.go
+++ b/internal/ensigncycle/codex_liveenv_test.go
@@ -61,6 +61,51 @@ func TestDecideCodexLiveAuth(t *testing.T) {
 	})
 }
 
+func TestDecideCodexLiveAuthForCI(t *testing.T) {
+	for _, tc := range []struct {
+		name, oauth, key string
+		want             codexAuthMode
+	}{
+		{"oauth_preferred", `{"auth_mode":"chatgpt"}`, "sk-key", codexAuthOAuth},
+		{"api_key_fallback", "", "sk-key", codexAuthAPIKey},
+		{"missing_required", "", "", codexAuthFatal},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideCodexLiveAuthForCI(tc.oauth, tc.key, false, map[bool]string{true: "1", false: ""}[tc.want == codexAuthFatal])
+			if got.mode != tc.want {
+				t.Fatalf("mode = %d, want %d (%s)", got.mode, tc.want, got.message)
+			}
+		})
+	}
+}
+
+func TestSeedCodexOAuthAuth(t *testing.T) {
+	home := t.TempDir()
+	payload := `{"auth_mode":"chatgpt","tokens":{"refresh_token":"sentinel"}}`
+	if err := seedCodexOAuthAuth(home, payload); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(home, "auth.json"))
+	if err != nil || string(got) != payload {
+		t.Fatalf("auth.json = %q, err=%v", got, err)
+	}
+	if mode := fileMode(t, filepath.Join(home, "auth.json")); mode != 0o600 {
+		t.Fatalf("auth mode = %o, want 600", mode)
+	}
+	if err := seedCodexOAuthAuth(home, "not-json"); err == nil {
+		t.Fatal("malformed OAuth payload must fail")
+	}
+}
+
+func fileMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info.Mode().Perm()
+}
+
 func TestCodexLocalAuthAvailable(t *testing.T) {
 	realHome := t.TempDir()
 	if codexLocalAuthAvailable(realHome) {
@@ -345,7 +390,7 @@ func codexLiveWorkflowExecShim(t *testing.T) string {
 }
 
 func TestCodexLiveEnvOmitsEmptyAPIKey(t *testing.T) {
-	env := codexLiveEnv("/tmp/codex-home", "/tmp/home", "", "")
+	env := codexLiveEnv("/tmp/codex-home", "/tmp/home", "", "", codexAuthOAuth)
 	if _, ok := envValue(env, "OPENAI_API_KEY"); ok {
 		t.Fatal("OPENAI_API_KEY must be omitted for local subscription auth")
 	}
@@ -357,7 +402,7 @@ func TestCodexLiveEnvDropsForeignRuntimeMarkers(t *testing.T) {
 		t.Setenv(key, value)
 	}
 
-	env := codexLiveEnv("/target/codex", "/target/home", "/spacedock/bin", "target-key")
+	env := codexLiveEnv("/target/codex", "/target/home", "/spacedock/bin", "target-key", codexAuthAPIKey)
 
 	want := map[string]string{"CLAUDECODE": "", "PI_CODING_AGENT": "", "PI_CODING_AGENT_DIR": "",
 		"CODEX_THREAD_ID": "codex", "CODEX_HOME": "/target/codex", "HOME": "/target/home",
@@ -421,8 +466,8 @@ func TestCodexLiveHomeParentCandidatesRejectArtifactRootInsidePluginCheckout(t *
 	}
 }
 
-func codexLiveEnv(codexHome, home, pathPrefix, openAIAPIKey string) []string {
-	env := cleanEnviron("CODEX_HOME", "HOME", "OPENAI_API_KEY", "PATH",
+func codexLiveEnv(codexHome, home, pathPrefix, openAIAPIKey string, mode codexAuthMode) []string {
+	env := cleanEnviron("CODEX_HOME", "HOME", "OPENAI_API_KEY", "CODEX_AUTH_JSON", "PATH",
 		"CLAUDECODE", "PI_CODING_AGENT", "PI_CODING_AGENT_DIR")
 	path := os.Getenv("PATH")
 	if pathPrefix != "" {
@@ -433,7 +478,7 @@ func codexLiveEnv(codexHome, home, pathPrefix, openAIAPIKey string) []string {
 		"HOME="+home,
 		"PATH="+path,
 	)
-	if openAIAPIKey != "" {
+	if mode == codexAuthAPIKey && openAIAPIKey != "" {
 		env = append(env, "OPENAI_API_KEY="+openAIAPIKey)
 	}
 	return env

--- a/internal/ensigncycle/pi_live_controls_test.go
+++ b/internal/ensigncycle/pi_live_controls_test.go
@@ -53,7 +53,7 @@ func piLiveEnv(piHome, sessionDir, cleanHome, binaryDir, piSubagentsRoot string)
 	env := cleanEnviron(
 		"CODEX_THREAD_ID", "CLAUDECODE", "HOME", "PI_CODING_AGENT_DIR",
 		"PI_CODING_AGENT_SESSION_DIR", "PI_INTERCOM_PACKAGE_ROOT",
-		"PI_SUBAGENTS_PACKAGE_ROOT", "PI_OFFLINE", "OPENAI_API_KEY", "PI_OPENAI_CODEX_AUTH_JSON",
+		"PI_SUBAGENTS_PACKAGE_ROOT", "PI_OFFLINE", "OPENAI_API_KEY", "CODEX_AUTH_JSON", "PI_OPENAI_CODEX_AUTH_JSON",
 	)
 	env = dropEnvPrefix(env, "PI_SUBAGENT_")
 	env = append(env,
@@ -78,8 +78,8 @@ func piLiveEnvForAuth(piHome, sessionDir, cleanHome, binaryDir, piSubagentsRoot,
 }
 
 func TestPiLiveAuthSelectionAndSeeding(t *testing.T) {
-	oauth := `{"type":"oauth","access":"sentinel","refresh":"refresh"}`
-	if got := decidePiLiveAuth(oauth, "key", ""); got.mode != piAuthOAuth || got.model != "openai-codex/gpt-5.6-luna:max" {
+	oauth := codexFixtureAuthJSON()
+	if got := decidePiLiveAuth(oauth, "key", ""); got.mode != piAuthOAuth || got.model != piOAuthModel {
 		t.Fatalf("OAuth decision = %#v", got)
 	}
 	home := t.TempDir()
@@ -89,19 +89,34 @@ func TestPiLiveAuthSelectionAndSeeding(t *testing.T) {
 	if mode := fileMode(t, filepath.Join(home, "auth.json")); mode != 0o600 {
 		t.Fatalf("mode = %o", mode)
 	}
-	if got := readFile(t, filepath.Join(home, "auth.json")); !strings.Contains(got, `"openai-codex"`) || !strings.Contains(got, "sentinel") {
-		t.Fatalf("seeded auth = %s", got)
+	seeded := readFile(t, filepath.Join(home, "auth.json"))
+	for _, want := range []string{`"openai-codex"`, `"access":"header.eyJleHAiOjE3ODcwMjQ2ODF9.signature"`, `"refresh":"sentinel-refresh"`, `"expires":1787024681000`, `"accountId":"account-id"`} {
+		if !strings.Contains(seeded, want) {
+			t.Fatalf("seeded auth missing %q: %s", want, seeded)
+		}
 	}
-	if got := decidePiLiveAuth("", "key", ""); got.mode != piAuthAPIKey || got.model != "openai/gpt-5.6-luna:max" {
+	if got := decidePiLiveAuth("", "key", ""); got.mode != piAuthAPIKey || got.model != piAPIKeyModel {
 		t.Fatalf("key decision = %#v", got)
 	}
+}
+
+func TestPiLiveAuthRejectsIncompleteCodexCredentials(t *testing.T) {
+	for _, input := range []string{"not-json", `{"tokens":{"refresh_token":"refresh"}}`, `{"tokens":{"access_token":"not-a-jwt","refresh_token":"refresh","account_id":"account"}}`} {
+		if err := seedPiOAuthAuth(t.TempDir(), input); err == nil {
+			t.Fatalf("seed accepted malformed Codex auth %q", input)
+		}
+	}
+}
+
+func codexFixtureAuthJSON() string {
+	return `{"auth_mode":"chatgpt","tokens":{"access_token":"header.eyJleHAiOjE3ODcwMjQ2ODF9.signature","refresh_token":"sentinel-refresh","account_id":"account-id"}}`
 }
 
 func TestPiLiveEnvDropsForeignRuntimeMarkers(t *testing.T) {
 	for key, value := range map[string]string{"CODEX_THREAD_ID": "codex", "CLAUDECODE": "claude", "PI_CODING_AGENT": "pi", "PI_CODING_AGENT_DIR": "/parent/pi",
 		"PI_CODING_AGENT_SESSION_DIR": "/parent/sessions", "PI_INTERCOM_PACKAGE_ROOT": "/parent/intercom",
 		"PI_SUBAGENTS_PACKAGE_ROOT": "/parent/package",
-		"PI_OFFLINE":                "0", "HOME": "/parent/home", "OPENAI_API_KEY": "key", "PATH": "/parent/bin"} {
+		"PI_OFFLINE":                "0", "HOME": "/parent/home", "OPENAI_API_KEY": "key", "CODEX_AUTH_JSON": "oauth", "PATH": "/parent/bin"} {
 		t.Setenv(key, value)
 	}
 	env := piLiveEnv("/target/pi", "/target/sessions", "/target/home", "/spacedock/bin", "/target/package")
@@ -109,7 +124,7 @@ func TestPiLiveEnvDropsForeignRuntimeMarkers(t *testing.T) {
 		"PI_CODING_AGENT": "pi", "PI_CODING_AGENT_DIR": "/target/pi",
 		"PI_CODING_AGENT_SESSION_DIR": "/target/sessions", "PI_SUBAGENTS_PACKAGE_ROOT": "/target/package",
 		"PI_INTERCOM_PACKAGE_ROOT": "/parent/intercom",
-		"PI_OFFLINE":               "1", "HOME": "/target/home", "OPENAI_API_KEY": "",
+		"PI_OFFLINE":               "1", "HOME": "/target/home", "OPENAI_API_KEY": "", "CODEX_AUTH_JSON": "",
 		"PATH": "/spacedock/bin" + string(os.PathListSeparator) + "/parent/bin"}
 	for key, value := range want {
 		assertEnvValue(t, env, key, value)

--- a/internal/ensigncycle/pi_live_controls_test.go
+++ b/internal/ensigncycle/pi_live_controls_test.go
@@ -53,7 +53,7 @@ func piLiveEnv(piHome, sessionDir, cleanHome, binaryDir, piSubagentsRoot string)
 	env := cleanEnviron(
 		"CODEX_THREAD_ID", "CLAUDECODE", "HOME", "PI_CODING_AGENT_DIR",
 		"PI_CODING_AGENT_SESSION_DIR", "PI_INTERCOM_PACKAGE_ROOT",
-		"PI_SUBAGENTS_PACKAGE_ROOT", "PI_OFFLINE",
+		"PI_SUBAGENTS_PACKAGE_ROOT", "PI_OFFLINE", "OPENAI_API_KEY", "PI_OPENAI_CODEX_AUTH_JSON",
 	)
 	env = dropEnvPrefix(env, "PI_SUBAGENT_")
 	env = append(env,
@@ -65,6 +65,36 @@ func piLiveEnv(piHome, sessionDir, cleanHome, binaryDir, piSubagentsRoot string)
 		"PI_OFFLINE=1",
 	)
 	return withBinaryOnPath(env, filepath.Join(binaryDir, "spacedock"))
+}
+
+func piLiveEnvForAuth(piHome, sessionDir, cleanHome, binaryDir, piSubagentsRoot, openAIKey, mode string) []string {
+	env := piLiveEnv(piHome, sessionDir, cleanHome, binaryDir, piSubagentsRoot)
+	if mode == piAuthOAuth {
+		env = withoutPiEnvKey(env, "OPENAI_API_KEY")
+	} else if openAIKey != "" {
+		env = append(env, "OPENAI_API_KEY="+openAIKey)
+	}
+	return env
+}
+
+func TestPiLiveAuthSelectionAndSeeding(t *testing.T) {
+	oauth := `{"type":"oauth","access":"sentinel","refresh":"refresh"}`
+	if got := decidePiLiveAuth(oauth, "key", ""); got.mode != piAuthOAuth || got.model != "openai-codex/gpt-5.6-luna:max" {
+		t.Fatalf("OAuth decision = %#v", got)
+	}
+	home := t.TempDir()
+	if err := seedPiOAuthAuth(home, oauth); err != nil {
+		t.Fatal(err)
+	}
+	if mode := fileMode(t, filepath.Join(home, "auth.json")); mode != 0o600 {
+		t.Fatalf("mode = %o", mode)
+	}
+	if got := readFile(t, filepath.Join(home, "auth.json")); !strings.Contains(got, `"openai-codex"`) || !strings.Contains(got, "sentinel") {
+		t.Fatalf("seeded auth = %s", got)
+	}
+	if got := decidePiLiveAuth("", "key", ""); got.mode != piAuthAPIKey || got.model != "openai/gpt-5.6-luna:max" {
+		t.Fatalf("key decision = %#v", got)
+	}
 }
 
 func TestPiLiveEnvDropsForeignRuntimeMarkers(t *testing.T) {
@@ -79,7 +109,7 @@ func TestPiLiveEnvDropsForeignRuntimeMarkers(t *testing.T) {
 		"PI_CODING_AGENT": "pi", "PI_CODING_AGENT_DIR": "/target/pi",
 		"PI_CODING_AGENT_SESSION_DIR": "/target/sessions", "PI_SUBAGENTS_PACKAGE_ROOT": "/target/package",
 		"PI_INTERCOM_PACKAGE_ROOT": "/parent/intercom",
-		"PI_OFFLINE":               "1", "HOME": "/target/home", "OPENAI_API_KEY": "key",
+		"PI_OFFLINE":               "1", "HOME": "/target/home", "OPENAI_API_KEY": "",
 		"PATH": "/spacedock/bin" + string(os.PathListSeparator) + "/parent/bin"}
 	for key, value := range want {
 		assertEnvValue(t, env, key, value)

--- a/internal/ensigncycle/pi_live_runner_test.go
+++ b/internal/ensigncycle/pi_live_runner_test.go
@@ -15,14 +15,12 @@ import (
 	"time"
 )
 
-const defaultPiLiveModel = "openai/gpt-5.6-luna:max"
-
 //spacedock:live-proof id=pi-front-door-subagent-dispatch lane=pi-live
 func TestLivePiFrontDoorSmoke(t *testing.T) {
 	repo := repoRoot(t)
 	piSubagentsRoot := piSubagentsPackageRoot(t)
 	binary := piSpacedockBinary(t, repo)
-	workflowRoot, stateRoot, entityPath, artifactDir, env := newPiLiveSmokeFixture(t, "pi-frontdoor-smoke", repo, piSubagentsRoot, binary)
+	workflowRoot, stateRoot, entityPath, artifactDir, env, model := newPiLiveSmokeFixture(t, "pi-frontdoor-smoke", repo, piSubagentsRoot, binary)
 
 	envelope := runPiSmokeDispatchBuild(t, binary, workflowRoot, entityPath)
 	prompt := piLiveSmokePrompt(repo, workflowRoot, stateRoot, entityPath, envelope)
@@ -32,19 +30,19 @@ func TestLivePiFrontDoorSmoke(t *testing.T) {
 		"--plugin-dir", repo,
 		"--",
 		"--print",
-		"--model", piLiveModelName(),
+		"--model", model,
 		"--session-dir", filepath.Join(artifactDir, "sessions"),
 	)
 	assertPiLiveSmokeResult(t, stateRoot, entityPath, artifactDir)
 	assertPiEnsignBootContract(t, workflowRoot, envelope, artifactDir)
 }
 
-func newPiLiveSmokeFixture(t *testing.T, name, repo, piSubagentsRoot, binary string) (workflowRoot, stateRoot, entityPath, artifactDir string, env []string) {
+func newPiLiveSmokeFixture(t *testing.T, name, repo, piSubagentsRoot, binary string) (workflowRoot, stateRoot, entityPath, artifactDir string, env []string, model string) {
 	t.Helper()
 	piHome := t.TempDir()
 	sessionDir := t.TempDir()
 	cleanHome := t.TempDir()
-	decision := seedPiLiveAuth(t, piHome, os.Getenv("HOME"), os.Getenv("PI_OPENAI_CODEX_AUTH_JSON"), os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_PI_LIVE_REQUIRED"))
+	decision := seedPiLiveAuth(t, piHome, os.Getenv("HOME"), os.Getenv("CODEX_AUTH_JSON"), os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_PI_LIVE_REQUIRED"))
 	// Patch 3 (validation attempt-1 correction): seed piHome/settings.json with
 	// the repo as a path package so pi-subagents' settings-package skill
 	// discovery (skills.ts collectSettingsPackageSkillPaths over
@@ -57,7 +55,11 @@ func newPiLiveSmokeFixture(t *testing.T, name, repo, piSubagentsRoot, binary str
 		t.Fatal(err)
 	}
 	env = piLiveEnvForAuth(piHome, sessionDir, cleanHome, filepath.Dir(binary), piSubagentsRoot, os.Getenv("OPENAI_API_KEY"), decision.mode)
-	return workflowRoot, stateRoot, entityPath, artifactDir, env
+	model = decision.model
+	if override := os.Getenv("SPACEDOCK_PI_LIVE_CHILD_MODEL"); override != "" {
+		model = override
+	}
+	return workflowRoot, stateRoot, entityPath, artifactDir, env, model
 }
 
 func runPiLiveCommand(t *testing.T, artifactDir, workflowRoot string, env []string, argv ...string) {
@@ -267,16 +269,6 @@ func piSubagentsPackageRoot(t *testing.T) string {
 		t.Fatalf("pi-subagents package extension not found at %s: %v; set PI_SUBAGENTS_PACKAGE_ROOT", p, err)
 	}
 	return p
-}
-
-func piLiveModelName() string {
-	if model := os.Getenv("SPACEDOCK_PI_LIVE_CHILD_MODEL"); model != "" {
-		return model
-	}
-	if strings.TrimSpace(os.Getenv("PI_OPENAI_CODEX_AUTH_JSON")) != "" {
-		return "openai-codex/gpt-5.6-luna:max"
-	}
-	return defaultPiLiveModel
 }
 
 func piLiveArtifactDir(t *testing.T, name string) string {

--- a/internal/ensigncycle/pi_live_runner_test.go
+++ b/internal/ensigncycle/pi_live_runner_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-const defaultPiLiveModel = "openrouter/openai/gpt-5.4"
+const defaultPiLiveModel = "openai/gpt-5.6-luna:max"
 
 //spacedock:live-proof id=pi-front-door-subagent-dispatch lane=pi-live
 func TestLivePiFrontDoorSmoke(t *testing.T) {
@@ -44,7 +44,7 @@ func newPiLiveSmokeFixture(t *testing.T, name, repo, piSubagentsRoot, binary str
 	piHome := t.TempDir()
 	sessionDir := t.TempDir()
 	cleanHome := t.TempDir()
-	seedPiLiveAuth(t, piHome, os.Getenv("HOME"), os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_PI_LIVE_REQUIRED"))
+	decision := seedPiLiveAuth(t, piHome, os.Getenv("HOME"), os.Getenv("PI_OPENAI_CODEX_AUTH_JSON"), os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_PI_LIVE_REQUIRED"))
 	// Patch 3 (validation attempt-1 correction): seed piHome/settings.json with
 	// the repo as a path package so pi-subagents' settings-package skill
 	// discovery (skills.ts collectSettingsPackageSkillPaths over
@@ -56,7 +56,7 @@ func newPiLiveSmokeFixture(t *testing.T, name, repo, piSubagentsRoot, binary str
 	if err := os.MkdirAll(filepath.Join(artifactDir, "sessions"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	env = piLiveEnv(piHome, sessionDir, cleanHome, filepath.Dir(binary), piSubagentsRoot)
+	env = piLiveEnvForAuth(piHome, sessionDir, cleanHome, filepath.Dir(binary), piSubagentsRoot, os.Getenv("OPENAI_API_KEY"), decision.mode)
 	return workflowRoot, stateRoot, entityPath, artifactDir, env
 }
 
@@ -219,14 +219,23 @@ func piLiveSmokeEntity() string {
 
 func seedPiLocalAuth(t *testing.T, piHome, realHome string) {
 	t.Helper()
-	seedPiLiveAuth(t, piHome, realHome, os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_PI_LIVE_REQUIRED"))
+	seedPiLiveAuth(t, piHome, realHome, "", os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_PI_LIVE_REQUIRED"))
 }
 
-func seedPiLiveAuth(t *testing.T, piHome, realHome, openAIAPIKey, required string) {
+func seedPiLiveAuth(t *testing.T, piHome, realHome, oauthJSON, openAIAPIKey, required string) piLiveAuthDecision {
 	t.Helper()
+	decision := decidePiLiveAuth(oauthJSON, openAIAPIKey, required)
+	if decision.mode == piAuthOAuth {
+		if err := seedPiOAuthAuth(piHome, oauthJSON); err != nil {
+			t.Fatal(err)
+		}
+		return decision
+	}
+	if decision.mode == piAuthAPIKey {
+		return decision
+	}
 	if realHome != "" {
-		authPath := filepath.Join(realHome, ".pi", "agent", "auth.json")
-		b, err := os.ReadFile(authPath)
+		b, err := os.ReadFile(filepath.Join(realHome, ".pi", "agent", "auth.json"))
 		if err == nil && strings.TrimSpace(string(b)) != "" {
 			if err := os.MkdirAll(piHome, 0o700); err != nil {
 				t.Fatal(err)
@@ -234,17 +243,14 @@ func seedPiLiveAuth(t *testing.T, piHome, realHome, openAIAPIKey, required strin
 			if err := os.WriteFile(filepath.Join(piHome, "auth.json"), b, 0o600); err != nil {
 				t.Fatal(err)
 			}
-			return
+			return piLiveAuthDecision{mode: piAuthOAuth, model: "openai-codex/gpt-5.6-luna:max"}
 		}
 	}
-	if strings.TrimSpace(openAIAPIKey) != "" {
-		return
-	}
-	message := "no live Pi auth available: expected ~/.pi/agent/auth.json or OPENAI_API_KEY"
 	if required != "" {
-		t.Fatal(message + " for the approval-gated pi-live lane")
+		t.Fatal(decision.message)
 	}
-	t.Skip(message + "; run pi login or set OPENAI_API_KEY to run the live Pi suite")
+	t.Skip(decision.message)
+	return decision
 }
 
 func piSubagentsPackageRoot(t *testing.T) string {

--- a/internal/ensigncycle/pi_live_runner_test.go
+++ b/internal/ensigncycle/pi_live_runner_test.go
@@ -270,7 +270,13 @@ func piSubagentsPackageRoot(t *testing.T) string {
 }
 
 func piLiveModelName() string {
-	return envOr("SPACEDOCK_PI_LIVE_CHILD_MODEL", defaultPiLiveModel)
+	if model := os.Getenv("SPACEDOCK_PI_LIVE_CHILD_MODEL"); model != "" {
+		return model
+	}
+	if strings.TrimSpace(os.Getenv("PI_OPENAI_CODEX_AUTH_JSON")) != "" {
+		return "openai-codex/gpt-5.6-luna:max"
+	}
+	return defaultPiLiveModel
 }
 
 func piLiveArtifactDir(t *testing.T, name string) string {

--- a/internal/ensigncycle/pi_liveenv.go
+++ b/internal/ensigncycle/pi_liveenv.go
@@ -1,0 +1,55 @@
+package ensigncycle
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	piAuthAPIKey = "api-key"
+	piAuthOAuth  = "oauth"
+)
+
+type piLiveAuthDecision struct{ mode, model, message string }
+
+func decidePiLiveAuth(oauthJSON, openAIKey, required string) piLiveAuthDecision {
+	if strings.TrimSpace(oauthJSON) != "" {
+		return piLiveAuthDecision{mode: piAuthOAuth, model: "openai-codex/gpt-5.6-luna:max"}
+	}
+	if strings.TrimSpace(openAIKey) != "" {
+		return piLiveAuthDecision{mode: piAuthAPIKey, model: "openai/gpt-5.6-luna:max"}
+	}
+	return piLiveAuthDecision{message: "Pi OAuth or OPENAI_API_KEY is required for the live lane"}
+}
+
+func seedPiOAuthAuth(piHome, oauthJSON string) error {
+	var record map[string]any
+	if err := json.Unmarshal([]byte(oauthJSON), &record); err != nil || record == nil {
+		return fmt.Errorf("Pi OAuth auth is not a JSON object")
+	}
+	if err := os.MkdirAll(piHome, 0o700); err != nil {
+		return fmt.Errorf("create isolated Pi home: %w", err)
+	}
+	payload, err := json.Marshal(map[string]any{"openai-codex": record})
+	if err != nil {
+		return fmt.Errorf("encode Pi OAuth auth: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(piHome, "auth.json"), payload, 0o600); err != nil {
+		return fmt.Errorf("write Pi OAuth auth: %w", err)
+	}
+	return nil
+}
+
+func withoutPiEnvKey(env []string, key string) []string {
+	prefix := key + "="
+	out := env[:0]
+	for _, value := range env {
+		if !strings.HasPrefix(value, prefix) {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/ensigncycle/pi_liveenv.go
+++ b/internal/ensigncycle/pi_liveenv.go
@@ -1,8 +1,10 @@
 package ensigncycle
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,29 +13,92 @@ import (
 const (
 	piAuthAPIKey = "api-key"
 	piAuthOAuth  = "oauth"
+
+	piOAuthModel  = "openai-codex/gpt-5.6-luna:max"
+	piAPIKeyModel = "openai/gpt-5.6-luna:max"
 )
 
 type piLiveAuthDecision struct{ mode, model, message string }
 
 func decidePiLiveAuth(oauthJSON, openAIKey, required string) piLiveAuthDecision {
 	if strings.TrimSpace(oauthJSON) != "" {
-		return piLiveAuthDecision{mode: piAuthOAuth, model: "openai-codex/gpt-5.6-luna:max"}
+		return piLiveAuthDecision{mode: piAuthOAuth, model: piOAuthModel}
 	}
 	if strings.TrimSpace(openAIKey) != "" {
-		return piLiveAuthDecision{mode: piAuthAPIKey, model: "openai/gpt-5.6-luna:max"}
+		return piLiveAuthDecision{mode: piAuthAPIKey, model: piAPIKeyModel}
 	}
 	return piLiveAuthDecision{message: "Pi OAuth or OPENAI_API_KEY is required for the live lane"}
 }
 
-func seedPiOAuthAuth(piHome, oauthJSON string) error {
-	var record map[string]any
-	if err := json.Unmarshal([]byte(oauthJSON), &record); err != nil || record == nil {
-		return fmt.Errorf("Pi OAuth auth is not a JSON object")
+type codexAuthFile struct {
+	AuthMode string `json:"auth_mode"`
+	Tokens   struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		AccountID    string `json:"account_id"`
+	} `json:"tokens"`
+}
+
+type piOAuthRecord struct {
+	Type      string `json:"type"`
+	Access    string `json:"access"`
+	Refresh   string `json:"refresh"`
+	Expires   int64  `json:"expires"`
+	AccountID string `json:"accountId"`
+}
+
+// codexOAuthRecord converts the complete Codex auth file into Pi's provider
+// record. The source file is intentionally never returned or passed through to
+// the child process; only the fields Pi consumes are retained.
+func codexOAuthRecord(authJSON string) (piOAuthRecord, error) {
+	var auth codexAuthFile
+	if err := json.Unmarshal([]byte(authJSON), &auth); err != nil || auth.Tokens.AccessToken == "" || auth.Tokens.RefreshToken == "" || auth.Tokens.AccountID == "" {
+		return piOAuthRecord{}, fmt.Errorf("Codex OAuth auth has an invalid credential record")
+	}
+	expires, err := jwtExpiryMillis(auth.Tokens.AccessToken)
+	if err != nil {
+		return piOAuthRecord{}, fmt.Errorf("Codex OAuth auth has an invalid access token")
+	}
+	return piOAuthRecord{
+		Type:      "oauth",
+		Access:    auth.Tokens.AccessToken,
+		Refresh:   auth.Tokens.RefreshToken,
+		Expires:   expires,
+		AccountID: auth.Tokens.AccountID,
+	}, nil
+}
+
+func jwtExpiryMillis(token string) (int64, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return 0, fmt.Errorf("not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return 0, fmt.Errorf("decode JWT payload: %w", err)
+	}
+	var claims struct {
+		ExpiresAt json.Number `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.ExpiresAt == "" {
+		return 0, fmt.Errorf("JWT expiry is missing")
+	}
+	seconds, err := claims.ExpiresAt.Int64()
+	if err != nil || seconds <= 0 || seconds > math.MaxInt64/1000 {
+		return 0, fmt.Errorf("JWT expiry is invalid")
+	}
+	return seconds * 1000, nil
+}
+
+func seedPiOAuthAuth(piHome, codexJSON string) error {
+	record, err := codexOAuthRecord(codexJSON)
+	if err != nil {
+		return err
 	}
 	if err := os.MkdirAll(piHome, 0o700); err != nil {
 		return fmt.Errorf("create isolated Pi home: %w", err)
 	}
-	payload, err := json.Marshal(map[string]any{"openai-codex": record})
+	payload, err := json.Marshal(map[string]piOAuthRecord{"openai-codex": record})
 	if err != nil {
 		return fmt.Errorf("encode Pi OAuth auth: %w", err)
 	}

--- a/internal/ensigncycle/pi_shared_live_runner_test.go
+++ b/internal/ensigncycle/pi_shared_live_runner_test.go
@@ -24,7 +24,7 @@ func newPiSharedLiveDriver(t *testing.T) piSharedLiveDriver {
 	repo := repoRoot(t)
 	binary := piSpacedockBinary(t, repo)
 	piHome := t.TempDir()
-	decision := seedPiLiveAuth(t, piHome, os.Getenv("HOME"), os.Getenv("PI_OPENAI_CODEX_AUTH_JSON"), os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_PI_LIVE_REQUIRED"))
+	decision := seedPiLiveAuth(t, piHome, os.Getenv("HOME"), os.Getenv("CODEX_AUTH_JSON"), os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_PI_LIVE_REQUIRED"))
 	writeFile(t, filepath.Join(piHome, "settings.json"), fmt.Sprintf("{\"packages\":[%q]}\n", "file:"+repo))
 	return piSharedLiveDriver{
 		t:      t,

--- a/internal/ensigncycle/pi_shared_live_runner_test.go
+++ b/internal/ensigncycle/pi_shared_live_runner_test.go
@@ -24,13 +24,13 @@ func newPiSharedLiveDriver(t *testing.T) piSharedLiveDriver {
 	repo := repoRoot(t)
 	binary := piSpacedockBinary(t, repo)
 	piHome := t.TempDir()
-	seedPiLiveAuth(t, piHome, os.Getenv("HOME"), os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_PI_LIVE_REQUIRED"))
+	decision := seedPiLiveAuth(t, piHome, os.Getenv("HOME"), os.Getenv("PI_OPENAI_CODEX_AUTH_JSON"), os.Getenv("OPENAI_API_KEY"), os.Getenv("SPACEDOCK_PI_LIVE_REQUIRED"))
 	writeFile(t, filepath.Join(piHome, "settings.json"), fmt.Sprintf("{\"packages\":[%q]}\n", "file:"+repo))
 	return piSharedLiveDriver{
 		t:      t,
-		binary: binary, pluginDir: repo, modelName: piLiveModelName(), piHome: piHome,
+		binary: binary, pluginDir: repo, modelName: decision.model, piHome: piHome,
 		artifactRoot: piLiveArtifactDir(t, "pi-common"),
-		env:          piLiveEnv(piHome, t.TempDir(), t.TempDir(), filepath.Dir(binary), piSubagentsPackageRoot(t)),
+		env:          piLiveEnvForAuth(piHome, t.TempDir(), t.TempDir(), filepath.Dir(binary), piSubagentsPackageRoot(t), os.Getenv("OPENAI_API_KEY"), decision.mode),
 	}
 }
 

--- a/internal/release/runtime_live_evidence_workflow_test.go
+++ b/internal/release/runtime_live_evidence_workflow_test.go
@@ -102,12 +102,24 @@ func assertOneClaudeCadence(workflow string) error {
 	if !ok || codex.Environment.Name != "CI-E2E-CODEX" || codex.If != codexCadenceIf {
 		return fmt.Errorf("Codex lane environment/if = %q/%q, want CI-E2E-CODEX/%q", codex.Environment.Name, codex.If, codexCadenceIf)
 	}
+	if codex.Env["CODEX_AUTH_JSON"] != `${{ secrets.CODEX_AUTH_JSON }}` || codex.Env["OPENAI_API_KEY"] != `${{ secrets.OPENAI_API_KEY }}` {
+		return fmt.Errorf("Codex lane auth = %q/%q, want OAuth and API-key fallback secrets", codex.Env["CODEX_AUTH_JSON"], codex.Env["OPENAI_API_KEY"])
+	}
+	if _, present := codex.Env["CODEX_HOME"]; present {
+		return fmt.Errorf("Codex HOME must be initialized in a step, not with the unavailable job-level runner.temp context")
+	}
 	pi, ok := parsed.Jobs["pi-live"]
 	if !ok || pi.Environment.Name != "CI-E2E-PI" || pi.If != piCadenceIf {
 		return fmt.Errorf("Pi lane environment/if = %q/%q, want CI-E2E-PI/%q", pi.Environment.Name, pi.If, piCadenceIf)
 	}
-	if pi.Env["OPENAI_API_KEY"] != `${{ secrets.OPENAI_API_KEY }}` || pi.Env["SPACEDOCK_PI_LIVE_CHILD_MODEL"] != "openai/gpt-5.6-luna:max" {
-		return fmt.Errorf("Pi lane key/model = %q/%q, want stored OpenAI key and Luna/max", pi.Env["OPENAI_API_KEY"], pi.Env["SPACEDOCK_PI_LIVE_CHILD_MODEL"])
+	if pi.Env["CODEX_AUTH_JSON"] != `${{ secrets.CODEX_AUTH_JSON }}` || pi.Env["OPENAI_API_KEY"] != `${{ secrets.OPENAI_API_KEY }}` {
+		return fmt.Errorf("Pi lane auth = %q/%q, want shared Codex auth and stored OpenAI key", pi.Env["CODEX_AUTH_JSON"], pi.Env["OPENAI_API_KEY"])
+	}
+	if _, present := pi.Env["PI_OPENAI_CODEX_AUTH_JSON"]; present {
+		return fmt.Errorf("Pi lane must not use the dedicated PI_OPENAI_CODEX_AUTH_JSON secret")
+	}
+	if _, present := pi.Env["SPACEDOCK_PI_LIVE_CHILD_MODEL"]; present {
+		return fmt.Errorf("Pi lane must derive its provider model from auth mode")
 	}
 	return nil
 }


### PR DESCRIPTION
OAuth-preferred Codex and Pi lanes use subscription credentials while preserving API-key fallback and isolated execution for safer live CI.

## What changed
- Bind dedicated OAuth secrets and either-credential preflights in the live workflow.
- Seed isolated Codex and Pi auth files with 0600 permissions.
- Select provider-qualified Pi models and omit API keys on OAuth launches.
- Document secret formats, rotation commands, refresh isolation, and fallback behavior.

## Evidence
- 1/1 focused and 1/1 race `internal/ensigncycle` package suites passed with ambient Pi markers unset.
- 1/1 full repository suite and live-tag compilation passed in validation; OAuth-only host journeys remain externally gated.

## Review guidance
Inspect CI preflights and Pi auth-mode selection; OAuth-only current-checkout proof was unavailable locally.

---
[hr](/spacedock-dev/spacedock/blob/15d0be901230a8cc44458bc427b8f3246246d464/codex-subscription-live-auth.md)
