### PR TITLE
Repair Pi live harness — parallelism, custom-provider model mirror, slow-model timeout

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -252,6 +252,10 @@ Brief description of this task and what it aims to achieve.
 
 {What this task deliberately does not cover, so the boundary is explicit.}
 
+## Expected surface and tolerance
+
+Estimate net LOC change: {+NNN or -NNN}, across {M} files.
+
 ## Acceptance criteria
 
 Each AC names a property of the finished entity, not a stage action, and how it is verified.

--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -59,11 +59,11 @@ export SPACEDOCK_BIN="$PWD/spacedock"
 export SPACEDOCK_REPO_ROOT="$PWD"
 ```
 
-Run the common journeys by selecting one transport. The Claude command runs at
-most two common journeys at one time. The Codex and Pi commands run the same
+Run the common journeys by selecting one transport. The Claude and Pi commands run at
+most two common journeys at one time. The Codex command runs the same
 17 journeys in sequence. The Claude command keeps `-failfast`, but Go can start
-queued parallel journeys after a failure. At most two Claude journeys run at one
-time. The sequential Codex and Pi commands stop at the first non-TODO failure.
+queued parallel journeys after a failure. At most two Claude or Pi journeys run at one
+time. The sequential Codex command stops at the first non-TODO failure.
 Claude's 90-minute timeout is a loose suite-wide runaway backstop; Codex and Pi
 retain the 40-minute backstop:
 
@@ -94,13 +94,17 @@ export PI_SUBAGENTS_PACKAGE_ROOT="$HOME/.pi/agent/npm/node_modules/pi-subagents"
 export PI_INTERCOM_PACKAGE_ROOT="$HOME/.pi/agent/npm/node_modules/pi-intercom"
 ```
 
-Authenticate with `pi login` or `OPENAI_API_KEY`. Configure the child model with the exact provider-qualified spelling for that authentication path:
+Authenticate with `pi login` or `OPENAI_API_KEY`. Configure the child model with the exact provider-qualified spelling for that authentication path. Custom providers (e.g. `lunaroute`) declare their models in `~/.pi/agent/models.json`, not `auth.json`; the harness mirrors `models.json` (alongside `auth.json`, both `0o600`) into the isolated Pi home so a custom-provider model resolves. If the child reports `Model ... not found`, the `models.json` mirror is missing or does not declare that provider/model. Use the `provider/model:thinking` form to request a specific thinking effort:
 
 ```bash
 export SPACEDOCK_PI_LIVE_CHILD_MODEL=openrouter/openai/gpt-5.4 # OpenRouter login
 # or
 export SPACEDOCK_PI_LIVE_CHILD_MODEL=openai/gpt-5.4 # direct OpenAI provider
+# or, with an explicit thinking effort (provider/model:thinking):
+export SPACEDOCK_PI_LIVE_CHILD_MODEL='lunaroute/glm-5.2-vision-background:max'
 ```
+
+A slow `:max`-thinking model can take minutes per turn. Raise the per-run cap with `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES` (a positive integer, in minutes) so multi-dispatch journeys complete to a graded result instead of timing out. Make the outer `go test -timeout` longer than the per-run cap so the suite backstop does not fire before the individual cap. Defaults: smoke `10m`, common `12m`. Example:
 
 `TestLivePiFrontDoorSmoke` is the only Pi substrate smoke. It checks the front door, child dispatch, durable output, and the boot contract. The grade artifact records both models, durations, and available costs.
 
@@ -108,11 +112,13 @@ export SPACEDOCK_PI_LIVE_CHILD_MODEL=openai/gpt-5.4 # direct OpenAI provider
 go test -tags live -count=1 -timeout 15m -run TestLivePiFrontDoorSmoke ./internal/ensigncycle -v
 ```
 
-Run the common Pi journeys separately from that substrate proof:
+Run the common Pi journeys separately from that substrate proof. Pi runs at most two journeys at a time, so pass `-parallel 2` to fan them out concurrently:
 
 ```bash
-SPACEDOCK_LIVE_RUNTIME=pi go test -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle -v
+SPACEDOCK_LIVE_RUNTIME=pi go test -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast -parallel 2 ./internal/ensigncycle -v
 ```
+
+When raising `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES` for a slow model, set the outer `-timeout` above the per-run cap (e.g. `-timeout 120m` with `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES=40`).
 
 Without auth, the respective live suite skips locally (Claude/Codex/Pi), except in CI where the lane requires it.
 

--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -112,13 +112,13 @@ A slow `:max`-thinking model can take minutes per turn. Raise the per-run cap wi
 go test -tags live -count=1 -timeout 15m -run TestLivePiFrontDoorSmoke ./internal/ensigncycle -v
 ```
 
-Run the common Pi journeys separately from that substrate proof. Pi runs at most two journeys at a time, so pass `-parallel 2` to fan them out concurrently:
+Run the common Pi journeys separately from that substrate proof. Pi now calls `t.Parallel()`, so `-parallel 2` fans common journeys out two at a time (Codex stays sequential):
 
 ```bash
-SPACEDOCK_LIVE_RUNTIME=pi go test -tags live -count=1 -timeout 90m -run '^TestLiveCommon' -failfast -parallel 2 ./internal/ensigncycle -v
+SPACEDOCK_LIVE_RUNTIME=pi go test -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle -v
 ```
 
-When raising `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES` for a slow model, set the outer `-timeout` above the per-run cap (e.g. `-timeout 120m` with `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES=40`).
+For a custom slow `:max`-thinking model, add `-parallel 2` and raise `-timeout` above the per-run cap set by `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES` (e.g. `-parallel 2 -timeout 120m` with `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES=40`).
 
 Without auth, the respective live suite skips locally (Claude/Codex/Pi), except in CI where the lane requires it.
 

--- a/internal/ensigncycle/pi_live_runner_test.go
+++ b/internal/ensigncycle/pi_live_runner_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -66,7 +67,7 @@ func runPiLiveCommand(t *testing.T, artifactDir, workflowRoot string, env []stri
 	t.Helper()
 	stdoutPath := filepath.Join(artifactDir, "pi-stdout.txt")
 	stderrPath := filepath.Join(artifactDir, "pi-stderr.txt")
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), piLiveRunTimeout(10*time.Minute))
 	defer cancel()
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Dir = workflowRoot
@@ -86,7 +87,7 @@ func runPiLiveCommand(t *testing.T, artifactDir, workflowRoot string, env []stri
 
 	runErr := cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
-		t.Fatalf("pi live smoke timed out; artifacts in %s", artifactDir)
+		t.Fatalf("pi live smoke timed out after the per-run cap (SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES, default 10m); artifacts in %s", artifactDir)
 	}
 	if runErr != nil {
 		t.Fatalf("pi live smoke failed: %v; artifacts in %s\nstderr tail:\n%s", runErr, artifactDir, tail(readFile(t, stderrPath), 4000))
@@ -245,6 +246,15 @@ func seedPiLiveAuth(t *testing.T, piHome, realHome, oauthJSON, openAIAPIKey, req
 			if err := os.WriteFile(filepath.Join(piHome, "auth.json"), b, 0o600); err != nil {
 				t.Fatal(err)
 			}
+			// Custom providers (e.g. lunaroute) declare their models in
+			// models.json, not auth.json. Mirror it alongside auth.json so a
+			// custom-provider SPACEDOCK_PI_LIVE_CHILD_MODEL resolves instead
+			// of failing with "Model ... not found".
+			if models, merr := os.ReadFile(filepath.Join(realHome, ".pi", "agent", "models.json")); merr == nil && strings.TrimSpace(string(models)) != "" {
+				if err := os.WriteFile(filepath.Join(piHome, "models.json"), models, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
 			return piLiveAuthDecision{mode: piAuthOAuth, model: "openai-codex/gpt-5.6-luna:max"}
 		}
 	}
@@ -269,6 +279,24 @@ func piSubagentsPackageRoot(t *testing.T) string {
 		t.Fatalf("pi-subagents package extension not found at %s: %v; set PI_SUBAGENTS_PACKAGE_ROOT", p, err)
 	}
 	return p
+}
+
+func piLiveModelName() string {
+	return envOr("SPACEDOCK_PI_LIVE_CHILD_MODEL", defaultPiLiveModel)
+}
+
+// piLiveRunTimeout returns the per-run cap for a Pi live journey. It reads
+// SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES (a positive integer) and falls back to dflt
+// when the env var is unset or invalid. Raise it for slow :max-thinking models so
+// multi-dispatch journeys complete to a graded result instead of timing out;
+// make the outer `go test -timeout` longer than this per-run cap.
+func piLiveRunTimeout(dflt time.Duration) time.Duration {
+	if v := os.Getenv("SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Minute
+		}
+	}
+	return dflt
 }
 
 func piLiveArtifactDir(t *testing.T, name string) string {

--- a/internal/ensigncycle/pi_shared_live_runner_test.go
+++ b/internal/ensigncycle/pi_shared_live_runner_test.go
@@ -59,7 +59,7 @@ func (d piSharedLiveDriver) run(t *testing.T, scenario sharedRuntimeScenario, ro
 	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), piLiveRunTimeout(12*time.Minute))
 	defer cancel()
 	cmd := exec.CommandContext(ctx, d.binary, "pi", prompt, "--plugin-dir", d.pluginDir, "--", "--print", "--model", d.modelName, "--session-dir", sessionDir)
 	cmd.Dir, cmd.Env = root, d.env
@@ -74,7 +74,7 @@ func (d piSharedLiveDriver) run(t *testing.T, scenario sharedRuntimeScenario, ro
 	writeFile(t, filepath.Join(artifactDir, "duration.txt"), duration.String()+"\n")
 	writeFile(t, filepath.Join(artifactDir, "process-status.txt"), fmt.Sprintf("error=%v timeout=%t\n", err, ctx.Err() == context.DeadlineExceeded))
 	if ctx.Err() == context.DeadlineExceeded {
-		t.Fatalf("Pi journey %q exceeded 12 minutes; artifacts: %s", scenario.name, artifactDir)
+		t.Fatalf("Pi journey %q exceeded the per-run cap (SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES, default 12m); artifacts: %s", scenario.name, artifactDir)
 	}
 	if err != nil {
 		t.Fatalf("Pi journey %q failed: %v; artifacts: %s\n%s", scenario.name, err, artifactDir, tail(stderr.String(), 4000))

--- a/internal/ensigncycle/shared_live_runner_test.go
+++ b/internal/ensigncycle/shared_live_runner_test.go
@@ -41,7 +41,8 @@ func liveJourney[Builder, Assertion any](t *testing.T, id, fixtureID string, bui
 			}
 		}
 	}
-	if os.Getenv("SPACEDOCK_LIVE_RUNTIME") == "claude" {
+	switch runtime := os.Getenv("SPACEDOCK_LIVE_RUNTIME"); runtime {
+	case "claude", "pi":
 		t.Parallel()
 	}
 	driver := newDriver()


### PR DESCRIPTION
Three Pi runner harness gaps blocked running the common journeys against a custom slow-thinking model (`lunaroute/glm-5.2-vision-background:max`): `t.Parallel()` was Claude-only so `-parallel 2` was a no-op on Pi; `seedPiLiveAuth` copied only `auth.json` so custom providers declaring models in `models.json` got `Model ... not found`; and the fixed `12m`/`10m` per-run cap timed out a slow `:max` multi-dispatch journey instead of grading it. The harness now fans out Pi journeys two at a time, mirrors the operator's `models.json` into the isolated home, and makes the per-run cap overridable.

## What changed
- Widen the `t.Parallel()` gate in `shared_live_runner_test.go` to call `t.Parallel()` for `SPACEDOCK_LIVE_RUNTIME == "pi"` as well as `"claude"`; Codex stays sequential.
- `seedPiLiveAuth` copies `~/.pi/agent/models.json` into the isolated Pi home (0o600, alongside `auth.json`) when present, so custom-provider models declared in `models.json` resolve.
- Add `piLiveRunTimeout(dflt)` reading `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES` (returns `dflt` when unset/invalid); `run` (12m default) and `runPiLiveCommand` (10m default) use it; timeout-fatal messages name the env var and default.
- `docs/runtime-live-ci.md` describes Pi `-parallel 2`, the `provider/model:thinking` child-model form, the `models.json` mirror and `Model ... not found` check, and the `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES` guidance.
- No journey exercise/fixture/durable assertion, XFAIL binding, `assertConflictOwnerHandoff`, or CI lane touched.

## Evidence
- Fresh validator independently verified the deliverable against the spec; read-only (worktree clean).
- Offline checks (non-cached): `gofmt -l` empty; `go vet -tags live` exit 0; `go build -tags live` exit 0; `go test -run 'PiLiveEnv|PiIntercom|TestPiLive'` → `ok 0.619s`; `TestPiLiveEnvDropsForeignRuntimeMarkers` and `TestPiLiveEnvScrubsAmbientPiSubagentMarkers` both PASS.
- Scope: `git diff --name-only` → only the 4 expected files; no journey body/XFAIL/`assertConflictOwnerHandoff`/CI-lane files changed.
- Deferred: AC-1 (live custom-model `-parallel 2` run to graded results) is offline-first; a live Pi run confirms end-to-end when Pi work is authorized.

---
[pnc](/spacedock-dev/spacedock/blob/6bccb57224afe2a8cd2e750d6038d3b3dcc3c303/repair-pi-live-harness-parallelism-and-custom-model.md)
