### PR TITLE
Trim stale prose in the dispatch core contract

### DIFF
--- a/skills/first-officer/references/fo-dispatch-core.md
+++ b/skills/first-officer/references/fo-dispatch-core.md
@@ -192,11 +192,9 @@ After each agent completion, run `«dispatch.next-action»()` (skeleton below).
 
 For `needs-preparation`, load `spacedock:fo-gate-lifecycle`, re-read the entity, latest exact-stage report/checklist, and path-scoped clean commit, then decide semantic completeness. A defect stops once with `report-incomplete: <concrete reason>` and zero prepare, legacy bind, state mutation/commit, presentation, idle, or repeat-next effects. On a semantic pass, supply only question, one committed Markdown Artifact, summary, and References to exactly one existing `gate prepare`; require emitted `room`, `briefing`, `digest`, `state=open`, commit its binding, and re-read the same envelope. Present only one same-slug `awaiting-captain`; any nonzero/mismatched result stops without retry. Existing open, withdrawn, stale, closed, pending, revise, hold, blocked, feedback, consumed, superseded, not-applicable, terminal, archived, malformed, and mismatched states retain their owners and never route through this candidate.
 
-An exact prior-stage replay candidate may exercise s4's existing selection/replay idempotency during that one invocation; FO creates no attempt counter, retry token, cache, or alternate authority.
+An exact prior-stage replay candidate may exercise `gate prepare`'s existing selection/replay idempotency during that one invocation; FO creates no attempt counter, retry token, cache, or alternate authority.
 
-These are FO-internal scheduling reads — consume them as `--json` (compact, byte-stable, every value a string), not the padded human table a token proxy can mangle; `--fields` narrows to the keys needed. Envelopes: `status`/`--where` → `{"command":"status","entities":[…]}`; `--next` → `{"command":"next","dispatchable":[…]}`. The captain-facing state display (shared-core) still forwards the human table verbatim.
-
-The `--next` envelope now also carries canonical `ready_gates`; the scheduler-envelope rule above supersedes the abbreviated shape in this historical sentence.
+These are FO-internal scheduling reads — consume them as `--json` (compact, byte-stable, every value a string), not the padded human table a token proxy can mangle; `--fields` narrows to the keys needed. Envelopes: `status`/`--where` → `{"command":"status","entities":[…],"pagination":{…}}`; `--next` → `{"command":"next","dispatchable":[…],"ready_gates":[…]}`. The captain-facing state display (shared-core) still forwards the human table verbatim.
 
 ## «dispatch.next-action»(): pick the next event-loop action — dispatch a ready entity, resume a block, or end the iteration
 


### PR DESCRIPTION
Removes contradicting and unresolvable prose from the shipped first-officer dispatch contract so every sentence an FO reads is true and resolvable.

## What changed
- Replace the unresolvable s4 referent with the command name it meant
- Fold the canonical envelope shapes, including pagination, into the Envelopes sentence
- Delete the sentence that existed only to retract its neighbor

## Evidence
- internal/contractlint and prose-routing suites: all passed
- Exercised key-set check: edited prose matches the binary on both envelopes; origin/main prose fails both

---
[71](/spacedock-dev/spacedock/blob/0acd3237dfc9981cf005e2b0623341d54d3692f0/trim-dispatch-core-stale-prose.md)
