### PR TITLE
Retire the extinct requires-contract manifest sentinel

### DIFF
--- a/internal/cli/codex_name_match_test.go
+++ b/internal/cli/codex_name_match_test.go
@@ -100,7 +100,7 @@ func buildCodexNamedMarketplace(t *testing.T, root, marketplaceName, entryName s
 }
 `)
 	mustWrite(t, filepath.Join(plugin, ".codex-plugin", "plugin.json"),
-		`{ "name": "spacedock", "version": "0.0.0", "requires-contract": ">=2,<3", "skills": "./skills/" }
+		`{ "name": "spacedock", "version": "0.0.0", "skills": "./skills/" }
 `)
 	mustWrite(t, filepath.Join(plugin, "skills", "demo", "SKILL.md"), "---\nname: demo\ndescription: demo skill\n---\ndemo\n")
 	return marketplace

--- a/internal/cli/codex_plugin_dir_test.go
+++ b/internal/cli/codex_plugin_dir_test.go
@@ -322,14 +322,14 @@ func TestInstallCodexLocalPluginDirResolvesOnEdgeChannel(t *testing.T) {
 }
 
 // buildCodexPluginCheckout writes a minimal valid codex plugin checkout under root
-// (a .codex-plugin/plugin.json bracketing CONTRACT_VERSION + one skill), the shape a
+// (a .codex-plugin/plugin.json with a version + one skill), the shape a
 // --plugin-dir target must have for codex's `plugin add` to copy it into its cache.
 func buildCodexPluginCheckout(t *testing.T, root, version string) string {
 	t.Helper()
 	mustMkdir(t, filepath.Join(root, ".codex-plugin"))
 	mustMkdir(t, filepath.Join(root, "skills", "demo"))
 	mustWrite(t, filepath.Join(root, ".codex-plugin", "plugin.json"),
-		`{ "name": "spacedock", "version": "`+version+`", "requires-contract": ">=2,<3", "skills": "./skills/" }
+		`{ "name": "spacedock", "version": "`+version+`", "skills": "./skills/" }
 `)
 	mustWrite(t, filepath.Join(root, "skills", "demo", "SKILL.md"), "---\nname: demo\ndescription: demo skill\n---\ndemo\n")
 	return root
@@ -340,7 +340,7 @@ func buildCodexFirstOfficerCheckout(t *testing.T, root, version, description str
 	mustMkdir(t, filepath.Join(root, ".codex-plugin"))
 	mustMkdir(t, filepath.Join(root, "skills", "first-officer"))
 	mustWrite(t, filepath.Join(root, ".codex-plugin", "plugin.json"),
-		`{ "name": "spacedock", "version": "`+version+`", "requires-contract": ">=3,<4", "skills": "./skills/" }
+		`{ "name": "spacedock", "version": "`+version+`", "skills": "./skills/" }
 `)
 	mustWrite(t, filepath.Join(root, "skills", "first-officer", "SKILL.md"), "---\nname: first-officer\ndescription: "+description+"\n---\n"+description+"\n")
 	return root

--- a/internal/cli/decoupling_behavior_test.go
+++ b/internal/cli/decoupling_behavior_test.go
@@ -99,7 +99,7 @@ func TestStableChannelDecoupledFromBranchHead(t *testing.T) {
 // buildPluginGitRepo writes a plugin git repo under root with a `next` branch
 // carrying tag v0.0.1 (version 0.0.1, skill body "body v0.0.1") on an early commit
 // and a `next` HEAD advanced to 0.0.2 ("body v0.0.2"). Returns the repo path. The
-// plugin manifest carries a requires-contract bracketing CONTRACT_VERSION.
+// plugin manifest carries the display version the doctor verdict reads.
 func buildPluginGitRepo(t *testing.T, root string) string {
 	t.Helper()
 	mustMkdir(t, filepath.Join(root, ".claude-plugin"))
@@ -123,7 +123,7 @@ func buildPluginGitRepo(t *testing.T, root string) string {
 func writePluginVersion(t *testing.T, root, version string) {
 	t.Helper()
 	mustWrite(t, filepath.Join(root, ".claude-plugin", "plugin.json"),
-		fmt.Sprintf(`{ "name": "spacedock", "version": "%s", "requires-contract": ">=2,<3", "skills": "./skills/" }`+"\n", version))
+		fmt.Sprintf(`{ "name": "spacedock", "version": "%s", "skills": "./skills/" }`+"\n", version))
 	mustWrite(t, filepath.Join(root, "skills", "demo", "SKILL.md"),
 		fmt.Sprintf("---\nname: demo\ndescription: demo\n---\nbody v%s\n", version))
 }

--- a/internal/cli/install_behavior_codex_test.go
+++ b/internal/cli/install_behavior_codex_test.go
@@ -159,7 +159,7 @@ func resolvedCodexManifestVersion(t *testing.T) string {
 // root and returns the marketplace directory. Codex reads the marketplace
 // manifest from .claude-plugin/marketplace.json (it reuses the claude manifest
 // layout) and the plugin manifest from the plugin's .codex-plugin/plugin.json.
-// The plugin manifest carries a requires-contract bracketing CONTRACT_VERSION.
+// The plugin manifest carries the display version the doctor verdict reads.
 func buildLocalCodexMarketplace(t *testing.T, root string) string {
 	return buildCodexMarketplaceAtVersion(t, root, "0.0.0")
 }
@@ -184,7 +184,7 @@ func buildCodexMarketplaceAtVersion(t *testing.T, root, version string) string {
 }
 `)
 	mustWrite(t, filepath.Join(plugin, ".codex-plugin", "plugin.json"),
-		`{ "name": "spacedock", "version": "`+version+`", "requires-contract": ">=2,<3", "skills": "./skills/" }
+		`{ "name": "spacedock", "version": "`+version+`", "skills": "./skills/" }
 `)
 	mustWrite(t, filepath.Join(plugin, "skills", "demo", "SKILL.md"), "---\nname: demo\ndescription: demo skill\n---\ndemo\n")
 	return marketplace

--- a/internal/cli/upgrade_from_stale_test.go
+++ b/internal/cli/upgrade_from_stale_test.go
@@ -1,5 +1,5 @@
 // ABOUTME: AC-3 live upgrade-from-stale smoke — a real isolated-CLAUDE_CONFIG_DIR
-// ABOUTME: install of a stale (no requires-contract) plugin, then the 3-command upgrade to green.
+// ABOUTME: install of an ancient-minor (0.12.1) plugin, then the 3-command upgrade to green.
 package cli
 
 import (
@@ -125,9 +125,9 @@ func TestFreshBoxInstallSucceeds(t *testing.T) {
 	t.Fatalf("spacedock@spacedock not installed after fresh-box Install; combined output=%q\nplugin list=%s", out, listOut)
 }
 
-// buildStaleMarketplace writes a local-path marketplace whose plugin manifest has
-// NO requires-contract field — the 0.12.1 shape that predates the contract
-// mechanism. Returns the marketplace directory.
+// buildStaleMarketplace writes a local-path marketplace whose plugin manifest
+// declares version 0.12.1 — an ancient minor that resolves to too-old-plugin.
+// Returns the marketplace directory.
 func buildStaleMarketplace(t *testing.T, root string) string {
 	t.Helper()
 	marketplace := filepath.Join(root, "stale")

--- a/internal/contract/doctor.go
+++ b/internal/contract/doctor.go
@@ -15,8 +15,7 @@ import (
 var errNoManifest = errors.New("manifest not found")
 
 // readManifest reads a plugin manifest JSON and returns its display version. A
-// missing file yields errNoManifest. requires-contract, if present, is not read —
-// it is a frozen cross-era sentinel for integer-era binaries only (D4). The
+// missing file yields errNoManifest. Every other manifest field is ignored. The
 // display version is the user-facing semver shown in the verdict message.
 func readManifest(manifestPath string) (version string, err error) {
 	data, err := os.ReadFile(manifestPath)

--- a/internal/contractlint/prose_manifest_minor_sync_test.go
+++ b/internal/contractlint/prose_manifest_minor_sync_test.go
@@ -1,5 +1,5 @@
 // ABOUTME: D5 sync test — the FO shared-core's stamped minor must equal the
-// ABOUTME: vendored plugin manifests' own minor; the D4 tombstones stay frozen.
+// ABOUTME: vendored plugin manifests' own minor.
 package contractlint
 
 import (

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -17,8 +17,7 @@ func TestStampVersionRewritesPluginVersion(t *testing.T) {
 	src := `{
   "name": "spacedock",
   "version": "0.1.0-dev",
-  "skills": "./skills/",
-  "requires-contract": ">=1,<2"
+  "skills": "./skills/"
 }
 `
 	out, err := StampVersion([]byte(src), "0.19.0")
@@ -35,9 +34,6 @@ func TestStampVersionRewritesPluginVersion(t *testing.T) {
 	// Untouched fields survive.
 	if m["name"] != "spacedock" {
 		t.Errorf("name field lost: %v", m["name"])
-	}
-	if m["requires-contract"] != ">=1,<2" {
-		t.Errorf("requires-contract field lost: %v", m["requires-contract"])
 	}
 	if m["skills"] != "./skills/" {
 		t.Errorf("skills field lost: %v", m["skills"])

--- a/skills/integration/marketplace_manifest_test.go
+++ b/skills/integration/marketplace_manifest_test.go
@@ -35,9 +35,8 @@ func TestMainCarriesMarketplaceBridgeManifest(t *testing.T) {
 // check: .codex-plugin/plugin.json's `version` field parses as a well-formed
 // major.minor semver (so `spacedock doctor --host codex` resolves a compatible
 // manifest under minor-version coupling), names the plugin `spacedock`, and
-// points skills at ./skills/. The D4 cross-era tombstone and its binding to the
-// FO shared-core's stamped minor are pinned by the internal/contractlint sync
-// test.
+// points skills at ./skills/. That version's binding to the FO shared-core's
+// stamped minor is pinned by the internal/contractlint sync test.
 func TestCodexManifestVersionParses(t *testing.T) {
 	path := filepath.Join(repoRoot(t), ".codex-plugin", "plugin.json")
 	data, err := os.ReadFile(path)

--- a/skills/integration/plugin_manifest_test.go
+++ b/skills/integration/plugin_manifest_test.go
@@ -24,12 +24,11 @@ func repoRoot(t *testing.T) string {
 
 // TestVendoredManifestVersionParses locks the manifest<->binary drift check
 // under minor-version coupling: the vendored .claude-plugin/plugin.json's
-// `version` field (the compatibility declaration itself — D2, no separate
-// requires-contract range is read by this binary) parses as a well-formed
-// major.minor semver. The D4 cross-era tombstone (requires-contract ">=3,<4")
-// and its binding to the FO shared-core's stamped minor are pinned by the
-// internal/contractlint sync test — the sanctioned home for a check that reads
-// the prose file this manifest binds against.
+// `version` field (the compatibility declaration itself — D2) parses as a
+// well-formed major.minor semver. That version's binding to the FO shared-core's
+// stamped minor is pinned by the internal/contractlint sync test — the
+// sanctioned home for a check that reads the prose file this manifest binds
+// against.
 func TestVendoredManifestVersionParses(t *testing.T) {
 	manifestPath := filepath.Join(repoRoot(t), ".claude-plugin", "plugin.json")
 	data, err := os.ReadFile(manifestPath)


### PR DESCRIPTION
Retires the extinct pre-0.19 requires-contract sentinel and every comment that claimed a verifier for it, so no dead jargon reaches new readers.

## What changed
- Delete the requires-contract field from all test fixtures and helpers
- Correct three comments claiming verifiers that do not verify
- Keep the live contract-3 sentinel and its six assertions untouched

## Evidence
- Test-name inventory byte-identical before and after (1375 names); suites green in the credential-free shape, plain and -race
- Fixture classes exercised against real claude and codex hosts

---
[6q](/spacedock-dev/spacedock/blob/0acd3237dfc9981cf005e2b0623341d54d3692f0/retire-requires-contract-sentinel.md)
