### PR TITLE
Remove the provider-evidence gate fields

### DIFF
--- a/docs/specs/gate-resolution-frontmatter-contract.md
+++ b/docs/specs/gate-resolution-frontmatter-contract.md
@@ -88,8 +88,12 @@ the pilot-only attempt selector, `current-attempt`, `sequence`, `previous-attemp
 and explicit attempt `state` encodings are rejected. A read tolerates unknown keys
 only under each `records[*].attempts[*].application` mapping, reports them as warnings
 on explicit `status --validate` or `gate validate`, ignores them for authority, and
-never writes them. All other unknown or malformed fields fail closed. There is no
-migration or compatibility rewrite. The `application` field is an approval-only
+never writes them. A read also drops the retired
+`records[*].attempts[*].provider-evidence` key silently: its writer was cut with
+provider-backed closure, frozen archived records still carry it, and it is retired
+rather than unknown, so it raises no warning and never reaches the model. All other
+unknown or malformed fields fail closed. There is no migration or compatibility
+rewrite. The `application` field is an approval-only
 authority token whose canonical fields are exactly `target-stage` and `state`, where
 state is `pending`, `consumed`, or `superseded`. Revise and hold carry no application.
 

--- a/internal/cli/gate_test.go
+++ b/internal/cli/gate_test.go
@@ -71,7 +71,7 @@ func TestGateWithdrawCLIUsesExactGrammarAndImplicitFirstOfficerAttribution(t *te
 	if parsed, err := time.Parse(time.RFC3339Nano, attempt.Withdrawal.At); err != nil || parsed.Location() != time.UTC {
 		t.Fatalf("withdrawal timestamp = %q (%v)", attempt.Withdrawal.At, err)
 	}
-	if attempt.Resolution != nil || attempt.ProviderEvidence != nil || attempt.Application != nil {
+	if attempt.Resolution != nil || attempt.Application != nil {
 		t.Fatalf("withdrawal fabricated closure: %#v", attempt)
 	}
 }

--- a/internal/ensigncycle/claude_live_runner_test.go
+++ b/internal/ensigncycle/claude_live_runner_test.go
@@ -376,10 +376,10 @@ func assertWithdrawnGateRecovery(doc *gates.Document) error {
 		return fmt.Errorf("recovery attempts = %#v", doc.Records)
 	}
 	withdrawn, current := doc.Records[0].Attempts[0], doc.Records[0].Attempts[1]
-	if withdrawn.Withdrawal == nil || withdrawn.Resolution != nil || withdrawn.ProviderEvidence != nil || withdrawn.Application != nil {
+	if withdrawn.Withdrawal == nil || withdrawn.Resolution != nil || withdrawn.Application != nil {
 		return fmt.Errorf("withdrawn attempt lost its clean terminal state: %#v", withdrawn)
 	}
-	if current.Withdrawal != nil || current.Resolution != nil || current.ProviderEvidence != nil || current.Application != nil || !strings.HasSuffix(current.ID, "-2") {
+	if current.Withdrawal != nil || current.Resolution != nil || current.Application != nil || !strings.HasSuffix(current.ID, "-2") {
 		return fmt.Errorf("recovery did not stop on open successor N+1: %#v", current)
 	}
 	return nil

--- a/internal/ensigncycle/recorded_gate_lifecycle_test.go
+++ b/internal/ensigncycle/recorded_gate_lifecycle_test.go
@@ -387,10 +387,10 @@ func TestRecordedGateLifecycleWithdrawColdBootReplaceAndConsume(t *testing.T) {
 	}
 	stale, current := doc.Records[0].Attempts[0], doc.Records[0].Attempts[1]
 	if stale.Withdrawal == nil || stale.Withdrawal.By != "agent:first-officer" ||
-		stale.Resolution != nil || stale.ProviderEvidence != nil || stale.Application != nil {
+		stale.Resolution != nil || stale.Application != nil {
 		t.Fatalf("withdrawn authority was not retained cleanly: %#v", stale)
 	}
-	if current.Withdrawal != nil || current.Resolution == nil || current.ProviderEvidence != nil ||
+	if current.Withdrawal != nil || current.Resolution == nil ||
 		current.Application == nil || current.Application.State != "consumed" {
 		t.Fatalf("replacement did not exclusively own consumed authority: %#v", current)
 	}

--- a/internal/gates/gates_test.go
+++ b/internal/gates/gates_test.go
@@ -43,7 +43,6 @@ func TestWithdrawalDefinesThirdValidatedFrozenAttemptState(t *testing.T) {
 		"blank reason":     func(a *Attempt) { a.Withdrawal.Reason = " \t" },
 		"no request":       func(a *Attempt) { a.Briefing.RequestDigest = "" },
 		"with resolution":  func(a *Attempt) { a.Resolution = eligibleDocument().Records[0].Attempts[0].Resolution },
-		"with evidence":    func(a *Attempt) { a.ProviderEvidence = &ProviderEvidence{} },
 		"with application": func(a *Attempt) { a.Application = &Application{} },
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -212,6 +211,66 @@ func TestPrototypeAndUnknownGateShapesFailClosed(t *testing.T) {
 	}
 }
 
+// TestRetiredProviderEvidenceKeyReadsSilentlyWithoutWideningAttemptTolerance
+// fences the one attempt-level key a read drops instead of refusing. The
+// provider-backed closure writer was cut, but frozen archived attempts still
+// carry the key, so a read must tolerate it silently while every other unknown
+// attempt key stays fail-closed.
+func TestRetiredProviderEvidenceKeyReadsSilentlyWithoutWideningAttemptTolerance(t *testing.T) {
+	entity := writeEntity(t, retiredEvidenceFrontmatter())
+	before := readFile(t, entity)
+
+	doc, expected, warnings, err := ReadDiagnostics(entity)
+	if err != nil {
+		t.Fatalf("retired provider-evidence key refused: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("retired key is not unknown and must stay silent, got %#v", warnings)
+	}
+	if got := readFile(t, entity); got != before {
+		t.Fatal("read rewrote the entity it only validated")
+	}
+	encoded, err := yaml.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "provider-evidence") {
+		t.Fatalf("retired key reached the canonical model: %s", encoded)
+	}
+
+	// The drop must run on the validation clone. The returned node is the
+	// compare-and-swap expectation, so filtering it instead would both lose the
+	// stored bytes and make every later write refuse as a stale expectation.
+	if !strings.Contains(nodeYAML(t, expected), "provider-evidence") {
+		t.Fatal("retired key was dropped from the write node instead of the validation clone")
+	}
+	// The frozen-attempt check reads the stored node on the old side and the
+	// filtered model on the new side, so the retired key must stay symmetric.
+	if err := ValidateTransition(expected, doc); err != nil {
+		t.Fatalf("frozen transition refused over a retired key: %v", err)
+	}
+	mutated := cloneDocument(t, doc)
+	mutated.Records[0].Attempts[0].Resolution.Reason = "rewritten"
+	if err := ValidateTransition(expected, mutated); err == nil {
+		t.Fatal("frozen closed attempt mutation accepted")
+	}
+
+	outsideBefore := outsideGates(t, entity)
+	if err := writeDocument(entity, expected, doc); err != nil {
+		t.Fatalf("canonical write over a retired-key entity: %v", err)
+	}
+	if outsideGates(t, entity) != outsideBefore {
+		t.Fatal("canonical write changed bytes outside the gates mapping")
+	}
+
+	// Tolerance widened by exactly one named key, not by attempt level.
+	unknown := writeEntity(t, strings.Replace(retiredEvidenceFrontmatter(),
+		"        - id: attempt:a-1\n", "        - id: attempt:a-1\n          note: prototype\n", 1))
+	if _, _, err := Read(unknown); err == nil || !strings.Contains(err.Error(), "field") {
+		t.Fatalf("unknown attempt field alongside the retired key = %v, want refusal", err)
+	}
+}
+
 func TestDigestDomainFieldFailsClosed(t *testing.T) {
 	entity := writeEntity(t, strings.Replace(canonicalOpenGates(), "            room-ref: ./room", "            room-ref: ./room\n            digest-domain: canonical-bytes", 1))
 	before := readFile(t, entity)
@@ -298,16 +357,6 @@ func TestAuthorityDocumentDecodersRejectRecursiveDuplicateMembers(t *testing.T) 
 		t.Fatalf("request duplicate error=%v", err)
 	}
 
-	duplicateResult := []byte(`{"type":"review-v1-result","briefing":"briefing:a","artifact":{"id":"artifact:a","rev":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"resolution":{"type":"Resolution","id":"resolution:a","briefing":"briefing:a","by":"person:captain","at":"now","decision":"approve","extra":{"authority":"one","authority":"two"}},"annotations":[]}`)
-	if _, err := decodeProviderResult(duplicateResult); err == nil || !strings.Contains(err.Error(), "duplicate JSON object member") {
-		t.Fatalf("Result duplicate error=%v", err)
-	}
-
-	duplicateInventory := []byte(`{"items":[{"type":"Artifact","id":"artifact:a","rev":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","extra":{"source":"one","source":"two"}}]}`)
-	if _, err := decodePresentedInventory(duplicateInventory); err == nil || !strings.Contains(err.Error(), "duplicate JSON object member") {
-		t.Fatalf("inventory duplicate error=%v", err)
-	}
-
 	deep := strings.Repeat(`{"nested":`, maxAuthorityJSONDepth+1) + `null` + strings.Repeat(`}`, maxAuthorityJSONDepth+1)
 	if err := rejectDuplicateMembers([]byte(deep)); err == nil || !strings.Contains(err.Error(), "nesting exceeds") {
 		t.Fatalf("deep authority JSON error=%v", err)
@@ -335,23 +384,6 @@ func TestPortableResolutionValidation(t *testing.T) {
 				t.Fatalf("err=%v, want %q", err, tc.wantErr)
 			}
 		})
-	}
-}
-
-func TestProviderResolutionIncludesRequireSameBriefingAnnotation(t *testing.T) {
-	result := providerResult{Briefing: "briefing:provider"}
-	result.Resolution = Resolution{Type: "Resolution", ID: "resolution:r", Briefing: result.Briefing, By: "person:reviewer", At: "now", Decision: "hold", Includes: []string{"annotation:a"}}
-	result.Annotations = append(result.Annotations, Annotation{Type: "Annotation", ID: "annotation:a", Briefing: result.Briefing})
-	if err := verifyProviderResolution(&result); err != nil {
-		t.Fatalf("compatible provider Annotation without by/at = %v", err)
-	}
-	result.Annotations[0].Briefing = "briefing:other"
-	if err := verifyProviderResolution(&result); err == nil || !strings.Contains(err.Error(), "same Briefing") {
-		t.Fatalf("cross-Briefing include = %v, want refusal", err)
-	}
-	result.Annotations[0].Briefing = result.Briefing
-	if err := verifyProviderResolution(&result); err != nil {
-		t.Fatalf("same-Briefing Annotation rejected: %v", err)
 	}
 }
 
@@ -389,6 +421,26 @@ func canonicalOpenGates() string {
 
 func canonicalClosedFrontmatter() string {
 	return "status: ideation\n" + canonicalOpenGates() + "          resolution:\n            type: Resolution\n            id: resolution:a-1\n            briefing: briefing:a-1\n            by: person:captain\n            at: 2026-07-22T00:00:00Z\n            decision: approve\n"
+}
+
+// retiredEvidenceFrontmatter mirrors the archived provider-closed attempt
+// shape: a closed attempt with a retained request-digest that still carries
+// both frozen provider-evidence digests.
+func retiredEvidenceFrontmatter() string {
+	return strings.Replace(canonicalClosedFrontmatter(),
+		"            room-ref: ./room\n",
+		"            room-ref: ./room\n            request-digest: sha256:"+strings.Repeat("3", 64)+"\n", 1) +
+		"          provider-evidence:\n            result-digest: sha256:" + strings.Repeat("4", 64) +
+		"\n            presented-inventory-digest: sha256:" + strings.Repeat("5", 64) + "\n"
+}
+
+func nodeYAML(t *testing.T, node *yaml.Node) string {
+	t.Helper()
+	b, err := yaml.Marshal(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
 }
 
 func canonicalTwoGateFrontmatter() string {

--- a/internal/gates/io.go
+++ b/internal/gates/io.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -130,11 +129,19 @@ func cloneYAMLNode(node *yaml.Node) *yaml.Node {
 	return &out
 }
 
-// filterApplicationMappings removes non-canonical keys only at
-// gates.records[*].attempts[*].application. It validates the application value
-// shape before filtering so null, sequence, and scalar legacy values remain
-// strict errors. Unknown keys are reported once per path/field and sorted for
-// deterministic operator output.
+// retiredAttemptKey is the one attempt-level key a read drops instead of
+// refusing. Its writer was cut with provider-backed closure, so no live command
+// produces it, but frozen archived attempts still carry the bytes. It is
+// retired rather than unknown: dropping it silently keeps those records
+// readable without widening attempt-level tolerance to any other key.
+const retiredAttemptKey = "provider-evidence"
+
+// filterApplicationMappings drops the retired attempt-level key and removes
+// non-canonical keys only at gates.records[*].attempts[*].application. It
+// validates the application value shape before filtering so null, sequence, and
+// scalar legacy values remain strict errors. Unknown keys are reported once per
+// path/field and sorted for deterministic operator output; the retired key is
+// silent and raises no warning.
 func filterApplicationMappings(gatesNode *yaml.Node) ([]Warning, error) {
 	var warnings []Warning
 	if gatesNode == nil || gatesNode.Kind != yaml.MappingNode {
@@ -156,6 +163,14 @@ func filterApplicationMappings(gatesNode *yaml.Node) ([]Warning, error) {
 			if attempt == nil || attempt.Kind != yaml.MappingNode {
 				continue
 			}
+			keptAttempt := make([]*yaml.Node, 0, len(attempt.Content))
+			for i := 0; i+1 < len(attempt.Content); i += 2 {
+				if attempt.Content[i].Value == retiredAttemptKey {
+					continue
+				}
+				keptAttempt = append(keptAttempt, attempt.Content[i], attempt.Content[i+1])
+			}
+			attempt.Content = keptAttempt
 			for i := 0; i+1 < len(attempt.Content); i += 2 {
 				if attempt.Content[i].Value != "application" {
 					continue
@@ -263,41 +278,6 @@ func validateRetainedAuthorityExcept(entityPath, workflowDir string, doc *Docume
 			}
 			if err := validatePresentationGitSources(roots, items); err != nil {
 				return fmt.Errorf("attempt %s %w", attempt.ID, err)
-			}
-			if attempt.ProviderEvidence == nil {
-				continue
-			}
-			resultBytes, err := os.ReadFile(filepath.Join(room, "provider", "result.json"))
-			if err != nil {
-				return fmt.Errorf("attempt %s retained provider/result.json: %w", attempt.ID, err)
-			}
-			inventoryBytes, err := os.ReadFile(filepath.Join(room, "provider", "presented-inventory.json"))
-			if err != nil {
-				return fmt.Errorf("attempt %s retained provider/presented-inventory.json: %w", attempt.ID, err)
-			}
-			if RawDigest(resultBytes) != attempt.ProviderEvidence.ResultDigest {
-				return fmt.Errorf("attempt %s retained provider/result.json does not match its frozen digest", attempt.ID)
-			}
-			if RawDigest(inventoryBytes) != attempt.ProviderEvidence.PresentedInventoryDigest {
-				return fmt.Errorf("attempt %s retained provider/presented-inventory.json does not match its frozen digest", attempt.ID)
-			}
-			result, err := decodeProviderResult(resultBytes)
-			if err != nil {
-				return err
-			}
-			if attempt.Resolution == nil || !reflect.DeepEqual(result.Resolution, *attempt.Resolution) {
-				return fmt.Errorf("attempt %s retained provider Resolution does not match its durable Resolution", attempt.ID)
-			}
-			inventory, err := decodePresentedInventory(inventoryBytes)
-			if err != nil {
-				return err
-			}
-			association, err := deriveAssociation(resultBytes, result, inventory, request.Approver, attempt.Briefing, items)
-			if err != nil {
-				return err
-			}
-			if err := verifyAssociation(resultBytes, result, association, request.Approver, attempt.Briefing, items); err != nil {
-				return err
 			}
 		}
 	}

--- a/internal/gates/model.go
+++ b/internal/gates/model.go
@@ -24,23 +24,17 @@ type GateRecord struct {
 }
 
 type Attempt struct {
-	ID               string            `yaml:"id" json:"id"`
-	Briefing         Briefing          `yaml:"briefing" json:"briefing"`
-	Withdrawal       *Withdrawal       `yaml:"withdrawal,omitempty" json:"withdrawal,omitempty"`
-	ProviderEvidence *ProviderEvidence `yaml:"provider-evidence,omitempty" json:"provider-evidence,omitempty"`
-	Resolution       *Resolution       `yaml:"resolution,omitempty" json:"resolution,omitempty"`
-	Application      *Application      `yaml:"application,omitempty" json:"application,omitempty"`
+	ID          string       `yaml:"id" json:"id"`
+	Briefing    Briefing     `yaml:"briefing" json:"briefing"`
+	Withdrawal  *Withdrawal  `yaml:"withdrawal,omitempty" json:"withdrawal,omitempty"`
+	Resolution  *Resolution  `yaml:"resolution,omitempty" json:"resolution,omitempty"`
+	Application *Application `yaml:"application,omitempty" json:"application,omitempty"`
 }
 
 type Withdrawal struct {
 	By     string `yaml:"by" json:"by"`
 	At     string `yaml:"at" json:"at"`
 	Reason string `yaml:"reason" json:"reason"`
-}
-
-type ProviderEvidence struct {
-	ResultDigest             string `yaml:"result-digest" json:"result-digest"`
-	PresentedInventoryDigest string `yaml:"presented-inventory-digest" json:"presented-inventory-digest"`
 }
 
 type Application struct {
@@ -264,9 +258,6 @@ func Validate(doc *Document) error {
 			}
 			switch attemptState(a) {
 			case "open":
-				if a.ProviderEvidence != nil {
-					return fmt.Errorf("open attempt %s cannot carry provider evidence", a.ID)
-				}
 				if a.Application != nil {
 					return fmt.Errorf("open attempt %s cannot carry application data", a.ID)
 				}
@@ -278,20 +269,13 @@ func Validate(doc *Document) error {
 				if err := validateWithdrawal(a.Withdrawal); err != nil {
 					return fmt.Errorf("attempt %s: %w", a.ID, err)
 				}
-				if a.ProviderEvidence != nil || a.Application != nil {
-					return fmt.Errorf("withdrawn attempt %s cannot carry provider evidence or application data", a.ID)
+				if a.Application != nil {
+					return fmt.Errorf("withdrawn attempt %s cannot carry application data", a.ID)
 				}
 				continue
 			case "closed":
 			default:
 				return fmt.Errorf("attempt %s has conflicting withdrawal and resolution state", a.ID)
-			}
-			if a.ProviderEvidence != nil {
-				if a.Briefing.RequestDigest == "" ||
-					!digestRE.MatchString(a.ProviderEvidence.ResultDigest) ||
-					!digestRE.MatchString(a.ProviderEvidence.PresentedInventoryDigest) {
-					return fmt.Errorf("provider-closed attempt %s has invalid provider evidence", a.ID)
-				}
 			}
 			if err := validateResolution(a.Resolution, a.Briefing.ID); err != nil {
 				return fmt.Errorf("attempt %s: %w", a.ID, err)

--- a/internal/gates/operation.go
+++ b/internal/gates/operation.go
@@ -55,14 +55,6 @@ type briefingManifest struct {
 	Context   []json.RawMessage  `json:"context"`
 }
 
-type providerResult struct {
-	Type        string       `json:"type"`
-	Briefing    string       `json:"briefing"`
-	Artifact    artifactRef  `json:"artifact"`
-	Resolution  Resolution   `json:"resolution"`
-	Annotations []Annotation `json:"annotations"`
-}
-
 type gateRoomRequest struct {
 	Type     string `json:"type"`
 	Version  string `json:"version"`
@@ -77,10 +69,6 @@ type gateRoomRequest struct {
 	Approver string `json:"approver"`
 }
 
-type presentedInventory struct {
-	Items []presentedItem `json:"items"`
-}
-
 type presentedItem struct {
 	Type string `json:"type"`
 	artifactRef
@@ -92,41 +80,6 @@ func decodeGateRoomRequest(data []byte) (*gateRoomRequest, error) {
 		return nil, err
 	}
 	return &request, nil
-}
-
-func decodeProviderResult(data []byte) (*providerResult, error) {
-	var result providerResult
-	if err := decodeAuthorityJSON(data, "parse Result", &result); err != nil {
-		return nil, err
-	}
-	return &result, nil
-}
-
-func decodePresentedInventory(data []byte) (*presentedInventory, error) {
-	var inventory presentedInventory
-	if err := decodeAuthorityJSON(data, "parse presented inventory", &inventory); err != nil {
-		return nil, err
-	}
-	return &inventory, nil
-}
-
-type resultAssociation struct {
-	Type    string `json:"type"`
-	Version string `json:"version"`
-	Result  struct {
-		Digest   string `json:"digest"`
-		Briefing string `json:"briefing"`
-	} `json:"result"`
-	Actor     string `json:"actor"`
-	Canonical struct {
-		Briefing  string        `json:"briefing"`
-		Revision  string        `json:"revision"`
-		Artifacts []artifactRef `json:"artifacts"`
-	} `json:"canonical"`
-	Presentation []struct {
-		Provider  artifactRef `json:"provider"`
-		Canonical artifactRef `json:"canonical"`
-	} `json:"presentation"`
 }
 
 // RecordSemantic accepts exactly one decision source while the entity lock is
@@ -500,113 +453,6 @@ func applicationStages(readme string) ([]applicationStage, error) {
 		return nil, fmt.Errorf("workflow has no application stages")
 	}
 	return result, nil
-}
-
-func verifyAssociation(resultBytes []byte, result *providerResult, association *resultAssociation, actor string, binding Briefing, inventory []presentedItem) error {
-	if result.Type != "review-v1-result" || result.Briefing == "" || result.Artifact.ID == "" || !digestRE.MatchString(result.Artifact.Rev) {
-		return fmt.Errorf("gate room Result is not a complete review-v1-result")
-	}
-	if association.Type != "spacedock-result-association" || association.Version != "1" {
-		return fmt.Errorf("derived presentation association is not spacedock-result-association v1")
-	}
-	if association.Result.Digest != RawDigest(resultBytes) || association.Result.Briefing != result.Briefing {
-		return fmt.Errorf("association does not bind the exact Result bytes and provider Briefing")
-	}
-	if association.Actor != actor || result.Resolution.By != actor {
-		return fmt.Errorf("Result actor is not authorized by the retained association")
-	}
-	if err := verifyProviderResolution(result); err != nil {
-		return err
-	}
-	if association.Canonical.Briefing != binding.ID || association.Canonical.Revision != binding.Digest {
-		return fmt.Errorf("association does not bind the current canonical Briefing revision")
-	}
-	if len(inventory) == 0 || len(association.Canonical.Artifacts) != len(inventory) || len(association.Presentation) != len(inventory) {
-		return fmt.Errorf("association does not cover the complete presentation mapping")
-	}
-	canonical := make(map[string]presentedItem, len(inventory))
-	for i, artifact := range inventory {
-		declared := association.Canonical.Artifacts[i]
-		if artifact.ID == "" || !digestRE.MatchString(artifact.Rev) || canonical[artifact.ID].ID != "" || declared.ID != artifact.ID || declared.Rev != artifact.Rev {
-			return fmt.Errorf("association canonical artifacts do not match the bound Briefing inventory")
-		}
-		canonical[artifact.ID] = artifact
-	}
-	seenCanonical := map[string]bool{}
-	seenProvider := map[string]bool{}
-	resultArtifactPresent := false
-	for _, mapping := range association.Presentation {
-		canonicalItem := canonical[mapping.Canonical.ID]
-		if mapping.Provider.ID == "" || !digestRE.MatchString(mapping.Provider.Rev) || canonicalItem.Rev != mapping.Canonical.Rev || seenCanonical[mapping.Canonical.ID] || seenProvider[mapping.Provider.ID] {
-			return fmt.Errorf("association does not cover the complete presentation mapping")
-		}
-		seenCanonical[mapping.Canonical.ID] = true
-		seenProvider[mapping.Provider.ID] = true
-		if canonicalItem.Type == "Artifact" && mapping.Provider.ID == result.Artifact.ID && mapping.Provider.Rev == result.Artifact.Rev {
-			resultArtifactPresent = true
-		}
-	}
-	if len(seenCanonical) != len(canonical) || !resultArtifactPresent {
-		return fmt.Errorf("association does not cover the exact Result artifact and complete presentation mapping")
-	}
-	return nil
-}
-
-func deriveAssociation(resultBytes []byte, result *providerResult, presented *presentedInventory, actor string, binding Briefing, inventory []presentedItem) (*resultAssociation, error) {
-	if len(inventory) == 0 || len(presented.Items) != len(inventory) {
-		return nil, fmt.Errorf("presented inventory does not cover the complete presentation mapping")
-	}
-	canonical := make(map[string]presentedItem, len(inventory))
-	for _, item := range inventory {
-		if item.ID == "" || !digestRE.MatchString(item.Rev) || canonical[item.ID].ID != "" {
-			return nil, fmt.Errorf("canonical Briefing has incomplete or duplicate presentation identity")
-		}
-		canonical[item.ID] = item
-	}
-	association := &resultAssociation{Type: "spacedock-result-association", Version: "1", Actor: actor}
-	association.Result.Digest = RawDigest(resultBytes)
-	association.Result.Briefing = result.Briefing
-	association.Canonical.Briefing = binding.ID
-	association.Canonical.Revision = binding.Digest
-	for _, item := range inventory {
-		association.Canonical.Artifacts = append(association.Canonical.Artifacts, item.artifactRef)
-	}
-	seen := make(map[string]bool, len(presented.Items))
-	for _, item := range presented.Items {
-		expected := canonical[item.ID]
-		if (item.Type != "Artifact" && item.Type != "Reference") || expected.ID == "" ||
-			item.Type != expected.Type || item.Rev != expected.Rev || seen[item.ID] {
-			return nil, fmt.Errorf("presented inventory does not cover the complete presentation mapping")
-		}
-		seen[item.ID] = true
-		association.Presentation = append(association.Presentation, struct {
-			Provider  artifactRef `json:"provider"`
-			Canonical artifactRef `json:"canonical"`
-		}{
-			Provider:  item.artifactRef,
-			Canonical: expected.artifactRef,
-		})
-	}
-	return association, nil
-}
-
-func verifyProviderResolution(result *providerResult) error {
-	if result.Resolution.Briefing != result.Briefing {
-		return fmt.Errorf("provider Resolution does not bind its provider Briefing")
-	}
-	annotations := map[string]string{}
-	for _, annotation := range result.Annotations {
-		if annotation.Type != "Annotation" || annotation.ID == "" || annotations[annotation.ID] != "" {
-			return fmt.Errorf("provider annotations have missing or duplicate identity")
-		}
-		annotations[annotation.ID] = annotation.Briefing
-	}
-	for _, included := range result.Resolution.Includes {
-		if annotations[included] != result.Briefing {
-			return fmt.Errorf("Resolution includes must name a provider Annotation from the same Briefing")
-		}
-	}
-	return validateResolution(&result.Resolution, result.Briefing)
 }
 
 func chatResolutionID(gateID, attemptID string) string {


### PR DESCRIPTION
Removes the provider-evidence gate fields nothing writes, retiring the key behind one named read tolerance so six archived records stay readable forever.

## What changed
- Delete the ProviderEvidence model, its policing branches, and 154 lines of orphaned verification helpers
- Add a single retired-key read tolerance at attempt level
- Add a tolerance test proving reads stay silent and bytes unchanged

## Evidence
- Validator PASSED with a frozen state snapshot and an independent corpus decoder: decode 119/16 identical, validate byte-identical both streams
- All four mutation fences fire; tolerance provably one named key

---
[7c](/spacedock-dev/spacedock/blob/6c01dd705ba0568b14cf30b165090daea8896a70/_archive/remove-provider-evidence-fields.md)
