### PR TITLE
Remove boot-time gate withdraw capability probe

### DIFF
--- a/docs/site/get-started/install.md
+++ b/docs/site/get-started/install.md
@@ -106,10 +106,6 @@ See [supported sandboxes](../reference/sandbox.md).
 
 Run `spacedock doctor`.
 
-If startup says the installed launcher is missing a required command, upgrade
-Spacedock and relaunch. On macOS, run `brew upgrade spacedock`. On Linux, rerun
-the checksum-verified binary installer shown above.
-
 ## Next
 
 Read about the [survey report](survey.md) to understand your usage pattern

--- a/internal/contractlint/version_gate_smoke_test.go
+++ b/internal/contractlint/version_gate_smoke_test.go
@@ -58,6 +58,9 @@ func TestVersionGateDeferredTrigger(t *testing.T) {
 	if !strings.Contains(body, "- `references/fo-install-gate.md`") {
 		t.Fatalf("deferred-load-points inventory must carry a references/fo-install-gate.md entry line")
 	}
+	if strings.Contains(body, "gate --help") {
+		t.Fatalf("boot-resident core must not carry an inline `gate --help` capability probe: the binary gate relies on the minor-version match alone, and a stale launcher fails at the first `gate withdraw`")
+	}
 	// The deferred body exists and is non-trivial.
 	gate := readSkillFile(t, installGatePath)
 	if len(gate) < 500 {

--- a/skills/first-officer/references/first-officer-shared-core.md
+++ b/skills/first-officer/references/first-officer-shared-core.md
@@ -9,8 +9,6 @@ Shared first-officer semantics — the boot-resident core. The active runtime ad
 1. **Binary gate.** Check `[ "${APP_SANDBOX_CONTAINER_ID:-}" = "agent-safehouse" ]`; inside, never offer/run installation; say to run it outside the sandbox. `${SPACEDOCK_BIN:-spacedock} --version` line 1 must be `spacedock <version>`. These skills require binary minor 0.27.
    - **Binary absent:** retry bare `spacedock` once if `SPACEDOCK_BIN` is unusable. Use `uname -s`, not `doctor`/`OS:`. Linux: `curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/main/install.sh | sh`; macOS: `brew tap spacedock-dev/homebrew-tap`, then `brew install spacedock-dev/homebrew-tap/spacedock`; other OS: unsupported OS, hint `go build -o spacedock ./cmd/spacedock`, ABORT. Outside sandbox read `references/fo-install-gate.md`.
    - **Wrong version:** major.minor below/above/absent (bare `dev`) → ABORT; `${SPACEDOCK_BIN:-spacedock} doctor`.
-   - **Compatible minor:** `${SPACEDOCK_BIN:-spacedock} gate --help` once; stdout must contain `spacedock gate withdraw <entity> --reason TEXT`. Read-only; no workflow state.
-   - **Missing capability** (nonzero/absent line): ABORT before boot. Name executable, line-1 version, missing `gate withdraw … --reason`. Give only macOS `brew upgrade spacedock` or Linux `curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/main/install.sh | sh`; say relaunch. No in-session install/repoint, source/repository advice, plugin refresh, network lookup, or alternate launcher.
 2. **Boot — local identify.** Invoke `«state.boot»()` once and retain its boot record.
 3. **Interaction boundary.** Invoke `«interaction.boundary»()` with that boot record and the launch context.
 


### PR DESCRIPTION
Removes the boot-time gate-withdraw capability probe; the minor version gate suffices, and a stale launcher already fails loudly at point of use.

## What changed
- Delete the Compatible-minor and Missing-capability bullets from the FO startup contract
- Delete the install.md paragraph explaining the removed abort
- Add a one-line reintroduction guard in contractlint

## Evidence
- Validator PASSED including a real merged-tree run with the harness deletion
- Reintroducing the probe bullet makes the new guard the package's sole failure

---
[dav](/spacedock-dev/spacedock/blob/6c01dd705ba0568b14cf30b165090daea8896a70/_archive/remove-startup-capability-probe.md)
