### PR TITLE
Trim --version decoration without a reader; name the sandbox

### DIFF
--- a/docs/site/reference/command-reference.md
+++ b/docs/site/reference/command-reference.md
@@ -9,29 +9,31 @@ The `spacedock` binary groups its subcommands into Launch, Setup, and Workflow, 
     spacedock 0.26.0
     OS: darwin/arm64
 
-Inside a session it also names the host OS/arch, the runtime it detected, the marker that proved it, which session this is, and whether this process is running inside a sandbox:
+Inside a session it also names the host OS/arch, the runtime it detected, the marker that proved it, and whether this process is running inside a sandbox:
 
     spacedock 0.26.0
     OS: darwin/arm64
-    Runtime: claude (CLAUDECODE, session afd74765)
-    Sandbox: inside (agent-safehouse)
+    Runtime: claude (CLAUDECODE)
+    Sandbox: agent-safehouse
     contract 3
 
-The session identifier is the first eight characters of the host's own session id — the same prefix Claude Code uses to name `~/.claude/teams/session-afd74765` — so you can tell two concurrent sessions apart and match one against its state on disk. Hosts that do not expose a session id, such as pi, omit it:
+A host detected by more than one marker reports all of them:
 
     Runtime: pi (PI_CODING_AGENT, PI_CODING_AGENT_DIR)
 
 When markers for more than one runtime are set — a nested session can leak them — it reports the ambiguity rather than guessing, and still exits 0:
 
-    Runtime: ambiguous (CODEX_THREAD_ID, CLAUDECODE) — pass --host
+    Runtime: ambiguous (CODEX_THREAD_ID, CLAUDECODE)
+
+Nothing on this surface fails, so it names no remedy. The one command the ambiguity does block is `spacedock dispatch build`, which refuses and prints the remedy with all three valid values.
 
 Being outside every runtime is a normal state, not a fault — it means a human at a terminal. There is no `Runtime:` line at all in that case, because there is no session to report: the output is the two lines shown above (the version line plus the `OS:` line).
 
-The `Sandbox:` line answers one question — is this process sandboxed? Inside a sandbox it names it; otherwise it reports whether safehouse is available to sandbox future launches:
+The `Sandbox:` line answers one question — is this process sandboxed? Sandboxed, the value is the sandbox's name and nothing else; otherwise it is `none`, followed by whether safehouse is available to sandbox future launches:
 
-    Sandbox: inside (agent-safehouse)
-    Sandbox: not sandboxed (safehouse available)
-    Sandbox: not sandboxed (safehouse not installed)
+    Sandbox: agent-safehouse
+    Sandbox: none (safehouse available)
+    Sandbox: none (safehouse not installed)
 
 `spacedock status --boot` reports the same three. The pre-launch banner answers the neighbouring but different question — whether the launch it is about to perform will be wrapped — so its `Sandbox:` line reads in terms of that launch.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -824,7 +824,9 @@ func cwd() string {
 // the abort correct in the old prose's own terms.
 //
 // The value must stay 3 — bumping it would false-green old skills against every
-// future binary. It is pinned by the internal/contractlint sync test.
+// future binary. It is pinned by internal/cli/version_session_test.go, which
+// asserts the literal below the Sandbox line — internal/contractlint carries no
+// reference to it at all.
 //
 // RETIREMENT CONDITION: removable once no plugin or binary predating #468 can
 // still be running. Both reader populations are ours — old spacedock skills and
@@ -856,7 +858,7 @@ func printVersion(w io.Writer, getenv func(string) string, lookPath func(string)
 	fmt.Fprintf(w, "spacedock %s\n", displayVersion())
 	fmt.Fprintf(w, "OS: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 
-	host, markers, identity, ambiguous := runtimehost.Detect(getenv)
+	host, markers, ambiguous := runtimehost.Detect(getenv)
 	if !ambiguous && host == "" {
 		// Outside every runtime — a human at a terminal. Two lines: the version
 		// line plus the OS line, nothing else.
@@ -864,29 +866,15 @@ func printVersion(w io.Writer, getenv func(string) string, lookPath func(string)
 	}
 
 	if ambiguous {
-		fmt.Fprintf(w, "Runtime: ambiguous (%s) — pass --host\n", strings.Join(markers, ", "))
+		fmt.Fprintf(w, "Runtime: ambiguous (%s)\n", strings.Join(markers, ", "))
 	} else {
-		fmt.Fprintf(w, "Runtime: %s\n", runtimeLine(host, markers, identity))
+		fmt.Fprintf(w, "Runtime: %s (%s)\n", host, strings.Join(markers, ", "))
 	}
 
 	insideName, inside := safehouse.Inside(getenv)
 	available, _ := safehouse.Available(lookPath)
 	fmt.Fprintf(w, "Sandbox: %s\n", safehouse.SessionState(insideName, inside, available))
 	fmt.Fprintln(w, frozenContractToken)
-}
-
-// runtimeLine renders the resolved-host Runtime value: the host, the markers that
-// proved it, and this session's own identifier where the host exposes one. A host
-// with no identity variable (pi) and a host whose identity variable is unset take
-// the SAME path — the segment is omitted — so no empty or dangling parenthetical
-// is reachable, and the day pi gains a session variable the change is one table
-// cell in internal/runtimehost.
-func runtimeLine(host string, markers []string, identity string) string {
-	detail := strings.Join(markers, ", ")
-	if short := runtimehost.ShortID(identity); short != "" {
-		detail += ", session " + short
-	}
-	return host + " (" + detail + ")"
 }
 
 // runCompletion emits a static shell-completion script for bash or zsh to

--- a/internal/cli/version_session_test.go
+++ b/internal/cli/version_session_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: --version reports the session it is actually in — the Runtime line
-// ABOUTME: with its session id, the session sandbox state, and no host CLI exec.
+// ABOUTME: --version reports the session it is actually in — the Runtime line,
+// ABOUTME: the session sandbox state, and no host CLI exec.
 package cli
 
 import (
@@ -53,15 +53,18 @@ func TestVersionSessionRender(t *testing.T) {
 	}{
 		{
 			// The live regression case: sandboxed, and safehouse off PATH precisely
-			// BECAUSE the wrap already happened. This rendered
-			// `Sandbox: unavailable (safehouse not on PATH)` before this change.
+			// BECAUSE the wrap already happened. The sandbox line names the sandbox
+			// and nothing else. CLAUDE_CODE_SESSION_ID is SET here and appears
+			// nowhere in the render — the Runtime line is byte-identical to the
+			// `claude-no-session-id-var` case below, which is what the session
+			// segment's removal means.
 			name:     "claude-inside-safehouse",
 			vars:     claudeSession,
 			lookPath: lookMissing,
 			want: "spacedock " + version + "\n" +
 				"OS: " + osToken + "\n" +
-				"Runtime: claude (CLAUDECODE, session afd74765)\n" +
-				"Sandbox: inside (agent-safehouse)\n" +
+				"Runtime: claude (CLAUDECODE)\n" +
+				"Sandbox: agent-safehouse\n" +
 				"contract 3\n",
 		},
 		{
@@ -72,23 +75,22 @@ func TestVersionSessionRender(t *testing.T) {
 				"OS: " + osToken + "\n",
 		},
 		{
-			// A host whose identity variable is unset takes the same path as a host
-			// with no identity variable at all: the segment is omitted. A stray
-			// `, session ` or `()` fails this exact-match.
-			name:     "claude-without-session-id",
+			// The same host with no session variable set at all. Its Runtime line
+			// matches the case above character for character; only the sandbox
+			// differs. A stray `, session ` or `()` fails this exact-match.
+			name:     "claude-no-session-id-var",
 			vars:     map[string]string{"CLAUDECODE": "1"},
 			lookPath: lookFound,
 			want: "spacedock " + version + "\n" +
 				"OS: " + osToken + "\n" +
 				"Runtime: claude (CLAUDECODE)\n" +
-				"Sandbox: not sandboxed (safehouse available)\n" +
+				"Sandbox: none (safehouse available)\n" +
 				"contract 3\n",
 		},
 		{
-			// Pi exposes no per-session identifier at all (PI_CODING_AGENT_SESSION_DIR
-			// is the sessions COLLECTION), and two markers of the same host are not
-			// ambiguity.
-			name: "pi-two-markers-no-identity",
+			// Two markers of the SAME host are not ambiguity: pi resolves, and both
+			// markers are reported in table order.
+			name: "pi-two-markers-same-host",
 			vars: map[string]string{
 				"PI_CODING_AGENT":     "1",
 				"PI_CODING_AGENT_DIR": "/home/u/.pi/agent",
@@ -97,24 +99,27 @@ func TestVersionSessionRender(t *testing.T) {
 			want: "spacedock " + version + "\n" +
 				"OS: " + osToken + "\n" +
 				"Runtime: pi (PI_CODING_AGENT, PI_CODING_AGENT_DIR)\n" +
-				"Sandbox: not sandboxed (safehouse not installed)\n" +
+				"Sandbox: none (safehouse not installed)\n" +
 				"contract 3\n",
 		},
 		{
-			// codex's detection marker doubles as its identity variable — the only
-			// host where they coincide.
-			name:     "codex-marker-doubles-as-identity",
+			// codex's marker carries a UUID-shaped value. The Runtime line reports
+			// that the marker is SET, never any part of what it holds, so no
+			// fragment of `01937f2a-bbbb-cccc` may appear.
+			name:     "codex-marker-value-never-rendered",
 			vars:     map[string]string{"CODEX_THREAD_ID": "01937f2a-bbbb-cccc"},
 			lookPath: lookFound,
 			want: "spacedock " + version + "\n" +
 				"OS: " + osToken + "\n" +
-				"Runtime: codex (CODEX_THREAD_ID, session 01937f2a)\n" +
-				"Sandbox: not sandboxed (safehouse available)\n" +
+				"Runtime: codex (CODEX_THREAD_ID)\n" +
+				"Sandbox: none (safehouse available)\n" +
 				"contract 3\n",
 		},
 		{
-			// AC-3: ambiguity is REPORTED, not guessed at, and carries no session
-			// identifier — printing one would assert a host had been resolved.
+			// Ambiguity is REPORTED, not guessed at, and carries no remedy: this
+			// surface exits 0 and has no fault to remedy. The one command the
+			// ambiguity blocks, `dispatch build`, prints its own complete remedy
+			// naming all three valid hosts.
 			name: "ambiguous-markers",
 			vars: map[string]string{
 				"CODEX_THREAD_ID":        "01937f2a",
@@ -124,19 +129,32 @@ func TestVersionSessionRender(t *testing.T) {
 			lookPath: lookFound,
 			want: "spacedock " + version + "\n" +
 				"OS: " + osToken + "\n" +
-				"Runtime: ambiguous (CODEX_THREAD_ID, CLAUDECODE) — pass --host\n" +
-				"Sandbox: not sandboxed (safehouse available)\n" +
+				"Runtime: ambiguous (CODEX_THREAD_ID, CLAUDECODE)\n" +
+				"Sandbox: none (safehouse available)\n" +
 				"contract 3\n",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := renderSession(tc.vars, tc.lookPath)
+			// AC-2: the trimmed decorations are unreachable in EVERY shape. These
+			// run before the exact match on purpose: re-adding a decoration and
+			// regenerating the `want` literals in step would slip past an
+			// exact-match-only test, and these name what came back instead.
+			for _, banned := range []struct{ token, what string }{
+				{", session ", "a session identifier segment"},
+				{"pass --host", "a --host remedy suffix"},
+				{"inside", "the Sandbox line restating its own label"},
+			} {
+				if strings.Contains(got, banned.token) {
+					t.Fatalf("--version rendered %q — %s, which has no reader:\n%s", banned.token, banned.what, got)
+				}
+			}
 			if got != tc.want {
 				t.Fatalf("--version render mismatch:\n got=%q\nwant=%q", got, tc.want)
 			}
 			// AC-2a: no empty or dangling parenthetical is ever reachable.
-			if strings.Contains(got, "()") || strings.Contains(got, "session )") {
+			if strings.Contains(got, "()") {
 				t.Fatalf("--version rendered an empty parenthetical: %q", got)
 			}
 			// AC-2b: the session sandbox line never mentions a launch fact.
@@ -183,35 +201,46 @@ func TestVersionContractTokenPlacement(t *testing.T) {
 	}
 }
 
-// TestVersionRuntimeLineDistinguishesConcurrentSessions (AC-2) is the point of
-// printing an identifier at all: two concurrent sessions on the same host must
-// render DIFFERENT Runtime lines. An implementation that reused the detection
-// marker's value would render `session 1` for both and turn this red.
-func TestVersionRuntimeLineDistinguishesConcurrentSessions(t *testing.T) {
-	runtimeLineOf := func(sessionID string) string {
-		out := renderSession(map[string]string{
-			"CLAUDECODE":             "1",
-			"CLAUDE_CODE_SESSION_ID": sessionID,
-		}, lookFound)
+// TestVersionSandboxLineNamesTheSandbox (AC-2) is the positive half of the
+// Sandbox rename: the absence loop above says what must not appear, and this
+// says what must. Sandboxed, the value is the sandbox's NAME and nothing else —
+// under a `Sandbox: ` label the name alone already carries both facts. Both
+// unsandboxed arms lead with `none`, so a reader classifies on name-or-`none`
+// rather than on a relationship word.
+//
+// It holds independently of the banned literals: restoring SessionState's old
+// `inside (...)` / `not sandboxed (...)` shape turns this red by name even with
+// every `want` string in TestVersionSessionRender regenerated to match.
+func TestVersionSandboxLineNamesTheSandbox(t *testing.T) {
+	sandboxLineOf := func(out string) string {
 		for _, line := range strings.Split(out, "\n") {
-			if strings.HasPrefix(line, "Runtime: ") {
+			if strings.HasPrefix(line, "Sandbox: ") {
 				return line
 			}
 		}
-		t.Fatalf("no Runtime: line in %q", out)
+		t.Fatalf("no Sandbox: line in %q", out)
 		return ""
 	}
 
-	first := runtimeLineOf("afd74765-9000-4e63-acf4-3b1f4645a8f3")
-	second := runtimeLineOf("afd74799-9000-4e63-acf4-3b1f4645a8f3")
-	if first == second {
-		t.Fatalf("two sessions rendered the same Runtime line %q — the identifier does not distinguish them", first)
+	cases := []struct {
+		name     string
+		vars     map[string]string
+		lookPath func(string) (string, error)
+		want     string
+	}{
+		// Sandboxed with safehouse off PATH — the live configuration, and the one
+		// where the name is the only honest answer.
+		{"sandboxed-renders-the-bare-name", claudeSession, lookMissing, "Sandbox: agent-safehouse"},
+		{"unsandboxed-safehouse-available", map[string]string{"CLAUDECODE": "1"}, lookFound, "Sandbox: none (safehouse available)"},
+		{"unsandboxed-safehouse-not-installed", map[string]string{"CLAUDECODE": "1"}, lookMissing, "Sandbox: none (safehouse not installed)"},
 	}
-	if first != "Runtime: claude (CLAUDECODE, session afd74765)" {
-		t.Fatalf("first Runtime line = %q", first)
-	}
-	if second != "Runtime: claude (CLAUDECODE, session afd74799)" {
-		t.Fatalf("second Runtime line = %q", second)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sandboxLineOf(renderSession(tc.vars, tc.lookPath))
+			if got != tc.want {
+				t.Fatalf("Sandbox line = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -263,7 +292,7 @@ func TestVersionAmbiguousMarkersExitZero(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("--version with ambiguous markers exited %d, want 0 (stderr=%q)", code, stderr.String())
 	}
-	want := "Runtime: ambiguous (CODEX_THREAD_ID, CLAUDECODE) — pass --host"
+	want := "Runtime: ambiguous (CODEX_THREAD_ID, CLAUDECODE)"
 	if !lineEquals(stdout.String(), want) {
 		t.Fatalf("--version output = %q, want a whole line %q", stdout.String(), want)
 	}

--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -273,7 +273,7 @@ func resolveBuildHost(flagHost, jsonHost string, getenv func(string) string) (st
 	// dispositions of the same facts: a build must REFUSE against an ambiguous
 	// host, while --version must REPORT the ambiguity and exit 0. So the
 	// detection is shared and the policy stays here.
-	host, markers, _, ambiguous := runtimehost.Detect(getenv)
+	host, markers, ambiguous := runtimehost.Detect(getenv)
 	if ambiguous {
 		return "", fmt.Errorf("ambiguous runtime host sources: multiple runtime markers are set (%s); pass --host claude, codex, or pi", strings.Join(markers, ", "))
 	}

--- a/internal/runtimehost/runtimehost.go
+++ b/internal/runtimehost/runtimehost.go
@@ -1,32 +1,23 @@
 // ABOUTME: Env-only detection of the agent runtime host this process is running
-// ABOUTME: under — the marker table, the per-host session identity, and ShortID.
+// ABOUTME: under — the marker table and the ambiguity rule.
 package runtimehost
 
 // markerTable is the single marker table for runtime-host detection. Order is
 // load-bearing: it fixes the order markers are reported in, which both the
 // `--version` Runtime line and dispatch's ambiguity error render.
-//
-// `identity` is a SEPARATE column from `marker` and is not interchangeable with
-// it. A detection marker only has to be set; an identity variable has to name
-// THIS session. They coincide for codex alone (CODEX_THREAD_ID is both), and
-// reusing the marker's value elsewhere would render `session 1` for every claude
-// session, since CLAUDECODE is the literal flag `1`. An empty identity means the
-// host exposes none (pi) or its variable is unset; both take the same path and
-// the caller omits the segment.
 var markerTable = []struct {
-	host     string
-	marker   string
-	identity string
+	host   string
+	marker string
 }{
-	{host: "codex", marker: "CODEX_THREAD_ID", identity: "CODEX_THREAD_ID"},
-	{host: "claude", marker: "CLAUDECODE", identity: "CLAUDE_CODE_SESSION_ID"},
-	{host: "pi", marker: "PI_CODING_AGENT", identity: ""},
-	{host: "pi", marker: "PI_CODING_AGENT_DIR", identity: ""},
+	{host: "codex", marker: "CODEX_THREAD_ID"},
+	{host: "claude", marker: "CLAUDECODE"},
+	{host: "pi", marker: "PI_CODING_AGENT"},
+	{host: "pi", marker: "PI_CODING_AGENT_DIR"},
 }
 
 // Detect resolves the runtime host from env alone. It returns the host name, the
-// markers that were set (in table order), the session's own identifier where the
-// host exposes one, and whether the set markers belong to more than one host.
+// markers that were set (in table order), and whether the set markers belong to
+// more than one host.
 //
 // It NEVER returns an error, because its two callers need opposite dispositions
 // of the same facts: dispatch must refuse to build against an ambiguous host,
@@ -38,11 +29,11 @@ var markerTable = []struct {
 // PI_CODING_AGENT_DIR — are not ambiguity. A naive "more than one marker set"
 // rule gets that wrong.
 //
-// When markers are ambiguous, host and identity are both empty: naming either
-// would assert a host was resolved, which is precisely what this branch declines
-// to do. With no markers set at all, host and markers are empty and ambiguous is
-// false — being outside every runtime is a normal state, not a fault.
-func Detect(getenv func(string) string) (host string, markers []string, identity string, ambiguous bool) {
+// When markers are ambiguous, host is empty: naming one would assert a host was
+// resolved, which is precisely what this branch declines to do. With no markers
+// set at all, host and markers are empty and ambiguous is false — being outside
+// every runtime is a normal state, not a fault.
+func Detect(getenv func(string) string) (host string, markers []string, ambiguous bool) {
 	for _, entry := range markerTable {
 		if getenv(entry.marker) == "" {
 			continue
@@ -50,9 +41,6 @@ func Detect(getenv func(string) string) (host string, markers []string, identity
 		markers = append(markers, entry.marker)
 		if host == "" {
 			host = entry.host
-			if entry.identity != "" {
-				identity = getenv(entry.identity)
-			}
 			continue
 		}
 		if host != entry.host {
@@ -60,26 +48,7 @@ func Detect(getenv func(string) string) (host string, markers []string, identity
 		}
 	}
 	if ambiguous {
-		return "", markers, "", true
+		return "", markers, true
 	}
-	return host, markers, identity, false
-}
-
-// shortIDLen is the session-identifier prefix length. It is not arbitrary: it
-// matches the convention already on disk, since Claude Code names its own team
-// directory `~/.claude/teams/session-<first 8 chars>` of the session id. Printing
-// the same eight characters makes the token directly greppable against session
-// state on the filesystem, and eight hex characters distinguish the handful of
-// sessions a human runs concurrently with room to spare.
-const shortIDLen = 8
-
-// ShortID truncates a session identifier to the greppable prefix. These ids are
-// UUID-shaped and would otherwise dominate a four-line output. An id of
-// shortIDLen characters or fewer is returned whole rather than padded, and an
-// empty id stays empty so the caller omits the segment entirely.
-func ShortID(id string) string {
-	if len(id) <= shortIDLen {
-		return id
-	}
-	return id[:shortIDLen]
+	return host, markers, false
 }

--- a/internal/runtimehost/runtimehost_test.go
+++ b/internal/runtimehost/runtimehost_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: Unit tests for env-only runtime-host detection: the marker matrix,
-// ABOUTME: the same-host-two-markers non-ambiguity case, identity, and ShortID.
+// ABOUTME: Unit tests for env-only runtime-host detection: the marker matrix
+// ABOUTME: and the same-host-two-markers non-ambiguity case.
 package runtimehost
 
 import (
@@ -51,7 +51,7 @@ func TestDetectMarkerMatrix(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			host, markers, _, ambiguous := Detect(fakeEnv(tc.vars))
+			host, markers, ambiguous := Detect(fakeEnv(tc.vars))
 			if host != tc.wantHost {
 				t.Errorf("host = %q, want %q", host, tc.wantHost)
 			}
@@ -60,76 +60,6 @@ func TestDetectMarkerMatrix(t *testing.T) {
 			}
 			if ambiguous != tc.wantAmbiguous {
 				t.Errorf("ambiguous = %v, want %v", ambiguous, tc.wantAmbiguous)
-			}
-		})
-	}
-}
-
-// TestDetectIdentity pins the identity column against the detection marker. The
-// load-bearing row is claude: CLAUDECODE is the literal flag `1`, so an
-// implementation that reuses the detection marker's VALUE as the identifier
-// would render `session 1` for every claude session — that row asserts the
-// identity is not "1". An ambiguous marker set carries no identity, since naming
-// one would assert a host had been resolved.
-func TestDetectIdentity(t *testing.T) {
-	cases := []struct {
-		name string
-		vars map[string]string
-		want string
-	}{
-		{
-			"claude-reads-CLAUDE_CODE_SESSION_ID-not-CLAUDECODE",
-			map[string]string{"CLAUDECODE": "1", "CLAUDE_CODE_SESSION_ID": "afd74765-9000-4e63-acf4-3b1f4645a8f3"},
-			"afd74765-9000-4e63-acf4-3b1f4645a8f3",
-		},
-		{"claude-identity-unset", map[string]string{"CLAUDECODE": "1"}, ""},
-		{
-			"codex-marker-doubles-as-identity",
-			map[string]string{"CODEX_THREAD_ID": "01937f2a-bbbb"},
-			"01937f2a-bbbb",
-		},
-		{
-			"pi-exposes-no-session-identity",
-			map[string]string{"PI_CODING_AGENT": "1", "PI_CODING_AGENT_DIR": "/home/u/.pi/agent"},
-			"",
-		},
-		{
-			"ambiguous-carries-no-identity",
-			map[string]string{"CLAUDECODE": "1", "CLAUDE_CODE_SESSION_ID": "afd74765", "CODEX_THREAD_ID": "01937f2a"},
-			"",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			_, _, identity, _ := Detect(fakeEnv(tc.vars))
-			if identity != tc.want {
-				t.Fatalf("identity = %q, want %q", identity, tc.want)
-			}
-			if identity == "1" {
-				t.Fatalf("identity = %q — the detection marker's value was reused as the session id", identity)
-			}
-		})
-	}
-}
-
-// TestShortID pins the truncation rule: longer than the prefix truncates,
-// exactly the prefix and shorter render whole (never padded), and empty stays
-// empty so the caller omits the segment rather than printing `session `.
-func TestShortID(t *testing.T) {
-	cases := []struct {
-		name string
-		id   string
-		want string
-	}{
-		{"longer-than-8", "afd74765-9000-4e63-acf4-3b1f4645a8f3", "afd74765"},
-		{"exactly-8", "afd74765", "afd74765"},
-		{"shorter-than-8", "ab12", "ab12"},
-		{"empty", "", ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := ShortID(tc.id); got != tc.want {
-				t.Fatalf("ShortID(%q) = %q, want %q", tc.id, got, tc.want)
 			}
 		})
 	}

--- a/internal/safehouse/state.go
+++ b/internal/safehouse/state.go
@@ -45,19 +45,25 @@ func Inside(getenv func(string) string) (name string, ok bool) {
 // nothing more, because "not wrapped" would be constant across every such case
 // and so would carry no information while reading as though it did.
 //
-//   - inside — this process is running inside the named sandbox. This dominates:
+// The value never restates its own label. Under a `Sandbox: ` prefix, the
+// sandbox's NAME alone is the whole answer — it both says that this process is
+// sandboxed and says which sandbox — and `none` is its counterpart, so a reader
+// classifies on a name-or-`none` distinction rather than on a relationship word
+// like "inside" or "not sandboxed" that the label already implies.
+//
+//   - <name> — this process is running inside the named sandbox. This dominates:
 //     whether safehouse could wrap a future launch says nothing about a session
 //     that is already sandboxed.
-//   - not sandboxed (safehouse available) — the binary resolves on PATH.
-//   - not sandboxed (safehouse not installed) — it does not.
+//   - none (safehouse available) — the binary resolves on PATH.
+//   - none (safehouse not installed) — it does not.
 func SessionState(insideName string, inside, available bool) string {
 	if inside {
-		return "inside (" + insideName + ")"
+		return insideName
 	}
 	if available {
-		return "not sandboxed (safehouse available)"
+		return "none (safehouse available)"
 	}
-	return "not sandboxed (safehouse not installed)"
+	return "none (safehouse not installed)"
 }
 
 // LaunchState renders the answer to "will this launch be wrapped?" — the

--- a/internal/safehouse/state_test.go
+++ b/internal/safehouse/state_test.go
@@ -54,10 +54,10 @@ func TestSessionStateThreeWay(t *testing.T) {
 		available  bool
 		want       string
 	}{
-		{"inside-safehouse-absent-from-PATH", "agent-safehouse", true, false, "inside (agent-safehouse)"},
-		{"inside-safehouse-on-PATH", "agent-safehouse", true, true, "inside (agent-safehouse)"},
-		{"not-sandboxed-available", "", false, true, "not sandboxed (safehouse available)"},
-		{"not-sandboxed-not-installed", "", false, false, "not sandboxed (safehouse not installed)"},
+		{"inside-safehouse-absent-from-PATH", "agent-safehouse", true, false, "agent-safehouse"},
+		{"inside-safehouse-on-PATH", "agent-safehouse", true, true, "agent-safehouse"},
+		{"not-sandboxed-available", "", false, true, "none (safehouse available)"},
+		{"not-sandboxed-not-installed", "", false, false, "none (safehouse not installed)"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/status/boot_sandbox_test.go
+++ b/internal/status/boot_sandbox_test.go
@@ -90,10 +90,10 @@ func TestBootSandboxSection(t *testing.T) {
 		available bool
 		want      string
 	}{
-		{"inside-safehouse-absent-from-PATH", true, false, "SANDBOX: inside (agent-safehouse)"},
-		{"inside-safehouse-on-PATH", true, true, "SANDBOX: inside (agent-safehouse)"},
-		{"not-sandboxed-available", false, true, "SANDBOX: not sandboxed (safehouse available)"},
-		{"not-sandboxed-not-installed", false, false, "SANDBOX: not sandboxed (safehouse not installed)"},
+		{"inside-safehouse-absent-from-PATH", true, false, "SANDBOX: agent-safehouse"},
+		{"inside-safehouse-on-PATH", true, true, "SANDBOX: agent-safehouse"},
+		{"not-sandboxed-available", false, true, "SANDBOX: none (safehouse available)"},
+		{"not-sandboxed-not-installed", false, false, "SANDBOX: none (safehouse not installed)"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -126,8 +126,8 @@ func TestBootSandboxJSONField(t *testing.T) {
 		available bool
 		want      string
 	}{
-		{"inside-safehouse-absent-from-PATH", true, false, "inside (agent-safehouse)"},
-		{"not-sandboxed-not-installed", false, false, "not sandboxed (safehouse not installed)"},
+		{"inside-safehouse-absent-from-PATH", true, false, "agent-safehouse"},
+		{"not-sandboxed-not-installed", false, false, "none (safehouse not installed)"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Trims --version decoration no reader consumes, keeping the OS line for bug reports and renaming the Sandbox value to the sandbox name or none.

## What changed
- Delete the session-id segment and the pass-host remedy suffix
- Rename the Sandbox value; the prefix-anchored install-gate consumer needs no edit
- Keep the OS line and the contract-3 sentinel; correct its pin-attribution comment

## Evidence
- Validator PASSED: five-shape byte matrix, live drives of both keep-boundary commands, two falsifying mutations
- Suite differential clean against merge-base; contract-3 retirement blocked by a live pre-#468 cache population, recorded for the 0.28 re-query

---
[x8](/spacedock-dev/spacedock/blob/6c01dd705ba0568b14cf30b165090daea8896a70/_archive/trim-version-output-decoration.md)
