### PR TITLE
Remove the copied proof-gap oracle from the reconciliation lint

### DIFF
--- a/internal/contractlint/live_registry_reconciliation_test.go
+++ b/internal/contractlint/live_registry_reconciliation_test.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -48,13 +47,9 @@ func TestRuntimeLiveRegistryReconciliation(t *testing.T) {
 	targets := readRegistryTargets(t, registryPath)
 	registryFixtures := readRegistryFixtureUnion(t, registryPath)
 	actual, fixtureOwners := readActualLiveJourneys(t, repo, targets)
-	proofGaps := readRuntimeProofGaps(t, repo, targets)
-	wantProofGaps := map[string][]liveGapRow{
-		"TestLiveBreakGlassShimRecovery": {{"xfail", "claude-sonnet", "060xp69y61yhrww23g3wvwqy"}},
-	}
-	if !reflect.DeepEqual(proofGaps, wantProofGaps) {
-		t.Errorf("runtime proof gaps = %#v, want %#v", proofGaps, wantProofGaps)
-	}
+	// Fatals on a malformed live-proof gap binding; the owner join re-derives these
+	// under SPACEDOCK_LIVE_STATE_DIR.
+	readRuntimeProofGaps(t, repo, targets)
 	if len(desired) != len(actual) {
 		t.Errorf("common live registry/source counts = %d/%d", len(desired), len(actual))
 	}


### PR DESCRIPTION
Removes the copied proof-gap oracle so an XFAIL change on a live-proof test is a one-file edit and the lint derives truth from source alone.

## What changed
- Delete the wantProofGaps hand-copied map and its DeepEqual check
- Keep readRuntimeProofGaps as the bare validating call that holds the parseLiveGap boundary in CI

## Evidence
- Validator PASSED: base red / branch green both ways; malformed-binding falsifier fires; contractlint green plain and -race

---
[pp](/spacedock-dev/spacedock/blob/8c4b0754a9731d61ccff659d6383ccf49ac0778e/remove-proof-gap-copied-oracle.md)
