### PR TITLE
Retire the test-only gate summary reader trio

### DIFF
--- a/internal/gates/application_test.go
+++ b/internal/gates/application_test.go
@@ -362,9 +362,16 @@ func TestResolutionSummaryDoesNotHashBriefing(t *testing.T) {
 	if err := os.Remove(briefing); err != nil {
 		t.Fatal(err)
 	}
-	summary, err := SummaryFile(entity)
-	if err != nil || summary.Decision != "approve" {
-		t.Fatalf("resolution-only summary = %#v, %v", summary, err)
+	summaryDoc, _, err := Read(entity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage, err := entityStatus(entity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary := CurrentSummary(summaryDoc, stage); summary.Decision != "approve" {
+		t.Fatalf("resolution-only summary = %#v", summary)
 	}
 	eligibility, err := EligibilityFileAt(entity, root)
 	if err != nil || eligibility.Condition != "ineligible" {

--- a/internal/gates/io.go
+++ b/internal/gates/io.go
@@ -188,34 +188,6 @@ func filterApplicationMappings(gatesNode *yaml.Node) ([]Warning, error) {
 	return warnings, nil
 }
 
-func SummaryFile(path string) (Summary, error) {
-	return SummaryFileAt(path, nearestWorkflowDir(filepath.Dir(path)))
-}
-
-func SummaryFileAt(path, workflowDir string) (Summary, error) {
-	summary, _, err := SummaryFileDiagnosticsAt(path, workflowDir)
-	return summary, err
-}
-
-// SummaryFileDiagnosticsAt is the diagnostics-carrying form of SummaryFileAt:
-// the same retained-authority checks, plus any bounded application-extension
-// warnings. No command prints that warnings slice today — status --validate
-// derives the same class through its own reader.
-func SummaryFileDiagnosticsAt(path, workflowDir string) (Summary, []Warning, error) {
-	doc, _, warnings, err := ReadDiagnostics(path)
-	if err != nil {
-		return Summary{}, nil, err
-	}
-	if err := validateRetainedAuthority(path, workflowDir, doc); err != nil {
-		return Summary{}, nil, err
-	}
-	status, err := entityStatus(path)
-	if err != nil {
-		return Summary{}, nil, err
-	}
-	return CurrentSummary(doc, status), warnings, nil
-}
-
 func validateRetainedAuthority(entityPath, workflowDir string, doc *Document) error {
 	return validateRetainedAuthorityExcept(entityPath, workflowDir, doc, "", "")
 }

--- a/internal/gates/prepare_test.go
+++ b/internal/gates/prepare_test.go
@@ -953,7 +953,7 @@ func TestPreparedAuthorityIsRecomputedDuringReadOnlyValidation(t *testing.T) {
 				t.Fatal(err)
 			}
 			tc.mutate(t, workflow, entity, artifact, result.Room)
-			if _, err := SummaryFileAt(entity, workflow); err == nil {
+			if _, err := EligibilityFileAt(entity, workflow); err == nil {
 				t.Fatal("read-only validation accepted drifted prepared authority")
 			}
 		})


### PR DESCRIPTION
Removes the production-unreachable gate summary reader trio left behind by the gate-validate removal, so no reader survives whose output nothing can observe.

## What changed
- Delete SummaryFile, SummaryFileAt, and SummaryFileDiagnosticsAt
- Re-point both dependent tests, one onto a production-called reader

## Evidence
- Validator PASSED: compiler and repo-sweep oracles; both re-points red under named breaking changes with predicted messages; suites green plain and -race

---
[77](/spacedock-dev/spacedock/blob/8c4b0754a9731d61ccff659d6383ccf49ac0778e/retire-test-only-gate-summary-readers.md)
