### PR TITLE
Rule the superseded verdict out of the schema vocabulary

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -69,7 +69,7 @@ Every task file has YAML frontmatter. Fields are documented below; see **Task Te
 | `source` | string | Where this task came from |
 | `started` | ISO 8601 | When active work began |
 | `completed` | ISO 8601 | When the task reached terminal status |
-| `verdict` | enum | PASSED or REJECTED - set at final stage |
+| `verdict` | enum | PASSED or REJECTED - set at final stage. Closed on write: `--set` refuses any other token (`--force` bypasses). To supersede an entity, leave `verdict` empty and `--archive` it, recording why in the body. |
 | `score` | number | Priority score, 0.0-1.0 (optional). Workflows can upgrade to a multi-dimension rubric in their README. |
 | `worktree` | string | Worktree path while a dispatched agent is active, empty otherwise |
 | `issue` | string | Optional external ticket reference, such as `ENG-123`, `kata:task-abc123`, or `owner/repo#42` |

--- a/docs/schema/entity.mdschema.yml
+++ b/docs/schema/entity.mdschema.yml
@@ -90,7 +90,8 @@
           "PASSED",
           "REJECTED"
         ],
-        "invalid_severity": "warn"
+        "invalid_severity": "warn",
+        "semantics": "the conventional list is advisory on read and closed on write: a non-conventional token already in history warns and is never rewritten, while `status --set` refuses to write one (--force bypasses). Clearing always passes — to supersede an entity, leave verdict empty and archive it, recording why in the body"
       },
       "mod-block": {
         "type": "string",

--- a/internal/status/handlers.go
+++ b/internal/status/handlers.go
@@ -368,6 +368,34 @@ func runSet(roots roots, set *setUpdate, args []string, whereFilters []whereFilt
 		}
 	}
 
+	// Conventional-vocabulary admission: a field declaring a schema `conventional`
+	// list is closed on write (conventionalViolation), so `--set verdict=superseded`
+	// — the exact write that produced the four archived records carrying a token the
+	// enum never admitted — refuses instead of storing it. The write path already
+	// consulted this list to fold case (canonicalConventional, inside
+	// updateFrontmatter); this is that same lookup used for admission, not a second
+	// source of truth. `verdict` is the only conventional field today, so the blast
+	// radius is exactly it, but nothing here is verdict-specific.
+	//
+	// The guard lives here rather than in updateFrontmatter because `force` is in
+	// scope here alongside the other --set guards, and because the shared write
+	// engine stays a pure normaliser for finalize and archive, which pass
+	// already-canonical values. It is placed last, immediately before the write, so
+	// every already-refused command keeps reporting its existing cause first and the
+	// refusal is byte-clean by construction. --force bypasses, the uniform escape
+	// the guards above honor.
+	if !force {
+		for _, u := range set.updates {
+			problem := conventionalViolation(u.field, u.value)
+			if problem == "" {
+				continue
+			}
+			return errExit(stderr, fmt.Sprintf(
+				"entity %s: %s. Pick one of those, clear it with `%s=`, or use --force.",
+				slug, problem, u.field))
+		}
+	}
+
 	resolvedFields, err := updateFrontmatter(entityPath, set.updates)
 	if err != nil {
 		return errExit(stderr, err.Error())

--- a/internal/status/live_guard_test.go
+++ b/internal/status/live_guard_test.go
@@ -99,7 +99,7 @@ func TestLiveRunGuardPassesCitedRuntimeAC(t *testing.T) {
 	root, entityPath := stageLiveGuardFixture(t, "require-external-proof: true\n", acBody)
 
 	_, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--set", "010-live-ac",
-		"status=done", "completed", "verdict=accepted")
+		"status=done", "completed", "verdict=passed")
 	if nCode != 0 {
 		t.Fatalf("cited runtime-observable AC must pass, got %d (%q)", nCode, nErr)
 	}
@@ -119,7 +119,7 @@ func TestLiveRunGuardNeverRefusesOfflineAC(t *testing.T) {
 	root, entityPath := stageLiveGuardFixture(t, "require-external-proof: true\n", acBody)
 
 	_, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--set", "010-live-ac",
-		"status=done", "completed", "verdict=accepted")
+		"status=done", "completed", "verdict=passed")
 	if nCode != 0 {
 		t.Fatalf("offline AC must never be refused by the live-run guard, got %d (%q)", nCode, nErr)
 	}
@@ -144,7 +144,7 @@ func TestLiveRunGuardInertWhenOptInAbsentOrFalse(t *testing.T) {
 		t.Run(strings.TrimSpace(name), func(t *testing.T) {
 			root, entityPath := stageLiveGuardFixture(t, optIn, acBody)
 			_, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--set", "010-live-ac",
-				"status=done", "completed", "verdict=accepted")
+				"status=done", "completed", "verdict=passed")
 			if nCode != 0 {
 				t.Fatalf("guard must be inert when opt-in absent/false, got %d (%q)", nCode, nErr)
 			}
@@ -167,7 +167,7 @@ func TestLiveRunGuardForceBypassWarnsLoudly(t *testing.T) {
 	root, entityPath := stageLiveGuardFixture(t, "require-external-proof: true\n", acBody)
 
 	_, nErr, nCode := runNative(t, root, env, "--workflow-dir", root, "--set", "010-live-ac",
-		"status=done", "completed", "verdict=accepted", "--force")
+		"status=done", "completed", "verdict=passed", "--force")
 	if nCode != 0 {
 		t.Fatalf("--force must bypass the live-run guard, got %d (%q)", nCode, nErr)
 	}

--- a/internal/status/verdict.go
+++ b/internal/status/verdict.go
@@ -2,7 +2,10 @@
 // ABOUTME: spelling in frontmatter, and case-insensitive on every read back.
 package status
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // canonicalConventional maps value to the conventional spelling it matches
 // case-insensitively, and returns it UNCHANGED otherwise. The allowed set is
@@ -27,6 +30,41 @@ func canonicalConventional(field, value string) string {
 		}
 	}
 	return value
+}
+
+// conventionalViolation reports why value is inadmissible for field on WRITE, or
+// "" when the write may proceed. It states the other half of the conventional
+// contract: a conventional list is advisory ON READ — fieldViolation warns and
+// never errors, so history keeps whatever token it carries and no archived record
+// is ever edited to silence a diagnostic — and CLOSED ON WRITE, so a NEW write
+// must pick a token from the list.
+//
+// The allowed set comes from the same schema lookup canonicalConventional folds
+// case against, so the schema stays the single source of truth for what is
+// canonicalised, what is accepted on read, and what is admitted on write. The
+// problem string matches fieldViolation's wording, so the write refusal and the
+// read warning name the same thing the same way.
+//
+// An empty value always passes. Clearing is the supported way to say "no verdict"
+// and it is how an entity is superseded — clear `verdict`, then `--archive`,
+// recording why in the body. Refusing the clear would close the one exit the
+// ruling depends on.
+func conventionalViolation(field, value string) string {
+	spec, ok := loadEntitySchema().fields[field]
+	if !ok || len(spec.Conventional) == 0 {
+		return ""
+	}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	for _, allowed := range spec.Conventional {
+		if strings.EqualFold(trimmed, allowed) {
+			return ""
+		}
+	}
+	return fmt.Sprintf("field '%s' value %q is not one of [%s]",
+		field, trimmed, strings.Join(spec.Conventional, " "))
 }
 
 // storedVerdict maps a CLI verdict (`--verdict passed|rejected`, lowercase, as

--- a/internal/status/verdict_case_test.go
+++ b/internal/status/verdict_case_test.go
@@ -90,11 +90,15 @@ func TestSetStoresSchemaCasedVerdict(t *testing.T) {
 }
 
 // TestNonConventionalValuePassesThroughUnchanged pins the deliberate limit on
-// canonicalisation. A conventional list is advisory (`invalid_severity: warn`),
-// so a field may legitimately carry a value outside it — canonicalisation
-// snaps values ONTO the schema's spellings, it does not case-fold everything.
-// A blanket strings.ToUpper would silently rewrite `needs-work` to `NEEDS-WORK`,
-// editing state the caller wrote on purpose.
+// canonicalisation. A conventional list is advisory ON READ
+// (`invalid_severity: warn`), so a field may legitimately carry a value outside
+// it — canonicalisation snaps values ONTO the schema's spellings, it does not
+// case-fold everything. A blanket strings.ToUpper would silently rewrite
+// `needs-work` to `NEEDS-WORK`, editing state the caller wrote on purpose.
+//
+// The list is closed ON WRITE, so an unforced `--set verdict=needs-work` is now
+// refused (conventionalViolation) — this test forces past that admission check to
+// reach the normaliser underneath, which is what it is pinning.
 func TestNonConventionalValuePassesThroughUnchanged(t *testing.T) {
 	root := stageFixture(t, "seq-workflow")
 	_, errOut, code := runNative(t, root, pinnedEnv(t), "--workflow-dir", root,

--- a/internal/status/verdict_vocabulary_test.go
+++ b/internal/status/verdict_vocabulary_test.go
@@ -1,0 +1,281 @@
+// ABOUTME: the verdict-vocabulary ruling — `superseded` stays OUT of the enum, and
+// ABOUTME: a schema `conventional` list is advisory on read but closed on --set write.
+package status
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// verdictEntity renders a minimal active-scope entity for the enum-scope fixture.
+// An empty verdict omits the field entirely — the supported no-verdict shape, and
+// what the supported supersede path leaves behind.
+func verdictEntity(slug, title, stage, verdict string) string {
+	verdictLine := ""
+	if verdict != "" {
+		verdictLine = "verdict: " + verdict + "\n"
+	}
+	return fmt.Sprintf("---\nid: %s\ntitle: %s\nstatus: %s\nscore: \"0.50\"\n"+
+		"source: verdict-vocabulary fixture\n%s---\n\nFixture entity for the verdict-vocabulary ruling.\n",
+		slug, title, stage, verdictLine)
+}
+
+// warningLines returns the `Warning:` diagnostics in a validate stderr. The count
+// is load-bearing for AC-1 (the 1 -> 0 delta) and AC-3 (exactly one), so the tests
+// assert on the lines rather than on a substring anywhere in stderr.
+func warningLines(stderr string) []string {
+	var out []string
+	for _, line := range strings.Split(stderr, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "Warning:") {
+			out = append(out, strings.TrimSpace(line))
+		}
+	}
+	return out
+}
+
+// TestSetRefusesNonConventionalToken pins AC-2: the ruling is enforced where
+// verdicts are WRITTEN. A field declaring a schema `conventional` list is closed
+// on write, so `--set verdict=superseded` — the exact write that produced the four
+// archived records — refuses non-zero and leaves the entity byte-identical.
+//
+// Byte-identity is the assertion that matters: an exit code alone would pass a
+// guard that mutates and then errors. The table is keyed on field so a future
+// field that declares a `conventional` list is one new row, not a new test.
+func TestSetRefusesNonConventionalToken(t *testing.T) {
+	env := pinnedEnv(t)
+	cases := []struct {
+		name    string
+		field   string
+		token   string
+		allowed string
+	}{
+		{"the token that produced the four records", "verdict", "superseded", "[PASSED REJECTED]"},
+		{"the writer gap is general, not superseded-specific", "verdict", "banana", "[PASSED REJECTED]"},
+		{"refusal is case-insensitive, like the case-fold it extends", "verdict", "SUPERSEDED", "[PASSED REJECTED]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := stageFixtureWith(t, "enum-scope-workflow", map[string]string{
+				"probe.md": verdictEntity("probe", "Write-path probe", "backlog", ""),
+			})
+			path := filepath.Join(root, "probe.md")
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			out, errOut, code := runNative(t, root, env,
+				"--workflow-dir", root, "--set", "probe", tc.field+"="+tc.token)
+
+			if code == 0 {
+				t.Fatalf("--set %s=%s must exit non-zero; got 0 (stdout=%q)", tc.field, tc.token, out)
+			}
+			for _, want := range []string{tc.field, tc.token, tc.allowed} {
+				if !strings.Contains(errOut, want) {
+					t.Errorf("refusal must name %q; stderr=%q", want, errOut)
+				}
+			}
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(after) != string(before) {
+				t.Fatalf("refusal must be byte-clean — entity changed.\nbefore:\n%s\nafter:\n%s", before, after)
+			}
+		})
+	}
+}
+
+// TestSetForceWritesNonConventionalToken pins AC-2's escape: --force is the
+// uniform bypass every other --set guard honors, so the admission check must not
+// become the one guard with no escape hatch. Fails if --force stops writing the
+// non-conventional token.
+func TestSetForceWritesNonConventionalToken(t *testing.T) {
+	env := pinnedEnv(t)
+	root := stageFixtureWith(t, "enum-scope-workflow", map[string]string{
+		"probe.md": verdictEntity("probe", "Write-path probe", "backlog", ""),
+	})
+
+	_, errOut, code := runNative(t, root, env,
+		"--workflow-dir", root, "--set", "probe", "verdict=superseded", "--force")
+	if code != 0 {
+		t.Fatalf("--force must bypass the admission check; exit=%d stderr=%q", code, errOut)
+	}
+
+	got := ParseFrontmatter(filepath.Join(root, "probe.md"))["verdict"]
+	if strings.TrimSpace(got) != "superseded" {
+		t.Fatalf("--force must write the token verbatim; verdict=%q", got)
+	}
+}
+
+// TestSetClearAndCaseFoldStillPass pins the other half of AC-2: the admission
+// check must not swallow the writes the ruling depends on. Clearing is the
+// supported supersede shape, the case-fold is the behavior the guard's own schema
+// lookup was already performing, and a field with no `conventional` list is
+// outside the guard's blast radius entirely.
+func TestSetClearAndCaseFoldStillPass(t *testing.T) {
+	env := pinnedEnv(t)
+	cases := []struct {
+		name       string
+		startsWith string
+		assign     string
+		wantStored string
+	}{
+		{"clearing always passes — the supported supersede shape", "PASSED", "verdict=", ""},
+		{"lowercase CLI spelling still folds to the schema spelling", "", "verdict=passed", "PASSED"},
+		{"the other conventional token folds too", "", "verdict=rejected", "REJECTED"},
+		{"an already-canonical token is admitted unchanged", "", "verdict=PASSED", "PASSED"},
+		{"a field with no conventional list is untouched by the guard", "", "source=anything at all", "anything at all"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := stageFixtureWith(t, "enum-scope-workflow", map[string]string{
+				"probe.md": verdictEntity("probe", "Write-path probe", "backlog", tc.startsWith),
+			})
+
+			_, errOut, code := runNative(t, root, env,
+				"--workflow-dir", root, "--set", "probe", tc.assign)
+			if code != 0 {
+				t.Fatalf("--set %s must succeed; exit=%d stderr=%q", tc.assign, code, errOut)
+			}
+
+			field := strings.SplitN(tc.assign, "=", 2)[0]
+			got := strings.TrimSpace(ParseFrontmatter(filepath.Join(root, "probe.md"))[field])
+			if got != tc.wantStored {
+				t.Fatalf("--set %s stored %s=%q, want %q", tc.assign, field, got, tc.wantStored)
+			}
+		})
+	}
+}
+
+// TestSupersededVerdictBaselineWarnsAndBlocks pins the baseline half of AC-1 —
+// the two numbers that must move. An active entity carrying `verdict: superseded`
+// emits exactly ONE validate warning AND makes `--archive` exit 1, because the
+// archive guard reads every non-empty, non-`rejected` verdict as approval-style:
+// the field written to say "this was superseded" is exactly what blocks the
+// superseding. The fixture is written directly rather than through `--set`,
+// since `--set` now refuses the token.
+//
+// Fails when the baseline stops being measurable — i.e. when the "wrong way"
+// numbers stop being 1 and 1, which is what makes the 1 -> 0 delta in
+// TestSupersedePathIsWarningFree an end-value rather than a tautology.
+func TestSupersededVerdictBaselineWarnsAndBlocks(t *testing.T) {
+	env := pinnedEnv(t)
+	root := stageFixtureWith(t, "enum-scope-workflow", map[string]string{
+		"stranded.md": verdictEntity("stranded", "Superseded the unsupported way", "backlog", "superseded"),
+	})
+
+	_, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--validate")
+	if code != 0 {
+		t.Fatalf("--validate exit=%d, want 0 (field conformance is warn-tier); stderr=%q", code, errOut)
+	}
+	warns := warningLines(errOut)
+	if len(warns) != 1 {
+		t.Fatalf("baseline warning count = %d, want 1:\n%s", len(warns), errOut)
+	}
+	if !strings.Contains(warns[0], "superseded") || !strings.Contains(warns[0], "[PASSED REJECTED]") {
+		t.Fatalf("baseline warning must name the token and the allowed set: %q", warns[0])
+	}
+
+	_, archErr, archCode := runNative(t, root, env, "--workflow-dir", root, "--archive", "stranded")
+	if archCode != 1 {
+		t.Fatalf("baseline --archive exit=%d, want 1 (the token strands the entity); stderr=%q", archCode, archErr)
+	}
+	if !strings.Contains(archErr, "superseded") {
+		t.Fatalf("baseline archive refusal must name the blocking verdict: %q", archErr)
+	}
+}
+
+// TestSupersedePathIsWarningFree pins the value half of AC-1: an intentional
+// supersede of an active entity completes with zero validate warnings and zero
+// archive refusals, through the supported path the ruling names — leave `verdict`
+// empty and `--archive`. Read against the baseline above, this is the pair
+// (warning count 1 -> 0, archive exit 1 -> 0).
+//
+// Fails if the supported path regains a warning, or if `--archive` starts
+// refusing an empty-verdict entity.
+func TestSupersedePathIsWarningFree(t *testing.T) {
+	env := pinnedEnv(t)
+	root := stageFixtureWith(t, "enum-scope-workflow", map[string]string{
+		"stranded.md": verdictEntity("stranded", "Superseded the supported way", "backlog", "superseded"),
+	})
+
+	// The supported supersede: clear the verdict, which the admission check must
+	// keep passing, then archive.
+	_, clearErr, clearCode := runNative(t, root, env,
+		"--workflow-dir", root, "--set", "stranded", "verdict=")
+	if clearCode != 0 {
+		t.Fatalf("clearing verdict must succeed; exit=%d stderr=%q", clearCode, clearErr)
+	}
+
+	_, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--validate")
+	if code != 0 {
+		t.Fatalf("--validate exit=%d, want 0; stderr=%q", code, errOut)
+	}
+	if warns := warningLines(errOut); len(warns) != 0 {
+		t.Fatalf("supported supersede must validate with zero warnings; got %d:\n%s", len(warns), errOut)
+	}
+
+	_, archErr, archCode := runNative(t, root, env, "--workflow-dir", root, "--archive", "stranded")
+	if archCode != 0 {
+		t.Fatalf("supported supersede must archive cleanly; exit=%d stderr=%q", archCode, archErr)
+	}
+	if _, err := os.Stat(filepath.Join(root, "_archive", "stranded.md")); err != nil {
+		t.Fatalf("archived entity must land in _archive/: %v", err)
+	}
+}
+
+// TestNonConventionalVerdictStillWarns is AC-3, the negative control. AC-1 asks
+// for zero warnings, and the cheapest way to "achieve" that is to silence the
+// checker: setting `verdict.invalid_severity: error` makes isWarnSeverity return
+// false and the field is skipped entirely (there is no error path for field
+// conformance), and deleting the `conventional` list has the same effect while
+// also discarding the case-fold the write path depends on. Either cheat drops the
+// warning count to 0 and fails this test.
+func TestNonConventionalVerdictStillWarns(t *testing.T) {
+	env := pinnedEnv(t)
+	root := stageFixtureWith(t, "enum-scope-workflow", map[string]string{
+		"odd.md": verdictEntity("odd", "Non-conventional verdict on an active entity", "backlog", "banana"),
+	})
+
+	_, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--validate")
+	if code != 0 {
+		t.Fatalf("--validate exit=%d, want 0 (warn-tier, never exit 1); stderr=%q", code, errOut)
+	}
+	warns := warningLines(errOut)
+	if len(warns) != 1 {
+		t.Fatalf("an active non-conventional verdict must produce exactly one warning; got %d:\n%s", len(warns), errOut)
+	}
+	for _, want := range []string{"verdict", "banana", "[PASSED REJECTED]", "odd"} {
+		if !strings.Contains(warns[0], want) {
+			t.Errorf("warning must name %q: %q", want, warns[0])
+		}
+	}
+}
+
+// TestArchivedScopeStaysSilent is AC-4's fixture half: archived scope is
+// publish-only, so an archived entity carrying `verdict: superseded` emits
+// nothing. This is what lets the ruling leave the four archived records
+// untouched. Fails if archived scope starts warning again.
+//
+// AC-4's state half — that those four records still read `verdict: superseded`
+// byte-for-byte — is a check against the state checkout, not this module, so it
+// is verified and cited in the stage report rather than tested here.
+func TestArchivedScopeStaysSilent(t *testing.T) {
+	env := pinnedEnv(t)
+	root := stageFixtureWith(t, "enum-scope-workflow", map[string]string{
+		filepath.Join("_archive", "sup-arch.md"): verdictEntity(
+			"sup-arch", "Archived record carrying the retired token", "done", "superseded"),
+	})
+
+	_, errOut, code := runNative(t, root, env, "--workflow-dir", root, "--validate")
+	if code != 0 {
+		t.Fatalf("--validate exit=%d, want 0; stderr=%q", code, errOut)
+	}
+	if warns := warningLines(errOut); len(warns) != 0 {
+		t.Fatalf("archived scope must stay silent; got %d warning(s):\n%s", len(warns), errOut)
+	}
+}

--- a/skills/fo-status-viewer/SKILL.md
+++ b/skills/fo-status-viewer/SKILL.md
@@ -32,6 +32,7 @@ The `--set` flag updates entity frontmatter fields:
 - `--set {slug} field=value` sets a field
 - `--set {slug} field=` clears a field
 - `--set {slug} started` or `completed` auto-fills a UTC ISO 8601 timestamp (skipped if already set)
+- a field with a schema `conventional` list (today: `verdict`, `[PASSED REJECTED]`) is closed on write — any other token is refused byte-clean; `--force` bypasses. Clearing always passes. To supersede an entity, clear `verdict` and `--archive` it.
 
 ### Captain-Facing State Display
 


### PR DESCRIPTION
Closes the verdict write gap: --set now admits only schema vocabulary, so no future entity can carry an unadmitted verdict token.

## What changed
- --set gains a schema-lookup admission check for verdict values
- superseded ruled out of the vocabulary; archived records untouched
- Negative-control test guards against silencing the conformance check

## Evidence
- Validator PASSED end-to-end: active-entity supersede warning 1 to 0 and archive exit 1 to 0; controls falsified three ways
- Suites green plain and -race; surface overrun ruled AC-bearing test density

---
[x2](/spacedock-dev/spacedock/blob/90f298ea1cd70657c58bd8d48731b8a975ab5934/rule-superseded-verdict-vocabulary.md)
