### PR TITLE
Make inline state commit durable; split the unprepared-gate code

### DIFF
--- a/docs/site/reference/command-reference.md
+++ b/docs/site/reference/command-reference.md
@@ -114,7 +114,11 @@ command; `gate record --briefing` is not a recovery route.
 ### `state commit`
 
 `spacedock state commit <slug>` commits and synchronizes one active or clean
-archived entity from a split-root state checkout. The operand is one canonical top-level entity slug,
+archived entity. In a split-root workflow it commits and pushes in the state
+checkout. In an inline workflow it commits the same entity paths in the
+workflow's own repository and pushes nothing; if the workflow directory is not
+inside a git work tree, it reports that and does nothing.
+The operand is one canonical top-level entity slug,
 not a nested path. A flat entity commits exactly `<slug>.md` plus its `<slug>/`
 companion directory when present or tracked; a folder-form entity
 commits every changed, new, or deleted non-ignored path below `<slug>/`, including
@@ -126,7 +130,10 @@ to active entities and has no effect for an archived slug.
 The gate `record`/`consume` verbs (their close/consume forms — chat-decision and
 standalone `consume`; NOT the `--round` advisory-publication
 form, which is out of mechanism 1's scope and still needs an explicit `state
-commit` afterward, same as before) and `dispatch build --stamp` run this same
+commit` afterward, same as before. In an inline workflow that `state commit` is
+what makes the entity's recorded round visible to `gate prepare` and to the
+`needs-preparation` scheduler row; both read committed bytes only) and
+`dispatch build --stamp` run this same
 commit+publish sequence themselves whenever they write in a split-root workflow
 (their own `sync=.../phase=...` line, or `--stamp`'s stderr/exit, is the
 result) — do not re-run `state commit` after them. Recovering a `sync=failed`

--- a/internal/cli/state_commit_test.go
+++ b/internal/cli/state_commit_test.go
@@ -4,12 +4,14 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spacedock-dev/spacedock/internal/status"
+	"github.com/spacedock-dev/spacedock/internal/testgit"
 )
 
 // twoHostStateWorkflow builds a bare origin carrying a commissioned split-root
@@ -930,5 +932,197 @@ func TestStateCommitRefusesDirtyArchivedEntityBeforePublication(t *testing.T) {
 				t.Fatalf("published folder archive should no-op: exit=%d stdout=%q stderr=%q", code, stdout, errOut)
 			}
 		})
+	}
+}
+
+// inlineGatedWorkflowReadme is an INLINE workflow (no `state:` key — entities live
+// beside the README) whose validation stage is gated, the shape the live
+// rejection-flow journey runs against.
+const inlineGatedWorkflowReadme = `---
+commissioned-by: spacedock@1
+entity-type: task
+id-style: slug
+stages:
+  states:
+    - name: backlog
+      initial: true
+    - name: implementation
+    - name: validation
+      gate: true
+      feedback-to: implementation
+    - name: done
+      terminal: true
+---
+
+# Inline Gated Workflow
+`
+
+const inlineGatedEntity = `---
+id: rejection-task
+status: validation
+score: "0.90"
+---
+# Rejection Task
+
+## Stage Report: validation
+
+- DONE: Verify the corrected candidate carries the fix marker.
+  Cycle 2 re-review confirms the marker is present.
+
+### Summary
+
+Validation is complete and ready for its decision gate.
+`
+
+// inlineGatedWorkflow builds a committed inline workflow inside its own Git work
+// tree, carrying one folder-form entity parked at a gated validation stage with a
+// mechanically complete report. Returns the workflow dir.
+func inlineGatedWorkflow(t *testing.T) string {
+	t.Helper()
+	workflow := filepath.Join(t.TempDir(), "inline")
+	writeFileWithDirs(t, filepath.Join(workflow, "README.md"), inlineGatedWorkflowReadme)
+	writeFileWithDirs(t, filepath.Join(workflow, "rejection-task", "index.md"), inlineGatedEntity)
+	writeFileWithDirs(t, filepath.Join(workflow, "rejection-task", "inputs", "gate-validation", "gate-review.md"),
+		"# Rejection Task — validation review\n\nSeed review.\n")
+	testgit.InitRepo(t, workflow, "-q")
+	git(t, workflow, "add", "-A")
+	git(t, workflow, "commit", "-q", "-m", "seed inline gated workflow")
+	return workflow
+}
+
+// runInlineCmd runs an arbitrary spacedock command with the workflow dir as cwd.
+func runInlineCmd(t *testing.T, workflow string, args ...string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errBuf strings.Builder
+	code = run(context.Background(), args, os.Environ(), workflow, nil, &out, &errBuf, &status.NativeRunner{}, nil)
+	return code, out.String(), errBuf.String()
+}
+
+// inlineReadyGates returns the `status --next --json` ready_gates rows.
+func inlineReadyGates(t *testing.T, workflow string) []map[string]string {
+	t.Helper()
+	code, stdout, errOut := runInlineCmd(t, workflow, "status", "--workflow-dir", workflow, "--next", "--json")
+	if code != 0 {
+		t.Fatalf("status --next exit=%d stderr=%q", code, errOut)
+	}
+	var next struct {
+		ReadyGates []map[string]string `json:"ready_gates"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &next); err != nil {
+		t.Fatalf("parse status --next: %v\n%s", err, stdout)
+	}
+	return next.ReadyGates
+}
+
+func runInlineGatePrepare(t *testing.T, workflow, review string) (code int, stdout, stderr string) {
+	t.Helper()
+	return runInlineCmd(t, workflow, "gate", "prepare", "rejection-task", "--workflow-dir", workflow,
+		"--question", "Does the second validation confirm the fix marker?",
+		"--artifact", review,
+		"--summary", "The corrected candidate is ready for a decision.")
+}
+
+// TestStateCommitInlineUnblocksGatePreparationChain pins the whole causal chain the
+// live rejection flow walks after the neutral round recorder writes: an inline
+// workflow's entity and its fresh gate-review artifact are uncommitted, which makes
+// `status --next` drop the candidate row (dirty bytes are never mechanical proof —
+// TestGateReadinessRejectsDirtyAndMalformedColdReports pins that deliberately) and
+// makes `gate prepare` refuse the artifact. `state commit` is the only durability
+// verb the First Officer contract names, so if it no-ops here the run is stranded
+// with no verb that can clear either refusal. The pre-condition assertions are the
+// falsifying baseline: they are the exact refusals observed in CI, and they must
+// hold BEFORE the verb runs and be gone after it.
+func TestStateCommitInlineUnblocksGatePreparationChain(t *testing.T) {
+	workflow := inlineGatedWorkflow(t)
+	entity := filepath.Join(workflow, "rejection-task", "index.md")
+	review := filepath.Join(workflow, "rejection-task", "inputs", "gate-validation", "gate-review.md")
+	entityDirt := func() string {
+		return strings.TrimSpace(git(t, workflow, "status", "--porcelain", "--untracked-files=all", "--", "rejection-task"))
+	}
+
+	// The durable state the round recorder plus the FO's fresh gate review leave:
+	// entity edited, review artifact rewritten, nothing committed.
+	writeFile(t, entity, inlineGatedEntity+"\n### Feedback Cycles\n\n- Cycle 1: REJECTED — validation reviewer; surface 1 marker vs estimate 1 (100%); AC unchanged\n")
+	writeFile(t, review, "# Rejection Task — validation review (cycle 2)\n\nThe corrected candidate carries the fix marker.\n")
+
+	if entityDirt() == "" {
+		t.Fatal("fixture must start dirty; the whole chain is about clearing that dirt")
+	}
+	if ready := inlineReadyGates(t, workflow); len(ready) != 0 {
+		t.Fatalf("baseline broken: a dirty entity must not be offered as a gate candidate; got %v", ready)
+	}
+	if code, _, errOut := runInlineGatePrepare(t, workflow, review); code == 0 ||
+		!strings.Contains(errOut, "commit the exact source before preparation") {
+		t.Fatalf("baseline broken: gate prepare must refuse an uncommitted artifact; exit=%d stderr=%q", code, errOut)
+	}
+
+	code, stdout, errOut := runStateCommitCmd(t, workflow, workflow, "rejection-task", "--json")
+	if code != 0 || decodeOneJSON(t, stdout)["result"] != "committed" {
+		t.Fatalf("inline state commit must commit; exit=%d stdout=%q stderr=%q", code, stdout, errOut)
+	}
+
+	if dirt := entityDirt(); dirt != "" {
+		t.Fatalf("inline state commit left the entity dirty:\n%s", dirt)
+	}
+	ready := inlineReadyGates(t, workflow)
+	if len(ready) != 1 || ready[0]["slug"] != "rejection-task" || ready[0]["readiness"] != "needs-preparation" {
+		t.Fatalf("ready_gates=%v, want exactly one needs-preparation row for rejection-task", ready)
+	}
+	if code, stdout, errOut := runInlineGatePrepare(t, workflow, review); code != 0 || !strings.Contains(stdout, "state=open") {
+		t.Fatalf("gate prepare must succeed on the committed artifact; exit=%d stdout=%q stderr=%q", code, stdout, errOut)
+	}
+}
+
+// TestStateCommitInlineScopeAndPublishBoundary pins the two boundaries the inline
+// commit must not cross: it stages only the named entity's commit unit, and it
+// never pushes — an inline workflow repo is the caller's own code repo, so a push
+// would move a branch the caller never asked this verb to touch. A workflow dir
+// outside a Git work tree stays an exit-0 no-op that names the reason instead of
+// reporting a commit that did not happen.
+func TestStateCommitInlineScopeAndPublishBoundary(t *testing.T) {
+	workflow := inlineGatedWorkflow(t)
+	// Give the inline repo an origin, so "never pushes" is observable rather than
+	// vacuous: the bare ref must not move across a successful commit.
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	git(t, t.TempDir(), "init", "-q", "--bare", bare)
+	git(t, workflow, "remote", "add", "origin", bare)
+	git(t, workflow, "push", "-q", "origin", "HEAD:refs/heads/main")
+	originBefore := strings.TrimSpace(git(t, bare, "rev-parse", "refs/heads/main"))
+
+	writeFileWithDirs(t, filepath.Join(workflow, "sibling-task", "index.md"),
+		"---\nid: sibling-task\nstatus: backlog\n---\n# Sibling\n")
+	git(t, workflow, "add", "-A")
+	git(t, workflow, "commit", "-q", "-m", "seed sibling")
+
+	writeFile(t, filepath.Join(workflow, "rejection-task", "index.md"), inlineGatedEntity+"\ntarget dirt\n")
+	writeFile(t, filepath.Join(workflow, "sibling-task", "index.md"),
+		"---\nid: sibling-task\nstatus: backlog\n---\n# Sibling\n\nsibling dirt\n")
+
+	if code, stdout, errOut := runStateCommitCmd(t, workflow, workflow, "rejection-task", "--json"); code != 0 ||
+		decodeOneJSON(t, stdout)["result"] != "committed" {
+		t.Fatalf("inline state commit exit=%d stdout=%q stderr=%q", code, stdout, errOut)
+	}
+	if dirt := strings.TrimSpace(git(t, workflow, "status", "--porcelain", "--", "sibling-task")); dirt == "" {
+		t.Fatal("inline state commit swept up a dirty sibling entity; the commit must be path-scoped")
+	}
+	if got := strings.TrimSpace(git(t, bare, "rev-parse", "refs/heads/main")); got != originBefore {
+		t.Fatalf("inline state commit pushed the caller's own repo: origin main before=%s after=%s", originBefore, got)
+	}
+
+	// A second run has nothing left to stage: a no-op, not a claimed commit.
+	if code, stdout, errOut := runStateCommitCmd(t, workflow, workflow, "rejection-task", "--json"); code != 0 ||
+		decodeOneJSON(t, stdout)["result"] != "no-op" {
+		t.Fatalf("clean inline entity should no-op; exit=%d stdout=%q stderr=%q", code, stdout, errOut)
+	}
+
+	// Outside a Git work tree the verb has nothing to commit to, and says so.
+	plain := filepath.Join(t.TempDir(), "plain")
+	writeFileWithDirs(t, filepath.Join(plain, "README.md"), inlineGatedWorkflowReadme)
+	writeFileWithDirs(t, filepath.Join(plain, "rejection-task", "index.md"), inlineGatedEntity)
+	code, stdout, errOut := runStateCommitCmd(t, plain, plain, "rejection-task", "--json")
+	result := decodeOneJSON(t, stdout)
+	if code != 0 || result["result"] != "no-op" ||
+		!strings.Contains(result["reason"].(string), "not inside a Git work tree") {
+		t.Fatalf("non-repo workflow dir must be an honest no-op; exit=%d stdout=%q stderr=%q", code, stdout, errOut)
 	}
 }

--- a/internal/cli/state_commit_test.go
+++ b/internal/cli/state_commit_test.go
@@ -979,15 +979,27 @@ Validation is complete and ready for its decision gate.
 // mechanically complete report. Returns the workflow dir.
 func inlineGatedWorkflow(t *testing.T) string {
 	t.Helper()
-	workflow := filepath.Join(t.TempDir(), "inline")
+	_, workflow := inlineGatedWorkflowAt(t, ".")
+	return workflow
+}
+
+// inlineGatedWorkflowAt builds the inline fixture with the workflow dir at
+// workflowRel below the repo root, and returns both. workflowRel "." puts the
+// workflow AT the repo root; a nested path like "docs/dev" is the ordinary
+// project shape, where Git reports staged names relative to the repo root rather
+// than to the workflow. Returns (repoRoot, workflowDir).
+func inlineGatedWorkflowAt(t *testing.T, workflowRel string) (string, string) {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	workflow := filepath.Join(repo, filepath.FromSlash(workflowRel))
 	writeFileWithDirs(t, filepath.Join(workflow, "README.md"), inlineGatedWorkflowReadme)
 	writeFileWithDirs(t, filepath.Join(workflow, "rejection-task", "index.md"), inlineGatedEntity)
 	writeFileWithDirs(t, filepath.Join(workflow, "rejection-task", "inputs", "gate-validation", "gate-review.md"),
 		"# Rejection Task — validation review\n\nSeed review.\n")
-	testgit.InitRepo(t, workflow, "-q")
-	git(t, workflow, "add", "-A")
-	git(t, workflow, "commit", "-q", "-m", "seed inline gated workflow")
-	return workflow
+	testgit.InitRepo(t, repo, "-q")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-q", "-m", "seed inline gated workflow")
+	return repo, workflow
 }
 
 // runInlineCmd runs an arbitrary spacedock command with the workflow dir as cwd.
@@ -1124,5 +1136,61 @@ func TestStateCommitInlineScopeAndPublishBoundary(t *testing.T) {
 	if code != 0 || result["result"] != "no-op" ||
 		!strings.Contains(result["reason"].(string), "not inside a Git work tree") {
 		t.Fatalf("non-repo workflow dir must be an honest no-op; exit=%d stdout=%q stderr=%q", code, stdout, errOut)
+	}
+}
+
+// TestStateCommitInlineCommitsWhateverTheWorkflowDepth pins the inline commit
+// against BOTH repo shapes, because the seam reads staged names from Git and
+// compares them to entity paths, and those two are relative to different roots
+// unless the workflow dir happens to be the repo root.
+//
+// The nested case is the ordinary project shape and it was silently broken: `git
+// -C <workflow> diff --cached --name-only` answers with repo-root-relative names
+// (docs/dev/rejection-task/index.md) while the entity pathspec is
+// workflow-relative (rejection-task), so nothing matched, nothing was selected to
+// commit, and the verb reported "already up to date" — after its own `git add`
+// had staged the change. That is worse than the exit-0 no-op this entity set out
+// to remove: it mutates the index and still claims there was nothing to do.
+//
+// Asserting a clean porcelain rather than just a fresh commit is what makes this
+// falsifying: the pre-fix bug left the entity STAGED, which a commit-count check
+// alone would miss. Dropping `--relative` from the diff reds the nested case and
+// leaves the root case passing.
+func TestStateCommitInlineCommitsWhateverTheWorkflowDepth(t *testing.T) {
+	for name, workflowRel := range map[string]string{
+		"workflow at repo root": ".",
+		"workflow nested":       "docs/dev",
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo, workflow := inlineGatedWorkflowAt(t, workflowRel)
+			entity := filepath.Join(workflow, "rejection-task", "index.md")
+			writeFile(t, entity, inlineGatedEntity+"\nrecorded round, not yet durable\n")
+
+			before := strings.TrimSpace(git(t, repo, "rev-parse", "HEAD"))
+			code, stdout, errOut := runStateCommitCmd(t, workflow, workflow, "rejection-task", "--json")
+			result := decodeOneJSON(t, stdout)
+			if code != 0 || result["result"] != "committed" {
+				t.Fatalf("inline state commit must report a commit, not a no-op; exit=%d stdout=%q stderr=%q", code, stdout, errOut)
+			}
+
+			// Empty porcelain, not just a new commit: the pre-fix bug left the
+			// entity staged, which is invisible to a HEAD-moved check alone.
+			if dirt := strings.TrimSpace(git(t, repo, "status", "--porcelain", "--untracked-files=all")); dirt != "" {
+				t.Fatalf("entity left uncommitted (staged or modified) after state commit:\n%s", dirt)
+			}
+			if after := strings.TrimSpace(git(t, repo, "rev-parse", "HEAD")); after == before {
+				t.Fatal("state commit reported a commit but HEAD did not move")
+			}
+
+			// The commit carries the entity, addressed from the repo root.
+			entityRel, err := filepath.Rel(repo, entity)
+			if err != nil {
+				t.Fatal(err)
+			}
+			files := git(t, repo, "show", "--name-only", "--format=", "HEAD")
+			if !strings.Contains(files, filepath.ToSlash(entityRel)) {
+				t.Fatalf("commit does not contain %s; it contains:\n%s", entityRel, files)
+			}
+		})
 	}
 }

--- a/internal/cli/state_sync.go
+++ b/internal/cli/state_sync.go
@@ -44,7 +44,9 @@ func emitSync(stdout io.Writer, jsonOut bool, res syncResult, code int) int {
 	return code
 }
 
-// runStateCommit implements `spacedock state commit <slug>`. Active scope commits
+// runStateCommit implements `spacedock state commit <slug>`. An inline workflow
+// commits in the workflow's own repository and pushes nothing (commitInlineEntity);
+// the rest of this function is the split-root path. Active scope commits
 // path-scoped; clean archived scope publishes existing history. Both use the
 // shared push → on-reject pull --rebase → re-push sequence. A same-entity rebase
 // conflict HALTS: the rebase is aborted (clean tree restored), no force-push is
@@ -62,10 +64,7 @@ func runStateCommit(ctx context.Context, args []string, env []string, dir string
 		return code
 	}
 	if mode == status.StateInline {
-		return emitSync(stdout, jsonOut, syncResult{
-			Command: "state commit", Slug: slug, Result: "no-op",
-			Reason: "Inline workflow — entities live beside the README; nothing to commit to a state checkout.",
-		}, 0)
+		return commitInlineEntity(stdout, stderr, jsonOut, workflowDir, slug, msg)
 	}
 
 	if outcome := statesync.Preflight(checkout, branch); outcome.Result == statesync.ResultHalted {
@@ -168,6 +167,78 @@ func runStateCommit(ctx context.Context, args []string, env []string, dir string
 		fmt.Fprintln(stderr, "spacedock state commit: unexpected state publication result")
 		return 1
 	}
+}
+
+// commitInlineEntity is `state commit`'s inline half. An inline workflow keeps
+// its entities beside the README, so the workflow dir IS the entity root and the
+// same path-scoped commit-unit seam split-root uses applies to the workflow's own
+// repository. It never publishes: an inline workflow repo is the caller's code
+// repo, and this verb has no authority to push it. That durability matters
+// because `gate prepare` and `status --next`'s `needs-preparation` row both read
+// committed bytes only — an uncommitted entity is invisible to the first and
+// refused by the second, so a no-op here strands the caller with no verb that can
+// clear the condition. A workflow dir outside a Git work tree stays an exit-0
+// no-op, but names that as the reason instead of claiming a commit happened.
+func commitInlineEntity(stdout, stderr io.Writer, jsonOut bool, workflowDir, slug, msg string) int {
+	if !insideGitWorkTree(workflowDir) {
+		return emitSync(stdout, jsonOut, syncResult{
+			Command: "state commit", Slug: slug, Result: "no-op",
+			Reason: fmt.Sprintf("Inline workflow at %s is not inside a Git work tree — %s has nothing to commit to.", workflowDir, slug),
+		}, 0)
+	}
+	target, found, resolveErr := resolveEntityCommitTarget(workflowDir, slug)
+	if resolveErr != nil {
+		fmt.Fprintf(stderr, "spacedock state commit: %v\n", resolveErr)
+		return 1
+	}
+	if !found {
+		fmt.Fprintf(stderr, "spacedock state commit: no entity %q under %s (looked in active and _archive scope)\n", slug, workflowDir)
+		return 1
+	}
+	// Archived scope is publish-only in split-root, and inline has nothing to
+	// publish to — so the dirt refusal still applies (it protects the archive
+	// move from a half-staged commit), and clean archived state is a no-op.
+	if target.scope == entityScopeArchived {
+		clean, detail, checkErr := archivedTargetClean(workflowDir, target.pathspecs)
+		if checkErr != nil {
+			fmt.Fprintf(stderr, "spacedock state commit: could not inspect archived entity %q: %v\n", slug, checkErr)
+			return 1
+		}
+		if !clean {
+			fmt.Fprintf(stderr, "spacedock state commit: archived entity %q is dirty; archived scope is publish-only and will not stage or commit it:\n%s\n", slug, detail)
+			return 1
+		}
+		return emitSync(stdout, jsonOut, syncResult{
+			Command: "state commit", Slug: slug, Result: "no-op",
+			Reason: fmt.Sprintf("Archived state for %s is already committed; an inline workflow publishes nothing.", slug),
+		}, 0)
+	}
+	if msg == "" {
+		msg = fmt.Sprintf("state: update %s", slug)
+	}
+	ok, out := commitEntityPathsScoped(workflowDir, target.entityPaths, msg)
+	if !ok {
+		fmt.Fprintf(stderr, "spacedock state commit: git commit failed:\n%s\n", out)
+		return 1
+	}
+	if out == "" {
+		return emitSync(stdout, jsonOut, syncResult{
+			Command: "state commit", Slug: slug, Result: "no-op",
+			Reason: fmt.Sprintf("Nothing to commit for %s — inline workflow already up to date.", slug),
+		}, 0)
+	}
+	return emitSync(stdout, jsonOut, syncResult{
+		Command: "state commit", Slug: slug, Result: "committed",
+		Reason: fmt.Sprintf("Committed %s in the inline workflow repository; nothing pushed.", slug),
+	}, 0)
+}
+
+// insideGitWorkTree reports whether dir sits inside a Git work tree. A bare repo
+// or a plain directory answers no, which keeps the inline commit an honest no-op
+// rather than a git failure the caller cannot act on.
+func insideGitWorkTree(dir string) bool {
+	ok, out := runGitOutput(dir, "rev-parse", "--is-inside-work-tree")
+	return ok && strings.TrimSpace(out) == "true"
 }
 
 // runStateReady implements `spacedock state ready`. It is the boot gate: an inline

--- a/internal/cli/state_sync.go
+++ b/internal/cli/state_sync.go
@@ -394,7 +394,17 @@ func commitEntityPathsScoped(checkout string, entityPaths []string, msg string) 
 	// Commit only paths with staged changes. A flat entity's companion path is
 	// part of its commit unit, but an absent, never-tracked companion is not a
 	// valid `git commit -- <path>` operand.
-	ok, stagedNames := runGitOutput(checkout, "diff", "--cached", "--name-only", "--no-renames", "-z")
+	//
+	// `--relative` is load-bearing, not tidiness: without it `diff --cached`
+	// reports names relative to the REPO ROOT while entityPaths are relative to
+	// checkout. Those agree only when checkout IS the repo root — true for a
+	// split-root state worktree, false for an inline workflow nested under the
+	// repo (docs/dev/...). There the names never match, nothing is selected to
+	// commit, and the verb reports "already up to date" having just staged the
+	// change — the lying no-op this seam exists to prevent. The commit pathspecs
+	// below are resolved against `git -C checkout`, so they must be
+	// checkout-relative too.
+	ok, stagedNames := runGitOutput(checkout, "diff", "--cached", "--name-only", "--no-renames", "--relative", "-z")
 	if !ok {
 		return false, stagedNames
 	}

--- a/internal/ensigncycle/claude_live_runner_test.go
+++ b/internal/ensigncycle/claude_live_runner_test.go
@@ -207,16 +207,6 @@ func (r claudeLiveRunner) withStubPATH(dir string) liveDriver {
 	return r
 }
 
-func durableSemantic(code string, err error) error {
-	if err == nil {
-		return nil
-	}
-	if _, ok := err.(*gradedErr); ok {
-		return err
-	}
-	return &gradedErr{code: code, msg: err.Error()}
-}
-
 func finishLiveScenario(t *testing.T, runner liveDriver, scenario sharedRuntimeScenario, result liveResult, semantic ...error) {
 	t.Helper()
 	scenario.grade = gradeLive(scenario.gap.kind == "xfail", semantic...)
@@ -228,7 +218,14 @@ func finishLiveScenario(t *testing.T, runner liveDriver, scenario sharedRuntimeS
 		t.Logf("XPASS ALERT %s/%s owner=%s observed=%v", scenario.gap.target, scenario.name, scenario.gap.owner, scenario.grade.codes)
 	}
 	if liveGradeFailsLane(scenario.grade.status) {
-		t.Fatalf("%s %s/%s owner=%s observed=%v\nFinal message:\n%s\nArtifacts: %s", strings.ToUpper(scenario.grade.status), scenario.gap.target, scenario.name, scenario.gap.owner, scenario.grade.codes, result.finalMessage, result.artifactDir)
+		// The durable end state each finding graded lives in a t.TempDir that is
+		// gone by the time anyone reads CI, so the messages are the only surviving
+		// account of what the codes mean.
+		details := ""
+		if len(scenario.grade.details) > 0 {
+			details = "\nFindings:\n  " + strings.Join(scenario.grade.details, "\n  ")
+		}
+		t.Fatalf("%s %s/%s owner=%s observed=%v%s\nFinal message:\n%s\nArtifacts: %s", strings.ToUpper(scenario.grade.status), scenario.gap.target, scenario.name, scenario.gap.owner, scenario.grade.codes, details, result.finalMessage, result.artifactDir)
 	}
 }
 
@@ -397,13 +394,12 @@ func runClaudeRejectionFlowScenario(t *testing.T, runner liveDriver, scenario sh
 	// behavior that was observed, not the wording of the skill that produced it.
 	publications := claudeRejectionRoundPublications(result.stream)
 	reviewerFlow := assertClaudeSingleEntityRejectionFlow(result.stream)
+	var gatePrepared error
 	if _, ok := runner.(codexAsLiveDriver); ok {
 		recordedRound = codexRecordedRejectionRound(result.stream)
 		publications = codexRejectionRoundPublications(result.stream)
 		reviewerFlow = assertImplementationWorkerLifecycle(nativeLifecycleStream(t, runner, result), after)
-		if _, _, err := gates.Read(entityPath); err != nil {
-			recordedRound = false
-		}
+		gatePrepared = assertRejectionGatePrepared(entityPath)
 	}
 	// Single-entity (`-p`) reviewer producer-signal. The Claude runner launches
 	// `spacedock claude -- -p {prompt}` with a prompt naming one entity, so the run
@@ -418,6 +414,7 @@ func runClaudeRejectionFlowScenario(t *testing.T, runner liveDriver, scenario sh
 		durableSemantic("rejection-flow-state", assert(after, result.finalMessage+"\n"+result.stream)),
 		durableSemantic("rejection-round-missing", assertRejectionRecordedRound(workflowRoot, entityPath, "validation", recordedRound)),
 		durableSemantic("rejection-round-publication-count", assertSingleRejectionRoundPublication(publications)),
+		durableSemantic("rejection-gate-not-prepared", gatePrepared),
 		durableSemantic("rejection-reviewer-flow", reviewerFlow))
 }
 

--- a/internal/ensigncycle/claude_runtime_helpers_test.go
+++ b/internal/ensigncycle/claude_runtime_helpers_test.go
@@ -389,13 +389,32 @@ func TestAssertRecordedGateHoldLogAcceptsPrepareFirstLifecycle(t *testing.T) {
 
 func errGraded(msg string) error { return &gradedErr{code: "gate-hold-violation", msg: msg} }
 
+// durableSemantic labels a scenario assertion's failure with the semantic code the
+// lane reports it under, preserving the assertion's own message as the finding
+// detail. An assertion that already chose its own code keeps it.
+func durableSemantic(code string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := err.(*gradedErr); ok {
+		return err
+	}
+	return &gradedErr{code: code, msg: err.Error()}
+}
+
 type gradedErr struct{ code, msg string }
 
 func (e *gradedErr) Error() string { return e.msg }
 
+// liveGrade carries the lane verdict plus, for each observed code, the graded
+// finding's own message. codes alone say which check failed; details say what it
+// saw. Without details a CI failure prints a bare code and the durable end state
+// that produced it is gone with the test's TempDir, so the failing sub-check is
+// unrecoverable from the run's artifacts.
 type liveGrade struct {
-	status string
-	codes  []string
+	status  string
+	codes   []string
+	details []string
 }
 
 func liveGradeFailsLane(status string) bool {
@@ -403,12 +422,16 @@ func liveGradeFailsLane(status string) bool {
 }
 
 func gradeLive(xfail bool, errs ...error) liveGrade {
-	seen := map[string]bool{}
+	seen := map[string]string{}
 	grade := liveGrade{}
 	infrastructureFailure := false
 	for _, err := range errs {
 		if graded, ok := err.(*gradedErr); ok {
-			seen[graded.code] = true
+			// First message per code wins; a later duplicate code must not
+			// overwrite the finding that first reported it.
+			if existing, ok := seen[graded.code]; !ok || existing == "" {
+				seen[graded.code] = graded.msg
+			}
 		} else if err != nil {
 			infrastructureFailure = true
 		}
@@ -417,6 +440,11 @@ func gradeLive(xfail bool, errs ...error) liveGrade {
 		grade.codes = append(grade.codes, code)
 	}
 	sort.Strings(grade.codes)
+	for _, code := range grade.codes {
+		if msg := seen[code]; msg != "" {
+			grade.details = append(grade.details, code+": "+msg)
+		}
+	}
 	switch {
 	case infrastructureFailure:
 		grade.status = "fail"

--- a/internal/ensigncycle/live_grade_unit_test.go
+++ b/internal/ensigncycle/live_grade_unit_test.go
@@ -67,3 +67,45 @@ func TestFilingSemanticFailureUsesTargetXFail(t *testing.T) {
 		})
 	}
 }
+
+// TestGradeLiveRetainsFindingMessages pins AC-3's second half. Every graded
+// finding constructs a message explaining what it saw, and until now gradeLive
+// discarded all of them — a CI failure printed a bare code list, and the durable
+// end state that produced it lives in a t.TempDir that is gone by the time anyone
+// reads the run. Each observed code must carry its own message through, paired
+// with that code and ordered with it. Dropping the msg field, or pairing a message
+// with the wrong code, fails this.
+func TestGradeLiveRetainsFindingMessages(t *testing.T) {
+	grade := gradeLive(false,
+		&gradedErr{code: "rejection-round-missing", msg: "resolved launcher never invoked `gate record --round validation/1`"},
+		&gradedErr{code: "rejection-gate-not-prepared", msg: "FO never prepared the cycle-2 validation gate: entity has no gates record"},
+	)
+	want := []string{
+		"rejection-gate-not-prepared: FO never prepared the cycle-2 validation gate: entity has no gates record",
+		"rejection-round-missing: resolved launcher never invoked `gate record --round validation/1`",
+	}
+	if !reflect.DeepEqual(grade.details, want) {
+		t.Fatalf("details = %#v, want %#v", grade.details, want)
+	}
+	if !reflect.DeepEqual(grade.codes, []string{"rejection-gate-not-prepared", "rejection-round-missing"}) {
+		t.Fatalf("codes = %v, want the details' codes in the same order", grade.codes)
+	}
+
+	// A repeated code keeps the finding that first reported it; a messageless
+	// finding contributes a code but no empty detail line.
+	repeated := gradeLive(false,
+		&gradedErr{code: "gate-not-held", msg: "first observation"},
+		&gradedErr{code: "gate-not-held", msg: "second observation"},
+		&gradedErr{code: "worker-order"},
+	)
+	if !reflect.DeepEqual(repeated.details, []string{"gate-not-held: first observation"}) {
+		t.Fatalf("repeated/messageless details = %#v", repeated.details)
+	}
+
+	// durableSemantic is the wrapper every scenario assertion goes through; the
+	// assertion's own error text must be what survives.
+	wrapped := gradeLive(false, durableSemantic("rejection-flow-state", fmt.Errorf("fix marker absent from the corrected candidate")))
+	if !reflect.DeepEqual(wrapped.details, []string{"rejection-flow-state: fix marker absent from the corrected candidate"}) {
+		t.Fatalf("durableSemantic details = %#v", wrapped.details)
+	}
+}

--- a/internal/ensigncycle/shared_round_recording_test.go
+++ b/internal/ensigncycle/shared_round_recording_test.go
@@ -16,7 +16,11 @@ import (
 
 var directRoundLauncher = regexp.MustCompile(`(?:^|[\s;&|])['"]*(?:spacedock|\$(?:\{SPACEDOCK_BIN(?::-[^}]*)?\}|SPACEDOCK_BIN)|/[^ \t\r\n'";&|]+/spacedock)['"]*\s+gate\s+record(?:\s|$)`)
 var rejectionRoundSuccess = regexp.MustCompile(`(?m)^round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=4$`)
-var rejectionRoundEntity = regexp.MustCompile(`(?:^|\s)['"]?rejection-task['"]?(?:\s|$)`)
+
+// Quote runs here are `['"]*` for the same reason as rejectionRoundFlag below:
+// Codex reaches the launcher through nested shell quoting and can wrap any
+// argument, the entity operand included, in a multi-character run like `'"'`.
+var rejectionRoundEntity = regexp.MustCompile(`(?:^|\s)['"]*rejection-task['"]*(?:\s|$)`)
 
 // Quote runs are `['"]*`, not `['"]?`, because Codex emits multi-character runs
 // like `'"'` around arguments. Missing a round would let the counter under-report,
@@ -25,9 +29,16 @@ var rejectionRoundFlag = regexp.MustCompile(`--round(?:=|\s+)['"]*([A-Za-z][A-Za
 
 const rejectionPreparedBriefingID = "briefing:rejection-task:validation:attempt-1:revision-1"
 
+// rejectionRoundArtifactArg matches one `--briefing`/`--log` argument pointing at
+// the fixture's canonical artifact path. The quote runs are `*`, not `?`: codex
+// emits the launcher through nested shell quoting, so a real invocation carries
+// a RUN of quote characters against the path — `--briefing '"'rejection-task/...`
+// — and a single optional quote reported a round that WAS recorded as missing.
+// The flag name and the artifact path stay exact, so this relaxes only the
+// quoting, not which arguments count.
 func rejectionRoundArtifactArg(flag, filename string) *regexp.Regexp {
-	return regexp.MustCompile(`--` + regexp.QuoteMeta(flag) + `(?:=|\s+)['"]?(?:[^ \t\r\n'";&|]*/)?rejection-task/inputs/` +
-		regexp.QuoteMeta(filename) + `['"]?(?:\s|[;&|]|$)`)
+	return regexp.MustCompile(`--` + regexp.QuoteMeta(flag) + `(?:=|\s+)['"]*(?:[^ \t\r\n'";&|]*/)?rejection-task/inputs/` +
+		regexp.QuoteMeta(filename) + `['"]*(?:\s|[;&|]|$)`)
 }
 
 // invokesRejectionRoundRecorder reports whether a command reaches `gate record`
@@ -84,7 +95,7 @@ func commandRecordsRejectionRound(command string) bool {
 	command = strings.ReplaceAll(command, "\\\n", " ")
 	for _, required := range []*regexp.Regexp{
 		rejectionRoundEntity,
-		regexp.MustCompile(`--round(?:=|\s+)['"]?validation/1['"]?(?:\s|$)`),
+		regexp.MustCompile(`--round(?:=|\s+)['"]*validation/1['"]*(?:\s|$)`),
 		rejectionRoundArtifactArg("briefing", "briefing.json"),
 		rejectionRoundArtifactArg("log", "briefing.review.jsonl"),
 	} {
@@ -596,6 +607,51 @@ func TestRejectionRoundPublicationCounter(t *testing.T) {
 				case tc.want != "" && !strings.Contains(got.Error(), tc.want):
 					t.Fatalf("%s counter diagnostic = %v, want %q", host, got, tc.want)
 				}
+			}
+		})
+	}
+}
+
+// TestRejectionRoundRecognizerAcceptsNestedShellQuoting pins the quoting shape a
+// real codex FO emits. Captured verbatim from a live rejection-flow run: codex
+// wraps the launcher in nested shell quoting, so `--briefing` is followed by the
+// run `'"'` before the path. The recognizer previously allowed a single optional
+// quote there, so this exact command — which exited 0 and printed the complete
+// four-entry round summary — was graded `rejection-round-missing`. Narrowing the
+// quote runs back to `?` reds this test. The wrong-artifact controls confirm the
+// relaxation did not make the recognizer accept any artifact path.
+func TestRejectionRoundRecognizerAcceptsNestedShellQuoting(t *testing.T) {
+	const captured = `/bin/zsh -lc '${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/1 --briefing '"'rejection-task/inputs/briefing.json' --log 'rejection-task/inputs/briefing.review.jsonl' --workflow-dir '/tmp/TestLiveCommonRejectionFlow/002'"`
+	if !commandRecordsRejectionRound(captured) {
+		t.Fatal("recognizer rejected the nested-shell quoting a real codex run emits")
+	}
+	result := "round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=4"
+	if !codexRecordedRejectionRound(codexCommandOutput(captured, result, 0, "completed")) {
+		t.Fatal("codex extractor missed the nested-shell-quoted round invocation")
+	}
+	// A quote run can land on any argument, so every operand the recognizer pins
+	// must tolerate one. Each case below reds if its own site narrows back to `?`.
+	for site, quoted := range map[string]string{
+		"entity":   `${SPACEDOCK_BIN:-spacedock} gate record '"'rejection-task'"' --round validation/1 --briefing rejection-task/inputs/briefing.json --log rejection-task/inputs/briefing.review.jsonl`,
+		"round":    `${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round '"'validation/1'"' --briefing rejection-task/inputs/briefing.json --log rejection-task/inputs/briefing.review.jsonl`,
+		"briefing": `${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/1 --briefing '"'rejection-task/inputs/briefing.json'"' --log rejection-task/inputs/briefing.review.jsonl`,
+		"log":      `${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/1 --briefing rejection-task/inputs/briefing.json --log '"'rejection-task/inputs/briefing.review.jsonl'"'`,
+	} {
+		t.Run("quote run on "+site, func(t *testing.T) {
+			if !commandRecordsRejectionRound(quoted) {
+				t.Fatalf("recognizer rejected a quote run around the %s operand", site)
+			}
+		})
+	}
+	for name, invalid := range map[string]string{
+		"wrong_briefing_file": strings.Replace(captured, "briefing.json", "other.json", 1),
+		"wrong_log_file":      strings.Replace(captured, "briefing.review.jsonl", "other.review.jsonl", 1),
+		"wrong_entity":        strings.Replace(captured, "gate record rejection-task", "gate record other-task", 1),
+		"wrong_round":         strings.Replace(captured, "--round validation/1", "--round validation/2", 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if commandRecordsRejectionRound(invalid) {
+				t.Fatal("relaxed quoting made the recognizer accept an invalid argument")
 			}
 		})
 	}

--- a/internal/ensigncycle/shared_round_recording_test.go
+++ b/internal/ensigncycle/shared_round_recording_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -244,6 +245,22 @@ func assertRejectionRoundGateBoundary(entityPath, wantStatus string) error {
 	}
 	if attempt.Resolution != nil || attempt.Application != nil {
 		return fmt.Errorf("prepared validation gate is not open")
+	}
+	return nil
+}
+
+// assertRejectionGatePrepared grades the requirement that the FO left the cycle-2
+// validation gate PREPARED, not merely round-recorded. It is deliberately separate
+// from assertRejectionRecordedRound: that oracle's boundary check
+// (assertRejectionRoundGateBoundary, directly above) TOLERATES an entity with no
+// gates record and returns nil. Folding this condition into the round oracle's
+// result made one journey hold two contradictory positions on the same state and
+// report both under `rejection-round-missing`, so a run whose round WAS recorded
+// but whose gate was never prepared was diagnosed as a missing round. Each
+// condition now carries its own code.
+func assertRejectionGatePrepared(entityPath string) error {
+	if _, _, err := gates.Read(entityPath); err != nil {
+		return fmt.Errorf("FO never prepared the cycle-2 validation gate: %v", err)
 	}
 	return nil
 }
@@ -581,5 +598,76 @@ func TestRejectionRoundPublicationCounter(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestRejectionUnpreparedGateReportsItsOwnCode pins AC-3's separation. The input is
+// the exact durable end state both failing CI runs produced: the round IS recorded
+// (the codex stream oracle says so) and the entity status reached validation, but
+// the FO never prepared the cycle-2 gate, so the entity carries no gates record.
+// Before this split, that state graded as `rejection-round-missing` — the round
+// oracle was told a recorded round had not been recorded — and the real condition
+// was invisible. The lane must now name the unprepared gate and must NOT claim the
+// round is missing. Flipping either oracle back to the other's code fails this.
+func TestRejectionUnpreparedGateReportsItsOwnCode(t *testing.T) {
+	root := t.TempDir()
+	entityPath := writeRejectionWorkflow(t, root)
+	writeFile(t, filepath.Join(root, "rejection-task", "inputs", "briefing.review.jsonl"), rejectionCompleteLog())
+	if err := gates.RecordSemantic(entityPath, gates.RecordInput{
+		Round:        "validation/1",
+		BriefingPath: filepath.Join(root, "rejection-task", "inputs", "briefing.json"),
+		LogPath:      filepath.Join(root, "rejection-task", "inputs", "briefing.review.jsonl"),
+		WorkflowDir:  root,
+	}); err != nil {
+		t.Fatalf("record rejection round: %v", err)
+	}
+	writeFile(t, entityPath, strings.Replace(readFile(t, entityPath), "status: backlog", "status: validation", 1))
+
+	// The stream the FO actually produced: the round-recording invocation ran and
+	// exited 0. Nothing about round recording failed in either CI run.
+	stream := codexCommandOutput(
+		"${SPACEDOCK_BIN:-spacedock} gate record rejection-task --workflow-dir . --round validation/1 --briefing rejection-task/inputs/briefing.json --log rejection-task/inputs/briefing.review.jsonl",
+		"round=round:rejection-task:validation:1 stage=validation cycle=1 briefing=briefing:rejection-task:validation:round-1 entries=4",
+		0, "completed")
+	recordedRound := codexRecordedRejectionRound(stream)
+	if !recordedRound {
+		t.Fatal("fixture stream must satisfy the round oracle; otherwise this test proves nothing about the gate")
+	}
+	if _, _, err := gates.Read(entityPath); err == nil {
+		t.Fatal("fixture entity must carry no gates record; otherwise the unprepared-gate condition is absent")
+	}
+
+	grade := gradeLive(false,
+		durableSemantic("rejection-round-missing", assertRejectionRecordedRound(root, entityPath, "validation", recordedRound)),
+		durableSemantic("rejection-gate-not-prepared", assertRejectionGatePrepared(entityPath)))
+	if !reflect.DeepEqual(grade.codes, []string{"rejection-gate-not-prepared"}) {
+		t.Fatalf("grade codes = %v, want exactly [rejection-gate-not-prepared]", grade.codes)
+	}
+	if len(grade.details) != 1 || !strings.Contains(grade.details[0], "never prepared the cycle-2 validation gate") {
+		t.Fatalf("grade details = %v, want the unprepared-gate finding's own message", grade.details)
+	}
+
+	// Control: prepare the gate and the code clears, so the code tracks the gate
+	// rather than some unrelated property of the fixture.
+	gateReviewPath := filepath.Join(root, "rejection-task", "inputs", "gate-validation", "gate-review.md")
+	writeFile(t, gateReviewPath, "# Rejection Task — validation review\n\nReady for its prepared decision gate.\n")
+	gateReviewRel, err := filepath.Rel(root, gateReviewPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	git(t, root, "add", "--", gateReviewRel)
+	git(t, root, "commit", "-q", "-m", "add prepared validation review", "--", gateReviewRel)
+	if _, err := gates.Prepare(entityPath, gates.PrepareInput{
+		WorkflowDir: root,
+		Question:    "Does the second validation confirm the fix marker is present and PASS?",
+		Artifact:    gateReviewPath,
+		Summary:     "The corrected rejection-flow candidate is ready for a decision.",
+	}); err != nil {
+		t.Fatalf("prepare validation gate: %v", err)
+	}
+	if grade := gradeLive(false,
+		durableSemantic("rejection-round-missing", assertRejectionRecordedRound(root, entityPath, "validation", recordedRound)),
+		durableSemantic("rejection-gate-not-prepared", assertRejectionGatePrepared(entityPath))); grade.status != "pass" {
+		t.Fatalf("prepared gate must grade pass; got %#v", grade)
 	}
 }

--- a/internal/ensigncycle/shared_round_recording_test.go
+++ b/internal/ensigncycle/shared_round_recording_test.go
@@ -621,7 +621,10 @@ func TestRejectionRoundPublicationCounter(t *testing.T) {
 // quote runs back to `?` reds this test. The wrong-artifact controls confirm the
 // relaxation did not make the recognizer accept any artifact path.
 func TestRejectionRoundRecognizerAcceptsNestedShellQuoting(t *testing.T) {
-	const captured = `/bin/zsh -lc '${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/1 --briefing '"'rejection-task/inputs/briefing.json' --log 'rejection-task/inputs/briefing.review.jsonl' --workflow-dir '/tmp/TestLiveCommonRejectionFlow/002'"`
+	// Verbatim capture, transcribed byte-for-byte from a live run's
+	// codex-exec.jsonl including its own t.TempDir path. Retyping the shape by
+	// hand risks silently normalizing the very quoting under test.
+	const captured = `/bin/zsh -lc '${SPACEDOCK_BIN:-spacedock} gate record rejection-task --round validation/1 --briefing '"'rejection-task/inputs/briefing.json' --log 'rejection-task/inputs/briefing.review.jsonl' --workflow-dir '/var/folders/h1/vnssm1dj6ks4nzzvx8y29yjm0000gn/T/TestLiveCommonRejectionFlow3029195893/002'"`
 	if !commandRecordsRejectionRound(captured) {
 		t.Fatal("recognizer rejected the nested-shell quoting a real codex run emits")
 	}


### PR DESCRIPTION
Stack layer on top of #718. Entity `hz2ankag6fk379ssabpv4ckc`.

## What this fixes

After the neutral round recorder writes, an inline workflow's entity is
uncommitted, and two surfaces then refuse: `status --next` drops the
`needs-preparation` row (dirty bytes are never mechanical proof) and `gate
prepare` refuses the uncommitted artifact. The only durability verb the First
Officer contract names is `state commit`, and on an inline workflow it was an
unconditional exit-0 no-op. Nothing could clear either refusal, so a run passed
only if the model happened to retry with raw git. That is host-neutral: the
claude-sonnet lane of run 31915540750 hit the identical refusal and passed only
by falling back to `git add && git commit`.

`runStateCommit`'s inline branch now resolves the entity under the workflow dir
and commits its commit unit through the existing path-scoped seam. It never
pushes — an inline workflow repo is the caller's own code repo. A workflow dir
outside a Git work tree stays an exit-0 no-op that names that as the reason.

Two lane-honesty repairs ride along. The prepared-gate check reports under its
own `rejection-gate-not-prepared` code instead of borrowing
`rejection-round-missing`: the round oracle's boundary check deliberately
tolerates an entity with no gates record, so folding the two together made one
journey hold contradictory positions on the same state and diagnose an
unprepared gate as a missing round. And `liveGrade` now retains each finding's
message, so a CI failure says what it saw rather than printing a bare code whose
durable end state died with the test's TempDir.

The recognizer's quote runs become `*`. Codex reaches the launcher through
nested shell quoting and emits runs like `'"'` around any operand; a single
optional quote graded a round that WAS recorded as missing.

## Proof

`gate prepare` refusal, `state commit`, and the retried `gate prepare`, captured
in one live codex exec stream:

    exit=1  gate prepare   --artifact ...: selected source differs from its committed Git object
    exit=0  state commit   Committed rejection-task in the inline workflow repository; nothing pushed.
    exit=0  gate prepare   ... state=open

Offline, `TestStateCommitInlineUnblocksGatePreparationChain` drives the real
command surface across the whole chain on an inline fixture and asserts the two
refusals hold BEFORE the verb and are gone after. Against the pre-fix source it
fails at the `state commit` no-op; its preconditions pass there, so they are
real observed refusals rather than tautologies.

Composed-tree live loop (4 runs, CI's pinned model and reasoning effort): 2 green.
`state commit` reported the inline commit in 4 of 4 and the pre-fix no-op string
appeared in 0 of 4. The two reds were single non-overlapping codes outside this
layer — one unprepared gate, one worker-lifecycle selector.

`go test ./...` plain and `-race` are green. No live-registry file is touched and
no XFAIL binding is added; the lane ships unbound.

## Declared deviations

Surface is 7 files and 512 insertions against an ideation estimate of 5 files and
~105 insertions (tolerance ±2 files, ±35 LOC). File count is at the boundary; the
LOC overrun is test code the acceptance criteria mandate but the surface table
never allocated lines for. Product plus docs is 85 insertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)