### PR TITLE
pi-live: operator model override + explicit parallel pin

### DIFF
--- a/.github/workflows/runtime-live-e2e.yml
+++ b/.github/workflows/runtime-live-e2e.yml
@@ -28,6 +28,11 @@ on:
           - sonnet
           - opus-pre-release
           - pi
+      live_parallel:
+        description: "go test -parallel for the Pi common journeys (positive integer; default 4, the standard runner core count)."
+        required: false
+        type: string
+        default: "4"
       claude_version:
         description: "Pin Claude Code to a specific version (e.g. 2.1.107, stable, latest). Empty = installer default."
         required: false
@@ -587,6 +592,7 @@ jobs:
       SPACEDOCK_LIVE_ARTIFACT_DIR: ${{ github.workspace }}/live-artifacts/pi
       SPACEDOCK_JOURNEY_METRICS_DIR: ${{ github.workspace }}/live-artifacts/journey-metrics/pi
       PI_OFFLINE: "1"
+      SPACEDOCK_PI_LIVE_PARALLEL: ${{ inputs.live_parallel }}
     steps:
       - name: Check required secret
         run: |
@@ -775,7 +781,18 @@ jobs:
       - name: Run live Pi common journeys
         run: |
           set -o pipefail
-          SPACEDOCK_LIVE_RUNTIME=pi gotestsum --jsonfile pi-coverage-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle
+          PI_LIVE_PARALLEL="${SPACEDOCK_PI_LIVE_PARALLEL:-4}"
+          case "$PI_LIVE_PARALLEL" in
+            ''|*[!0-9]*)
+              echo "live_parallel must be a positive integer (got \"$PI_LIVE_PARALLEL\")" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$PI_LIVE_PARALLEL" -lt 1 ]; then
+            echo "live_parallel must be at least 1 (got \"$PI_LIVE_PARALLEL\")" >&2
+            exit 1
+          fi
+          SPACEDOCK_LIVE_RUNTIME=pi gotestsum --jsonfile pi-coverage-detail.jsonl --format pkgname -- -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast -parallel "$PI_LIVE_PARALLEL" ./internal/ensigncycle
 
       - name: Run live Pi front-door smoke
         if: ${{ !cancelled() }}

--- a/docs/runtime-live-ci.md
+++ b/docs/runtime-live-ci.md
@@ -113,13 +113,14 @@ A slow `:max`-thinking model can take minutes per turn. Raise the per-run cap wi
 go test -tags live -count=1 -timeout 15m -run TestLivePiFrontDoorSmoke ./internal/ensigncycle -v
 ```
 
-Run the common Pi journeys separately from that substrate proof. Pi now calls `t.Parallel()`, so `-parallel 2` fans common journeys out two at a time (Codex uses its separate `-parallel 3` command above):
+Run the common Pi journeys separately from that substrate proof. Pi calls `t.Parallel()`; the workflow pins `-parallel` to `SPACEDOCK_PI_LIVE_PARALLEL` (the `live_parallel` dispatch input, default 4), and the local command keeps the same pin:
 
 ```bash
-SPACEDOCK_LIVE_RUNTIME=pi go test -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast ./internal/ensigncycle -v
+PI_LIVE_PARALLEL="${SPACEDOCK_PI_LIVE_PARALLEL:-4}"
+SPACEDOCK_LIVE_RUNTIME=pi go test -tags live -count=1 -timeout 40m -run '^TestLiveCommon' -failfast -parallel "$PI_LIVE_PARALLEL" ./internal/ensigncycle -v
 ```
 
-For a custom slow `:max`-thinking model, add `-parallel 2` and raise `-timeout` above the per-run cap set by `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES` (e.g. `-parallel 2 -timeout 120m` with `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES=40`).
+For a custom slow `:max`-thinking model, lower `PI_LIVE_PARALLEL` (e.g. `PI_LIVE_PARALLEL=2`) and raise `-timeout` above the per-run cap set by `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES` (e.g. `-timeout 120m` with `SPACEDOCK_PI_LIVE_TIMEOUT_MINUTES=40`).
 
 Without auth, the respective live suite skips locally (Claude/Codex/Pi), except in CI where the lane requires it.
 

--- a/internal/ensigncycle/pi_live_runner_test.go
+++ b/internal/ensigncycle/pi_live_runner_test.go
@@ -56,10 +56,7 @@ func newPiLiveSmokeFixture(t *testing.T, name, repo, piSubagentsRoot, binary str
 		t.Fatal(err)
 	}
 	env = piLiveEnvForAuth(piHome, sessionDir, cleanHome, filepath.Dir(binary), piSubagentsRoot, os.Getenv("OPENAI_API_KEY"), decision.mode)
-	model = decision.model
-	if override := os.Getenv("SPACEDOCK_PI_LIVE_CHILD_MODEL"); override != "" {
-		model = override
-	}
+	model = piLiveChildModel(decision)
 	return workflowRoot, stateRoot, entityPath, artifactDir, env, model
 }
 
@@ -279,6 +276,19 @@ func piSubagentsPackageRoot(t *testing.T) string {
 		t.Fatalf("pi-subagents package extension not found at %s: %v; set PI_SUBAGENTS_PACKAGE_ROOT", p, err)
 	}
 	return p
+}
+
+// piLiveChildModel resolves the model the Pi live child runs on. An operator
+// sets SPACEDOCK_PI_LIVE_CHILD_MODEL (provider/model:thinking) to re-run
+// journeys against a non-default model; the operator-mirrored auth.json and
+// models.json from seedPiLiveAuth make custom providers resolve. Unset, the
+// auth decision's model is used, so the CI pi-live lane keeps its
+// openai-codex default.
+func piLiveChildModel(decision piLiveAuthDecision) string {
+	if override := strings.TrimSpace(os.Getenv("SPACEDOCK_PI_LIVE_CHILD_MODEL")); override != "" {
+		return override
+	}
+	return decision.model
 }
 
 // piLiveRunTimeout returns the per-run cap for a Pi live journey. It reads

--- a/internal/ensigncycle/pi_shared_live_runner_test.go
+++ b/internal/ensigncycle/pi_shared_live_runner_test.go
@@ -28,7 +28,7 @@ func newPiSharedLiveDriver(t *testing.T) piSharedLiveDriver {
 	writeFile(t, filepath.Join(piHome, "settings.json"), fmt.Sprintf("{\"packages\":[%q]}\n", "file:"+repo))
 	return piSharedLiveDriver{
 		t:      t,
-		binary: binary, pluginDir: repo, modelName: decision.model, piHome: piHome,
+		binary: binary, pluginDir: repo, modelName: piLiveChildModel(decision), piHome: piHome,
 		artifactRoot: piLiveArtifactDir(t, "pi-common"),
 		env:          piLiveEnvForAuth(piHome, t.TempDir(), t.TempDir(), filepath.Dir(binary), piSubagentsPackageRoot(t), os.Getenv("OPENAI_API_KEY"), decision.mode),
 	}

--- a/internal/release/runtime_live_evidence_workflow_test.go
+++ b/internal/release/runtime_live_evidence_workflow_test.go
@@ -13,6 +13,14 @@ import (
 // liveCadenceWorkflow reads only the job-level env of the live jobs — the
 // surface the retired/unavailable-secret bans below inspect.
 type liveCadenceWorkflow struct {
+	On struct {
+		WorkflowDispatch struct {
+			Inputs map[string]struct {
+				Default  string   `yaml:"default"`
+				Options  []string `yaml:"options"`
+			} `yaml:"inputs"`
+		} `yaml:"workflow_dispatch"`
+	} `yaml:"on"`
 	Jobs map[string]struct {
 		Env map[string]string `yaml:"env"`
 	} `yaml:"jobs"`
@@ -45,6 +53,13 @@ func assertLiveSecretsBansHold(workflow string) error {
 	}
 	if _, present := pi.Env["SPACEDOCK_PI_LIVE_CHILD_MODEL"]; present {
 		return fmt.Errorf("Pi lane must derive its provider model from auth mode")
+	}
+	parallel, ok := parsed.On.WorkflowDispatch.Inputs["live_parallel"]
+	if !ok || parallel.Default != "4" {
+		return fmt.Errorf("workflow_dispatch live_parallel input = %#v, want a string input defaulting to \"4\"", parallel)
+	}
+	if pi.Env["SPACEDOCK_PI_LIVE_PARALLEL"] != `${{ inputs.live_parallel }}` {
+		return fmt.Errorf("Pi lane SPACEDOCK_PI_LIVE_PARALLEL = %q, want the live_parallel input", pi.Env["SPACEDOCK_PI_LIVE_PARALLEL"])
 	}
 	return nil
 }
@@ -85,6 +100,9 @@ func TestRuntimeLiveWorkflowNamedEvidenceMutationControls(t *testing.T) {
 	mutations := map[string]func(string) string{
 		"legacy PTY flag": func(s string) string {
 			return strings.Replace(s, "DISABLE_AUTOUPDATER: \"1\"", "DISABLE_AUTOUPDATER: \"1\"\n      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: \"1\"", 1)
+		},
+		"Pi parallel override lost": func(s string) string {
+			return strings.Replace(s, `-parallel "$PI_LIVE_PARALLEL" `, "", 1)
 		},
 		"offline live tag": func(s string) string {
 			return strings.Replace(s, "go test ./internal/ensigncycle -count=1 -run", "go test -tags live ./internal/ensigncycle -count=1 -run", 1)
@@ -128,6 +146,9 @@ func assertNamedLiveEvidence(workflow string) error {
 	}
 	for _, step := range parseWorkflowSteps(workflow) {
 		got := selectedTests(step.run)
+		if step.name == "Run live Pi common journeys" && !strings.Contains(step.run, `-parallel "$PI_LIVE_PARALLEL"`) {
+			return fmt.Errorf("Pi common journeys step lost the explicit -parallel override")
+		}
 		if len(got) > 0 && !owned[step.name] {
 			return fmt.Errorf("step %q selects unowned tests %v", step.name, got)
 		}


### PR DESCRIPTION
## What

Two pi-live lane control surfaces, both previously missing or implicit:

1. **Model override for common journeys** — `SPACEDOCK_PI_LIVE_CHILD_MODEL` (provider/model:thinking) was honored only by the front-door smoke fixture. The shared journey driver passed the auth decision's default (`openai-codex/gpt-5.6-luna:max`) to child pi, so the 17 common journeys could not be re-run against any other provider/model. Both paths now route through one `piLiveChildModel` helper. Unset, behavior is unchanged (CI derives the model from auth mode, as the workflow evidence test pins).

2. **Explicit `-parallel` pin** — pi-live was the only common-journey lane omitting `-parallel`, inheriting GOMAXPROCS (4 on standard runners) implicitly while claude-live and codex-live pin `-parallel 3`. The lane now takes the `live_parallel` dispatch input (default `"4"`, the current effective concurrency), exposed as `SPACEDOCK_PI_LIVE_PARALLEL`, validated as a positive integer in the step, and passed to `go test` after `-failfast`.

## Pins

- Workflow evidence test: new input default, job env binding, step flag, and a `Pi parallel override lost` mutation control.
- Local guide (`docs/runtime-live-ci.md`): the pi common-suite command now carries the same `-parallel "$PI_LIVE_PARALLEL"` pin, keeping the contractlint run-shape reconciliation (timeout/parallel/failfast) green.

## Evidence

- Both `go test ./...` and `go test ./... -race` green on this branch (20 packages, 0 failures, incl. `internal/cli` 167s under race).
- Harness fix exercised for real: the four CI-red journeys (`GateGuardrail`, `RecordedGateLifecycle`, `DefaultHeadlessGateStop`, `KeepMovingPosture`) plus `RejectionFlow` (CI timeout) all PASS locally on `modal/Qwen/Qwen3.8-27B:xhigh`, run from the stack tip with `SPACEDOCK_PI_LIVE_CHILD_MODEL` set — the exact configuration that failed at launch (`No API key found for openai-codex`) before this change.