### PR TITLE
Prerelease releases ship a stable-stamped binary under the default asset name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -74,7 +74,14 @@ archives:
       - spacedock-stable
     formats:
       - tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    # On a `-pre` tag (Prerelease true, IsSnapshot false — a --snapshot build also
+    # carries a semver prerelease part but is not a real release) the stable
+    # archive gains a `_stable` suffix, so a prerelease never publishes an
+    # unsuffixed asset: reaching for "the" default-looking asset is impossible,
+    # closing the trap where that asset silently held the stable-stamped binary.
+    # A stable tag and a snapshot keep today's name byte-identical (spiked:
+    # goreleaser 2.16.0, scratch clone, both channel builds end to end).
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if and .Prerelease (not .IsSnapshot) }}_stable{{ end }}"
     wrap_in_directory: false
   - id: spacedock-edge
     ids:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,7 +10,12 @@ marketplace source.
 
 - cross-builds darwin and linux (arm64 + amd64) tarballs plus `checksums.txt`,
   stamping `git describe --tags` into `internal/cli.Version`, for BOTH channels —
-  a stable build (`cli.devBranch=main`) and an edge build (`cli.devBranch=next`);
+  a stable build (`cli.devBranch=main`) and an edge build (`cli.devBranch=next`).
+  The asset name carries the channel: the edge tarball always ends `_edge`; the
+  stable tarball is unsuffixed on a stable tag but ends `_stable` on a `-pre`
+  tag, so a prerelease never offers a default-named asset. Nothing consumes a
+  prerelease's `_stable` tarball — it exists only because the cask pipe cannot
+  tolerate a skipped build;
 - publishes the GitHub Release with those assets;
 - bumps BOTH `spacedock-dev/homebrew-tap` casks (`spacedock` stable +
   `spacedock@next` edge) via `HOMEBREW_TAP_TOKEN`;
@@ -268,3 +273,11 @@ a dev-only path.
   marketplace-repo task and is NOT part of this flow.
 - This flow is the v1 adaptation of the original `scripts/release.sh` from the
   upstream spacedock plugin repo.
+- Prerelease releases cut before the `_stable` suffix landed shipped the
+  stable-stamped binary under the unsuffixed default asset name. An operator
+  who installed one holds a stable-channel binary at a prerelease version: it
+  re-ensures the `spacedock@spacedock` plugin on every launch. Detection:
+  `spacedock --version` prints a `Channel:` line on new binaries; on older
+  ones `go version -m $(command -v spacedock)` shows `cli.devBranch=main`.
+  Remedy: reinstall from the release's `_edge` tarball or
+  `brew install spacedock-dev/tap/spacedock@next`.

--- a/docs/site/reference/command-reference.md
+++ b/docs/site/reference/command-reference.md
@@ -1,18 +1,20 @@
 # Command reference
 
-The `spacedock` binary groups its subcommands into Launch, Setup, and Workflow, plus a top-level `spacedock --version` (the binary version and the host OS/arch, and — inside an agent session — that session's runtime and sandbox state). For the exact flags of any command, run `spacedock <command> --help`, the always-current source of truth; `spacedock` with no arguments prints the grouped help.
+The `spacedock` binary groups its subcommands into Launch, Setup, and Workflow, plus a top-level `spacedock --version` (the binary version, the host OS/arch, and release channel, and — inside an agent session — that session's runtime and sandbox state). For the exact flags of any command, run `spacedock <command> --help`, the always-current source of truth; `spacedock` with no arguments prints the grouped help.
 
 ## --version
 
-`spacedock --version` reports the binary version and the host OS/arch, and — when it is running inside an agent session — that session's runtime and sandbox state. Outside any session it prints two lines:
+`spacedock --version` reports the binary version, the host OS/arch, and the release channel the binary drives (`stable` installs `spacedock@spacedock`; `edge` installs `spacedock@spacedock-edge`), and — when it is running inside an agent session — that session's runtime and sandbox state. Outside any session it prints three lines:
 
     spacedock 0.26.0
     OS: darwin/arm64
+    Channel: stable (spacedock@spacedock)
 
 Inside a session it also names the host OS/arch, the runtime it detected, the marker that proved it, and whether this process is running inside a sandbox:
 
     spacedock 0.26.0
     OS: darwin/arm64
+    Channel: stable (spacedock@spacedock)
     Runtime: claude (CLAUDECODE)
     Sandbox: agent-safehouse
     contract 3
@@ -27,7 +29,7 @@ When markers for more than one runtime are set — a nested session can leak the
 
 Nothing on this surface fails, so it names no remedy. The one command the ambiguity does block is `spacedock dispatch build`, which refuses and prints the remedy with all three valid values.
 
-Being outside every runtime is a normal state, not a fault — it means a human at a terminal. There is no `Runtime:` line at all in that case, because there is no session to report: the output is the two lines shown above (the version line plus the `OS:` line).
+Being outside every runtime is a normal state, not a fault — it means a human at a terminal. There is no `Runtime:` line at all in that case, because there is no session to report: the output is the three lines shown above (the version line, the `OS:` line, and the `Channel:` line).
 
 The `Sandbox:` line answers one question — is this process sandboxed? Sandboxed, the value is the sandbox's name and nothing else; otherwise it is `none`, followed by whether safehouse is available to sandbox future launches:
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -119,6 +119,11 @@ func newRootCommand(ctx context.Context, rawArgs []string, env []string, dir str
 		CompletionOptions:  cobra.CompletionOptions{DisableDefaultCmd: true},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if versionFlag {
+				// The Channel line must report what the binary will ACTUALLY do, so
+				// an explicit SPACEDOCK_DEV_BRANCH override (including empty) applies
+				// before printVersion reads the package devBranch var — the same
+				// helper every install path already calls.
+				applyDevBranchOverride(env)
 				printVersion(stdout, envGetenv(env), exec.LookPath)
 				return nil
 			}
@@ -846,10 +851,13 @@ const frozenContractToken = "contract 3"
 // auto version-flag is deliberately NOT used). Line 2 is always
 // `OS: <goos>/<goarch>` — in BOTH output shapes — so user issue reports carry
 // the platform and later gate-logic versions can read the OS from `--version`
-// once a compatible binary exists. The frozen contract token moved BELOW line 1
-// — the integer-era prose says "run --version and parse contract <N>" and never
-// pins it to line 1 — and prints inside a session only, since every integer-era
-// reader is itself a session.
+// once a compatible binary exists. Line 3 is always `Channel: <stable|edge>
+// (<plugin-id>)` — in BOTH output shapes — reporting the EFFECTIVE devBranch: the
+// `--version` path applies applyDevBranchOverride(env) before this call, so a
+// SPACEDOCK_DEV_BRANCH override renders what the binary will really do. The
+// frozen contract token moved BELOW line 1 — the integer-era prose says "run
+// --version and parse contract <N>" and never pins it to line 1 — and prints
+// inside a session only, since every integer-era reader is itself a session.
 //
 // Ambiguous markers are REPORTED, never guessed at, and never fail: refusing here
 // would break the version gate and therefore every boot, including the nested-
@@ -857,11 +865,20 @@ const frozenContractToken = "contract 3"
 func printVersion(w io.Writer, getenv func(string) string, lookPath func(string) (string, error)) {
 	fmt.Fprintf(w, "spacedock %s\n", displayVersion())
 	fmt.Fprintf(w, "OS: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	// The channel word mirrors channelMarketplace's own two-way branch (main →
+	// stable, anything else → edge); the parenthetical is the plugin id the
+	// frontdoor re-ensures on every launch, so the incident's symptom (the
+	// spacedock@spacedock reinstall loop) and its cause read off one line.
+	channelWord := "edge"
+	if devBranch == "main" {
+		channelWord = "stable"
+	}
+	fmt.Fprintf(w, "Channel: %s (%s)\n", channelWord, channelPluginID(devBranch))
 
 	host, markers, ambiguous := runtimehost.Detect(getenv)
 	if !ambiguous && host == "" {
-		// Outside every runtime — a human at a terminal. Two lines: the version
-		// line plus the OS line, nothing else.
+		// Outside every runtime — a human at a terminal. Three lines: the version
+		// line, the OS line, and the Channel line, nothing else.
 		return
 	}
 

--- a/internal/cli/version_session_test.go
+++ b/internal/cli/version_session_test.go
@@ -38,10 +38,12 @@ var claudeSession = map[string]string{
 // expected outputs are in-test literals, independent of the production strings.
 //
 // The organising rule under test: inside a session, report the session; outside
-// one, report the version. Both shapes start with the same TWO lines — the
-// version line and the `OS: <goos>/<goarch>` line — so the outside case is two
-// lines (no Runtime line, no Sandbox line, and no contract token), while every
-// in-session case adds exactly three lines below them.
+// one, report the version. Both shapes start with the same THREE lines — the
+// version line, the `OS: <goos>/<goarch>` line, and the `Channel:` line — so the
+// outside case is three lines (no Runtime line, no Sandbox line, and no contract
+// token), while every in-session case adds exactly three lines below them.
+// devBranch is untouched by this file (package default "next"), so every
+// Channel line here renders the edge rendering: `edge (spacedock@spacedock-edge)`.
 func TestVersionSessionRender(t *testing.T) {
 	version := displayVersion()
 	osToken := runtime.GOOS + "/" + runtime.GOARCH
@@ -63,16 +65,18 @@ func TestVersionSessionRender(t *testing.T) {
 			lookPath: lookMissing,
 			want: "spacedock " + version + "\n" +
 				"OS: " + osToken + "\n" +
+				"Channel: edge (spacedock@spacedock-edge)\n" +
 				"Runtime: claude (CLAUDECODE)\n" +
 				"Sandbox: agent-safehouse\n" +
 				"contract 3\n",
 		},
 		{
-			name:     "outside-every-runtime-is-two-lines",
+			name:     "outside-every-runtime-is-three-lines",
 			vars:     map[string]string{},
 			lookPath: lookFound,
 			want: "spacedock " + version + "\n" +
-				"OS: " + osToken + "\n",
+				"OS: " + osToken + "\n" +
+				"Channel: edge (spacedock@spacedock-edge)\n",
 		},
 		{
 			// The same host with no session variable set at all. Its Runtime line
@@ -83,6 +87,7 @@ func TestVersionSessionRender(t *testing.T) {
 			lookPath: lookFound,
 			want: "spacedock " + version + "\n" +
 				"OS: " + osToken + "\n" +
+				"Channel: edge (spacedock@spacedock-edge)\n" +
 				"Runtime: claude (CLAUDECODE)\n" +
 				"Sandbox: none (safehouse available)\n" +
 				"contract 3\n",
@@ -98,6 +103,7 @@ func TestVersionSessionRender(t *testing.T) {
 			lookPath: lookMissing,
 			want: "spacedock " + version + "\n" +
 				"OS: " + osToken + "\n" +
+				"Channel: edge (spacedock@spacedock-edge)\n" +
 				"Runtime: pi (PI_CODING_AGENT, PI_CODING_AGENT_DIR)\n" +
 				"Sandbox: none (safehouse not installed)\n" +
 				"contract 3\n",
@@ -111,6 +117,7 @@ func TestVersionSessionRender(t *testing.T) {
 			lookPath: lookFound,
 			want: "spacedock " + version + "\n" +
 				"OS: " + osToken + "\n" +
+				"Channel: edge (spacedock@spacedock-edge)\n" +
 				"Runtime: codex (CODEX_THREAD_ID)\n" +
 				"Sandbox: none (safehouse available)\n" +
 				"contract 3\n",
@@ -129,6 +136,7 @@ func TestVersionSessionRender(t *testing.T) {
 			lookPath: lookFound,
 			want: "spacedock " + version + "\n" +
 				"OS: " + osToken + "\n" +
+				"Channel: edge (spacedock@spacedock-edge)\n" +
 				"Runtime: ambiguous (CODEX_THREAD_ID, CLAUDECODE)\n" +
 				"Sandbox: none (safehouse available)\n" +
 				"contract 3\n",


### PR DESCRIPTION
A prerelease tag published two linux/amd64 tarballs, and the stable-stamped one took the unsuffixed name. A user who downloaded the obvious asset from a `-pre` page got a stable-channel binary that printed a prerelease version. That binary then re-installed the `spacedock@spacedock` plugin on every launch, which is correct behavior for a stable binary and looked like a front-door bug. Nothing in the binary's own output named its channel, so telling the two apart needed `go version -m`.

## What changed

- `.goreleaser.yaml`: the stable archive gains a `_stable` suffix on a real prerelease tag only. A prerelease now publishes `_stable` and `_edge` and nothing under the default name. Stable-tag and snapshot names stay byte-identical.
- `internal/cli/cli.go`: `--version` prints `Channel: <stable|edge> (<plugin-id>)` after the `OS:` line, in both output shapes. It reads the effective devBranch through `applyDevBranchOverride(env)`, so a `SPACEDOCK_DEV_BRANCH` override renders what the binary will actually do.
- Docs: the release guide names the new asset shape and carries a migration note for anyone holding an unsuffixed prerelease binary. The command reference shows the third line.

No verifier tool, no CI lane, and no new test file. An earlier design proposed about 477 lines of artifact-verification for this five-line fix. It was rejected: the existing config-parsing guard was green while this defect shipped, so more tests of that kind do not address it. What survives as the guard is the line a human reads during normal use.

## Evidence

- Real `goreleaser release` runs (2.16.0, throwaway clone) over all three naming contexts: prerelease tag produced 8 archives with zero unsuffixed; stable tag and snapshot produced today's names. Falsified against the pre-fix config on the same tags, which produced 4 unsuffixed archives on a prerelease.
- The `Channel:` line proven on real stable- and edge-stamped binaries extracted from those runs, not on fixtures. Override semantics exercised across `main`, `next`, empty, and malformed values.
- Verified live that the id in the parenthetical equals the id the binary passes to `claude plugin install`.
- Mutation checks: deleting the line, moving it, or inverting the map each turns the suite red.
- `go test ./...` and `go test ./... -race` green. `gofmt` clean.
- Known and accepted: a Channel line hardcoded to `edge` would pass every fixture, because the fixture default is `devBranch=next`. Recorded as a deferred risk with its promote condition.

One obligation carries past this merge: on the first prerelease cut after it lands, read the release page and record the zero-unsuffixed count against AC-1. That evidence cannot exist until a cut happens, and this change is what enables the cut.

---

[c9](https://github.com/spacedock-dev/spacedock/blob/5a216c63aa591bf23a35b8b6ac4cf20920e6c018/prerelease-ships-stable-stamped-default-artifact.md)
