### PR TITLE
Make the auto-pre0 cut idempotent under a workflow re-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -397,7 +397,11 @@ jobs:
           PRE0_BODY="Edge prerelease auto-cut with stable $GITHUB_REF_NAME: publishes the ${PRE0_VERSION%.*}-line edge binary so spacedock@next catches up to the new release line. No standalone changes."
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$PRE0_TAG" "$RELEASE_COMMIT" -m "$PRE0_BODY"
+          # Idempotent under re-run: a prior attempt may have pushed the pre0
+          # tag and then failed in the verify poll below. Never re-mint (or
+          # move) an existing tag; push and verify-or-fail still run.
+          git rev-parse -q --verify "refs/tags/$PRE0_TAG" >/dev/null \
+            || git tag -a "$PRE0_TAG" "$RELEASE_COMMIT" -m "$PRE0_BODY"
           # Push over SSH with the write deploy key — the one credential GitHub
           # never suppresses for triggering, so the pre0 release.yml run fires.
           mkdir -p ~/.ssh

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -212,8 +212,12 @@ already published):
   v0.25.0 and v0.26.0 cuts, the cross-repo tap PAT — does NOT create the pre0
   `release.yml` run, so the step pushes with the deploy key and then **verifies
   a run was created for the pre0 tag, failing `edge-advance` loudly if none
-  appears** rather than leaving the edge binary silently behind. Expect two
-  GitHub releases per stable cut.
+  appears** rather than leaving the edge binary silently behind. Re-running the
+  job after such a failure is safe: an existing pre0 tag is never re-minted or
+  moved (the step checks `refs/tags/` before tagging), the push of an
+  already-landed tag is a no-op, and the run-verification poll executes again —
+  so the re-run turns green once the pre0 run exists, and still fails loudly if
+  the credential remains suppressed. Expect two GitHub releases per stable cut.
 - **Old-line / patch (`vX.Y.1`, cut after a newer `X.(Y').Z` line already
   shipped):** the decision step compares this tag's own version against the
   highest OTHER existing bare stable tag in the repo and prints `skip`, logged

--- a/internal/release/edge_advance_decision_shell_test.go
+++ b/internal/release/edge_advance_decision_shell_test.go
@@ -148,16 +148,12 @@ func TestDecisionStepScriptFailsClosedOnEmptyCandidatePool(t *testing.T) {
 	}
 }
 
-// runAutoPre0StepScript executes the ACTUAL always-cut-pre0 step's run script
-// from the on-disk release.yml against a fixture repo, with
-// EDGE_RELEASE_DEPLOY_KEY stripped so the tail dies at its first credential
-// line under set -u — before ssh-keyscan, so no shim or network is needed.
-// HOME is sandboxed because that death happens after `mkdir -p ~/.ssh`.
-// Returns the exit code and combined stdout/stderr.
+// runAutoPre0StepScript runs the real always-cut-pre0 step script with
+// EDGE_RELEASE_DEPLOY_KEY stripped, so it dies unbound before ssh-keyscan;
+// HOME is sandboxed since `mkdir -p ~/.ssh` runs just before that death.
 func runAutoPre0StepScript(t *testing.T, refName, fixtureRepo, home string) (exitCode int, output string) {
 	t.Helper()
-	workflow := readWorkflow(t, "release.yml")
-	job := edgeAdvanceJob(workflow)
+	job := edgeAdvanceJob(readWorkflow(t, "release.yml"))
 	if job == nil {
 		t.Fatal("release.yml has no edge-advance job")
 	}
@@ -182,26 +178,22 @@ func runAutoPre0StepScript(t *testing.T, refName, fixtureRepo, home string) (exi
 		"HOME="+home,
 	)
 	cmd := exec.Command("bash", "-c", step.run)
-	cmd.Dir = repoRoot
-	cmd.Env = env
+	cmd.Dir, cmd.Env = repoRoot, env
 	out, err := cmd.CombinedOutput()
-	var exitErr *exec.ExitError
-	if err != nil && !errors.As(err, &exitErr) {
-		t.Fatalf("real release.yml auto-pre0 step script: %v\n%s", err, out)
-	}
 	code := 0
-	if exitErr != nil {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
 		code = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("real release.yml auto-pre0 step script: %v\n%s", err, out)
 	}
 	return code, string(out)
 }
 
-// TestAutoPre0StepScriptRerunNeverRemintsExistingTag runs the REAL
-// always-cut-pre0 script twice against one fixture (v0.25.1, v0.26.0 at C1),
-// proving AC-1's exit 1-vs-128 discrimination (verified live in the cycle-3
-// spike): a guarded run that gets past the mint dies at the unbound-credential
-// line (exit 1); an unguarded mint on an existing tag dies AT the mint (exit
-// 128, "already exists") — the two failure modes never share a code.
+// TestAutoPre0StepScriptRerunNeverRemintsExistingTag runs the real script
+// twice (v0.25.1, v0.26.0 at C1): guarded + past-mint dies unbound (exit 1);
+// unguarded + tag-exists dies AT the mint (exit 128, "already exists") —
+// AC-1's discrimination, verified live in the cycle-3 spike.
 func TestAutoPre0StepScriptRerunNeverRemintsExistingTag(t *testing.T) {
 	fixture := tagFixtureRepo(t, []string{"v0.25.1", "v0.26.0"})
 	home := t.TempDir()
@@ -215,40 +207,39 @@ func TestAutoPre0StepScriptRerunNeverRemintsExistingTag(t *testing.T) {
 		}
 		return strings.TrimSpace(string(out))
 	}
-	c1 := git("rev-parse", "v0.26.0")
 	const wantMarker = "EDGE_RELEASE_DEPLOY_KEY: unbound variable"
 
-	// Mint pass: no pre0 exists yet. Pins that the guard doesn't wrongly skip
-	// on a first run, and catches a broken/lost `||` mint arm.
-	code, out := runAutoPre0StepScript(t, "v0.26.0", fixture, home)
-	if code != 1 || !strings.Contains(out, wantMarker) {
-		t.Fatalf("mint pass: exit=%d, want 1 with %q\n%s", code, wantMarker, out)
+	// Shared by both passes: past the mint (exit 1, unbound marker), pre0 SHA
+	// exactly at wantSHA — passes differ only in where the guard leaves it.
+	runAndAssertSHA := func(pass, wantSHA string) string {
+		t.Helper()
+		code, out := runAutoPre0StepScript(t, "v0.26.0", fixture, home)
+		if code != 1 || !strings.Contains(out, wantMarker) {
+			t.Fatalf("%s: exit=%d, want 1 with %q\n%s", pass, code, wantMarker, out)
+		}
+		if got := git("rev-list", "-1", "v0.27.0-pre0"); got != wantSHA {
+			t.Fatalf("%s: v0.27.0-pre0 targets %s, want %s", pass, got, wantSHA)
+		}
+		return out
 	}
+
+	// Mint pass: no pre0 exists yet — pins the guard doesn't wrongly skip a
+	// first run, a lost `||` mint arm, and that the mint is annotated.
+	c1 := git("rev-parse", "v0.26.0")
+	runAndAssertSHA("mint pass", c1)
 	if typ := git("cat-file", "-t", "v0.27.0-pre0"); typ != "tag" {
 		t.Fatalf("mint pass: v0.27.0-pre0 cat-file -t = %q, want an annotated tag", typ)
 	}
-	if got := git("rev-list", "-1", "v0.27.0-pre0"); got != c1 {
-		t.Fatalf("mint pass: v0.27.0-pre0 targets %s, want release commit %s", got, c1)
-	}
 
-	// Repoint pre0 to a divergent C2 before the re-run: a `git tag -a -f`
-	// re-mint mutant would also reach exit 1 here, so only the SHA assert
-	// below — not the exit code/marker — catches it.
+	// Repoint pre0 to a divergent C2: a `git tag -a -f` re-mint mutant also
+	// reaches exit 1, so only the SHA assert above/below catches it.
 	git("commit", "--allow-empty", "-q", "-m", "C2")
 	c2 := git("rev-parse", "HEAD")
 	git("tag", "-f", "-a", "v0.27.0-pre0", c2, "-m", "divergent")
 
-	// Tag-exists pass (the red/green core, AC-1): must get past the mint —
-	// same marker, never "already exists" — pre0 SHA still C2. An unguarded
-	// script instead dies AT the mint: exit 128, "already exists".
-	code, out = runAutoPre0StepScript(t, "v0.26.0", fixture, home)
-	if code != 1 || !strings.Contains(out, wantMarker) {
-		t.Fatalf("tag-exists pass: exit=%d, want 1 with %q (unguarded reds this at exit 128 \"already exists\")\n%s", code, wantMarker, out)
-	}
-	if strings.Contains(out, "already exists") {
+	// Tag-exists pass (the red/green core, AC-1): must get PAST the mint, not
+	// hit it — an unguarded script instead dies AT the mint (exit 128).
+	if out := runAndAssertSHA("tag-exists pass", c2); strings.Contains(out, "already exists") {
 		t.Fatalf("tag-exists pass: hit the mint instead of skipping it: %s", out)
-	}
-	if got := git("rev-list", "-1", "v0.27.0-pre0"); got != c2 {
-		t.Fatalf("tag-exists pass: v0.27.0-pre0 moved to %s, want it to stay at divergent C2 %s", got, c2)
 	}
 }

--- a/internal/release/edge_advance_decision_shell_test.go
+++ b/internal/release/edge_advance_decision_shell_test.go
@@ -5,6 +5,7 @@
 package release
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -144,5 +145,110 @@ func TestDecisionStepScriptFailsClosedOnEmptyCandidatePool(t *testing.T) {
 	}
 	if strings.Contains(output, "advance=true") {
 		t.Fatalf("decision step wrote both advance=true and advance=false: %q", output)
+	}
+}
+
+// runAutoPre0StepScript executes the ACTUAL always-cut-pre0 step's run script
+// from the on-disk release.yml against a fixture repo, with
+// EDGE_RELEASE_DEPLOY_KEY stripped so the tail dies at its first credential
+// line under set -u — before ssh-keyscan, so no shim or network is needed.
+// HOME is sandboxed because that death happens after `mkdir -p ~/.ssh`.
+// Returns the exit code and combined stdout/stderr.
+func runAutoPre0StepScript(t *testing.T, refName, fixtureRepo, home string) (exitCode int, output string) {
+	t.Helper()
+	workflow := readWorkflow(t, "release.yml")
+	job := edgeAdvanceJob(workflow)
+	if job == nil {
+		t.Fatal("release.yml has no edge-advance job")
+	}
+	step := edgeAdvanceAutoPre0Step(*job)
+	if step == nil {
+		t.Fatal("edge-advance has no auto-cut pre0 step")
+	}
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var env []string
+	for _, kv := range os.Environ() {
+		if !strings.HasPrefix(kv, "EDGE_RELEASE_DEPLOY_KEY=") {
+			env = append(env, kv)
+		}
+	}
+	env = append(env,
+		"GIT_DIR="+filepath.Join(fixtureRepo, ".git"),
+		"GIT_WORK_TREE="+fixtureRepo,
+		"GITHUB_REF_NAME="+refName,
+		"HOME="+home,
+	)
+	cmd := exec.Command("bash", "-c", step.run)
+	cmd.Dir = repoRoot
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	if err != nil && !errors.As(err, &exitErr) {
+		t.Fatalf("real release.yml auto-pre0 step script: %v\n%s", err, out)
+	}
+	code := 0
+	if exitErr != nil {
+		code = exitErr.ExitCode()
+	}
+	return code, string(out)
+}
+
+// TestAutoPre0StepScriptRerunNeverRemintsExistingTag runs the REAL
+// always-cut-pre0 script twice against one fixture (v0.25.1, v0.26.0 at C1),
+// proving AC-1's exit 1-vs-128 discrimination (verified live in the cycle-3
+// spike): a guarded run that gets past the mint dies at the unbound-credential
+// line (exit 1); an unguarded mint on an existing tag dies AT the mint (exit
+// 128, "already exists") — the two failure modes never share a code.
+func TestAutoPre0StepScriptRerunNeverRemintsExistingTag(t *testing.T) {
+	fixture := tagFixtureRepo(t, []string{"v0.25.1", "v0.26.0"})
+	home := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = fixture
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	c1 := git("rev-parse", "v0.26.0")
+	const wantMarker = "EDGE_RELEASE_DEPLOY_KEY: unbound variable"
+
+	// Mint pass: no pre0 exists yet. Pins that the guard doesn't wrongly skip
+	// on a first run, and catches a broken/lost `||` mint arm.
+	code, out := runAutoPre0StepScript(t, "v0.26.0", fixture, home)
+	if code != 1 || !strings.Contains(out, wantMarker) {
+		t.Fatalf("mint pass: exit=%d, want 1 with %q\n%s", code, wantMarker, out)
+	}
+	if typ := git("cat-file", "-t", "v0.27.0-pre0"); typ != "tag" {
+		t.Fatalf("mint pass: v0.27.0-pre0 cat-file -t = %q, want an annotated tag", typ)
+	}
+	if got := git("rev-list", "-1", "v0.27.0-pre0"); got != c1 {
+		t.Fatalf("mint pass: v0.27.0-pre0 targets %s, want release commit %s", got, c1)
+	}
+
+	// Repoint pre0 to a divergent C2 before the re-run: a `git tag -a -f`
+	// re-mint mutant would also reach exit 1 here, so only the SHA assert
+	// below — not the exit code/marker — catches it.
+	git("commit", "--allow-empty", "-q", "-m", "C2")
+	c2 := git("rev-parse", "HEAD")
+	git("tag", "-f", "-a", "v0.27.0-pre0", c2, "-m", "divergent")
+
+	// Tag-exists pass (the red/green core, AC-1): must get past the mint —
+	// same marker, never "already exists" — pre0 SHA still C2. An unguarded
+	// script instead dies AT the mint: exit 128, "already exists".
+	code, out = runAutoPre0StepScript(t, "v0.26.0", fixture, home)
+	if code != 1 || !strings.Contains(out, wantMarker) {
+		t.Fatalf("tag-exists pass: exit=%d, want 1 with %q (unguarded reds this at exit 128 \"already exists\")\n%s", code, wantMarker, out)
+	}
+	if strings.Contains(out, "already exists") {
+		t.Fatalf("tag-exists pass: hit the mint instead of skipping it: %s", out)
+	}
+	if got := git("rev-list", "-1", "v0.27.0-pre0"); got != c2 {
+		t.Fatalf("tag-exists pass: v0.27.0-pre0 moved to %s, want it to stay at divergent C2 %s", got, c2)
 	}
 }

--- a/internal/release/edge_advance_wiring_test.go
+++ b/internal/release/edge_advance_wiring_test.go
@@ -86,8 +86,13 @@ func assertAlwaysCutPre0(workflow string) error {
 	verifiesRun, failsOnMiss := false, false
 	for _, command := range executableShellCommands(pre0.run) {
 		switch {
-		case strings.HasPrefix(command, "git tag "):
-			tagCmd = command
+		case strings.Contains(command, "git tag "):
+			// The mint may be guarded by a "cmd || git tag …" existence check
+			// on the same logical line (idempotent-under-rerun); take the
+			// suffix from "git tag " on so tagCmdIsAnnotatedWithBody and
+			// tagCmdTarget still see a normalized `git tag …` command, not
+			// the guard's own leading command and args.
+			tagCmd = command[strings.Index(command, "git tag "):]
 		case strings.Contains(command, "git push"):
 			pushCmd = command
 		case command == `RELEASE_COMMIT="$(git rev-list -1 "$GITHUB_REF_NAME")"`:


### PR DESCRIPTION
A stable release cuts a `vX.(Y+1).0-pre0` tag automatically. If that job is re-run after the tag already reached origin, it dies on the tag it created:

    fatal: tag 'v0.27.0-pre0' already exists

Exit code 128, red under `set -euo pipefail`.

The trigger is real. The step's verify poll exits 1 AFTER the tag is pushed, so a re-run is the natural response to that failure. Three release runs in this repository already carry `run_attempt > 1`.

This is a regression against the mechanism it replaced. The retired `next`-manifest read decided skip at this moment, because its stable path stamped one notch above the tag it had just cut. The git-tag scan that replaced it excludes the ref being decided, so nothing supplies that notch on a re-run.

## What changed

The mint is guarded. Two code lines:

    git rev-parse -q --verify "refs/tags/$PRE0_TAG" >/dev/null \
      || git tag -a "$PRE0_TAG" "$RELEASE_COMMIT" -m "$PRE0_BODY"

Only the mint. Push and the verify-or-fail poll still run.

That placement was chosen over two alternatives. Exiting the whole step when the tag exists would disable the poll on exactly the path where it matters: a re-run includes the case where the credential is genuinely suppressed and no release run exists, and an early exit turns that into a green job with the edge binary silently missing. Folding the check into the decision step has the same defect.

The guard composes with the version notch rather than replacing it. They take different inputs. The notch answers whether a tag's version rank entitles it to cut. The guard answers whether the concrete ref already exists. Neither can answer the other's case.

## Evidence

The test extracts the real step script from `release.yml` and runs it under bash against constructed tag states. It is hermetic: with the deploy key stripped, an unguarded run dies at the mint with 128 and a guarded run gets past it and dies at the credential line with 1. Both deaths occur before any network call.

Validation ran seven mutants against it. All go red: reverted guard, unconditional `-f`, inverted guard, wrong-ref guard, swallowed mint, deleted mint, early-exit form. Each of the four assertions is uniquely killed by a different mutant, so none is redundant. The SHA assertion is the only one that catches an `-f` re-mint, which would corrupt a published ref while passing an exit-code check.

`go test ./...` and `-race` both exit 0. `gofmt` is clean. No Go source and no decision-step logic changed; the notch suite is byte-unchanged and green.

## Recorded, not fixed

No durable test observes the push and poll executing on the skip-mint path. That evidence was cut deliberately to reduce the test's size, with the tradeoff stated at the gate. The entity records it so a later reader does not read the gap as an oversight.

---

[83](https://github.com/spacedock-dev/spacedock/blob/9396a7063ec07af1d4844886e9bd108d63058c96/pre0-cut-idempotent-on-rerun.md)
