### PR TITLE
spacedock pi dedupes the pi-subagents extension when it is installed as a package

### DIFF
--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -51,6 +51,7 @@ type piPackageStatus struct {
 	firstOfficerDiscoverable bool
 	source                   string // the settings.json packages entry for spacedock
 	packageRoot              string // the resolved package root
+	subagentsRegistered      bool   // a package named pi-subagents is in settings.json packages
 }
 
 type execPiRuntimeOps struct{}
@@ -239,10 +240,15 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 	// has no per-action permission-prompting flag to suppress, so NO inner
 	// permission-mode flag is added on the wrap arm — safehouse isolation alone is
 	// the boundary, and the operator's --tools/--exclude-tools passthrough wins.
-	argv := []string{
-		"pi",
-		"--extension", cfg.extensionPath,
-		"--skill", cfg.subagentsSkill,
+	// When pi-subagents is registered in settings.json `packages`, pi's own
+	// package discovery loads <pkg>/index.ts (re-exporting ./src/extension/index.ts)
+	// as the sole extension specifier — passing the explicit --extension/--skill
+	// would register a second specifier for the same extension and collide
+	// (Tool "subagent" conflicts). Gate the explicit flags on the package NOT
+	// being registered so the only load path is pi's discovery (one specifier).
+	argv := []string{"pi"}
+	if !check.packageStatus.subagentsRegistered {
+		argv = append(argv, "--extension", cfg.extensionPath, "--skill", cfg.subagentsSkill)
 	}
 	// Dev override (--plugin-dir / SPACEDOCK_REPO_ROOT, i.e. cfg.repoRoot != ""):
 	// the Spacedock extension (.pi/extensions/spacedock.ts) is NOT registered in
@@ -588,6 +594,7 @@ func checkPiRuntime(ops piRuntimeOps, cfg piRuntimeConfig) piCheckResult {
 			firstOfficerDiscoverable: ops.Stat(filepath.Join(cfg.repoRoot, "skills", "first-officer", "SKILL.md")) == nil,
 			source:                   cfg.repoRoot + " (dev override)",
 			packageRoot:              cfg.repoRoot,
+			subagentsRegistered:      res.packageStatus.subagentsRegistered,
 		}
 	}
 	return res
@@ -692,6 +699,7 @@ func piSpacedockPackageStatus(agentDir, home string) piPackageStatus {
 	if json.Unmarshal(data, &settings) != nil {
 		return piPackageStatus{}
 	}
+	var st piPackageStatus
 	for _, raw := range settings.Packages {
 		src := piPackageSourceFromEntry(raw)
 		if src == "" {
@@ -702,22 +710,24 @@ func piSpacedockPackageStatus(agentDir, home string) piPackageStatus {
 			continue
 		}
 		name, skillPaths := readPackagePiSkills(root)
-		if name != "spacedock" {
-			continue
-		}
-		st := piPackageStatus{registered: true, source: src, packageRoot: root}
-		for _, sp := range skillPaths {
-			dir := filepath.Join(root, sp)
-			if piSkillFileExists(dir, "ensign") {
-				st.ensignDiscoverable = true
+		if name == "spacedock" && !st.registered {
+			st.registered = true
+			st.source = src
+			st.packageRoot = root
+			for _, sp := range skillPaths {
+				dir := filepath.Join(root, sp)
+				if piSkillFileExists(dir, "ensign") {
+					st.ensignDiscoverable = true
+				}
+				if piSkillFileExists(dir, "first-officer") {
+					st.firstOfficerDiscoverable = true
+				}
 			}
-			if piSkillFileExists(dir, "first-officer") {
-				st.firstOfficerDiscoverable = true
-			}
+		} else if name == "pi-subagents" {
+			st.subagentsRegistered = true
 		}
-		return st
 	}
-	return piPackageStatus{}
+	return st
 }
 
 func piPackageSourceFromEntry(raw json.RawMessage) string {

--- a/internal/cli/pi_frontdoor_test.go
+++ b/internal/cli/pi_frontdoor_test.go
@@ -1047,3 +1047,61 @@ func TestPiHelpCarriesSafehouseDetail(t *testing.T) {
 		}
 	}
 }
+
+// writePiSettingsJSON writes a settings.json with the given package source
+// entries under <agentDir>/settings.json and creates the resolved package
+// directory trees (package.json with name + pi.skills) for each npm: entry.
+func writePiSettingsJSON(t *testing.T, agentDir, home string, packages []string) {
+	t.Helper()
+	for _, src := range packages {
+		if !strings.HasPrefix(src, "npm:") {
+			continue
+		}
+		name := parseNpmPackageName(strings.TrimPrefix(src, "npm:"))
+		root := filepath.Join(agentDir, "npm", "node_modules", name)
+		skills := []string{"skills"}
+		var piSkills string
+		for _, s := range skills {
+			if piSkills != "" {
+				piSkills += ","
+			}
+			piSkills += "\"" + s + "\""
+		}
+		pkgJSON := "{\"name\":\"" + name + "\",\"pi\":{\"skills\":[" + piSkills + "]}}"
+		writeFileWithDirs(t, filepath.Join(root, "package.json"), pkgJSON)
+		writeFileWithDirs(t, filepath.Join(root, "skills", "ensign", "SKILL.md"), "---\nname: ensign\n---\n")
+		writeFileWithDirs(t, filepath.Join(root, "skills", "first-officer", "SKILL.md"), "---\nname: first-officer\n---\n")
+	}
+	var entries string
+	for i, src := range packages {
+		if i > 0 {
+			entries += ","
+		}
+		entries += "\"" + src + "\""
+	}
+	settings := "{\"packages\":[" + entries + "]}"
+	writeFileWithDirs(t, filepath.Join(agentDir, "settings.json"), settings)
+}
+
+// TestPiSpacedockPackageStatus_SubagentsRegistered pins the new detection: the
+// settings.json scan sets subagentsRegistered iff npm:pi-subagents is in packages.
+func TestPiSpacedockPackageStatus_SubagentsRegistered(t *testing.T) {
+	home := t.TempDir()
+	for _, tc := range []struct {
+		name     string
+		packages []string
+		want     bool
+	}{
+		{"with pi-subagents", []string{"npm:spacedock", "npm:pi-subagents"}, true},
+		{"without pi-subagents", []string{"npm:spacedock"}, false},
+		{"pi-subagents only", []string{"npm:pi-subagents"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			agentDir := filepath.Join(home, ".pi", "agent-"+strings.ReplaceAll(tc.name, " ", "-"))
+			writePiSettingsJSON(t, agentDir, home, tc.packages)
+			if got := piSpacedockPackageStatus(agentDir, home).subagentsRegistered; got != tc.want {
+				t.Fatalf("subagentsRegistered = %v, want %v (packages=%v)", got, tc.want, tc.packages)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stop `spacedock pi` crashing on startup when `pi-subagents` is installed as a package — the duplicate extension load is gone.

## What changed
- Gate the explicit `--extension`/`--skill` for pi-subagents in `runPi` on the package NOT being registered in `settings.json` `packages`.
- Extend `piSpacedockPackageStatus` to set `subagentsRegistered` during the existing settings.json scan (zero new I/O).
- Preserve `subagentsRegistered` through the dev-override fallback; the dev-override Spacedock extension block is unchanged.

## Evidence
- `internal/cli` suite: new `TestPiSpacedockPackageStatus_SubagentsRegistered` 3/3 passed; a falsifying change (`name == "pi-subagents-BROKEN"`) fails 2/3, proving the detection is match-driven.
- `go test ./...` green on every package except `internal/cli`'s 4 pre-existing/environmental failures, confirmed identical on the rebased-725 base; `go build ./...` and `gofmt` clean. Diff +85/-17.

---

[5xww](/spacedock-dev/spacedock/blob/aac68d5d81a84fd5992955f755f6e2431a0f7109/pi-subagents-duplicate-extension-load.md)
Closes spacedock-dev/spacedock#746
