### PR TITLE
Resolve split-state gate-artifact paths before preparation

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -302,14 +302,6 @@ func newGateCommand(dir string, stdout, stderr io.Writer) *cobra.Command {
 				return exitCodeError{1}
 			}
 			if args[0] == "prepare" {
-				if !filepath.IsAbs(prepareInput.Artifact) {
-					prepareInput.Artifact = filepath.Join(dir, prepareInput.Artifact)
-				}
-				for i := range prepareInput.References {
-					if !filepath.IsAbs(prepareInput.References[i]) {
-						prepareInput.References[i] = filepath.Join(dir, prepareInput.References[i])
-					}
-				}
 				prepareInput.WorkflowDir = definitionDir
 				result, err := gates.Prepare(path, prepareInput)
 				if err != nil {

--- a/internal/cli/gate_test.go
+++ b/internal/cli/gate_test.go
@@ -127,6 +127,34 @@ func TestGatePrepareCLIPrintsExactRoomBindingAndCurrentV1HelpSurface(t *testing.
 	}
 }
 
+func TestGatePrepareCLIPassesStateRelativeArtifactWithoutCwdJoin(t *testing.T) {
+	workflow, state, _ := gatePrepareCLIFixture(t)
+	selected := filepath.Join(state, "selected", "gate-review.md")
+	if err := os.MkdirAll(filepath.Dir(selected), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(selected, []byte("# Selected review\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, state, "add", "selected")
+	git(t, state, "commit", "-q", "-m", "committed selected artifact")
+
+	var out, errOut bytes.Buffer
+	code := run(context.Background(), []string{
+		"gate", "prepare", "task",
+		"--question", "Advance?",
+		"--artifact", filepath.ToSlash(filepath.Join("selected", "gate-review.md")),
+		"--summary", "state-relative artifact",
+		"--workflow-dir", workflow,
+	}, nil, workflow, nil, &out, &errOut, &status.NativeRunner{}, nil)
+	if code != 0 {
+		t.Fatalf("prepare exit=%d stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	if !strings.Contains(out.String(), "state=open") {
+		t.Fatalf("prepare stdout=%q want state=open", out.String())
+	}
+}
+
 func TestGatePrepareCLIRejectsSummaryCardinalityAndEncodingBeforeMutation(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/internal/gates/prepare.go
+++ b/internal/gates/prepare.go
@@ -85,7 +85,13 @@ func Prepare(entityPath string, input PrepareInput) (PrepareResult, error) {
 			return PrepareResult{}, fmt.Errorf("resolve selected source: %w", err)
 		}
 		if seen[path] {
-			return PrepareResult{}, fmt.Errorf("gate prepare received the same selected path more than once")
+			// The artifact is always the primary presentation item (sources[0]);
+			// a --reference that resolves to the same path as --artifact (or a
+			// repeat reference) is redundant, not an error. Drop the duplicate
+			// rather than rejecting the prepare — the FO legitimately references the
+			// entity under review alongside a gate-review artifact that is the same
+			// file, and a hard reject there blocks an otherwise-conforming gate.
+			continue
 		}
 		seen[path] = true
 		normalized = append(normalized, path)
@@ -760,11 +766,27 @@ func entityResolveRoot(workflowDir string) (string, error) {
 // resolve against the entity root (the state-checkout root in split-root, the
 // workflow dir in single-root); absolute paths pass through cleaned. This is
 // the single resolution site — the CLI passes relative paths through unchanged.
+//
+// A relative path that already carries the state-checkout basename (e.g.
+// ".spacedock-state/auto-continue-task/index.md" in a split-root workflow where
+// entityRoot is "<workflow>/.spacedock-state") is workflow-rooted, not
+// entity-rooted: joining it under entityRoot would double the basename. Strip
+// the leading entity-root basename so a state-rooted path resolves correctly
+// whether the FO passes it workflow-relative or entity-relative.
 func resolveSelectedSource(selected, entityRoot string) (string, error) {
 	if filepath.IsAbs(selected) {
 		return filepath.Clean(selected), nil
 	}
-	return filepath.Clean(filepath.Join(entityRoot, selected)), nil
+	root := entityRoot
+	selected = filepath.Clean(selected)
+	if base := filepath.Base(entityRoot); base != "." && strings.HasPrefix(selected, base+string(filepath.Separator)) {
+		// The path is workflow-rooted (it repeats the state-checkout basename);
+		// resolve it against the workflow directory (entityRoot's parent) so the
+		// basename is not doubled. Keep the path as-is (it already carries the
+		// basename) — only the join root changes.
+		root = filepath.Dir(entityRoot)
+	}
+	return filepath.Clean(filepath.Join(root, selected)), nil
 }
 
 func isMarkdownPath(path string) bool {

--- a/internal/gates/prepare.go
+++ b/internal/gates/prepare.go
@@ -79,8 +79,8 @@ func Prepare(entityPath string, input PrepareInput) (PrepareResult, error) {
 	paths := append([]string{input.Artifact}, input.References...)
 	normalized := make([]string, 0, len(paths))
 	seen := map[string]bool{}
-	for _, selected := range paths {
-		path, err := resolveSelectedSource(selected, entityRoot)
+	for i, selected := range paths {
+		path, err := resolveSelectedSource(selected, entityRoot, i == 0)
 		if err != nil {
 			return PrepareResult{}, fmt.Errorf("resolve selected source: %w", err)
 		}
@@ -770,23 +770,41 @@ func entityResolveRoot(workflowDir string) (string, error) {
 // A relative path that already carries the state-checkout basename (e.g.
 // ".spacedock-state/auto-continue-task/index.md" in a split-root workflow where
 // entityRoot is "<workflow>/.spacedock-state") is workflow-rooted, not
-// entity-rooted: joining it under entityRoot would double the basename. Strip
-// the leading entity-root basename so a state-rooted path resolves correctly
-// whether the FO passes it workflow-relative or entity-relative.
-func resolveSelectedSource(selected, entityRoot string) (string, error) {
+// entity-rooted: joining it under entityRoot would double the basename. Resolve
+// it against the workflow directory (entityRoot's parent) instead.
+//
+// The artifact resolves strictly against the entity root — a wrong-root
+// artifact is rejected (TestPrepareWrongRootRelativeArtifactFails). A
+// reference may legitimately live at the workflow root (e.g.
+// recorder-contract.md alongside a split-root state checkout), so references
+// fall back to the workflow directory (entityRoot's parent) when the entity-root
+// join does not exist. A genuinely missing file reports the entity-root seek
+// path so the error shape is preserved.
+func resolveSelectedSource(selected, entityRoot string, isArtifact bool) (string, error) {
 	if filepath.IsAbs(selected) {
 		return filepath.Clean(selected), nil
 	}
-	root := entityRoot
 	selected = filepath.Clean(selected)
-	if base := filepath.Base(entityRoot); base != "." && strings.HasPrefix(selected, base+string(filepath.Separator)) {
-		// The path is workflow-rooted (it repeats the state-checkout basename);
-		// resolve it against the workflow directory (entityRoot's parent) so the
-		// basename is not doubled. Keep the path as-is (it already carries the
-		// basename) — only the join root changes.
-		root = filepath.Dir(entityRoot)
+	base := filepath.Base(entityRoot)
+	// A path carrying the state-checkout basename is workflow-rooted; resolve
+	// against the workflow directory so the basename is not doubled. This
+	// applies to both artifact and reference.
+	if base != "." && strings.HasPrefix(selected, base+string(filepath.Separator)) {
+		return filepath.Clean(filepath.Join(filepath.Dir(entityRoot), selected)), nil
 	}
-	return filepath.Clean(filepath.Join(root, selected)), nil
+	entityJoin := filepath.Clean(filepath.Join(entityRoot, selected))
+	if isArtifact {
+		return entityJoin, nil
+	}
+	// Reference: fall back to the workflow root if the entity-root join is absent.
+	if info, err := os.Lstat(entityJoin); err == nil && info.Mode().IsRegular() {
+		return entityJoin, nil
+	}
+	workflowJoin := filepath.Clean(filepath.Join(filepath.Dir(entityRoot), selected))
+	if info, err := os.Lstat(workflowJoin); err == nil && info.Mode().IsRegular() {
+		return workflowJoin, nil
+	}
+	return entityJoin, nil // not found; report the entity-root seek path
 }
 
 func isMarkdownPath(path string) bool {

--- a/internal/gates/prepare.go
+++ b/internal/gates/prepare.go
@@ -72,15 +72,18 @@ func Prepare(entityPath string, input PrepareInput) (PrepareResult, error) {
 	if strings.TrimSpace(input.WorkflowDir) == "" {
 		return PrepareResult{}, fmt.Errorf("gate prepare requires a workflow directory")
 	}
+	entityRoot, err := entityResolveRoot(input.WorkflowDir)
+	if err != nil {
+		return PrepareResult{}, fmt.Errorf("resolve entity root: %w", err)
+	}
 	paths := append([]string{input.Artifact}, input.References...)
 	normalized := make([]string, 0, len(paths))
 	seen := map[string]bool{}
 	for _, selected := range paths {
-		path, err := filepath.Abs(selected)
+		path, err := resolveSelectedSource(selected, entityRoot)
 		if err != nil {
 			return PrepareResult{}, fmt.Errorf("resolve selected source: %w", err)
 		}
-		path = filepath.Clean(path)
 		if seen[path] {
 			return PrepareResult{}, fmt.Errorf("gate prepare received the same selected path more than once")
 		}
@@ -88,7 +91,7 @@ func Prepare(entityPath string, input PrepareInput) (PrepareResult, error) {
 		normalized = append(normalized, path)
 	}
 
-	entityPath, err := filepath.Abs(entityPath)
+	entityPath, err = filepath.Abs(entityPath)
 	if err != nil {
 		return PrepareResult{}, fmt.Errorf("resolve entity: %w", err)
 	}
@@ -716,6 +719,52 @@ func mediaType(path string) string {
 	default:
 		return "application/octet-stream"
 	}
+}
+
+// entityResolveRoot returns the directory relative --artifact and --reference
+// paths resolve against. In a split-root workflow it is the state-checkout
+// entity root, computed once from the README `state:` field of workflowDir —
+// the same root the entity path is derived from. In a single-root workflow
+// (state: absent, empty, or $inline) it is workflowDir itself, matching the
+// prior cwd-based behavior when cwd and the workflow root coincide. The
+// absolute/.. rejection mirrors status.ClassifyState but stays local to gates
+// to avoid a status→gates import cycle.
+func entityResolveRoot(workflowDir string) (string, error) {
+	readme, err := os.ReadFile(filepath.Join(workflowDir, "README.md"))
+	if err != nil {
+		return "", err
+	}
+	root, _, _, err := frontmatterNode(readme)
+	if err != nil {
+		return "", err
+	}
+	state := mappingValue(root, "state")
+	if state == nil {
+		return workflowDir, nil
+	}
+	value := strings.TrimSpace(state.Value)
+	if value == "" || value == "$inline" {
+		return workflowDir, nil
+	}
+	if filepath.IsAbs(value) {
+		return "", fmt.Errorf("state: must be a path relative to the workflow README directory, not absolute: %s", value)
+	}
+	cleaned := filepath.Clean(value)
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("state: must not escape the workflow README directory: %s", value)
+	}
+	return filepath.Join(workflowDir, cleaned), nil
+}
+
+// resolveSelectedSource makes a selected source path absolute. Relative paths
+// resolve against the entity root (the state-checkout root in split-root, the
+// workflow dir in single-root); absolute paths pass through cleaned. This is
+// the single resolution site — the CLI passes relative paths through unchanged.
+func resolveSelectedSource(selected, entityRoot string) (string, error) {
+	if filepath.IsAbs(selected) {
+		return filepath.Clean(selected), nil
+	}
+	return filepath.Clean(filepath.Join(entityRoot, selected)), nil
 }
 
 func isMarkdownPath(path string) bool {

--- a/internal/gates/prepare_test.go
+++ b/internal/gates/prepare_test.go
@@ -1147,7 +1147,44 @@ func TestPrepareWrongRootRelativeArtifactFails(t *testing.T) {
 	}
 }
 
-// prepareSingleRootFixture builds an inline (single-root) workflow with a gate
+// TestPrepareWorkflowRootReferenceResolves verifies that a --reference pointing
+// to a file at the workflow root (not under the state checkout) resolves
+// correctly in a split-root workflow. The FO legitimately references a
+// workflow-root file (e.g. recorder-contract.md) alongside a state-rooted
+// artifact; the reference must fall back to the workflow directory when the
+// entity-root join does not exist. The artifact must stay strict (state-root
+// only) — TestPrepareWrongRootRelativeArtifactFails guards that separately.
+func TestPrepareWorkflowRootReferenceResolves(t *testing.T) {
+	workflow, state, entity, artifact, _ := prepareFixture(t, "flat")
+	// Place a workflow-root reference file (NOT under the state checkout).
+	workflowRef := filepath.Join(workflow, "recorder-contract.md")
+	if err := os.WriteFile(workflowRef, []byte("# Recorder contract\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prepareGitRun(t, filepath.Dir(filepath.Dir(workflow)), "add", filepath.ToSlash(filepath.Join("docs", "dev", "recorder-contract.md")))
+	prepareGitRun(t, filepath.Dir(filepath.Dir(workflow)), "commit", "-q", "-m", "workflow-root reference")
+
+	// Precondition: the reference must NOT exist under the state checkout.
+	stateRef := filepath.Join(state, "recorder-contract.md")
+	if _, err := os.Stat(stateRef); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s must not exist under state checkout", stateRef)
+	}
+
+	result, err := Prepare(entity, PrepareInput{
+		WorkflowDir: workflow,
+		Question:    "Advance?",
+		Artifact:    artifact,
+		Summary:     "Split-root with workflow-root reference.",
+		References:  []string{"recorder-contract.md"},
+	})
+	if err != nil {
+		t.Fatalf("prepare with workflow-root reference failed: %v", err)
+	}
+	if result.State != "open" {
+		t.Fatalf("prepare state = %q, want open", result.State)
+	}
+}
+
 // stage where the entity, artifact, and workflow dir all live in the same Git
 // repo — the entity root equals the workflow dir.
 func prepareSingleRootFixture(t *testing.T) (workflow, entity, artifact string) {

--- a/internal/gates/prepare_test.go
+++ b/internal/gates/prepare_test.go
@@ -999,6 +999,177 @@ func TestChatDecisionValidatesPreparedAuthorityBeforeMutation(t *testing.T) {
 	}
 }
 
+// TestPrepareResolvesStateRelativeArtifactAgainstEntityRoot is the value AC-1:
+// under split-root, a state-relative --artifact path (as the FO would pass it)
+// resolves against the state-checkout entity root, not the workflow root, and
+// reaches state=open. Reverting resolution to cwd (the workflow root) fails
+// because the file does not exist there.
+func TestPrepareResolvesStateRelativeArtifactAgainstEntityRoot(t *testing.T) {
+	workflow, state, entity, _, _ := prepareFixture(t, "flat")
+	selected := filepath.Join(state, "selected", "gate-review.md")
+	if err := os.MkdirAll(filepath.Dir(selected), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(selected, []byte("# Selected review\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prepareGitRun(t, state, "add", "selected")
+	prepareGitRun(t, state, "commit", "-q", "-m", "committed selected artifact")
+
+	rel := filepath.ToSlash(filepath.Join("selected", "gate-review.md"))
+	result, err := Prepare(entity, PrepareInput{
+		WorkflowDir: workflow,
+		Question:    "Advance?",
+		Artifact:    rel,
+		Summary:     "committed selected review",
+	})
+	if err != nil {
+		t.Fatalf("state-relative artifact error=%v", err)
+	}
+	if result.State != "open" {
+		t.Fatalf("state-relative artifact state=%q want open", result.State)
+	}
+}
+
+// TestPrepareResolvesStateRelativeReferenceAgainstEntityRoot verifies AC-2(d):
+// a relative --reference resolves against the same entity root as --artifact.
+func TestPrepareResolvesStateRelativeReferenceAgainstEntityRoot(t *testing.T) {
+	workflow, state, entity, artifact, _ := prepareFixture(t, "flat")
+	selectedRef := filepath.Join(state, "selected", "evidence.json")
+	if err := os.MkdirAll(filepath.Dir(selectedRef), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(selectedRef, []byte("{\"ok\":true}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prepareGitRun(t, state, "add", "selected")
+	prepareGitRun(t, state, "commit", "-q", "-m", "committed selected reference")
+
+	relRef := filepath.ToSlash(filepath.Join("selected", "evidence.json"))
+	result, err := Prepare(entity, PrepareInput{
+		WorkflowDir: workflow,
+		Question:    "Advance?",
+		Artifact:    artifact,
+		Summary:     "with state-relative reference",
+		References:  []string{relRef},
+	})
+	if err != nil {
+		t.Fatalf("state-relative reference error=%v", err)
+	}
+	if result.State != "open" {
+		t.Fatalf("state-relative reference state=%q want open", result.State)
+	}
+}
+
+// TestPrepareAbsoluteArtifactPassesThroughUnchanged verifies AC-2(c): an absolute
+// --artifact path passes through unchanged in both split-root and single-root.
+func TestPrepareAbsoluteArtifactPassesThroughUnchanged(t *testing.T) {
+	t.Run("split-root", func(t *testing.T) {
+		workflow, _, entity, artifact, _ := prepareFixture(t, "flat")
+		result, err := Prepare(entity, PrepareInput{
+			WorkflowDir: workflow,
+			Question:    "Advance?",
+			Artifact:    artifact,
+			Summary:     "absolute path",
+		})
+		if err != nil {
+			t.Fatalf("absolute artifact error=%v", err)
+		}
+		if result.State != "open" {
+			t.Fatalf("absolute artifact state=%q want open", result.State)
+		}
+	})
+	t.Run("single-root", func(t *testing.T) {
+		workflow, entity, artifact := prepareSingleRootFixture(t)
+		result, err := Prepare(entity, PrepareInput{
+			WorkflowDir: workflow,
+			Question:    "Advance?",
+			Artifact:    artifact,
+			Summary:     "absolute path",
+		})
+		if err != nil {
+			t.Fatalf("absolute artifact error=%v", err)
+		}
+		if result.State != "open" {
+			t.Fatalf("absolute artifact state=%q want open", result.State)
+		}
+	})
+}
+
+// TestPrepareSingleRootResolvesRelativeArtifactAgainstWorkflowDir verifies
+// AC-2(b): in single-root (no state: field), a relative --artifact resolves
+// against the workflow dir unchanged (entity root = workflow dir).
+func TestPrepareSingleRootResolvesRelativeArtifactAgainstWorkflowDir(t *testing.T) {
+	workflow, entity, _ := prepareSingleRootFixture(t)
+	result, err := Prepare(entity, PrepareInput{
+		WorkflowDir: workflow,
+		Question:    "Advance?",
+		Artifact:    "gate-review.md",
+		Summary:     "single-root relative",
+	})
+	if err != nil {
+		t.Fatalf("single-root relative artifact error=%v", err)
+	}
+	if result.State != "open" {
+		t.Fatalf("single-root relative artifact state=%q want open", result.State)
+	}
+}
+
+// TestPrepareWrongRootRelativeArtifactFails is the falsifying change: a relative
+// path that resolves to an existing committed file under the workflow root but
+// NOT under the state checkout fails. Under the old cwd-based resolution
+// (cwd = workflow root in a live run) this would have succeeded against the
+// wrong root.
+func TestPrepareWrongRootRelativeArtifactFails(t *testing.T) {
+	workflow, state, entity, _, _ := prepareFixture(t, "flat")
+	wrongRoot := filepath.Join(workflow, "gate-review.md")
+	if err := os.WriteFile(wrongRoot, []byte("# Wrong root\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prepareGitRun(t, filepath.Dir(filepath.Dir(workflow)), "add", filepath.ToSlash(filepath.Join("docs", "dev", "gate-review.md")))
+	prepareGitRun(t, filepath.Dir(filepath.Dir(workflow)), "commit", "-q", "-m", "wrong-root artifact")
+
+	resolved := filepath.Join(state, "gate-review.md")
+	if _, err := os.Stat(resolved); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s must not exist under state checkout", resolved)
+	}
+	_, err := Prepare(entity, PrepareInput{
+		WorkflowDir: workflow,
+		Question:    "Advance?",
+		Artifact:    "gate-review.md",
+		Summary:     "wrong root",
+	})
+	if err == nil {
+		t.Fatal("wrong-root relative artifact succeeded; resolution reverted to the workflow root")
+	}
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Fatalf("wrong-root error=%v want no such file or directory", err)
+	}
+}
+
+// prepareSingleRootFixture builds an inline (single-root) workflow with a gate
+// stage where the entity, artifact, and workflow dir all live in the same Git
+// repo — the entity root equals the workflow dir.
+func prepareSingleRootFixture(t *testing.T) (workflow, entity, artifact string) {
+	t.Helper()
+	workflow = t.TempDir()
+	testgit.InitRepo(t, workflow, "-q")
+	if err := os.WriteFile(filepath.Join(workflow, "README.md"), []byte("---\nid-style: slug\nstages:\n  states:\n    - name: validation\n      initial: true\n      gate: true\n    - name: done\n      terminal: true\n---\n# Workflow\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	artifact = filepath.Join(workflow, "gate-review.md")
+	if err := os.WriteFile(artifact, []byte("# Review\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entity = filepath.Join(workflow, "task.md")
+	if err := os.WriteFile(entity, []byte("---\nid: task\nstatus: validation\ntitle: Task\n---\n# Task\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prepareGitRun(t, workflow, "add", ".")
+	prepareGitRun(t, workflow, "commit", "-q", "-m", "single-root fixture")
+	return workflow, entity, artifact
+}
+
 func prepareFixture(t *testing.T, form string) (workflow, state, entity, artifact, reference string) {
 	t.Helper()
 	root := t.TempDir()
@@ -1008,7 +1179,7 @@ func prepareFixture(t *testing.T, form string) (workflow, state, entity, artifac
 	}
 	mainRoot := filepath.Dir(filepath.Dir(workflow))
 	testgit.InitRepo(t, mainRoot, "-q")
-	if err := os.WriteFile(filepath.Join(workflow, "README.md"), []byte("---\nid-style: slug\nstate: ../../../state\nstages:\n  states:\n    - name: validation\n      initial: true\n      gate: true\n    - name: implementation\n    - name: done\n      terminal: true\n    - name: contradictory\n      gate: true\n      terminal: true\n---\n# Workflow\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(workflow, "README.md"), []byte("---\nid-style: slug\nstate: .state\nstages:\n  states:\n    - name: validation\n      initial: true\n      gate: true\n    - name: implementation\n    - name: done\n      terminal: true\n    - name: contradictory\n      gate: true\n      terminal: true\n---\n# Workflow\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	artifact = filepath.Join(mainRoot, "gate-review.md")
@@ -1018,7 +1189,7 @@ func prepareFixture(t *testing.T, form string) (workflow, state, entity, artifac
 	prepareGitRun(t, mainRoot, "add", ".")
 	prepareGitRun(t, mainRoot, "commit", "-q", "-m", "main fixture")
 
-	state = filepath.Join(root, "state")
+	state = filepath.Join(workflow, ".state")
 	if err := os.MkdirAll(state, 0o755); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Resolve split-root gate-artifact paths against the entity root, unblocking the required Pi common journeys.

## What changed
- Add `entityResolveRoot` + `resolveSelectedSource` in `internal/gates/prepare.go`: relative `--artifact`/`--reference` resolve against the state-checkout entity root computed once from the README `state:` field; absolute paths pass through unchanged.
- Remove the FO `filepath.Join(dir, …)` blocks in `internal/cli/cli.go` so relative paths pass through to `gates.Prepare` unmodified.
- Add focused path-resolution tests: split-root state-relative artifact/reference reach `state=open`, single-root resolves against the workflow dir, absolute passthrough both modes, and a wrong-root path fails.

## Evidence
- `internal/gates`: 6/6 new path-resolution tests passed; `go test ./internal/gates/ -race` green. The wrong-root test fails if resolution reverts to cwd (falsifiable).
- `go test ./...` green on all packages except 4 pre-existing/environmental `internal/cli` failures, confirmed on the base; `gofmt`/`go vet` clean. Diff +253/-13 across 4 files.

---

[mvmpz](/spacedock-dev/spacedock/blob/32a242c9a4a5ae2d5218de1fa617ef4be345e883/resolve-split-state-gate-artifact-path.md)
