### PR TITLE
Align the Pi compaction boundary with force-boot (re-read state, not re-inject contract)

### DIFF
--- a/.pi/extensions/spacedock.ts
+++ b/.pi/extensions/spacedock.ts
@@ -15,12 +15,23 @@
 // Pi's context hook. The launcher keeps only its minimal skill-trigger prompt;
 // this extension owns the durable warm/contract bootstrap because context hooks
 // can re-inject after compaction while launch argv prompts cannot.
+//
+// Compaction boundary: PR #738 (force-boot-at-compaction-boundary) established
+// that at compaction the FO re-reads durable state (one «state.boot»()), NOT
+// re-inject the contract.  The session_compact hook fires a boot read via
+// pi.exec and injects the boot record as a context message; the contract
+// survives compaction in the system prompt (rebuilt from the skill via
+// resources_discover), so re-injecting FO_BOOTSTRAP_TEXT would be the thing
+// #738 rejected.
 
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
 
 const FO_BOOTSTRAP_MARKER = "SPACEDOCK-FO-BOOTSTRAP-v1";
 const FO_BOOTSTRAP_TEXT = `<EXTREMELY_IMPORTANT>\n[${FO_BOOTSTRAP_MARKER}] You are the Spacedock first officer. Load the $spacedock:first-officer skill (skills/first-officer/SKILL.md) and treat it as your operating contract: re-satisfy every load precondition at its trigger (shared core, runtime adapter, write/merge/dispatch cores), re-read durable state before the next workflow effect — the compacted summary is not authoritative. Pi tool mapping: read/write/edit/bash/grep/find/ls; load skills via read; subagent via pi-subagents when available; plans live in plan files / TODO.md.\n</EXTREMELY_IMPORTANT>`;
+
+const FO_BOOT_RECORD_MARKER = "[SPACEDOCK-FO-BOOT-v2]";
+const FO_BOOT_RECORD_DIRECTIVE = `${FO_BOOT_RECORD_MARKER} Durable state boot record — re-read before the next workflow effect. The compacted summary is not authoritative. Resume the loop where it stopped; do NOT greet or re-present a session summary. Pi tool mapping: read/write/edit/bash/grep/find/ls; load skills via read; subagent via pi-subagents when available.`;
 
 // pi-subagents marks every spawned child session with PI_SUBAGENT_CHILD=1
 // (src/runs/shared/pi-args.ts); a child is a delegated worker by definition,
@@ -44,6 +55,11 @@ function hasStructuralBootstrap(message) {
 	return text.startsWith("<EXTREMELY_IMPORTANT>") && text.includes(FO_BOOTSTRAP_MARKER);
 }
 
+function hasBootRecord(message) {
+	if (message?.role !== "user") return false;
+	return messageText(message).includes(FO_BOOT_RECORD_MARKER);
+}
+
 function isLeadingCompactionSummary(message) {
 	const text = messageText(message).toLowerCase();
 	return text.includes("compaction") && text.includes("summary");
@@ -51,6 +67,7 @@ function isLeadingCompactionSummary(message) {
 
 export default function registerSpacedockExtension(pi) {
 	let injectBootstrap = false;
+	let injectBootRecord = false;
 
 	pi.on("resources_discover", () => {
 		const extDir = path.dirname(fileURLToPath(import.meta.url));
@@ -65,34 +82,81 @@ export default function registerSpacedockExtension(pi) {
 	});
 
 	pi.on("session_compact", () => {
-		injectBootstrap = true;
+		injectBootstrap = false;
+		injectBootRecord = true;
 	});
 
 	pi.on("agent_end", () => {
 		injectBootstrap = false;
+		injectBootRecord = false;
 	});
 
-	pi.on("context", (event) => {
-		if (isPiSubagentChild || !injectBootstrap) return;
-		if (event.messages.some(hasStructuralBootstrap)) return;
+	pi.on("context", async (event) => {
+		if (isPiSubagentChild) return;
 
-		const bootstrapMessage = {
-			role: "user",
-			content: [{ type: "text", text: FO_BOOTSTRAP_TEXT }],
-			timestamp: Date.now(),
-		};
+		if (injectBootRecord) {
+			if (event.messages.some(hasBootRecord)) return;
 
-		let insertAt = 0;
-		while (insertAt < event.messages.length && isLeadingCompactionSummary(event.messages[insertAt])) {
-			insertAt++;
+			let bootRecordJson = "";
+			try {
+				const result = await pi.exec("spacedock", ["status", "--boot", "--identify", "--json"]);
+				if (result.code === 0 && result.stdout) {
+					bootRecordJson = result.stdout;
+				}
+			} catch {
+				// Boot read failed — fall back to the directive without the
+				// boot record so a compaction boundary never blocks the
+				// session.  The directive alone still tells the FO to re-read
+				// durable state; the extension just couldn't pre-read it.
+			}
+
+			const text = bootRecordJson
+				? `${FO_BOOT_RECORD_DIRECTIVE}\n\n${bootRecordJson}`
+				: FO_BOOT_RECORD_DIRECTIVE;
+
+			const bootMessage = {
+				role: "user",
+				content: [{ type: "text", text }],
+				timestamp: Date.now(),
+			};
+
+			let insertAt = 0;
+			while (insertAt < event.messages.length && isLeadingCompactionSummary(event.messages[insertAt])) {
+				insertAt++;
+			}
+
+			return {
+				messages: [
+					...event.messages.slice(0, insertAt),
+					bootMessage,
+					...event.messages.slice(insertAt),
+				],
+			};
 		}
 
-		return {
-			messages: [
-				...event.messages.slice(0, insertAt),
-				bootstrapMessage,
-				...event.messages.slice(insertAt),
-			],
-		};
+		if (injectBootstrap) {
+			if (event.messages.some(hasStructuralBootstrap)) return;
+
+			const bootstrapMessage = {
+				role: "user",
+				content: [{ type: "text", text: FO_BOOTSTRAP_TEXT }],
+				timestamp: Date.now(),
+			};
+
+			let insertAt = 0;
+			while (insertAt < event.messages.length && isLeadingCompactionSummary(event.messages[insertAt])) {
+				insertAt++;
+			}
+
+			return {
+				messages: [
+					...event.messages.slice(0, insertAt),
+					bootstrapMessage,
+					...event.messages.slice(insertAt),
+				],
+			};
+		}
+
+		return;
 	});
 }

--- a/internal/piruntime/spacedock_extension_test.go
+++ b/internal/piruntime/spacedock_extension_test.go
@@ -33,39 +33,63 @@ func TestSpacedockPiExtensionBootstrapBehavior(t *testing.T) {
 import register from './spacedock-extension.mjs';
 
 const handlers = new Map();
-const pi = { on(event, handler) { handlers.set(event, handler); } };
+const execCalls = [];
+const pi = {
+  on(event, handler) { handlers.set(event, handler); },
+  exec(command, args, options) {
+    execCalls.push({ command, args, options });
+    return Promise.resolve({ stdout: '{"command":"boot","mods":{},"ready_gates":[],"state_backend":"single-root"}', stderr: '', code: 0, killed: false });
+  }
+};
 register(pi);
 
 const marker = 'SPACEDOCK-FO-BOOTSTRAP-v1';
+const bootRecordMarker = '[SPACEDOCK-FO-BOOT-v2]';
 const textOf = (message) => Array.isArray(message?.content)
   ? message.content.filter((part) => part?.type === 'text').map((part) => String(part.text ?? '')).join('')
   : String(message?.content ?? '');
 const countBootstraps = (messages) => messages.filter((message) => message?.role === 'user' && textOf(message).startsWith('<EXTREMELY_IMPORTANT>') && textOf(message).includes(marker)).length;
+const countBootRecords = (messages) => messages.filter((message) => message?.role === 'user' && textOf(message).includes(bootRecordMarker)).length;
 const assert = (condition, message) => { if (!condition) throw new Error(message); };
 
 const resources = handlers.get('resources_discover')({ type: 'resources_discover', cwd: process.cwd(), reason: 'test' });
 assert(resources.skillPaths.length === 1 && resources.skillPaths[0].endsWith('/skills'), 'resources_discover returns the package skills directory');
 
+// --- session_start path (AC-3: unchanged) ---
 handlers.get('session_start')({ type: 'session_start' });
-let first = handlers.get('context')({ messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }] });
+let first = await handlers.get('context')({ messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }] });
 assert(countBootstraps(first.messages) === 1, 'session_start injects exactly one structural bootstrap');
 assert(textOf(first.messages[0]).includes('Load the $spacedock:first-officer skill'), 'bootstrap points at the shipped first-officer contract');
 assert(textOf(first.messages[0]).includes('Pi tool mapping: read/write/edit/bash/grep/find/ls'), 'bootstrap includes the Pi tool mapping');
 
+// --- session_compact path (AC-1 value-measuring, AC-2 mechanism) ---
+handlers.get('agent_end')({ type: 'agent_end' }); // clear flags between paths
+execCalls.length = 0; // reset exec call tracking
 handlers.get('session_compact')({ type: 'session_compact' });
 const compactSummary = { role: 'assistant', content: [{ type: 'text', text: 'Compaction summary mentions SPACEDOCK-FO-BOOTSTRAP-v1 but is not the bootstrap message.' }] };
-let afterCompact = handlers.get('context')({ messages: [compactSummary, { role: 'user', content: [{ type: 'text', text: 'continue' }] }] });
-assert(countBootstraps(afterCompact.messages) === 1, 'summary marker mention does not suppress reinjection');
-assert(afterCompact.messages[0] === compactSummary, 'bootstrap is inserted after the leading compaction summary');
-assert(textOf(afterCompact.messages[1]).startsWith('<EXTREMELY_IMPORTANT>'), 'bootstrap is the first non-summary message after compaction');
+let afterCompact = await handlers.get('context')({ messages: [compactSummary, { role: 'user', content: [{ type: 'text', text: 'continue' }] }] });
+// AC-1: boot record present, contract re-injection absent
+assert(countBootstraps(afterCompact.messages) === 0, 'compaction does NOT inject structural bootstrap text');
+assert(countBootRecords(afterCompact.messages) === 1, 'compaction injects exactly one boot record');
+assert(afterCompact.messages[0] === compactSummary, 'boot record is inserted after the leading compaction summary');
+const bootRecordText = textOf(afterCompact.messages[1]);
+assert(bootRecordText.includes('"command":"boot"'), 'compaction injects the boot record (command:boot)');
+assert(!bootRecordText.includes(marker), 'compaction does NOT inject the FO bootstrap marker');
+assert(!bootRecordText.includes('Load the $spacedock:first-officer skill'), 'compaction does NOT inject the contract pointer');
+// AC-2: pi.exec called with the right args
+assert(execCalls.length === 1, 'pi.exec called exactly once for the boot read');
+assert(execCalls[0].command === 'spacedock', 'pi.exec called with spacedock');
+assert(JSON.stringify(execCalls[0].args) === JSON.stringify(['status','--boot','--identify','--json']), 'pi.exec called with status --boot --identify --json');
 
+// --- dedup (AC-5) ---
 handlers.get('session_compact')({ type: 'session_compact' });
-let deduped = handlers.get('context')({ messages: afterCompact.messages });
-assert(deduped === undefined, 'existing structural bootstrap de-duplicates context injection');
+let deduped = await handlers.get('context')({ messages: afterCompact.messages });
+assert(deduped === undefined, 'existing boot record de-duplicates context injection');
 
+// --- agent_end suppresses further injection ---
 handlers.get('agent_end')({ type: 'agent_end' });
-let suppressed = handlers.get('context')({ messages: [{ role: 'user', content: [{ type: 'text', text: 'new turn' }] }] });
-assert(suppressed === undefined, 'agent_end suppresses further bootstrap injection');
+let suppressed = await handlers.get('context')({ messages: [{ role: 'user', content: [{ type: 'text', text: 'new turn' }] }] });
+assert(suppressed === undefined, 'agent_end suppresses further injection');
 `
 	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
 		t.Fatalf("write harness: %v", err)
@@ -102,7 +126,10 @@ func TestSpacedockPiExtensionChildExemption(t *testing.T) {
 import register from './spacedock-extension.mjs';
 
 const handlers = new Map();
-const pi = { on(event, handler) { handlers.set(event, handler); } };
+const pi = {
+  on(event, handler) { handlers.set(event, handler); },
+  exec() { return Promise.resolve({ stdout: '', stderr: '', code: 0, killed: false }); }
+};
 register(pi);
 
 const assert = (condition, message) => { if (!condition) throw new Error(message); };
@@ -112,11 +139,11 @@ const resources = handlers.get('resources_discover')({ type: 'resources_discover
 assert(resources.skillPaths.length === 1 && resources.skillPaths[0].endsWith('/skills'), 'child sessions still discover the package skills directory');
 
 handlers.get('session_start')({ type: 'session_start' });
-const afterStart = handlers.get('context')({ messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }] });
+const afterStart = await handlers.get('context')({ messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }] });
 assert(afterStart === undefined, 'PI_SUBAGENT_CHILD=1 session_start injects zero FO bootstrap');
 
 handlers.get('session_compact')({ type: 'session_compact' });
-const afterCompact = handlers.get('context')({ messages: [{ role: 'user', content: [{ type: 'text', text: 'continue' }] }] });
+const afterCompact = await handlers.get('context')({ messages: [{ role: 'user', content: [{ type: 'text', text: 'continue' }] }] });
 assert(afterCompact === undefined, 'PI_SUBAGENT_CHILD=1 session_compact injects zero FO bootstrap');
 `
 	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {


### PR DESCRIPTION
Align the Pi compaction boundary with force-boot (#738): re-read durable state, not re-inject the contract.

## What changed
- Add `injectBootRecord` flag set by `session_compact` only; `session_start` keeps `injectBootstrap`.
- Make the `context` handler async; fire `spacedock status --boot --identify --json` via `pi.exec()` on compaction.
- Inject the boot record as a context message with a `[SPACEDOCK-FO-BOOT-v2]` marker + framing directive.
- Remove `FO_BOOTSTRAP_TEXT` (contract re-injection) from the compaction path; retain it for `session_start`.
- Add `hasBootRecord` dedup; clear both flags on `agent_end`; fall back to directive-only on `pi.exec` failure.

## Evidence
- `internal/piruntime` focused test (real `.pi/extensions/spacedock.ts` through Node harness): 2/2 passed.

---
[h9](/spacedock-dev/spacedock/blob/1fe3fae4720f873fde4903baf9afda9c5d1f1f90/align-pi-compaction-with-force-boot.md)
Related: #738 (force-boot-at-compaction-boundary), stacks on #753.
