### PR TITLE
install.sh resolves releases/latest and silently breaks edge version parity

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -58,6 +58,33 @@ jobs:
             *) echo "::error::unexpected --version output: $ver"; exit 1 ;;
           esac
 
+      # Edge channel: the SAME snapshot dist carries BOTH channels' archives (the
+      # edge one suffixed `_edge`), so SPACEDOCK_CHANNEL=edge asserts the whole
+      # value property offline — the edge asset is selected AND the binary it
+      # lands is edge-stamped at the minor the first-officer boot gate requires.
+      # The required minor is read from the FO shared-core's own stamped literal,
+      # not hardcoded, so it tracks the release line. This leg also covers Linux,
+      # the platform with no other scripted edge binary path.
+      - name: Install the edge channel from local snapshot and run
+        run: |
+          set -euo pipefail
+          export SPACEDOCK_CHANNEL=edge
+          export SPACEDOCK_INSTALL_FROM="$PWD/dist"
+          export SPACEDOCK_INSTALL_DIR="$RUNNER_TEMP/sd-bin-edge"
+          sh ./install.sh
+          out="$("$SPACEDOCK_INSTALL_DIR/spacedock" --version)"
+          echo "$out"
+          want="$(sed -n 's/.*These skills require binary minor \([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+            skills/first-officer/references/first-officer-shared-core.md)"
+          got="$(printf '%s\n' "$out" | head -n 1 | awk '{print $2}' | cut -d. -f1,2)"
+          if [ "$want" != "$got" ]; then
+            echo "::error::edge binary minor $got != the minor the FO boot gate requires ($want)"; exit 1
+          fi
+          case "$out" in
+            *"Channel: edge"*) echo "edge install ok: minor $got, edge-stamped" ;;
+            *) echo "::error::edge channel installed a binary that is not edge-stamped: $out"; exit 1 ;;
+          esac
+
       # Tamper case: corrupt the native-OS tarball so its sha256 no longer matches
       # checksums.txt, then assert install.sh exits NON-ZERO and installs nothing.
       # This keeps the checksum gate load-bearing — without it a swapped tarball

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -234,6 +234,14 @@ stamps the edge binary from the highest tag pointing at the commit (`git tag
 `X.(Y+1)` binary version is correct without an override; a
 `GORELEASER_CURRENT_TAG` pin is set on the goreleaser step as belt-and-suspenders.
 
+Both edge binary install paths track those prerelease tags: the `spacedock@next`
+cask, bumped on every tag including prereleases, and
+`SPACEDOCK_CHANNEL=edge … install.sh | sh`, which resolves the newest release
+including prereleases and fetches that tag's `_edge` asset. The default stable
+path resolves `/releases/latest`, which excludes prereleases — so a default
+install on an edge machine lands a lower minor and aborts at first-officer boot.
+Casks are macOS-only; on Linux the script is the only edge binary path.
+
 ## Dev-Only `next` Publishing
 
 Keep `next` for development. Source builds may use

--- a/docs/site/get-started/install.md
+++ b/docs/site/get-started/install.md
@@ -20,7 +20,23 @@ Pi. Install one of those first.
     curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/main/install.sh | sh
     ```
 
-    Installs a checksum-verified binary to `~/.local/bin`.
+    Installs a checksum-verified binary to `~/.local/bin`. This is the stable
+    channel: it resolves the latest stable release and prints the tag it
+    resolved before it installs anything.
+
+    To track edge, set `SPACEDOCK_CHANNEL=edge`. Edge resolves the newest
+    release including prereleases, and installs the edge-stamped binary:
+
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/main/install.sh | SPACEDOCK_CHANNEL=edge sh
+    ```
+
+    Match the channel to the skills you run. The edge plugin requires an
+    edge-line binary minor, so a stable binary with edge skills aborts at
+    first-officer boot. On macOS,
+    `brew install spacedock-dev/tap/spacedock@next` is the Homebrew
+    equivalent; casks are macOS-only, so on Linux this script is the only
+    edge path.
 
 ## Launch
 
@@ -47,7 +63,7 @@ Spacedock installs the relevant skills on launch. To install them manually:
 claude plugin marketplace add spacedock-dev/marketplace
 claude plugin install spacedock@spacedock
 
-# Edge (tracks next) — marketplace named `spacedock-edge`, entry still `spacedock`
+# Edge (tracks main) — marketplace named `spacedock-edge`, entry still `spacedock`
 claude plugin marketplace add spacedock-dev/marketplace@edge
 claude plugin install spacedock@spacedock-edge
 ```

--- a/install.sh
+++ b/install.sh
@@ -3,16 +3,23 @@
 # ABOUTME: release tarball for this host's OS/arch and install the bare binary.
 #
 # Usage (Linux or macOS):
-#   curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/next/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/spacedock-dev/spacedock/main/install.sh | sh
+#
+# SPACEDOCK_CHANNEL selects the release channel: `stable` (default) resolves the
+#   latest stable release and the unsuffixed asset; `edge` resolves the newest
+#   release INCLUDING prereleases and the `_edge` asset. Any other value aborts —
+#   a typo must not silently install the other channel. The resolved tag is
+#   printed to stderr before any download.
 #
 # Behavior:
 #   * Detects OS (darwin|linux) and arch (amd64|arm64) from uname.
 #   * Resolves the asset to fetch from one of two sources, same extract/verify/
 #     install path for both:
-#       - SPACEDOCK_INSTALL_FROM unset (production): the latest GitHub Release.
+#       - SPACEDOCK_INSTALL_FROM unset (production): the newest GitHub Release on
+#         the selected channel.
 #       - SPACEDOCK_INSTALL_FROM=<dir|url-base> (tests / pinned mirror): a local
 #         goreleaser `dist/` directory or a URL prefix holding the same
-#         `spacedock_<ver>_<os>_<arch>.tar.gz` + `checksums.txt` layout.
+#         `spacedock_<ver>_<os>_<arch>[_edge].tar.gz` + `checksums.txt` layout.
 #   * Verifies the tarball sha256 against the matching `checksums.txt` line and
 #     ABORTS (installs nothing) on any mismatch — the gate is fail-closed.
 #   * Extracts the bare `spacedock` binary and installs it to SPACEDOCK_INSTALL_DIR
@@ -28,11 +35,22 @@ set -eu
 
 REPO="spacedock-dev/spacedock"
 INSTALL_DIR="${SPACEDOCK_INSTALL_DIR:-$HOME/.local/bin}"
+CHANNEL="${SPACEDOCK_CHANNEL:-stable}"
 
 err() { printf 'install.sh: %s\n' "$*" >&2; }
 die() { err "$*"; exit 1; }
 
 need() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
+
+# validate_channel rejects any channel value other than the two accepted ones.
+# Falling through to stable would silently install the OTHER channel on a typo
+# (`SPACEDOCK_CHANNEL=egde`) — the silent skew this script exists to close.
+validate_channel() {
+	case "$CHANNEL" in
+		stable | edge) ;;
+		*) die "unknown SPACEDOCK_CHANNEL '$CHANNEL'; accepted values: stable, edge" ;;
+	esac
+}
 
 # detect_os maps `uname -s` to the goreleaser goos token. Only darwin and linux
 # ship release tarballs; anything else is unsupported here (use Homebrew on mac,
@@ -84,24 +102,41 @@ fetch() {
 	esac
 }
 
-# resolve_latest_tag asks the GitHub API for the repo's latest release tag (e.g.
-# v0.20.0). Unauthenticated; the public releases endpoint needs no token.
+# resolve_latest_tag asks the GitHub API for the newest release tag on the
+# selected channel (e.g. v0.20.0). `/releases/latest` EXCLUDES prereleases, which
+# is exactly the stable channel; the edge line ships as `-pre` tags, so edge
+# reads the newest entry of the created_at-descending releases list instead.
+# Unauthenticated and one request either way, and `tag_name` appears only at
+# release level in both responses, so the same first-match parse serves both.
 resolve_latest_tag() {
-	api="https://api.github.com/repos/$REPO/releases/latest"
+	if [ "$CHANNEL" = edge ]; then
+		api="https://api.github.com/repos/$REPO/releases?per_page=1"
+	else
+		api="https://api.github.com/repos/$REPO/releases/latest"
+	fi
 	curl -fsSL "$api" \
 		| grep '"tag_name"' \
 		| head -n 1 \
 		| sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
 }
 
-# asset_name builds the goreleaser archive name for a version/os/arch. The
-# version carries no leading `v` (goreleaser stamps the bare semver into the
-# `{{ .Version }}` template); the tag does, so callers strip it.
+# asset_name builds the goreleaser archive name for a version/os/arch on the
+# selected channel. The version carries no leading `v` (goreleaser stamps the
+# bare semver into the `{{ .Version }}` template); the tag does, so callers strip
+# it. Every release publishes a PAIR of per-arch archives: the edge-stamped one
+# always carries `_edge`, and on a prerelease the stable one carries `_stable`
+# (.goreleaser.yaml), so the unsuffixed name exists only on stable tags — the
+# only tags the stable channel ever resolves.
 asset_name() {
-	printf 'spacedock_%s_%s_%s.tar.gz' "$1" "$2" "$3"
+	if [ "$CHANNEL" = edge ]; then
+		printf 'spacedock_%s_%s_%s_edge.tar.gz' "$1" "$2" "$3"
+	else
+		printf 'spacedock_%s_%s_%s.tar.gz' "$1" "$2" "$3"
+	fi
 }
 
 main() {
+	validate_channel
 	need uname
 	need curl
 	need tar
@@ -126,8 +161,16 @@ main() {
 				;;
 			*)
 				[ -d "$from" ] || die "SPACEDOCK_INSTALL_FROM is not a directory or URL: $from"
-				asset="$(cd "$from" && ls spacedock_*_"${os}"_"${arch}".tar.gz 2>/dev/null | head -n 1)"
-				[ -n "$asset" ] || die "no spacedock_*_${os}_${arch}.tar.gz in $from"
+				# A goreleaser dist holds BOTH channels' archives, so the glob
+				# carries the channel too. The two are disjoint: the unsuffixed
+				# pattern cannot match a name ending `_edge.tar.gz`.
+				if [ "$CHANNEL" = edge ]; then
+					glob="spacedock_*_${os}_${arch}_edge.tar.gz"
+				else
+					glob="spacedock_*_${os}_${arch}.tar.gz"
+				fi
+				asset="$(cd "$from" && ls $glob 2>/dev/null | head -n 1)"
+				[ -n "$asset" ] || die "no $glob in $from"
 				tarball_src="$from/$asset"
 				checksums_src="$from/checksums.txt"
 				;;
@@ -135,6 +178,11 @@ main() {
 	else
 		tag="$(resolve_latest_tag)"
 		[ -n "$tag" ] || die "could not resolve the latest release tag for $REPO"
+		# Say which version this run resolved, before anything is downloaded, so a
+		# channel skew is visible at install time instead of surfacing later as a
+		# first-officer boot abort. stderr and `=`-free, so the print-target
+		# stdout below stays machine-parseable.
+		err "resolved $CHANNEL channel to $tag"
 		ver="${tag#v}"
 		asset="$(asset_name "$ver" "$os" "$arch")"
 		base="https://github.com/$REPO/releases/download/$tag"

--- a/internal/contractlint/install_hint_drift_test.go
+++ b/internal/contractlint/install_hint_drift_test.go
@@ -40,8 +40,10 @@ func installMDSection(t *testing.T, lines []string, header string) []string {
 //
 //  1. The curl|sh token in the FO prose equals install.md's documented Linux
 //     command — extraction: the single line inside the
-//     `=== "Binary (macOS / Linux)"` fence matching `^curl `, trimmed of the
-//     tab's 4-space indentation.
+//     `=== "Binary (macOS / Linux)"` fence matching `^curl ` and carrying no
+//     channel selector, trimmed of the tab's 4-space indentation. The tab also
+//     documents the `SPACEDOCK_CHANNEL=edge` variant; the hint tracks the
+//     DEFAULT command, so that line is excluded and the default stays unique.
 //  2. The FO prose's brew-install hint refers to the same tap and formula as
 //     install.md's Homebrew tab (`spacedock-dev/homebrew-tap` + `spacedock`);
 //     both the two-line `brew tap` + `brew install` form and the one-line
@@ -61,12 +63,13 @@ func TestInstallHintNoDrift(t *testing.T) {
 	// Arm 1: curl|sh token equality.
 	var curlLines []string
 	for _, l := range installMDSection(t, lines, "Binary (macOS / Linux)") {
-		if trimmed := strings.TrimSpace(l); strings.HasPrefix(trimmed, "curl ") {
+		trimmed := strings.TrimSpace(l)
+		if strings.HasPrefix(trimmed, "curl ") && !strings.Contains(trimmed, "SPACEDOCK_CHANNEL=") {
 			curlLines = append(curlLines, trimmed)
 		}
 	}
 	if len(curlLines) != 1 {
-		t.Fatalf("install.md Binary tab carries %d `^curl ` lines, want exactly 1", len(curlLines))
+		t.Fatalf("install.md Binary tab carries %d default (channel-free) `^curl ` lines, want exactly 1", len(curlLines))
 	}
 	documentedCurl := curlLines[0]
 	if !strings.Contains(prose, documentedCurl) {

--- a/internal/release/install_channel_test.go
+++ b/internal/release/install_channel_test.go
@@ -1,0 +1,253 @@
+// ABOUTME: Pins install.sh's SPACEDOCK_CHANNEL branches — the asset each channel
+// ABOUTME: selects, the resolved-tag disclosure, and the typo abort.
+package release
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func installScript() string { return filepath.Join("..", "..", "install.sh") }
+
+// TestInstallChannelEdgeInstallsTheEdgeAsset locks AC-1's mechanism (and AC-4's
+// converse) offline: from ONE dist holding BOTH channels' archives, the edge
+// channel installs the edge binary. The two payloads print different markers, so
+// this asserts which artifact actually landed and ran — not which name the
+// script printed. The default channel's half of the choice is the pre-existing
+// happy-path test, which now runs against the same both-assets dist.
+func TestInstallChannelEdgeInstallsTheEdgeAsset(t *testing.T) {
+	fx := buildInstallFixture(t)
+	installDir, code := runInstall(t, installScript(), fx.dir, "edge")
+	if code != 0 {
+		t.Fatalf("edge install exited %d, want 0", code)
+	}
+	out, err := exec.Command(filepath.Join(installDir, "spacedock")).CombinedOutput()
+	if err != nil {
+		t.Fatalf("installed spacedock did not run: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), fx.edgeMarker) {
+		t.Errorf("installed binary printed %q, want the edge payload %q", out, fx.edgeMarker)
+	}
+	if strings.Contains(string(out), fx.marker) {
+		t.Errorf("installed binary printed %q — the STABLE payload, from an edge run", out)
+	}
+}
+
+// TestInstallChannelEdgeTamperInstallsNothing locks AC-5: the edge asset flows
+// through the same fail-closed checksum gate. The `_edge` tarball is swapped for
+// a valid-but-different archive after checksums.txt is written, so only the hash
+// mismatch can reject it — and the abort names that asset, which also proves the
+// run had SELECTED the edge archive rather than failing to find one.
+func TestInstallChannelEdgeTamperInstallsNothing(t *testing.T) {
+	fx := buildInstallFixture(t)
+	writeTarGz(t, fx.edgePath, "spacedock", []byte("#!/bin/sh\necho "+fx.edgeMarker+"-tampered\n"))
+	if sha256OfFile(t, fx.edgePath) == fx.edgeChecksum {
+		t.Fatal("tampered _edge tarball hash still equals the recorded checksum; the swap changed nothing")
+	}
+
+	installDir, code, _, stderr := runInstallCapture(t, installScript(), fx.dir, "edge")
+	if code == 0 {
+		t.Fatal("install.sh accepted a tampered _edge tarball (exit 0); the edge channel is not behind the fail-closed gate")
+	}
+	if want := "checksum mismatch for " + fx.edgeAsset; !strings.Contains(stderr, want) {
+		t.Errorf("edge run aborted with %q, want %q — the rejection must come from the checksum gate", stderr, want)
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "spacedock")); err == nil {
+		t.Error("install.sh installed a binary despite the _edge checksum mismatch")
+	}
+}
+
+// TestInstallChannelRejectsUnknownValue locks AC-6. The dist holds both assets,
+// so a defaulting `case *)` would install stable and exit 0 — this abort is the
+// only thing between a typo and silently installing the other channel.
+func TestInstallChannelRejectsUnknownValue(t *testing.T) {
+	fx := buildInstallFixture(t)
+	installDir, code, _, stderr := runInstallCapture(t, installScript(), fx.dir, "egde")
+	if code == 0 {
+		t.Fatal("install.sh accepted SPACEDOCK_CHANNEL=egde (exit 0); a typo silently picks a channel")
+	}
+	for _, want := range []string{"egde", "stable", "edge"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("abort message %q does not name %q", stderr, want)
+		}
+	}
+	if _, err := os.Stat(installDir); err == nil {
+		t.Error("install.sh created the install dir on an unknown channel")
+	}
+}
+
+// TestInstallChannelPrintTarget locks AC-4: on the default and explicit-stable
+// runs install.sh prints the EXACT five-line target the pre-channel script
+// printed for the same dist, and edge differs only in the asset it names. The
+// whole-stdout match also catches the disclosure line landing on stdout, which
+// would break the `key=value` parser install_url_test.go depends on.
+func TestInstallChannelPrintTarget(t *testing.T) {
+	goos, arch := goosArch(t)
+	fx := buildInstallFixture(t)
+	for _, tc := range []struct{ name, channel, asset string }{
+		{"unset channel names the unsuffixed asset", "", fx.asset},
+		{"explicit stable names the unsuffixed asset", "stable", fx.asset},
+		{"edge names the _edge asset", "edge", fx.edgeAsset},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, code := runInstallSh(t, installScript(), tc.channel,
+				"SPACEDOCK_PRINT_TARGET=1", "SPACEDOCK_INSTALL_FROM="+fx.dir)
+			if code != 0 {
+				t.Fatalf("print-target exited %d: %s", code, stderr)
+			}
+			want := fmt.Sprintf("os=%s\narch=%s\nasset=%s\ntarball=%s\nchecksums=%s\n",
+				goos, arch, tc.asset, filepath.Join(fx.dir, tc.asset), filepath.Join(fx.dir, "checksums.txt"))
+			if stdout != want {
+				t.Errorf("print-target stdout:\n%q\nwant:\n%q", stdout, want)
+			}
+			// The local-dist path resolves no version, so it discloses none.
+			if strings.Contains(stderr, "resolved") {
+				t.Errorf("local-dist run disclosed a resolved tag: %q", stderr)
+			}
+		})
+	}
+}
+
+// TestInstallChannelURLBaseAssetName pins asset_name's channel branch OFFLINE.
+// The local-dist source globs a directory and never calls asset_name, so without
+// this the naming the live release path depends on would be held up only by the
+// network test below, which skips on an unreachable API. The URL-base source
+// builds the name from the pinned version, and print-target returns before any
+// download — so the unreachable host is never contacted.
+func TestInstallChannelURLBaseAssetName(t *testing.T) {
+	goos, arch := goosArch(t)
+	const base, ver = "https://example.invalid/dl", "1.2.3"
+	for _, tc := range []struct{ name, channel, asset string }{
+		{"unset channel builds the unsuffixed name", "", "spacedock_" + ver + "_" + goos + "_" + arch + ".tar.gz"},
+		{"edge builds the _edge name", "edge", "spacedock_" + ver + "_" + goos + "_" + arch + "_edge.tar.gz"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, code := runInstallSh(t, installScript(), tc.channel,
+				"SPACEDOCK_PRINT_TARGET=1", "SPACEDOCK_INSTALL_FROM="+base, "SPACEDOCK_INSTALL_VERSION="+ver)
+			if code != 0 {
+				t.Fatalf("print-target exited %d: %s", code, stderr)
+			}
+			want := fmt.Sprintf("os=%s\narch=%s\nasset=%s\ntarball=%s/%s\nchecksums=%s/checksums.txt\n",
+				goos, arch, tc.asset, base, tc.asset, base)
+			if stdout != want {
+				t.Errorf("print-target stdout:\n%q\nwant:\n%q", stdout, want)
+			}
+		})
+	}
+}
+
+// TestInstallChannelLiveEdgeResolution locks AC-3 and AC-2's production half
+// against the live GitHub API: edge resolves the newest release INCLUDING
+// prereleases, both channels disclose the tag they resolved before any download,
+// and the constructed URL is one the release actually publishes. The
+// byte-for-byte match against browser_download_url is what catches an unsuffixed
+// asset name, which 404s on a prerelease; a name-shape check would not. Skips —
+// never reds — when the API is unreachable or rate-limited, the pattern
+// install_url_test.go already uses (a 403 produces the same resolution failure).
+func TestInstallChannelLiveEdgeResolution(t *testing.T) {
+	rel, ok := fetchNewestRelease(t)
+	if !ok {
+		t.Skip("github releases list API unreachable; skipping live edge resolution check")
+	}
+	goos, arch := goosArch(t)
+
+	stdout, stderr, code := runInstallSh(t, installScript(), "edge", "SPACEDOCK_PRINT_TARGET=1")
+	if code != 0 {
+		t.Skipf("install.sh could not reach the GitHub releases API:\n%s", stderr)
+	}
+	if want := "install.sh: resolved edge channel to " + rel.TagName + "\n"; !strings.Contains(stderr, want) {
+		t.Errorf("edge stderr = %q, want it to carry %q before any download", stderr, want)
+	}
+	if _, stableErr, stableCode := runInstallSh(t, installScript(), "", "SPACEDOCK_PRINT_TARGET=1"); stableCode == 0 &&
+		!strings.Contains(stableErr, "install.sh: resolved stable channel to v") {
+		t.Errorf("default-channel stderr = %q, want it to disclose the resolved stable tag", stableErr)
+	}
+
+	asset := "spacedock_" + strings.TrimPrefix(rel.TagName, "v") + "_" + goos + "_" + arch + "_edge.tar.gz"
+	base := "https://github.com/spacedock-dev/spacedock/releases/download/" + rel.TagName
+	want := fmt.Sprintf("os=%s\narch=%s\nasset=%s\ntarball=%s/%s\nchecksums=%s/checksums.txt\n",
+		goos, arch, asset, base, asset, base)
+	if stdout != want {
+		t.Errorf("edge print-target stdout:\n%q\nwant:\n%q", stdout, want)
+	}
+	for _, a := range rel.Assets {
+		if a.Name == asset {
+			if a.BrowserDownloadURL != base+"/"+asset {
+				t.Errorf("constructed URL %q != published browser_download_url %q", base+"/"+asset, a.BrowserDownloadURL)
+			}
+			return
+		}
+	}
+	t.Errorf("newest release %s publishes no %s, so the edge channel would 404 on this host", rel.TagName, asset)
+}
+
+// fetchNewestRelease pulls the newest release INCLUDING prereleases — the
+// endpoint the edge channel resolves, and the independent oracle for what it
+// should have resolved. ok=false on any network, status, or decode failure so
+// the caller skips rather than reds on flakiness or a rate limit.
+func fetchNewestRelease(t *testing.T) (ghRelease, bool) {
+	t.Helper()
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get("https://api.github.com/repos/spacedock-dev/spacedock/releases?per_page=1")
+	if err != nil {
+		return ghRelease{}, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ghRelease{}, false
+	}
+	var rels []ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rels); err != nil || len(rels) == 0 || rels[0].TagName == "" {
+		return ghRelease{}, false
+	}
+	return rels[0], true
+}
+
+// runInstallCapture installs from a local dist into a fresh dir on the given
+// channel, returning that dir plus the run's exit code and output streams.
+func runInstallCapture(t *testing.T, script, distDir, channel string) (installDir string, code int, stdout, stderr string) {
+	t.Helper()
+	installDir = filepath.Join(t.TempDir(), "bin")
+	stdout, stderr, code = runInstallSh(t, script, channel,
+		"SPACEDOCK_INSTALL_FROM="+distDir, "SPACEDOCK_INSTALL_DIR="+installDir)
+	return installDir, code, stdout, stderr
+}
+
+// runInstallSh runs install.sh with an explicit env — the process env minus every
+// install override (SPACEDOCK_CHANNEL included, which scrubInstallEnv predates),
+// plus the requested channel and extras. An empty channel leaves the variable
+// UNSET, which is the default-channel case a leaked env var would otherwise turn
+// into an edge run. stdout and stderr come back separately: the resolved-tag
+// disclosure is stderr-only by design, and stdout must stay machine-parseable.
+func runInstallSh(t *testing.T, script, channel string, extra ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	env := append([]string{}, extra...)
+	for _, kv := range scrubInstallEnv() {
+		if !strings.HasPrefix(kv, "SPACEDOCK_CHANNEL=") {
+			env = append(env, kv)
+		}
+	}
+	if channel != "" {
+		env = append(env, "SPACEDOCK_CHANNEL="+channel)
+	}
+	cmd := exec.Command("sh", script)
+	cmd.Env = env
+	var out, errOut bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &errOut
+	err := cmd.Run()
+	t.Logf("install.sh (%s, channel=%q)\nstdout:\n%sstderr:\n%s", filepath.Base(script), channel, out.String(), errOut.String())
+	var exitErr *exec.ExitError
+	if err != nil && !errors.As(err, &exitErr) {
+		t.Fatalf("install.sh failed to launch: %v", err)
+	}
+	return out.String(), errOut.String(), cmd.ProcessState.ExitCode()
+}

--- a/internal/release/install_checksum_gate_test.go
+++ b/internal/release/install_checksum_gate_test.go
@@ -14,71 +14,75 @@ import (
 	"testing"
 )
 
-// installFixture is a local goreleaser-shaped `dist/` directory: one
-// `spacedock_<ver>_<os>_<arch>.tar.gz` holding a bare runnable `spacedock` at the
-// archive root, plus a `checksums.txt` line matching that tarball — the same
-// layout install.sh's SPACEDOCK_INSTALL_FROM=<dir> path consumes.
+// installFixture is a local goreleaser-shaped `dist/` directory: the PAIR of
+// per-arch archives a real dist carries — `spacedock_<ver>_<os>_<arch>.tar.gz`
+// (stable) and `spacedock_<ver>_<os>_<arch>_edge.tar.gz` (edge) — each holding a
+// bare runnable `spacedock` at the archive root, plus a `checksums.txt` line for
+// each, the same layout install.sh's SPACEDOCK_INSTALL_FROM=<dir> path consumes.
+// Both channels present at once is what makes the channel selection a real
+// CHOICE the tests can bind, rather than the only file in the directory.
 type installFixture struct {
-	dir         string // the dist dir to point SPACEDOCK_INSTALL_FROM at
-	tarballPath string // absolute path to the single os/arch tarball
-	asset       string // the tarball's basename
-	marker      string // the string the installed binary prints when run
-	checksum    string // the sha256 recorded in checksums.txt for the original tarball
+	dir          string // the dist dir to point SPACEDOCK_INSTALL_FROM at
+	tarballPath  string // absolute path to the stable (unsuffixed) os/arch tarball
+	asset        string // the stable tarball's basename
+	marker       string // the string the installed stable binary prints when run
+	checksum     string // the sha256 recorded in checksums.txt for the original stable tarball
+	edgePath     string // absolute path to the `_edge` os/arch tarball
+	edgeAsset    string // the `_edge` tarball's basename
+	edgeMarker   string // the string the installed edge binary prints — distinct from marker
+	edgeChecksum string // the sha256 recorded in checksums.txt for the original edge tarball
 }
 
-// buildInstallFixture writes a dist/ fixture under a fresh temp dir. The bare
-// `spacedock` payload is a tiny shell script that echoes a unique marker, so the
-// happy-path test can exec the installed file and confirm a RUNNABLE binary
-// landed (not just any file). checksums.txt is computed from the real tarball
-// bytes, so the gate's expected hash is correct until a test mutates the tarball.
+// buildInstallFixture writes a dist/ fixture under a fresh temp dir. Each bare
+// `spacedock` payload is a tiny shell script that echoes a unique marker, so a
+// test can exec the installed file and confirm a RUNNABLE binary landed (not
+// just any file) AND tell the two channels' binaries apart. checksums.txt is
+// computed from the real tarball bytes, so the gate's expected hashes are
+// correct until a test mutates a tarball.
 func buildInstallFixture(t *testing.T) installFixture {
 	t.Helper()
 	os, arch := goosArch(t)
 	dist := t.TempDir()
 
 	const marker = "spacedock-fixture-ran-ok"
+	const edgeMarker = "spacedock-edge-fixture-ran-ok"
 	// A bare executable `spacedock` at the archive root. A shell script is enough
 	// for install.sh (it `install`s the file 0755) and lets the test exec it.
 	binary := "#!/bin/sh\necho " + marker + "\n"
+	edgeBinary := "#!/bin/sh\necho " + edgeMarker + "\n"
 
 	asset := "spacedock_0.0.0_" + os + "_" + arch + ".tar.gz"
 	tarballPath := filepath.Join(dist, asset)
 	writeTarGz(t, tarballPath, "spacedock", []byte(binary))
 
+	edgeAsset := "spacedock_0.0.0_" + os + "_" + arch + "_edge.tar.gz"
+	edgePath := filepath.Join(dist, edgeAsset)
+	writeTarGz(t, edgePath, "spacedock", []byte(edgeBinary))
+
 	sum := sha256OfFile(t, tarballPath)
+	edgeSum := sha256OfFile(t, edgePath)
 	// goreleaser's checksums.txt format is `<sha256>␣␣<filename>`; install.sh
 	// parses it with `awk '$2 == filename {print $1}'`, so two space-separated
 	// fields suffice.
-	checksums := sum + "  " + asset + "\n"
+	checksums := sum + "  " + asset + "\n" + edgeSum + "  " + edgeAsset + "\n"
 	if err := osWriteFile(filepath.Join(dist, "checksums.txt"), checksums); err != nil {
 		t.Fatal(err)
 	}
 
-	return installFixture{dir: dist, tarballPath: tarballPath, asset: asset, marker: marker, checksum: sum}
+	return installFixture{
+		dir: dist, tarballPath: tarballPath, asset: asset, marker: marker, checksum: sum,
+		edgePath: edgePath, edgeAsset: edgeAsset, edgeMarker: edgeMarker, edgeChecksum: edgeSum,
+	}
 }
 
 // runInstall runs the given install.sh script against a dist fixture via the
 // SPACEDOCK_INSTALL_FROM local-dist override, installing into a fresh dir. It
-// returns the install dir and the script's exit code (0 on success). The env is
-// set explicitly (not scrubbed) because this path REQUIRES the override.
-func runInstall(t *testing.T, script, distDir string) (installDir string, exitCode int) {
+// returns the install dir and the script's exit code (0 on success). channel is
+// the SPACEDOCK_CHANNEL value; "" leaves it unset (the default-channel case).
+func runInstall(t *testing.T, script, distDir, channel string) (installDir string, exitCode int) {
 	t.Helper()
-	installDir = filepath.Join(t.TempDir(), "bin")
-	cmd := exec.Command("sh", script)
-	cmd.Env = append(scrubInstallEnv(),
-		"SPACEDOCK_INSTALL_FROM="+distDir,
-		"SPACEDOCK_INSTALL_DIR="+installDir,
-	)
-	out, err := cmd.CombinedOutput()
-	t.Logf("install.sh (%s) output:\n%s", filepath.Base(script), out)
-	if err == nil {
-		return installDir, 0
-	}
-	if ee, ok := err.(*exec.ExitError); ok {
-		return installDir, ee.ExitCode()
-	}
-	t.Fatalf("install.sh failed to launch: %v", err)
-	return installDir, -1
+	installDir, exitCode, _, _ = runInstallCapture(t, script, distDir, channel)
+	return installDir, exitCode
 }
 
 // TestChecksumGateInstallsAndRejectsTamper locks AC-1: install.sh's checksum gate
@@ -91,7 +95,7 @@ func TestChecksumGateInstallsAndRejectsTamper(t *testing.T) {
 	// passes and a runnable `spacedock` lands and prints its marker.
 	t.Run("happy path installs a runnable binary", func(t *testing.T) {
 		fx := buildInstallFixture(t)
-		installDir, code := runInstall(t, script, fx.dir)
+		installDir, code := runInstall(t, script, fx.dir, "")
 		if code != 0 {
 			t.Fatalf("happy-path install exited %d, want 0", code)
 		}
@@ -115,7 +119,7 @@ func TestChecksumGateInstallsAndRejectsTamper(t *testing.T) {
 		fx := buildInstallFixture(t)
 		tamperFixtureTarball(t, fx)
 
-		installDir, code := runInstall(t, script, fx.dir)
+		installDir, code := runInstall(t, script, fx.dir, "")
 		if code == 0 {
 			t.Fatal("install.sh accepted a tampered tarball (exit 0); the checksum gate is not fail-closed")
 		}
@@ -149,7 +153,7 @@ func TestChecksumGateGuardIsLoadBearing(t *testing.T) {
 	fx := buildInstallFixture(t)
 	tamperFixtureTarball(t, fx)
 
-	installDir, code := runInstall(t, gatelessScript, fx.dir)
+	installDir, code := runInstall(t, gatelessScript, fx.dir, "")
 	if code != 0 {
 		t.Fatalf("gateless install.sh exited %d on a tampered tarball; expected 0 (the strip should let the tamper through), so the live tamper test is NOT exercising the gate", code)
 	}


### PR DESCRIPTION
A fresh machine tracking the edge channel had no scripted binary path: `install.sh` resolves `releases/latest`, which excludes prereleases, so it silently installed v0.26.0 while the edge plugin required 0.27 — the exact parity break a fresh-VM run surfaced on 2026-08-24. Worse, prerelease tags publish only `_edge`/`_stable`-suffixed assets, so fixing tag resolution alone 404s: install.sh could not install an edge-stamped binary at any tag, and Homebrew casks are macOS-only, leaving Linux edge machines with nothing.

## What changed

- One env var, `SPACEDOCK_CHANNEL` (`stable` default | `edge`), validate-first: an unrecognized value aborts naming the accepted values instead of defaulting through — the silent-skew class this task closes.
- The channel threads through the three places behavior differs: tag resolution (edge → `/releases?per_page=1`; stable → `/releases/latest`, unchanged), asset naming (edge → `_edge` suffix), and the local-dist glob (edge gets its own; stable untouched).
- One unconditional stderr disclosure before any download: `install.sh: resolved <channel> channel to <tag>` — a wrong-but-announced tag is a lesser failure than a wrong-and-silent one.
- New offline fixture suite (`install_channel_test.go`) pins channel selection against a both-assets dist: edge selection, stable selection, tampered `_edge` abort, typo abort, stable print-target exact match. `install-e2e.yml` gains an edge leg on both runners asserting minor-equals-prose-stamp + `Channel: edge`.
- Docs: install.md's Binary tab documents the edge path (and its stale "(tracks next)" comment becomes "(tracks main)"); releasing.md's "Advancing the Edge Line" names the edge binary paths; install.sh's header drops the dead `next` raw URL. The contractlint curl-extraction now excludes channel-carrying lines so the guarded one-default-command property survives the second documented curl line.

## Evidence

- Live fresh prefix (darwin/arm64, real API): `resolved edge channel to v0.27.0-pre8` → `spacedock 0.27.0-pre8` / `Channel: edge`; minor equals the FO shared-core prose stamp the boot gate enforces. The default path still lands v0.26.0 — unchanged, but now disclosed.
- Stable path locked byte-identical: print-target stdout `cmp`-equal to the pre-change script; a both-assets dist still selects the unsuffixed asset.
- Detached adversarial audit on a throwaway checkout: 8/8 claim-breaking mutations each red a distinct guard (asset naming, glob collapse, default-through, disclosure moved/removed, endpoint revert, doc drift ×2).
- `go test ./...` and `-race` green (one pre-existing machine-local codex-cache failure, identical on untouched main). Surface +359 net / 7 files vs the ideation +155/5 — reviewed and accepted at the gate as an estimate correction (the overage is the test battery).
- Validation re-verified all six ACs by exercising behavior; zero material findings; two evidence-class deferred risks recorded with promote-conditions (offline disclosure guard if the live leg ever skips repeatedly; Linux e2e halves run at PR CI, which is this lane).

---

[tdn](/spacedock-dev/spacedock/blob/e765bead6bd1570cddd37d15466022adbeed2783/install-sh-edge-prerelease-parity.md)
