### PR TITLE
claude install leaves the sibling edge plugin installed and enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,19 @@ Prerequisite: a coding agent harness. Claude Code, Codex, and Pi are tier-1
 supported; through skill systems it also runs in most other harnesses, including
 Hermes-class agents.
 
-Install with Homebrew:
+Install the stable channel with Homebrew:
 
 ```bash
-brew tap spacedock-dev/homebrew-tap
+brew tap spacedock-dev/tap
 brew install spacedock
 ```
+
+These commands install the **stable** channel, and the first launch below
+installs the matching stable plugin. Spacedock also ships an **edge** channel
+that tracks prereleases. The channel is chosen at install time, not with a flag
+later, so if you want edge — or you are matching a teammate who runs it — start
+from the [install guide](docs/site/get-started/install.md) instead of the
+commands above.
 
 Then launch. The first launch sets up the plugin for you, so a single line gets
 you a working session. Point it at a project you already have and let it survey:

--- a/README.md
+++ b/README.md
@@ -64,11 +64,10 @@ brew tap spacedock-dev/tap
 brew install spacedock
 ```
 
-These commands install the **stable** channel. The first launch below installs the
-stable plugin that matches it. Spacedock also has an **edge** channel that follows
-the prereleases. You select the channel at install time, not with a flag
-afterwards. If you want edge, or your teammate runs edge, start from the
-[install guide](docs/site/get-started/install.md) instead of the commands above.
+These commands install the **stable** channel. Spacedock also has an **edge**
+channel that follows the prereleases. You select the channel at install time, not
+with a flag afterwards. If you want edge, start from the
+[install guide](docs/site/get-started/install.md) instead.
 
 Then launch. The first launch sets up the plugin for you, so a single line gets
 you a working session. Point it at a project you already have and let it survey:

--- a/README.md
+++ b/README.md
@@ -64,12 +64,11 @@ brew tap spacedock-dev/tap
 brew install spacedock
 ```
 
-These commands install the **stable** channel, and the first launch below
-installs the matching stable plugin. Spacedock also ships an **edge** channel
-that tracks prereleases. The channel is chosen at install time, not with a flag
-later, so if you want edge — or you are matching a teammate who runs it — start
-from the [install guide](docs/site/get-started/install.md) instead of the
-commands above.
+These commands install the **stable** channel. The first launch below installs the
+stable plugin that matches it. Spacedock also has an **edge** channel that follows
+the prereleases. You select the channel at install time, not with a flag
+afterwards. If you want edge, or your teammate runs edge, start from the
+[install guide](docs/site/get-started/install.md) instead of the commands above.
 
 Then launch. The first launch sets up the plugin for you, so a single line gets
 you a working session. Point it at a project you already have and let it survey:

--- a/docs/site/get-started/install.md
+++ b/docs/site/get-started/install.md
@@ -83,11 +83,10 @@ same way with `codex plugin add`.
 
 `spacedock install --host claude` and `spacedock install --host codex` keep one
 channel on each host. The plugin of the selected channel replaces a co-installed
-stable or edge Spacedock plugin. Both channels use the entry name `spacedock` and
-the same skill names. If both plugins stay installed, the plugin that serves is
-unpredictable. The commands above install a channel by hand, and they do not remove
-the other channel. The next `spacedock install` removes it, and so does the
-auto-install of the launcher.
+stable or edge plugin. Both channels use the entry name `spacedock` and the same
+skill names, so two installed plugins make the plugin that serves unpredictable.
+The commands above do not remove the other channel. The next `spacedock install`
+does, and so does the auto-install of the launcher.
 
 Set `SPACEDOCK_MARKETPLACE_SOURCE` to install from a local or alternate
 marketplace instead of the default `spacedock-dev/marketplace` — useful for

--- a/docs/site/get-started/install.md
+++ b/docs/site/get-started/install.md
@@ -81,6 +81,13 @@ the `@edge` branch (named `spacedock-edge`) — so the `@edge` ref is what regis
 the `spacedock-edge` marketplace the edge entry resolves from. Codex installs the
 same way with `codex plugin add`.
 
+`spacedock install --host claude` and `spacedock install --host codex` keep exactly
+one channel installed per host: the selected channel's plugin replaces any
+co-installed stable or edge Spacedock plugin. Both channels ship the entry name
+`spacedock` and the same skill names, so leaving both installed makes which one
+serves unpredictable. Installing a channel by hand with the commands above does not
+remove the other; the next `spacedock install` — or the launcher's auto-install — does.
+
 Set `SPACEDOCK_MARKETPLACE_SOURCE` to install from a local or alternate
 marketplace instead of the default `spacedock-dev/marketplace` — useful for
 dogfooding a marketplace change before it reaches the production marketplace:

--- a/docs/site/get-started/install.md
+++ b/docs/site/get-started/install.md
@@ -81,12 +81,13 @@ the `@edge` branch (named `spacedock-edge`) — so the `@edge` ref is what regis
 the `spacedock-edge` marketplace the edge entry resolves from. Codex installs the
 same way with `codex plugin add`.
 
-`spacedock install --host claude` and `spacedock install --host codex` keep exactly
-one channel installed per host: the selected channel's plugin replaces any
-co-installed stable or edge Spacedock plugin. Both channels ship the entry name
-`spacedock` and the same skill names, so leaving both installed makes which one
-serves unpredictable. Installing a channel by hand with the commands above does not
-remove the other; the next `spacedock install` — or the launcher's auto-install — does.
+`spacedock install --host claude` and `spacedock install --host codex` keep one
+channel on each host. The plugin of the selected channel replaces a co-installed
+stable or edge Spacedock plugin. Both channels use the entry name `spacedock` and
+the same skill names. If both plugins stay installed, the plugin that serves is
+unpredictable. The commands above install a channel by hand, and they do not remove
+the other channel. The next `spacedock install` removes it, and so does the
+auto-install of the launcher.
 
 Set `SPACEDOCK_MARKETPLACE_SOURCE` to install from a local or alternate
 marketplace instead of the default `spacedock-dev/marketplace` — useful for

--- a/internal/cli/channel_selection_test.go
+++ b/internal/cli/channel_selection_test.go
@@ -38,22 +38,12 @@ func TestChannelMarketplaceFromDevBranch(t *testing.T) {
 	}
 }
 
-// TestClaudeChannelInstallArgvSequence is the claude half of AC-3.
-// marketplaceSource points at the marketplace repo, and devBranch selects the
-// channel. The claude install argv then installs the correct id for the channel:
-// `spacedock@spacedock` for stable and `spacedock@spacedock-edge` for edge. The
-// marketplace add carries the bare marketplace-repo source, with no `@<branch>`
-// shorthand.
+// TestClaudeChannelInstallArgvSequence is the claude half of AC-3: the argv installs
+// the id of the selected channel and adds the bare marketplace-repo source.
 //
-// The suffix of the plugin id is the marketplace name, which is the channel. The
-// entry name before the `@` is always `spacedock`. The marketplace update targets
-// the marketplace name of the channel. No step uses `marketplace remove`.
-//
-// wantSibling is the id of the other channel, which the sequence must uninstall to
-// keep one channel on the host. Each case spells this id as an independent literal.
-// It does not come from otherChannelMarketplace. A production sequence that takes
-// the sibling from the wrong side still satisfies a derived expectation. That fault
-// uninstalls the channel that the sequence just selected.
+// wantSibling is the id of the other channel. Each case spells it as an independent
+// literal. When the production sequence uninstalls the channel that it just
+// selected, a derived expectation also passes.
 func TestClaudeChannelInstallArgvSequence(t *testing.T) {
 	cases := []struct {
 		channel         string

--- a/internal/cli/channel_selection_test.go
+++ b/internal/cli/channel_selection_test.go
@@ -45,21 +45,27 @@ func TestChannelMarketplaceFromDevBranch(t *testing.T) {
 // marketplace-repo source — no `@<branch>` shorthand. The plugin id suffix is the
 // marketplace NAME (the channel); the entry before the `@` is always `spacedock`.
 // The marketplace-update refresh targets the channel's marketplace name; no step
-// spells `marketplace remove`.
+// spells `marketplace remove`. wantSibling is the OTHER channel's id the sequence
+// must uninstall for channel exclusivity, spelled out per case as an independent
+// literal rather than computed from otherChannelMarketplace — a production
+// sequence that derived the sibling from the wrong side (uninstalling the channel
+// it just selected) would still satisfy a derived expectation.
 func TestClaudeChannelInstallArgvSequence(t *testing.T) {
 	cases := []struct {
 		channel         string
 		devBranch       string
 		wantID          string
+		wantSibling     string
 		wantMarketplace string
 	}{
-		{channel: "stable", devBranch: "main", wantID: "spacedock@spacedock", wantMarketplace: "spacedock"},
-		{channel: "edge", devBranch: "next", wantID: "spacedock@spacedock-edge", wantMarketplace: "spacedock-edge"},
+		{channel: "stable", devBranch: "main", wantID: "spacedock@spacedock", wantSibling: "spacedock@spacedock-edge", wantMarketplace: "spacedock"},
+		{channel: "edge", devBranch: "next", wantID: "spacedock@spacedock-edge", wantSibling: "spacedock@spacedock", wantMarketplace: "spacedock-edge"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.channel, func(t *testing.T) {
 			want := []installStep{
 				{argv: []string{"plugin", "uninstall", tc.wantID}, tolerateExit: true},
+				{argv: []string{"plugin", "uninstall", tc.wantSibling}, tolerateExit: true},
 				{argv: []string{"plugin", "uninstall", "spacedock-edge@spacedock"}, tolerateExit: true},
 				{argv: []string{"plugin", "marketplace", "add", "spacedock-dev/marketplace"}},
 				{argv: []string{"plugin", "marketplace", "update", tc.wantMarketplace}, tolerateExit: true},

--- a/internal/cli/channel_selection_test.go
+++ b/internal/cli/channel_selection_test.go
@@ -38,18 +38,22 @@ func TestChannelMarketplaceFromDevBranch(t *testing.T) {
 	}
 }
 
-// TestClaudeChannelInstallArgvSequence is AC-3's claude half: with marketplaceSource
-// repointed to the marketplace repo and devBranch set per channel, the issued
-// claude install argv installs the channel-correct id (`spacedock@spacedock` stable
-// / `spacedock@spacedock-edge` edge) and the marketplace add carries the BARE
-// marketplace-repo source — no `@<branch>` shorthand. The plugin id suffix is the
-// marketplace NAME (the channel); the entry before the `@` is always `spacedock`.
-// The marketplace-update refresh targets the channel's marketplace name; no step
-// spells `marketplace remove`. wantSibling is the OTHER channel's id the sequence
-// must uninstall for channel exclusivity, spelled out per case as an independent
-// literal rather than computed from otherChannelMarketplace — a production
-// sequence that derived the sibling from the wrong side (uninstalling the channel
-// it just selected) would still satisfy a derived expectation.
+// TestClaudeChannelInstallArgvSequence is the claude half of AC-3.
+// marketplaceSource points at the marketplace repo, and devBranch selects the
+// channel. The claude install argv then installs the correct id for the channel:
+// `spacedock@spacedock` for stable and `spacedock@spacedock-edge` for edge. The
+// marketplace add carries the bare marketplace-repo source, with no `@<branch>`
+// shorthand.
+//
+// The suffix of the plugin id is the marketplace name, which is the channel. The
+// entry name before the `@` is always `spacedock`. The marketplace update targets
+// the marketplace name of the channel. No step uses `marketplace remove`.
+//
+// wantSibling is the id of the other channel, which the sequence must uninstall to
+// keep one channel on the host. Each case spells this id as an independent literal.
+// It does not come from otherChannelMarketplace. A production sequence that takes
+// the sibling from the wrong side still satisfies a derived expectation. That fault
+// uninstalls the channel that the sequence just selected.
 func TestClaudeChannelInstallArgvSequence(t *testing.T) {
 	cases := []struct {
 		channel         string

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -379,44 +379,20 @@ type installStep struct {
 // stable or edge — round 1's AC-4.
 const retiredRouteAID = "spacedock-edge@spacedock"
 
-// installArgvSequence gives the 6 commands that `Install` runs for claude. No step
-// uses `plugin marketplace remove`. On stable, that command names the `spacedock`
-// marketplace, which also holds other plugins (subspace, cargento). Probe 1
-// measured that this command uninstalls every plugin from the removed marketplace.
-// This sequence exists to prevent that damage.
+// installArgvSequence gives the commands that `Install` runs for claude. No step
+// uses `plugin marketplace remove`. That command names a marketplace which also
+// holds unrelated plugins, and probe 1 measured that it uninstalls all of them.
 //
-// The commands are:
+// The uninstalls come before the marketplace add. Claude tracks an installed plugin
+// through its marketplace record, so a removed record leaves the uninstall with
+// nothing to act on. The sibling uninstall keeps one channel on the host. Both
+// channels use the entry name `spacedock` and the same skill names. If both stay
+// installed, the plugin that serves is unpredictable.
 //
-//  1. Uninstall the plugin of the selected channel (tolerated). Claude tracks an
-//     installed plugin through its marketplace record. If the record goes first,
-//     the uninstall has no record to act on.
-//  2. Uninstall the plugin of the sibling channel (tolerated). This keeps one
-//     channel on the host, as codexInstallArgvSequence does. Both channels use the
-//     entry name `spacedock` and the same skill names. If both stay installed, the
-//     plugin that serves is unpredictable. `plugin uninstall` acts on one plugin,
-//     so it cannot cascade to a plugin on the sibling marketplace. This sequence
-//     never touches the marketplace record of the sibling.
-//  3. Uninstall the retired route-A plugin (tolerated). This is the round-1
-//     migration.
-//  4. Add the marketplace source of the channel (fail-fast). Claude re-pins a
-//     changed source at the same name (probe 3). This step alone makes the re-pin
-//     that the old remove step forced.
-//  5. Update the marketplace snapshot of the channel (tolerated). Probe 4 shows
-//     that this refresh is not destructive. It covers the case where step 4 made
-//     no change because the source was already current.
-//  6. Install the channel id that devBranch selects (fail-fast). Probe 9 shows
-//     that `plugin install` always clones the content again.
-//
-// The id is `spacedock@spacedock` for stable and `spacedock@spacedock-edge` for
-// edge. The entry name is always `spacedock`, and the channel is the marketplace
-// name. The marketplace manifest holds the version pin.
-//
-// The tolerance is asymmetric. The four cleanup commands are best-effort. Claude
-// exits 1 on a fresh box and on an already-current source. No stable stderr shape
-// separates these cases from a true failure. An absent sibling alone gives two
-// different non-zero shapes, which depend on the registration of its marketplace.
-// The two pinning commands stay fail-fast, and they report a broken install from
-// the network, a contract incompatibility, or a missing source.
+// The cleanup steps are tolerated. Claude exits 1 on a fresh box and on an
+// already-current source. No stable stderr shape separates those cases from a real
+// failure. An absent sibling alone gives two different non-zero shapes. The pinning
+// steps stay fail-fast, because they report a broken install.
 func installArgvSequence(source, devBranch string) []installStep {
 	id := channelPluginID(devBranch)
 	return []installStep{

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -379,37 +379,44 @@ type installStep struct {
 // stable or edge — round 1's AC-4.
 const retiredRouteAID = "spacedock-edge@spacedock"
 
-// installArgvSequence is the 6-command upgrade shape `Install` issues. No step
-// ever spells `plugin marketplace remove`: on stable that command names the
-// `spacedock` marketplace that also hosts unrelated co-installed plugins
-// (subspace, cargento), and claude's remove measurably CASCADE-UNINSTALLS every
-// plugin installed from the removed marketplace (probe 1) — the destructive
-// failure mode this shape exists to stop. The steps: uninstall any existing
-// channel plugin (tolerated — claude tracks an installed plugin via its
-// marketplace record, so removing the record before uninstalling would orphan a
-// live uninstall), uninstall the SIBLING channel's plugin (tolerated — channel
-// exclusivity, mirroring codexInstallArgvSequence's sibling remove: both channels
-// ship the entry name `spacedock` and the same skill names, so leaving both
-// installed makes which one serves unpredictable; `plugin uninstall` is
-// plugin-level, so it cannot cascade into a plugin co-hosted on the sibling
-// marketplace, and the sibling's marketplace record is never touched by this
-// sequence at all), uninstall a retired route-A holder if present (tolerated — the
-// round-1 migration), add the channel-resolved marketplace source (fail-fast —
-// claude natively re-pins a changed source at the same name, probe 3, so this
-// alone recovers the re-pin the old remove step existed to force), update the
-// channel marketplace snapshot (tolerated — probe 4's non-destructive refresh:
-// covers the case where add no-op'd because the source was already current), then
-// install the channel id the devBranch selects (`spacedock@spacedock` stable /
-// `spacedock@spacedock-edge` edge — the entry is always `spacedock`, the channel
-// is the marketplace name; probe 9 — plugin install unconditionally re-clones).
-// The version pin lives in the marketplace manifest. Tolerance asymmetry: the
-// four cleanup/refresh steps (all three uninstalls, marketplace update) are
-// best-effort — claude exits 1 on fresh-box or already-current cases with no
-// stable stderr shape to distinguish those from real failures (the absent sibling
-// alone has two distinct non-zero shapes, depending on whether its marketplace
-// happens to be registered). The two pinning steps (marketplace add + plugin
-// install) stay fail-fast — they are the real-failure backstops that surface a
-// broken install (network, contract incompatibility, missing source).
+// installArgvSequence gives the 6 commands that `Install` runs for claude. No step
+// uses `plugin marketplace remove`. On stable, that command names the `spacedock`
+// marketplace, which also holds other plugins (subspace, cargento). Probe 1
+// measured that this command uninstalls every plugin from the removed marketplace.
+// This sequence exists to prevent that damage.
+//
+// The commands are:
+//
+//  1. Uninstall the plugin of the selected channel (tolerated). Claude tracks an
+//     installed plugin through its marketplace record. If the record goes first,
+//     the uninstall has no record to act on.
+//  2. Uninstall the plugin of the sibling channel (tolerated). This keeps one
+//     channel on the host, as codexInstallArgvSequence does. Both channels use the
+//     entry name `spacedock` and the same skill names. If both stay installed, the
+//     plugin that serves is unpredictable. `plugin uninstall` acts on one plugin,
+//     so it cannot cascade to a plugin on the sibling marketplace. This sequence
+//     never touches the marketplace record of the sibling.
+//  3. Uninstall the retired route-A plugin (tolerated). This is the round-1
+//     migration.
+//  4. Add the marketplace source of the channel (fail-fast). Claude re-pins a
+//     changed source at the same name (probe 3). This step alone makes the re-pin
+//     that the old remove step forced.
+//  5. Update the marketplace snapshot of the channel (tolerated). Probe 4 shows
+//     that this refresh is not destructive. It covers the case where step 4 made
+//     no change because the source was already current.
+//  6. Install the channel id that devBranch selects (fail-fast). Probe 9 shows
+//     that `plugin install` always clones the content again.
+//
+// The id is `spacedock@spacedock` for stable and `spacedock@spacedock-edge` for
+// edge. The entry name is always `spacedock`, and the channel is the marketplace
+// name. The marketplace manifest holds the version pin.
+//
+// The tolerance is asymmetric. The four cleanup commands are best-effort. Claude
+// exits 1 on a fresh box and on an already-current source. No stable stderr shape
+// separates these cases from a true failure. An absent sibling alone gives two
+// different non-zero shapes, which depend on the registration of its marketplace.
+// The two pinning commands stay fail-fast, and they report a broken install from
+// the network, a contract incompatibility, or a missing source.
 func installArgvSequence(source, devBranch string) []installStep {
 	id := channelPluginID(devBranch)
 	return []installStep{

--- a/internal/cli/host_exec.go
+++ b/internal/cli/host_exec.go
@@ -379,7 +379,7 @@ type installStep struct {
 // stable or edge — round 1's AC-4.
 const retiredRouteAID = "spacedock-edge@spacedock"
 
-// installArgvSequence is the 5-command upgrade shape `Install` issues. No step
+// installArgvSequence is the 6-command upgrade shape `Install` issues. No step
 // ever spells `plugin marketplace remove`: on stable that command names the
 // `spacedock` marketplace that also hosts unrelated co-installed plugins
 // (subspace, cargento), and claude's remove measurably CASCADE-UNINSTALLS every
@@ -387,7 +387,13 @@ const retiredRouteAID = "spacedock-edge@spacedock"
 // failure mode this shape exists to stop. The steps: uninstall any existing
 // channel plugin (tolerated — claude tracks an installed plugin via its
 // marketplace record, so removing the record before uninstalling would orphan a
-// live uninstall), uninstall a retired route-A holder if present (tolerated — the
+// live uninstall), uninstall the SIBLING channel's plugin (tolerated — channel
+// exclusivity, mirroring codexInstallArgvSequence's sibling remove: both channels
+// ship the entry name `spacedock` and the same skill names, so leaving both
+// installed makes which one serves unpredictable; `plugin uninstall` is
+// plugin-level, so it cannot cascade into a plugin co-hosted on the sibling
+// marketplace, and the sibling's marketplace record is never touched by this
+// sequence at all), uninstall a retired route-A holder if present (tolerated — the
 // round-1 migration), add the channel-resolved marketplace source (fail-fast —
 // claude natively re-pins a changed source at the same name, probe 3, so this
 // alone recovers the re-pin the old remove step existed to force), update the
@@ -397,16 +403,18 @@ const retiredRouteAID = "spacedock-edge@spacedock"
 // `spacedock@spacedock-edge` edge — the entry is always `spacedock`, the channel
 // is the marketplace name; probe 9 — plugin install unconditionally re-clones).
 // The version pin lives in the marketplace manifest. Tolerance asymmetry: the
-// three cleanup/refresh steps (both uninstalls, marketplace update) are
+// four cleanup/refresh steps (all three uninstalls, marketplace update) are
 // best-effort — claude exits 1 on fresh-box or already-current cases with no
-// stable stderr shape to distinguish those from real failures. The two pinning
-// steps (marketplace add + plugin install) stay fail-fast — they are the
-// real-failure backstops that surface a broken install (network, contract
-// incompatibility, missing source).
+// stable stderr shape to distinguish those from real failures (the absent sibling
+// alone has two distinct non-zero shapes, depending on whether its marketplace
+// happens to be registered). The two pinning steps (marketplace add + plugin
+// install) stay fail-fast — they are the real-failure backstops that surface a
+// broken install (network, contract incompatibility, missing source).
 func installArgvSequence(source, devBranch string) []installStep {
 	id := channelPluginID(devBranch)
 	return []installStep{
 		{argv: []string{"plugin", "uninstall", id}, tolerateExit: true},
+		{argv: []string{"plugin", "uninstall", "spacedock@" + otherChannelMarketplace(devBranch)}, tolerateExit: true},
 		{argv: []string{"plugin", "uninstall", retiredRouteAID}, tolerateExit: true},
 		{argv: []string{"plugin", "marketplace", "add", source}},
 		{argv: []string{"plugin", "marketplace", "update", channelMarketplace(devBranch)}, tolerateExit: true},

--- a/internal/cli/init_devbranch_test.go
+++ b/internal/cli/init_devbranch_test.go
@@ -36,31 +36,9 @@ func TestInitTargetsNextWhenDevBranchPinned(t *testing.T) {
 	}
 }
 
-// TestInstallArgvSequence asserts the tolerance asymmetry of AC-1 and AC-3, and the
-// non-destructive shape. execHost.Install runs 6 commands in this order: `plugin
-// uninstall <id>`, `plugin uninstall <sibling channel id>`, `plugin uninstall
-// spacedock-edge@spacedock`, `plugin marketplace add <source>`, `plugin marketplace
-// update <marketplace>`, and `plugin install <id>`.
-//
-// The first uninstall is tolerated. Claude tracks an installed plugin through its
-// marketplace record, and it exits 1 on a fresh box with "Plugin not found in
-// installed plugins". The second uninstall keeps one channel on the host. The
-// sibling ids below are independent literals for each channel. They never come from
-// otherChannelMarketplace, so this test and the production sequence can diverge.
-// The third uninstall is the round-1 route-A migration, and devBranch does not gate
-// it.
-//
-// The builder takes any source. channelMarketplaceSource resolves the channel
-// source before this call: the bare repo for stable and `<repo>@edge` for edge. The
-// id is the channel that devBranch selects, with the channel in the marketplace
-// name. For the edge binary the id is `spacedock@spacedock-edge`, and the
-// marketplace update targets `spacedock-edge`. For stable the id is
-// `spacedock@spacedock`.
-//
-// No step uses `plugin marketplace remove`. Probe 1 measured that this command
-// uninstalls every co-hosted plugin. The four cleanup steps (three uninstalls and
-// the marketplace update) are tolerated. The two pinning steps (marketplace add and
-// plugin install) are fail-fast.
+// TestInstallArgvSequence asserts the argv sequence and the tolerance asymmetry of
+// AC-1 and AC-3. The sibling ids below are independent literals for each channel,
+// never derived from otherChannelMarketplace.
 func TestInstallArgvSequence(t *testing.T) {
 	wantEdge := []installStep{
 		{argv: []string{"plugin", "uninstall", "spacedock@spacedock-edge"}, tolerateExit: true},
@@ -86,10 +64,8 @@ func TestInstallArgvSequence(t *testing.T) {
 		t.Errorf("installArgvSequence(devBranch=main) = %v, want %v", got, wantStable)
 	}
 
-	// This loop asserts the tolerance asymmetry directly. The four cleanup steps
-	// (three uninstalls and the marketplace update) are tolerated. The two pinning
-	// steps (marketplace add and plugin install) are fail-fast. A change toward
-	// tolerance on every step, or tolerance on a pinning step, fails here.
+	// A change toward tolerance on every step, or tolerance on a pinning step,
+	// fails here.
 	seq := installArgvSequence("spacedock-dev/marketplace", "next")
 	for i, step := range seq {
 		isCleanup := isUninstallStep(step.argv) || isMarketplaceUpdateStep(step.argv)

--- a/internal/cli/init_devbranch_test.go
+++ b/internal/cli/init_devbranch_test.go
@@ -36,28 +36,31 @@ func TestInitTargetsNextWhenDevBranchPinned(t *testing.T) {
 	}
 }
 
-// TestInstallArgvSequence locks AC-1 and AC-3's tolerance asymmetry, and the
-// non-destructive shape: execHost.Install issues the 6-command upgrade sequence —
-// `plugin uninstall <id>` first (claude tracks an installed plugin via its
-// marketplace record; tolerated, fresh-box exit 1 with "Plugin not found in
-// installed plugins"), then `plugin uninstall <sibling channel id>` (tolerated —
-// channel exclusivity; the sibling ids below are written as independent literals
-// per channel, never derived from otherChannelMarketplace, so the test and the
-// production sequence can diverge), then `plugin uninstall spacedock-edge@spacedock` (tolerated
-// — the round-1 route-A migration, unconditional on devBranch), then `plugin
-// marketplace add <source>` with whatever source it is handed (the builder is
-// source-agnostic — channelMarketplaceSource upstream resolves the channel
-// source: bare repo for stable, `<repo>@edge` for edge; fail-fast — claude
-// natively re-pins a changed source at the same name), then `plugin marketplace
-// update <marketplace>` (tolerated — the non-destructive snapshot refresh), then
-// `plugin install <id>`. The id is the channel the devBranch selects, with the
-// channel in the marketplace name: `spacedock@spacedock-edge` for the edge binary
-// (marketplace update targets `spacedock-edge`), `spacedock@spacedock` for stable.
-// No step ever spells `plugin marketplace remove` — that command measurably
-// cascade-uninstalls every co-hosted plugin (probe 1), the destructive failure
-// mode this shape exists to stop. The asymmetry: the four cleanup/refresh steps
-// (all three uninstalls, marketplace update) are tolerated; both pinning steps
-// (marketplace add, plugin install) are fail-fast.
+// TestInstallArgvSequence asserts the tolerance asymmetry of AC-1 and AC-3, and the
+// non-destructive shape. execHost.Install runs 6 commands in this order: `plugin
+// uninstall <id>`, `plugin uninstall <sibling channel id>`, `plugin uninstall
+// spacedock-edge@spacedock`, `plugin marketplace add <source>`, `plugin marketplace
+// update <marketplace>`, and `plugin install <id>`.
+//
+// The first uninstall is tolerated. Claude tracks an installed plugin through its
+// marketplace record, and it exits 1 on a fresh box with "Plugin not found in
+// installed plugins". The second uninstall keeps one channel on the host. The
+// sibling ids below are independent literals for each channel. They never come from
+// otherChannelMarketplace, so this test and the production sequence can diverge.
+// The third uninstall is the round-1 route-A migration, and devBranch does not gate
+// it.
+//
+// The builder takes any source. channelMarketplaceSource resolves the channel
+// source before this call: the bare repo for stable and `<repo>@edge` for edge. The
+// id is the channel that devBranch selects, with the channel in the marketplace
+// name. For the edge binary the id is `spacedock@spacedock-edge`, and the
+// marketplace update targets `spacedock-edge`. For stable the id is
+// `spacedock@spacedock`.
+//
+// No step uses `plugin marketplace remove`. Probe 1 measured that this command
+// uninstalls every co-hosted plugin. The four cleanup steps (three uninstalls and
+// the marketplace update) are tolerated. The two pinning steps (marketplace add and
+// plugin install) are fail-fast.
 func TestInstallArgvSequence(t *testing.T) {
 	wantEdge := []installStep{
 		{argv: []string{"plugin", "uninstall", "spacedock@spacedock-edge"}, tolerateExit: true},
@@ -83,10 +86,10 @@ func TestInstallArgvSequence(t *testing.T) {
 		t.Errorf("installArgvSequence(devBranch=main) = %v, want %v", got, wantStable)
 	}
 
-	// Lock the tolerance asymmetry explicitly: the four cleanup/refresh steps
-	// (all three uninstalls, marketplace update) are tolerated; the two pinning steps
-	// (marketplace add, plugin install) are fail-fast. Any future drift toward
-	// tolerate-every-step (or shifting tolerance onto a pinning step) fails here.
+	// This loop asserts the tolerance asymmetry directly. The four cleanup steps
+	// (three uninstalls and the marketplace update) are tolerated. The two pinning
+	// steps (marketplace add and plugin install) are fail-fast. A change toward
+	// tolerance on every step, or tolerance on a pinning step, fails here.
 	seq := installArgvSequence("spacedock-dev/marketplace", "next")
 	for i, step := range seq {
 		isCleanup := isUninstallStep(step.argv) || isMarketplaceUpdateStep(step.argv)

--- a/internal/cli/init_devbranch_test.go
+++ b/internal/cli/init_devbranch_test.go
@@ -37,10 +37,13 @@ func TestInitTargetsNextWhenDevBranchPinned(t *testing.T) {
 }
 
 // TestInstallArgvSequence locks AC-1 and AC-3's tolerance asymmetry, and the
-// non-destructive shape: execHost.Install issues the 5-command upgrade sequence —
+// non-destructive shape: execHost.Install issues the 6-command upgrade sequence —
 // `plugin uninstall <id>` first (claude tracks an installed plugin via its
 // marketplace record; tolerated, fresh-box exit 1 with "Plugin not found in
-// installed plugins"), then `plugin uninstall spacedock-edge@spacedock` (tolerated
+// installed plugins"), then `plugin uninstall <sibling channel id>` (tolerated —
+// channel exclusivity; the sibling ids below are written as independent literals
+// per channel, never derived from otherChannelMarketplace, so the test and the
+// production sequence can diverge), then `plugin uninstall spacedock-edge@spacedock` (tolerated
 // — the round-1 route-A migration, unconditional on devBranch), then `plugin
 // marketplace add <source>` with whatever source it is handed (the builder is
 // source-agnostic — channelMarketplaceSource upstream resolves the channel
@@ -52,12 +55,13 @@ func TestInitTargetsNextWhenDevBranchPinned(t *testing.T) {
 // (marketplace update targets `spacedock-edge`), `spacedock@spacedock` for stable.
 // No step ever spells `plugin marketplace remove` — that command measurably
 // cascade-uninstalls every co-hosted plugin (probe 1), the destructive failure
-// mode this shape exists to stop. The asymmetry: the three cleanup/refresh steps
-// (both uninstalls, marketplace update) are tolerated; both pinning steps
+// mode this shape exists to stop. The asymmetry: the four cleanup/refresh steps
+// (all three uninstalls, marketplace update) are tolerated; both pinning steps
 // (marketplace add, plugin install) are fail-fast.
 func TestInstallArgvSequence(t *testing.T) {
 	wantEdge := []installStep{
 		{argv: []string{"plugin", "uninstall", "spacedock@spacedock-edge"}, tolerateExit: true},
+		{argv: []string{"plugin", "uninstall", "spacedock@spacedock"}, tolerateExit: true},
 		{argv: []string{"plugin", "uninstall", "spacedock-edge@spacedock"}, tolerateExit: true},
 		{argv: []string{"plugin", "marketplace", "add", "spacedock-dev/marketplace"}},
 		{argv: []string{"plugin", "marketplace", "update", "spacedock-edge"}, tolerateExit: true},
@@ -69,6 +73,7 @@ func TestInstallArgvSequence(t *testing.T) {
 
 	wantStable := []installStep{
 		{argv: []string{"plugin", "uninstall", "spacedock@spacedock"}, tolerateExit: true},
+		{argv: []string{"plugin", "uninstall", "spacedock@spacedock-edge"}, tolerateExit: true},
 		{argv: []string{"plugin", "uninstall", "spacedock-edge@spacedock"}, tolerateExit: true},
 		{argv: []string{"plugin", "marketplace", "add", "spacedock-dev/marketplace"}},
 		{argv: []string{"plugin", "marketplace", "update", "spacedock"}, tolerateExit: true},
@@ -78,8 +83,8 @@ func TestInstallArgvSequence(t *testing.T) {
 		t.Errorf("installArgvSequence(devBranch=main) = %v, want %v", got, wantStable)
 	}
 
-	// Lock the tolerance asymmetry explicitly: the three cleanup/refresh steps
-	// (both uninstalls, marketplace update) are tolerated; the two pinning steps
+	// Lock the tolerance asymmetry explicitly: the four cleanup/refresh steps
+	// (all three uninstalls, marketplace update) are tolerated; the two pinning steps
 	// (marketplace add, plugin install) are fail-fast. Any future drift toward
 	// tolerate-every-step (or shifting tolerance onto a pinning step) fails here.
 	seq := installArgvSequence("spacedock-dev/marketplace", "next")

--- a/internal/cli/install_tolerance_test.go
+++ b/internal/cli/install_tolerance_test.go
@@ -11,10 +11,7 @@ import (
 )
 
 // TestInstallToleratesMarketplaceUpdateStepFailure asserts AC-2 on the
-// already-current path. The stub makes `claude plugin marketplace update
-// spacedock-edge` exit 1, and every other subcommand exits 0. execHost.Install must
-// return a nil error. The combined output must contain the stub marker of all 6
-// steps. Without the tolerance flag on each step, this test fails at the update
+// already-current path. Without the tolerance flag, this test fails at the update
 // step.
 func TestInstallToleratesMarketplaceUpdateStepFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -42,12 +39,8 @@ func TestInstallToleratesMarketplaceUpdateStepFailure(t *testing.T) {
 }
 
 // TestInstallToleratesUninstallStepFailure asserts the fresh-box uninstall half of
-// AC-2. The stub makes `claude plugin uninstall <channel-id>` exit 1, and every
-// other subcommand exits 0. Claude 2.1.160 gives the shape "Plugin not found in
-// installed plugins" on a box where the plugin is not installed. execHost.Install
-// must return a nil error. The combined output must contain the stub marker of all
-// 6 steps. Without the tolerance flag on the uninstall step, this test fails at
-// step 0.
+// AC-2. When the plugin is absent, claude 2.1.160 exits 1 with "Plugin not found
+// in installed plugins". Without the tolerance flag, this test fails at step 0.
 func TestInstallToleratesUninstallStepFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("stub script uses /bin/sh; not portable to Windows")
@@ -74,11 +67,8 @@ func TestInstallToleratesUninstallStepFailure(t *testing.T) {
 }
 
 // TestInstallToleratesRouteAMigrationStepFailure asserts the tolerance of the
-// round-1 migration step. The stub makes `claude plugin uninstall
-// spacedock-edge@spacedock`, the retired route-A id, exit 1. Every other subcommand
-// exits 0. execHost.Install must return a nil error. The combined output must
-// contain the stub marker of all 6 steps. Without the tolerance flag on this step,
-// every install fails for a captain who never used the retired route.
+// round-1 migration step. Without it, every install fails for a captain who never
+// used the retired route.
 func TestInstallToleratesRouteAMigrationStepFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("stub script uses /bin/sh; not portable to Windows")

--- a/internal/cli/install_tolerance_test.go
+++ b/internal/cli/install_tolerance_test.go
@@ -13,7 +13,7 @@ import (
 // TestInstallToleratesMarketplaceUpdateStepFailure locks AC-2: the
 // already-current path where `claude plugin marketplace update spacedock-edge`
 // exits 1 and every other subcommand exits 0. execHost.Install MUST return a nil
-// error and the combined output MUST contain all five steps' stub markers.
+// error and the combined output MUST contain all six steps' stub markers.
 // Without the per-step tolerance flag this test would fail at the update step.
 func TestInstallToleratesMarketplaceUpdateStepFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -30,6 +30,7 @@ func TestInstallToleratesMarketplaceUpdateStepFailure(t *testing.T) {
 		"stub:plugin marketplace update spacedock-edge:exit=1",
 		"stub:plugin marketplace add spacedock-dev/marketplace:exit=0",
 		"stub:plugin uninstall spacedock@spacedock-edge:exit=0",
+		"stub:plugin uninstall spacedock@spacedock:exit=0",
 		"stub:plugin uninstall spacedock-edge@spacedock:exit=0",
 		"stub:plugin install spacedock@spacedock-edge:exit=0",
 	} {
@@ -44,7 +45,7 @@ func TestInstallToleratesMarketplaceUpdateStepFailure(t *testing.T) {
 // (the empirically observed "Plugin not found in installed plugins" shape against
 // claude 2.1.160 on a box where the plugin is not installed) and every other
 // subcommand exits 0, execHost.Install MUST return a nil error and the combined
-// output MUST contain all five steps' stub markers. Without the per-step tolerance
+// output MUST contain all six steps' stub markers. Without the per-step tolerance
 // flag on the uninstall step this test would fail at step 0.
 func TestInstallToleratesUninstallStepFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -59,6 +60,7 @@ func TestInstallToleratesUninstallStepFailure(t *testing.T) {
 	}
 	for _, want := range []string{
 		"stub:plugin uninstall spacedock@spacedock-edge:exit=1",
+		"stub:plugin uninstall spacedock@spacedock:exit=0",
 		"stub:plugin uninstall spacedock-edge@spacedock:exit=0",
 		"stub:plugin marketplace add spacedock-dev/marketplace:exit=0",
 		"stub:plugin marketplace update spacedock-edge:exit=0",
@@ -74,7 +76,7 @@ func TestInstallToleratesUninstallStepFailure(t *testing.T) {
 // step's tolerance: when `claude plugin uninstall spacedock-edge@spacedock`
 // (the retired route-A id) exits 1 and every other subcommand exits 0,
 // execHost.Install MUST return a nil error and the combined output MUST contain
-// all five steps' stub markers. Without the per-step tolerance flag on this step
+// all six steps' stub markers. Without the per-step tolerance flag on this step
 // a captain who never held the retired route would fail every install.
 func TestInstallToleratesRouteAMigrationStepFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -89,6 +91,7 @@ func TestInstallToleratesRouteAMigrationStepFailure(t *testing.T) {
 	}
 	for _, want := range []string{
 		"stub:plugin uninstall spacedock@spacedock-edge:exit=0",
+		"stub:plugin uninstall spacedock@spacedock:exit=0",
 		"stub:plugin uninstall spacedock-edge@spacedock:exit=1",
 		"stub:plugin marketplace add spacedock-dev/marketplace:exit=0",
 		"stub:plugin marketplace update spacedock-edge:exit=0",

--- a/internal/cli/install_tolerance_test.go
+++ b/internal/cli/install_tolerance_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 )
 
-// TestInstallToleratesMarketplaceUpdateStepFailure locks AC-2: the
-// already-current path where `claude plugin marketplace update spacedock-edge`
-// exits 1 and every other subcommand exits 0. execHost.Install MUST return a nil
-// error and the combined output MUST contain all six steps' stub markers.
-// Without the per-step tolerance flag this test would fail at the update step.
+// TestInstallToleratesMarketplaceUpdateStepFailure asserts AC-2 on the
+// already-current path. The stub makes `claude plugin marketplace update
+// spacedock-edge` exit 1, and every other subcommand exits 0. execHost.Install must
+// return a nil error. The combined output must contain the stub marker of all 6
+// steps. Without the tolerance flag on each step, this test fails at the update
+// step.
 func TestInstallToleratesMarketplaceUpdateStepFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("stub script uses /bin/sh; not portable to Windows")
@@ -40,13 +41,13 @@ func TestInstallToleratesMarketplaceUpdateStepFailure(t *testing.T) {
 	}
 }
 
-// TestInstallToleratesUninstallStepFailure locks the fresh-box uninstall
-// tolerance half of AC-2: when `claude plugin uninstall <channel-id>` exits 1
-// (the empirically observed "Plugin not found in installed plugins" shape against
-// claude 2.1.160 on a box where the plugin is not installed) and every other
-// subcommand exits 0, execHost.Install MUST return a nil error and the combined
-// output MUST contain all six steps' stub markers. Without the per-step tolerance
-// flag on the uninstall step this test would fail at step 0.
+// TestInstallToleratesUninstallStepFailure asserts the fresh-box uninstall half of
+// AC-2. The stub makes `claude plugin uninstall <channel-id>` exit 1, and every
+// other subcommand exits 0. Claude 2.1.160 gives the shape "Plugin not found in
+// installed plugins" on a box where the plugin is not installed. execHost.Install
+// must return a nil error. The combined output must contain the stub marker of all
+// 6 steps. Without the tolerance flag on the uninstall step, this test fails at
+// step 0.
 func TestInstallToleratesUninstallStepFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("stub script uses /bin/sh; not portable to Windows")
@@ -72,12 +73,12 @@ func TestInstallToleratesUninstallStepFailure(t *testing.T) {
 	}
 }
 
-// TestInstallToleratesRouteAMigrationStepFailure locks the round-1 migration
-// step's tolerance: when `claude plugin uninstall spacedock-edge@spacedock`
-// (the retired route-A id) exits 1 and every other subcommand exits 0,
-// execHost.Install MUST return a nil error and the combined output MUST contain
-// all six steps' stub markers. Without the per-step tolerance flag on this step
-// a captain who never held the retired route would fail every install.
+// TestInstallToleratesRouteAMigrationStepFailure asserts the tolerance of the
+// round-1 migration step. The stub makes `claude plugin uninstall
+// spacedock-edge@spacedock`, the retired route-A id, exit 1. Every other subcommand
+// exits 0. execHost.Install must return a nil error. The combined output must
+// contain the stub marker of all 6 steps. Without the tolerance flag on this step,
+// every install fails for a captain who never used the retired route.
 func TestInstallToleratesRouteAMigrationStepFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("stub script uses /bin/sh; not portable to Windows")

--- a/internal/cli/sibling_channel_exclusive_test.go
+++ b/internal/cli/sibling_channel_exclusive_test.go
@@ -1,0 +1,134 @@
+// ABOUTME: AC-1 live proof — a claude channel install against a two-channel local
+// ABOUTME: marketplace must leave exactly one enabled spacedock plugin: the selected one.
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestClaudeInstallLeavesOnlySelectedChannelEnabled locks AC-1 against the real
+// claude CLI: after execHost.Install, the COUNT of enabled `spacedock@*` entries in
+// `claude plugin list --json` — claude's own reporting, not a Spacedock value — is
+// exactly 1, and it is the selected channel's id. The baseline moves the wrong way:
+// delete the sibling-uninstall step from installArgvSequence and the sibling-present
+// and reverse subtests count 2, which is the captain's reported bug reproduced
+// hermetically. Three directions: a co-installed sibling (the reported shape), a
+// fresh box (proving the absent sibling's tolerated non-zero exit does not abort the
+// run), and edge-over-stable (proving the mapping works both ways rather than
+// hard-coding one channel). Skips when `claude` is not on PATH — CI's build job has
+// no host CLI, so validation MUST run this locally and treat a SKIP as a failure.
+func TestClaudeInstallLeavesOnlySelectedChannelEnabled(t *testing.T) {
+	claudeBin, err := exec.LookPath("claude")
+	if err != nil {
+		t.Skip("claude not on PATH; channel-exclusivity test requires the host CLI")
+	}
+
+	cases := []struct {
+		name      string
+		devBranch string
+		seedID    string // sibling installed before the run; empty means fresh box
+		wantID    string
+	}{
+		{name: "sibling-present", devBranch: "main", seedID: "spacedock@spacedock-edge", wantID: "spacedock@spacedock"},
+		{name: "fresh-box", devBranch: "main", wantID: "spacedock@spacedock"},
+		{name: "reverse", devBranch: "next", seedID: "spacedock@spacedock", wantID: "spacedock@spacedock-edge"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			stable := buildNamedChannelMarketplace(t, tmp, "spacedock")
+			edge := buildNamedChannelMarketplace(t, tmp, "spacedock-edge")
+			configDir := filepath.Join(tmp, "config")
+			cacheDir := filepath.Join(tmp, "cache")
+			mustMkdir(t, configDir)
+			mustMkdir(t, cacheDir)
+			// Isolation must land on the process environment: execHost.Install shells
+			// out with no explicit Env and inherits it (co_hosted_survival_test.go).
+			t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+			t.Setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", cacheDir)
+			env := os.Environ()
+
+			source := stable
+			if tc.devBranch != "main" {
+				source = edge
+			}
+			if tc.seedID != "" {
+				seedSource := edge
+				if tc.seedID == "spacedock@spacedock" {
+					seedSource = stable
+				}
+				runHost(t, claudeBin, env, "plugin", "marketplace", "add", seedSource)
+				runHost(t, claudeBin, env, "plugin", "install", tc.seedID)
+				if got := enabledSpacedockIDs(t, claudeBin, env); len(got) != 1 || got[0] != tc.seedID {
+					t.Fatalf("seed left enabled %v, want exactly [%s] — the fixture, not the install, is wrong", got, tc.seedID)
+				}
+			}
+
+			out, err := execHost{}.Install("claude", source, tc.devBranch)
+			if err != nil {
+				t.Fatalf("channel Install failed: %v\nout=%q", err, out)
+			}
+
+			got := enabledSpacedockIDs(t, claudeBin, env)
+			if len(got) != 1 || got[0] != tc.wantID {
+				t.Fatalf("enabled spacedock plugins after install = %v, want exactly [%s]\ninstall output:\n%s", got, tc.wantID, out)
+			}
+		})
+	}
+}
+
+// enabledSpacedockIDs returns the ids of every enabled `spacedock@*` entry claude
+// reports — the AC-1 quantity, read from the host's own JSON.
+func enabledSpacedockIDs(t *testing.T, claudeBin string, env []string) []string {
+	t.Helper()
+	listOut := runHost(t, claudeBin, env, "plugin", "list", "--json")
+	var entries []struct {
+		ID      string `json:"id"`
+		Enabled bool   `json:"enabled"`
+	}
+	if err := json.Unmarshal([]byte(listOut), &entries); err != nil {
+		t.Fatalf("parse plugin list --json: %v\n%s", err, listOut)
+	}
+	var ids []string
+	for _, e := range entries {
+		if e.Enabled && strings.HasPrefix(e.ID, "spacedock@") {
+			ids = append(ids, e.ID)
+		}
+	}
+	return ids
+}
+
+// buildNamedChannelMarketplace writes one local directory marketplace named for a
+// channel (`spacedock` or `spacedock-edge`), hosting the single `spacedock` entry —
+// the entry name is the same on both channels, which is why leaving both installed
+// is ambiguous in the first place. Called once per channel so both ids resolve
+// offline and both marketplaces can be registered side by side.
+// buildLocalMarketplaceWithDependent is left alone rather than generalized: it
+// builds one marketplace with a co-hosted dependent for the cascade probe, a
+// different fixture shape that the codex test shares.
+func buildNamedChannelMarketplace(t *testing.T, root, name string) string {
+	t.Helper()
+	marketplace := filepath.Join(root, name)
+	plugin := filepath.Join(marketplace, "spacedock")
+	mustMkdir(t, filepath.Join(marketplace, ".claude-plugin"))
+	mustMkdir(t, filepath.Join(plugin, ".claude-plugin"))
+	mustMkdir(t, filepath.Join(plugin, "skills", "demo"))
+
+	mustWrite(t, filepath.Join(marketplace, ".claude-plugin", "marketplace.json"), `{
+  "name": "`+name+`",
+  "owner": { "name": "CL Kao" },
+  "plugins": [
+    { "name": "spacedock", "source": "./spacedock", "description": "test", "category": "workflow" }
+  ]
+}
+`)
+	mustWrite(t, filepath.Join(plugin, ".claude-plugin", "plugin.json"),
+		`{ "name": "spacedock", "version": "`+displayVersion()+`", "skills": "./skills/" }`+"\n")
+	mustWrite(t, filepath.Join(plugin, "skills", "demo", "SKILL.md"), "---\nname: demo\ndescription: demo skill\n---\ndemo\n")
+	return marketplace
+}

--- a/internal/cli/sibling_channel_exclusive_test.go
+++ b/internal/cli/sibling_channel_exclusive_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: AC-1 live proof — a claude channel install against a two-channel local
-// ABOUTME: marketplace must leave exactly one enabled spacedock plugin: the selected one.
+// ABOUTME: AC-1 live proof. A claude channel install against a local marketplace
+// ABOUTME: for both channels must leave one enabled spacedock plugin.
 package cli
 
 import (
@@ -11,17 +11,22 @@ import (
 	"testing"
 )
 
-// TestClaudeInstallLeavesOnlySelectedChannelEnabled locks AC-1 against the real
-// claude CLI: after execHost.Install, the COUNT of enabled `spacedock@*` entries in
-// `claude plugin list --json` — claude's own reporting, not a Spacedock value — is
-// exactly 1, and it is the selected channel's id. The baseline moves the wrong way:
-// delete the sibling-uninstall step from installArgvSequence and the sibling-present
-// and reverse subtests count 2, which is the captain's reported bug reproduced
-// hermetically. Three directions: a co-installed sibling (the reported shape), a
-// fresh box (proving the absent sibling's tolerated non-zero exit does not abort the
-// run), and edge-over-stable (proving the mapping works both ways rather than
-// hard-coding one channel). Skips when `claude` is not on PATH — CI's build job has
-// no host CLI, so validation MUST run this locally and treat a SKIP as a failure.
+// TestClaudeInstallLeavesOnlySelectedChannelEnabled asserts AC-1 against the real
+// claude CLI. After execHost.Install, `claude plugin list --json` reports exactly
+// one enabled `spacedock@*` entry, and its id is the id of the selected channel.
+// Claude reports this count, not Spacedock.
+//
+// The baseline moves the wrong way. If you delete the sibling uninstall step from
+// installArgvSequence, the sibling-present subtest and the reverse subtest count 2.
+// This is the bug that the captain reported, in a hermetic form.
+//
+// The three subtests give three directions. A co-installed sibling is the shape
+// from the report. A fresh box shows that the tolerated non-zero exit of the absent
+// sibling does not stop the run. Edge over stable shows that the map works in both
+// directions.
+//
+// If `claude` is not on PATH, the test skips. The CI build job has no host CLI.
+// Validation must run this test locally and must treat a SKIP as a failure.
 func TestClaudeInstallLeavesOnlySelectedChannelEnabled(t *testing.T) {
 	claudeBin, err := exec.LookPath("claude")
 	if err != nil {
@@ -31,7 +36,7 @@ func TestClaudeInstallLeavesOnlySelectedChannelEnabled(t *testing.T) {
 	cases := []struct {
 		name      string
 		devBranch string
-		seedID    string // sibling installed before the run; empty means fresh box
+		seedID    string // sibling installed before the run. Empty means a fresh box.
 		wantID    string
 	}{
 		{name: "sibling-present", devBranch: "main", seedID: "spacedock@spacedock-edge", wantID: "spacedock@spacedock"},
@@ -47,8 +52,9 @@ func TestClaudeInstallLeavesOnlySelectedChannelEnabled(t *testing.T) {
 			cacheDir := filepath.Join(tmp, "cache")
 			mustMkdir(t, configDir)
 			mustMkdir(t, cacheDir)
-			// Isolation must land on the process environment: execHost.Install shells
-			// out with no explicit Env and inherits it (co_hosted_survival_test.go).
+			// The isolation must apply to the process environment. execHost.Install
+			// runs the host command with no explicit Env, so it inherits the
+			// environment of the process (co_hosted_survival_test.go).
 			t.Setenv("CLAUDE_CONFIG_DIR", configDir)
 			t.Setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", cacheDir)
 			env := os.Environ()
@@ -82,8 +88,9 @@ func TestClaudeInstallLeavesOnlySelectedChannelEnabled(t *testing.T) {
 	}
 }
 
-// enabledSpacedockIDs returns the ids of every enabled `spacedock@*` entry claude
-// reports — the AC-1 quantity, read from the host's own JSON.
+// enabledSpacedockIDs returns the id of every enabled `spacedock@*` entry that
+// claude reports. This count is the quantity that AC-1 measures. It comes from the
+// JSON of the host.
 func enabledSpacedockIDs(t *testing.T, claudeBin string, env []string) []string {
 	t.Helper()
 	listOut := runHost(t, claudeBin, env, "plugin", "list", "--json")
@@ -103,14 +110,14 @@ func enabledSpacedockIDs(t *testing.T, claudeBin string, env []string) []string 
 	return ids
 }
 
-// buildNamedChannelMarketplace writes one local directory marketplace named for a
-// channel (`spacedock` or `spacedock-edge`), hosting the single `spacedock` entry —
-// the entry name is the same on both channels, which is why leaving both installed
-// is ambiguous in the first place. Called once per channel so both ids resolve
-// offline and both marketplaces can be registered side by side.
-// buildLocalMarketplaceWithDependent is left alone rather than generalized: it
-// builds one marketplace with a co-hosted dependent for the cascade probe, a
-// different fixture shape that the codex test shares.
+// buildNamedChannelMarketplace writes one local directory marketplace with the name
+// of a channel (`spacedock` or `spacedock-edge`). The marketplace holds the single
+// `spacedock` entry. Both channels use the same entry name. If both plugins stay
+// installed, that entry name is ambiguous. The test calls this function once
+// for each channel, so both ids resolve offline and both marketplaces can register
+// at the same time. This function does not replace
+// buildLocalMarketplaceWithDependent, which builds one marketplace with a co-hosted
+// dependent for the cascade probe. The codex test shares that different fixture.
 func buildNamedChannelMarketplace(t *testing.T, root, name string) string {
 	t.Helper()
 	marketplace := filepath.Join(root, name)

--- a/internal/cli/sibling_channel_exclusive_test.go
+++ b/internal/cli/sibling_channel_exclusive_test.go
@@ -12,21 +12,14 @@ import (
 )
 
 // TestClaudeInstallLeavesOnlySelectedChannelEnabled asserts AC-1 against the real
-// claude CLI. After execHost.Install, `claude plugin list --json` reports exactly
-// one enabled `spacedock@*` entry, and its id is the id of the selected channel.
-// Claude reports this count, not Spacedock.
+// claude CLI: after execHost.Install, `claude plugin list --json` reports exactly
+// one enabled `spacedock@*` entry, and it is the selected channel.
 //
 // The baseline moves the wrong way. If you delete the sibling uninstall step from
-// installArgvSequence, the sibling-present subtest and the reverse subtest count 2.
-// This is the bug that the captain reported, in a hermetic form.
+// installArgvSequence, the sibling-present and reverse subtests count 2.
 //
-// The three subtests give three directions. A co-installed sibling is the shape
-// from the report. A fresh box shows that the tolerated non-zero exit of the absent
-// sibling does not stop the run. Edge over stable shows that the map works in both
-// directions.
-//
-// If `claude` is not on PATH, the test skips. The CI build job has no host CLI.
-// Validation must run this test locally and must treat a SKIP as a failure.
+// If `claude` is not on PATH, the test skips. Validation must run this test locally
+// and must treat a SKIP as a failure.
 func TestClaudeInstallLeavesOnlySelectedChannelEnabled(t *testing.T) {
 	claudeBin, err := exec.LookPath("claude")
 	if err != nil {
@@ -52,9 +45,8 @@ func TestClaudeInstallLeavesOnlySelectedChannelEnabled(t *testing.T) {
 			cacheDir := filepath.Join(tmp, "cache")
 			mustMkdir(t, configDir)
 			mustMkdir(t, cacheDir)
-			// The isolation must apply to the process environment. execHost.Install
-			// runs the host command with no explicit Env, so it inherits the
-			// environment of the process (co_hosted_survival_test.go).
+			// execHost.Install runs the host command with no explicit Env, so the
+			// isolation must apply to the process environment.
 			t.Setenv("CLAUDE_CONFIG_DIR", configDir)
 			t.Setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", cacheDir)
 			env := os.Environ()
@@ -89,8 +81,7 @@ func TestClaudeInstallLeavesOnlySelectedChannelEnabled(t *testing.T) {
 }
 
 // enabledSpacedockIDs returns the id of every enabled `spacedock@*` entry that
-// claude reports. This count is the quantity that AC-1 measures. It comes from the
-// JSON of the host.
+// claude reports. This count is the quantity that AC-1 measures.
 func enabledSpacedockIDs(t *testing.T, claudeBin string, env []string) []string {
 	t.Helper()
 	listOut := runHost(t, claudeBin, env, "plugin", "list", "--json")
@@ -112,12 +103,8 @@ func enabledSpacedockIDs(t *testing.T, claudeBin string, env []string) []string 
 
 // buildNamedChannelMarketplace writes one local directory marketplace with the name
 // of a channel (`spacedock` or `spacedock-edge`). The marketplace holds the single
-// `spacedock` entry. Both channels use the same entry name. If both plugins stay
-// installed, that entry name is ambiguous. The test calls this function once
-// for each channel, so both ids resolve offline and both marketplaces can register
-// at the same time. This function does not replace
-// buildLocalMarketplaceWithDependent, which builds one marketplace with a co-hosted
-// dependent for the cascade probe. The codex test shares that different fixture.
+// `spacedock` entry. The test calls it once for each channel, so both ids resolve
+// offline and both marketplaces can register at the same time.
 func buildNamedChannelMarketplace(t *testing.T, root, name string) string {
 	t.Helper()
 	marketplace := filepath.Join(root, name)

--- a/internal/contractlint/install_hint_drift_test.go
+++ b/internal/contractlint/install_hint_drift_test.go
@@ -79,16 +79,7 @@ func TestInstallHintNoDrift(t *testing.T) {
 	}
 
 	// Arm 2: Homebrew tap+formula token equality.
-	var tap, formula string
-	for _, l := range installMDSection(t, lines, "macOS (Homebrew)") {
-		trimmed := strings.TrimSpace(l)
-		if strings.HasPrefix(trimmed, "brew tap ") {
-			tap = strings.TrimPrefix(trimmed, "brew tap ")
-		}
-		if strings.HasPrefix(trimmed, "brew install ") {
-			formula = strings.TrimPrefix(trimmed, "brew install ")
-		}
-	}
+	tap, formula := brewTokens(installMDSection(t, lines, "macOS (Homebrew)"))
 	if tap == "" || formula == "" {
 		t.Fatalf("install.md Homebrew tab lacks the two-line brew tap/install form (tap=%q formula=%q)", tap, formula)
 	}
@@ -98,4 +89,55 @@ func TestInstallHintNoDrift(t *testing.T) {
 	if oneLine := "brew install " + tap + "/" + formula; !strings.Contains(prose, oneLine) {
 		t.Fatalf("FO install-reference prose must also carry the one-line form %q", oneLine)
 	}
+}
+
+// TestInstallHintProductReadmeNoDrift binds the product README's Homebrew
+// commands to install.md's `macOS (Homebrew)` tab, the same token-equality shape
+// as arm 2 above with the README standing in for the FO prose. The README is the
+// last unguarded copy of the install commands — mkdocs.yml does not include it, so
+// the docs strict build never validates it — and it had already drifted
+// (`spacedock-dev/homebrew-tap` against install.md's `spacedock-dev/tap`; Homebrew
+// strips the `homebrew-` prefix, so both resolved and nothing caught it). This
+// compares two independent files that can diverge; it asserts nothing about what
+// the README's prose says.
+func TestInstallHintProductReadmeNoDrift(t *testing.T) {
+	root := repoRoot(t)
+	rawInstall, err := os.ReadFile(filepath.Join(root, "docs", "site", "get-started", "install.md"))
+	if err != nil {
+		t.Fatalf("read install.md: %v", err)
+	}
+	tap, formula := brewTokens(installMDSection(t, strings.Split(string(rawInstall), "\n"), "macOS (Homebrew)"))
+	if tap == "" || formula == "" {
+		t.Fatalf("install.md Homebrew tab lacks the two-line brew tap/install form (tap=%q formula=%q)", tap, formula)
+	}
+
+	rawReadme, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	readmeInstall := markdownSectionFromText(t, string(rawReadme), "## Install")
+	readmeTap, readmeFormula := brewTokens(strings.Split(readmeInstall, "\n"))
+	if readmeTap != tap {
+		t.Errorf("README.md's Install section names tap %q; install.md's Homebrew tab names %q", readmeTap, tap)
+	}
+	if readmeFormula != formula {
+		t.Errorf("README.md's Install section names formula %q; install.md's Homebrew tab names %q", readmeFormula, formula)
+	}
+}
+
+// brewTokens returns the tap and formula named by the last `brew tap` /
+// `brew install` lines in a section, ignoring indentation and comment lines (the
+// Homebrew tab documents the edge cask as a commented `# brew install …`). Empty
+// strings mean the section documents no such command.
+func brewTokens(section []string) (tap, formula string) {
+	for _, l := range section {
+		trimmed := strings.TrimSpace(l)
+		if strings.HasPrefix(trimmed, "brew tap ") {
+			tap = strings.TrimPrefix(trimmed, "brew tap ")
+		}
+		if strings.HasPrefix(trimmed, "brew install ") {
+			formula = strings.TrimPrefix(trimmed, "brew install ")
+		}
+	}
+	return tap, formula
 }

--- a/internal/contractlint/install_hint_drift_test.go
+++ b/internal/contractlint/install_hint_drift_test.go
@@ -91,15 +91,19 @@ func TestInstallHintNoDrift(t *testing.T) {
 	}
 }
 
-// TestInstallHintProductReadmeNoDrift binds the product README's Homebrew
-// commands to install.md's `macOS (Homebrew)` tab, the same token-equality shape
-// as arm 2 above with the README standing in for the FO prose. The README is the
-// last unguarded copy of the install commands — mkdocs.yml does not include it, so
-// the docs strict build never validates it — and it had already drifted
-// (`spacedock-dev/homebrew-tap` against install.md's `spacedock-dev/tap`; Homebrew
-// strips the `homebrew-` prefix, so both resolved and nothing caught it). This
-// compares two independent files that can diverge; it asserts nothing about what
-// the README's prose says.
+// TestInstallHintProductReadmeNoDrift binds the Homebrew commands of the product
+// README to the `macOS (Homebrew)` tab of install.md. It uses the same token
+// equality as arm 2 above, with the README in place of the FO prose.
+//
+// The README holds the last copy of the install commands that no test protects.
+// mkdocs.yml does not include the README, so the docs strict build never reads it.
+// The two files diverged before this test: the README named
+// `spacedock-dev/homebrew-tap` and install.md named `spacedock-dev/tap`. Homebrew
+// removes the `homebrew-` prefix, so both names resolved and no reader found the
+// difference.
+//
+// This test compares two independent files that can diverge. It asserts nothing
+// about the prose of the README.
 func TestInstallHintProductReadmeNoDrift(t *testing.T) {
 	root := repoRoot(t)
 	rawInstall, err := os.ReadFile(filepath.Join(root, "docs", "site", "get-started", "install.md"))
@@ -125,10 +129,10 @@ func TestInstallHintProductReadmeNoDrift(t *testing.T) {
 	}
 }
 
-// brewTokens returns the tap and formula named by the last `brew tap` /
-// `brew install` lines in a section, ignoring indentation and comment lines (the
-// Homebrew tab documents the edge cask as a commented `# brew install …`). Empty
-// strings mean the section documents no such command.
+// brewTokens returns the tap and the formula from the last `brew tap` line and the
+// last `brew install` line of a section. It removes the indentation and it ignores
+// comment lines. The Homebrew tab gives the edge cask as a comment line that starts
+// with `# brew install`. An empty string shows that the section has no such command.
 func brewTokens(section []string) (tap, formula string) {
 	for _, l := range section {
 		trimmed := strings.TrimSpace(l)

--- a/internal/contractlint/install_hint_drift_test.go
+++ b/internal/contractlint/install_hint_drift_test.go
@@ -92,18 +92,11 @@ func TestInstallHintNoDrift(t *testing.T) {
 }
 
 // TestInstallHintProductReadmeNoDrift binds the Homebrew commands of the product
-// README to the `macOS (Homebrew)` tab of install.md. It uses the same token
-// equality as arm 2 above, with the README in place of the FO prose.
-//
-// The README holds the last copy of the install commands that no test protects.
-// mkdocs.yml does not include the README, so the docs strict build never reads it.
-// The two files diverged before this test: the README named
-// `spacedock-dev/homebrew-tap` and install.md named `spacedock-dev/tap`. Homebrew
-// removes the `homebrew-` prefix, so both names resolved and no reader found the
-// difference.
-//
-// This test compares two independent files that can diverge. It asserts nothing
-// about the prose of the README.
+// README to the `macOS (Homebrew)` tab of install.md. mkdocs.yml does not include
+// the README, so the docs strict build never reads it. The two files diverged
+// before this test: the README named `spacedock-dev/homebrew-tap` and install.md
+// named `spacedock-dev/tap`. Homebrew removes the `homebrew-` prefix, so both
+// names resolved and nothing caught the difference.
 func TestInstallHintProductReadmeNoDrift(t *testing.T) {
 	root := repoRoot(t)
 	rawInstall, err := os.ReadFile(filepath.Join(root, "docs", "site", "get-started", "install.md"))
@@ -129,10 +122,9 @@ func TestInstallHintProductReadmeNoDrift(t *testing.T) {
 	}
 }
 
-// brewTokens returns the tap and the formula from the last `brew tap` line and the
-// last `brew install` line of a section. It removes the indentation and it ignores
-// comment lines. The Homebrew tab gives the edge cask as a comment line that starts
-// with `# brew install`. An empty string shows that the section has no such command.
+// brewTokens returns the tap and the formula from the last `brew tap` and `brew
+// install` lines of a section. The Homebrew tab gives the edge cask as a comment
+// line, which the `brew ` prefixes skip. An empty string means no such command.
 func brewTokens(section []string) (tap, formula string) {
 	for _, l := range section {
 		trimmed := strings.TrimSpace(l)


### PR DESCRIPTION
A stable `spacedock install --host claude` on a machine holding the edge plugin left both channels enabled, making which skill set serves unpredictable.

## What changed
- Add a tolerated sibling-channel uninstall to the claude install sequence, mirroring codex.
- Extend argv and tolerance tests with per-channel sibling literals.
- Add a claude-on-PATH value test with a two-channel local marketplace fixture.
- Label the README brew block stable and point edge readers at the install guide.
- Add a contractlint arm binding README brew tokens to install.md's.

## Evidence
- `go test ./...` and `-race`: 20/20 packages passed, fresh runs.
- Live value test vs claude 2.1.226: 3/3 subtests passed; deleting the step reproduces the dual-install bug.

---
[7p](/spacedock-dev/spacedock/blob/4fc4ba741b6886e2f78aea45f33a232057fdf37e/claude-install-sibling-channel-cleanup.md)
Related: doctor-blind-to-sibling-dual-install (filed follow-up)
