### PR TITLE
Pin verified loader versions in piSpawnSkill comment

### DIFF
--- a/internal/dispatch/build.go
+++ b/internal/dispatch/build.go
@@ -55,7 +55,12 @@ var namePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
 var modelEnum = map[string]bool{"sonnet": true, "opus": true, "haiku": true, "fable": true}
 
 // Pi spawn delivery defaults for `dispatch build --host pi`: pi-subagents
-// resolves agents and skills by directory basename only, so the artifact
+// resolves agents and skills by directory basename only. Re-verified on
+// 2026-08-27 against pi-subagents 0.37.2 (installed) and 0.57.0 (latest npm):
+// both use exact basename match (skills.find((s) => s.name === skillName) in
+// resolveSkillPath, src/agents/skills.ts) — byte-identical across versions, no
+// namespace/qualified-name handling. The bare basename is the only resolving
+// form; passing "spacedock:ensign" would fail to match. The artifact therefore
 // carries the generic write-capable agent ("worker") and the basename skill
 // ("ensign"); a stage agent: override replaces agent and drops skill (the
 // override agent owns its own contract).


### PR DESCRIPTION
A field report claimed Pi-dispatched ensigns spawn contract-free because the dispatch artifact passes the bare skill name `"ensign"` while "newer Pi wants the exact name `spacedock:ensign`." The report's diagnosis is inverted: the bare basename is the only form that resolves; the qualified name would fail.

## What changed
- `internal/dispatch/build.go`: comment-only refinement of the `piSpawnSkill` block (lines 56-66) — replaced the stale unverified assumption ("pi-subagents resolves agents and skills by directory basename only") with pinned re-verification evidence. `piSpawnSkill` remains `"ensign"`, `piSpawnAgent` remains `"worker"` — byte-identical to main (only line numbers shifted). No behavior change.

## Evidence
- **Source spike:** `resolveSkillPath` in `pi-subagents/src/agents/skills.ts` is byte-identical on installed 0.37.2 and latest npm 0.57.0 — both use `skills.find((s) => s.name === skillName)` (exact basename match, no namespace handling). `normalizeSkillInput` only trims whitespace; no colon-splitting that would turn `spacedock:ensign` into `ensign`. Passing `spacedock:ensign` would fail to resolve and land in `missing` → contract-free boot.
- **Live transcript:** this session's dispatch (run 4c6e9c44) shows the ensign skill resident in `<available_skills>` — the bare name resolves end-to-end.
- **Existing test:** `TestBuildPiHostEmitsSpawnAgentAndSkill` asserts the artifact emits `skill = "ensign"` and `agent = "worker"`, locking the verified-correct values. PASS; `go build ./...` OK; gofmt clean.
- `git diff --numstat main` shows only `build.go` (6/1), comment lines only.

The report likely confused the `subagent_type` field (host-neutral `"spacedock:ensign"`) with the `skill` field (bare `"ensign"`) — two different fields that coexist on the artifact.

---

[ntn](/spacedock-dev/spacedock/blob/353cf1c0a416185e9fa1d44baa36ff2e8281a5e4/pi-spawn-skill-name-resolution.md)
