### PR TITLE
Gate the Pi front door bootstrap on resume

### DIFF
--- a/internal/cli/pi.go
+++ b/internal/cli/pi.go
@@ -268,7 +268,15 @@ func runPi(ctx context.Context, args []string, dir string, env []string, ops piR
 		}
 	}
 	argv = append(argv, fd.passthrough...)
-	argv = append(argv, launchPrompt(piBootstrapPrompt, fd))
+	// Suppress the fresh-start bootstrap prompt on a resume, mirroring the
+	// Claude/Codex front door (frontdoor.go containsResume): a resume carries
+	// its own session intent and the FO contract survives in the system prompt
+	// via resources_discover, so re-injecting piBootstrapPrompt would tell the
+	// resumed session to load the contract as if starting fresh. Covers --resume,
+	// --resume=<id>, -r, --continue, -c (the same token set as containsResume).
+	if !containsResume(fd.passthrough) {
+		argv = append(argv, launchPrompt(piBootstrapPrompt, fd))
+	}
 	// Resolve the fnm per-shell multishell symlink to its stable node-installation
 	// bin so execHost.Launch's stdlib exec.LookPath(<absolute>) hands Node a script
 	// path fnm never tears down. On any miss/failure argv[0] stays "pi" (current

--- a/internal/cli/pi_frontdoor_test.go
+++ b/internal/cli/pi_frontdoor_test.go
@@ -1105,3 +1105,73 @@ func TestPiSpacedockPackageStatus_SubagentsRegistered(t *testing.T) {
 		})
 	}
 }
+
+// TestPiResumeSuppressesBootstrapPrompt pins AC-1/AC-2: a Pi launch with a resume
+// token in the passthrough (--resume, --resume=<id>, -r, --continue, -c) must
+// NOT append piBootstrapPrompt to the argv, while a non-resume launch still
+// does. The non-resume case is the independent baseline that can move the wrong
+// way (if the gate regresses or the non-resume path loses the prompt).
+func TestPiResumeSuppressesBootstrapPrompt(t *testing.T) {
+	resumeTokens := []string{
+		"--resume",
+		"--resume=abc123",
+		"-r",
+		"--continue",
+		"-c",
+	}
+	for _, token := range resumeTokens {
+		t.Run("resume/"+token, func(t *testing.T) {
+			repo := t.TempDir()
+			writePiSkillFixtures(t, repo)
+			pkg := t.TempDir()
+			writePiSubagentsFixtures(t, pkg)
+			ops := &fakePiRuntimeOps{
+				lookPath:      piHealthyPathFixtures(),
+				statOK:        statOKForPiResources(repo, pkg),
+				packageStatus: healthyPiPackageStatus(),
+			}
+			var stdout, stderr bytes.Buffer
+			args := []string{"--plugin-dir", repo, "--", token}
+			code := runPi(context.Background(), args, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+			}
+			for _, tok := range ops.launched {
+				if strings.Contains(tok, piBootstrapPrompt) {
+					t.Fatalf("resume token %q: argv contains piBootstrapPrompt: %v", token, ops.launched)
+				}
+			}
+		})
+	}
+
+	nonResumeCases := []struct {
+		name     string
+		passthru []string
+	}{
+		{"model_flag", []string{"--model", "google/gemini"}},
+		{"task_string", []string{"review this code"}},
+	}
+	for _, tc := range nonResumeCases {
+		t.Run("nonresume/"+tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writePiSkillFixtures(t, repo)
+			pkg := t.TempDir()
+			writePiSubagentsFixtures(t, pkg)
+			ops := &fakePiRuntimeOps{
+				lookPath:      piHealthyPathFixtures(),
+				statOK:        statOKForPiResources(repo, pkg),
+				packageStatus: healthyPiPackageStatus(),
+			}
+			var stdout, stderr bytes.Buffer
+			args := append([]string{"--plugin-dir", repo, "--"}, tc.passthru...)
+			code := runPi(context.Background(), args, t.TempDir(), piTestEnv(pkg, t.TempDir()), ops, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+			}
+			prompt := ops.launched[len(ops.launched)-1]
+			if !strings.Contains(prompt, piBootstrapPrompt) {
+				t.Fatalf("non-resume passthrough %v: last argv token missing piBootstrapPrompt: %v", tc.passthru, ops.launched)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`spacedock pi --resume` re-loaded the FO contract as a fresh start because the Pi front door appends `piBootstrapPrompt` unconditionally — no `containsResume` gate, unlike Claude/Codex. This adds the gate, mirroring the shared `containsResume` helper.

Stacked on #776 (Pi firstActionBlock loads the ensign skill); merge #776 first.

## What changed
- `internal/cli/pi.go`: wrapped the `launchPrompt(piBootstrapPrompt, fd)` append in `if !containsResume(fd.passthrough)`, reusing the shared `containsResume` helper at `frontdoor.go:553`.
- `internal/cli/pi_frontdoor_test.go`: `TestPiResumeSuppressesBootstrapPrompt` — table-driven, asserts each resume token suppresses the prompt and non-resume keeps it.

## Evidence
- `go test ./internal/cli/ -run TestPiResumeSuppressesBootstrapPrompt -v` — 7/7 subtests PASS.
- gofmt/go vet/-race clean. `TestVersionAmbiguousMarkersExitZero` pre-existing on main.

---

[4av](/spacedock-dev/spacedock/blob/353cf1c0a416185e9fa1d44baa36ff2e8281a5e4/gate-pi-frontdoor-bootstrap-on-resume.md)
